### PR TITLE
Removed comment about Lua arrays as dictionaries

### DIFF
--- a/reference/gdscript_more_efficiently.rst
+++ b/reference/gdscript_more_efficiently.rst
@@ -238,8 +238,8 @@ only on limited form).
 Dictionaries can map any value to any other value with complete
 disregard for the datatype used as either key or value. Contrary to
 popular belief, they are very efficient because they can be implemented
-with hash tables. They are, in fact, so efficient that languages such as
-Lua will go as far as implementing arrays as dictionaries.
+with hash tables. They are, in fact, so efficient that some languages
+will go as far as implementing arrays as dictionaries.
 
 Example of Dictionary:
 


### PR DESCRIPTION
Since Lua 5.0 tables actually uses contiguous arrays when possible but hides this from the user. See page 2 of http://www.lua.org/doc/jucs05.pdf