### PR TITLE
Clarification about enter keys confusion for programmers from web background

### DIFF
--- a/classes/class_@global scope.rst
+++ b/classes/class_@global scope.rst
@@ -62,8 +62,8 @@ Numeric Constants
 - **KEY_TAB** = **16777218** --- Tab Key
 - **KEY_BACKTAB** = **16777219** --- Shift-Tab Key
 - **KEY_BACKSPACE** = **16777220** --- Backspace Key
-- **KEY_RETURN** = **16777221** --- Return Key
-- **KEY_ENTER** = **16777222** --- Enter Key
+- **KEY_RETURN** = **16777221** --- Return Key (On Main Keyboard)
+- **KEY_ENTER** = **16777222** --- Enter Key (On Numpad)
 - **KEY_INSERT** = **16777223** --- Insert Key
 - **KEY_DELETE** = **16777224** --- Delete Key
 - **KEY_PAUSE** = **16777225** --- Pause Key


### PR DESCRIPTION
Some Web Languages threat KEY_RETURN and KEY_ENTER keys having the same keycode (eg: Javascript). Added additional explanation about this issue. Related to godotengine/godot#4595