### PR TITLE
Update vector_math.rst

### DIFF
--- a/tutorials/vector_math.rst
+++ b/tutorials/vector_math.rst
@@ -165,11 +165,13 @@ Example:
 
 ::
 
-    var v = Vector2(0,1)
+    var v = Vector2(2,4)
+    
     # rotate right (clockwise)
-    var v_right = Vector2(-v.y, v.x)
-    # rotate left (counter-clockwise)
     var v_right = Vector2(v.y, -v.x)
+    
+    # rotate left (counter-clockwise)
+    var v_left = Vector2(-v.y, v.x)
 
 This is a handy trick that is often of use. It is impossible to do with
 3D vectors, because there are an infinite amount of perpendicular


### PR DESCRIPTION
There was an error in the "Perpendicular Vectors" example.

The example for rotating right would have rotated left and the example for rotating left would have rotated right.
Additionally the variable name for rotating left was also v_right.
I also changed the x and y values to fit the image in the example so there is an direct correlation.