### PR TITLE
Fixed wrong file name for QtCreator and added example for target executable

### DIFF
--- a/reference/configuring_an_ide.rst
+++ b/reference/configuring_an_ide.rst
@@ -85,7 +85,7 @@ Importing the project
    are added automatically. Potentially useful additions: \*.py for buildsystem files, \*.java for Android development,
    \*.mm for OSX. Click "Next".
 -  Click *Finish*.
--  Add a line containing ``.`` to *project_name.files* to get working code completion.
+-  Add a line containing ``.`` to *project_name.includes* to get working code completion.
 
 Build and run
 ^^^^^^^^^^^^^
@@ -101,7 +101,7 @@ Build configuration:
 Run configuration:
 
 -  Open the *Run* tab.
--  Point the *Executable* to your compiled Godot binary.
+-  Point the *Executable* to your compiled Godot binary (e.g: ``%{buildDir}\bin\godot.windows.tools.64.exe``)
 -  If you want to run a specific game or project, point *Working directory* to the game directory.
 -  If you want to run the editor, add ``-e`` to the *Command line arguments* field.
 


### PR DESCRIPTION
Related thread https://godotengine.org/qa/7205/qtcreator-c-completion-problem