### PR TITLE
Updating invalid call

### DIFF
--- a/tutorials/engine/mouse_and_input_coordinates.rst
+++ b/tutorials/engine/mouse_and_input_coordinates.rst
@@ -37,7 +37,7 @@ for example:
 
        # Print the size of the viewport
 
-       print("Viewport Resolution is: ",get_viewport_rect().size)
+       print("Viewport Resolution is: ", get_viewport().get_rect().size)
 
     func _ready():
         set_process_input(true)


### PR DESCRIPTION
Updating `get_viewport_rect()` to `get_viewport().get_rect().size`, to fix example errors.