### PR TITLE
Update documentation for class_meshinstace.rst

### DIFF
--- a/classes/class_meshinstance.rst
+++ b/classes/class_meshinstance.rst
@@ -33,6 +33,8 @@ Member Functions
 +----------------------------------+----------------------------------------------------------------------------------------------------------------------------+
 | void                             | :ref:`create_convex_collision<class_MeshInstance_create_convex_collision>`  **(** **)**                                    |
 +----------------------------------+----------------------------------------------------------------------------------------------------------------------------+
+| void                             | :ref:`set<class_MeshInstance_set>`  **(** :ref:`String<class_string>` property, :ref:`float<class_float>` value **)**      |                              |
++----------------------------------+----------------------------------------------------------------------------------------------------------------------------+
 
 Description
 -----------
@@ -78,4 +80,8 @@ This helper creates a :ref:`StaticBody<class_staticbody>` child :ref:`Node<class
 
 - void  **create_convex_collision**  **(** **)**
 
+.. _class_MeshInstance_set:
 
+- void  **set**  **(** :ref:`String<class_string>` property, :ref:`float<class_float>` value  **)**
+
+Set a morph value by string property for the instance.


### PR DESCRIPTION
MeshInstance contains the set(String property, var value) property for setting morph shapes from GDScript, but it isn't documented. I stumbled over a year old reference to it in the doc's of the old site. I've added reference to this function in the member function list and the member function description of this document.