### PR TITLE
Update shading_language.rst

### DIFF
--- a/reference/shading_language.rst
+++ b/reference/shading_language.rst
@@ -487,8 +487,15 @@ Obtaining world-space normal and position in material fragment program:
 
     // Use reverse multiply because INV_CAMERA_MATRIX is world2cam
 
-    vec3 world_normal = NORMAL * mat3(INV_CAMERA_MATRIX);
-    vec3 world_pos = (VERTEX - INV_CAMERA_MATRIX.w.xyz) * mat3(INV_CAMERA_MATRIX);
+    vec4 invcamx = INV_CAMERA_MATRIX.x;
+    vec4 invcamy = INV_CAMERA_MATRIX.y;
+    vec4 invcamz = INV_CAMERA_MATRIX.z;
+    vec4 invcamw = INV_CAMERA_MATRIX.w;
+
+    mat3 invcam = mat3(invcamx.xyz, invcamy.xyz, invcamz.xyz);
+
+    vec3 world_normal = NORMAL * invcam;
+    vec3 world_pos = (VERTEX - invcamw.xyz) * invcam;
 
 Notes
 -----


### PR DESCRIPTION
Current documentation for world_normal and world_pos is wrong.
You cannot use mat3(mat4) constructor and mat3.x.xyz cannot be compiled either.