### PR TITLE
Typo

### DIFF
--- a/reference/shading_language.rst
+++ b/reference/shading_language.rst
@@ -130,7 +130,7 @@ uniforms or other shader variables.
         return a+b;
     }
 
-    vec3 c = addtwo(vec3(1,1,1) + vec3(2,2,2));
+    vec3 c = addtwo(vec3(1,1,1), vec3(2,2,2));
 
 Built-in functions
 ------------------


### PR DESCRIPTION
A colon should be used instead of + to separate function variables