### PR TITLE
Add instructions on how to compile for X11 using Clang

### DIFF
--- a/reference/compiling_for_x11.rst
+++ b/reference/compiling_for_x11.rst
@@ -66,6 +66,12 @@ If all goes well, the resulting binary executable will be placed in the
 runs without any dependencies. Executing it will bring up the project
 manager.
 
+If you wish to compile using Clang rather than GCC, use this command:
+
+::
+
+    user@host:~/godot$ scons platform=x11 use_llvm=yes
+
 Building export templates
 -------------------------
 


### PR DESCRIPTION
This adds instructions on how to compile for Linux/X11 using Clang.