### PR TITLE
Added mesa-libGLU-devel to Fedora oneliner

### DIFF
--- a/reference/compiling_for_x11.rst
+++ b/reference/compiling_for_x11.rst
@@ -30,7 +30,8 @@ Distro-specific oneliners
 | **Fedora**    | ::                                                                                                         |
 |               |                                                                                                            |
 |               |     sudo dnf install scons pkgconfig libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel \     |
-|               |         mesa-libGL-devel alsa-lib-devel pulseaudio-libs-devel freetype-devel openssl-devel libudev-devel   |
+|               |         mesa-libGL-devel alsa-lib-devel pulseaudio-libs-devel freetype-devel openssl-devel libudev-devel \ |
+|               |         mesa-libGLU-devel                                                                                  |
 +---------------+------------------------------------------------------------------------------------------------------------+
 | **FreeBSD**   | ::                                                                                                         |
 |               |                                                                                                            |


### PR DESCRIPTION
Build failed with this message:
`In file included from ./drivers/gles2/rasterizer_gles2.h:51:0,
                 from platform/x11/os_x11.cpp:30:
drivers/gl_context/GL/glew.h:1202:24: fatal error: GL/glu.h: No such file or directory
 #    include <GL/glu.h>`

mesa-libGLU-devel was missing.