### PR TITLE
Change resulting APK

### DIFF
--- a/reference/compiling_for_android.rst
+++ b/reference/compiling_for_android.rst
@@ -156,7 +156,7 @@ Resulting APK is in:
 
 ::
 
-    platform/android/java/bin/Godot-release-unsigned.apk
+    platform/android/java/build/outputs/apk/java-release-unsigned.apk
 
 -  (release)
 
@@ -171,7 +171,7 @@ Resulting APK is in:
 
 ::
 
-    platform/android/java/bin/Godot-release-unsigned.apk
+    platform/android/java/build/outputs/apk/java-release-unsigned.apk
 
 (same as before)
 


### PR DESCRIPTION
Change resulting APK in templates compilation from:
platform/android/java/bin/Godot-release-unsigned.apk
to:
platform/android/java/build/outputs/apk/java-release-unsigned.apk