### PR TITLE
Fix deadlink, more canonical reference, and better wording

### DIFF
--- a/tutorials/2d/custom_gui_controls.rst
+++ b/tutorials/2d/custom_gui_controls.rst
@@ -108,7 +108,7 @@ Simply override it in your control. No processing needs to be set.
        if (ev.type==InputEvent.MOUSE_BUTTON and ev.button_index==BUTTON_LEFT and ev.pressed):
            print("Left mouse button was pressed!")
 
-For more information about events themselves, check the [[Input Events]]
+For more information about events themselves, check the :ref:`doc_inputevent`
 tutorial.
 
 Notifications

--- a/tutorials/engine/inputevent.rst
+++ b/tutorials/engine/inputevent.rst
@@ -47,7 +47,7 @@ not spread any more.
 will be called (enable with
 :ref:`Node.set_process_unhandled_input() <class_Node_set_process_unhandled_input>`) and override
 :ref:`Node._unhandled_input() <class_Node__unhandled_input>`). If any function consumes the
-event, it can call [[SceneTree.set_input_as_handled()]], and the
+event, it can call :ref:`SceneTree.set_input_as_handled() <class_SceneTree_set_input_as_handled>`, and the
 event will not spread any more.
 4. If no one wanted the event so far, and a :ref:`Camera <class_Camera>` is assigned
 to the Viewport, a ray to the physics world (in the ray direction from
@@ -116,8 +116,8 @@ logic. This allows for:
 -  Input to be reconfigured at run-time.
 
 Actions can be created from the Project Settings menu in the Actions
-tab. If you read the :ref:`doc_simple_2d_game`, there is an explanation on how
-does the action editor work.
+tab. If you read the :ref:`doc_simple_2d_game` tutorial, there is an
+explanation on how the action editor works.
 
 Any event has the methods :ref:`InputEvent.is_action() <class_InputEvent_is_action>`,
 :ref:`InputEvent.is_pressed() <class_InputEvent_is_pressed>` and :ref:`InputEvent <class_InputEvent>`.


### PR DESCRIPTION
I ran `grep -rIn "\[\[" tutorials/ reference/ files classes/` and found some usages of `[[`. The commit removes all except two commented out usages in `tutorials/3d/importing_3d_scenes.rst`.