### PR TITLE
adding missing 3 to vec

### DIFF
--- a/reference/shading_language.rst
+++ b/reference/shading_language.rst
@@ -471,7 +471,7 @@ Material that glows from red to white:
 
 ::
 
-    DIFFUSE = vec3(1,0,0) + vec(1,1,1) * mod(TIME, 1.0);
+    DIFFUSE = vec3(1,0,0) + vec3(1,1,1) * mod(TIME, 1.0);
 
 Standard Blinn Lighting Shader
 


### PR DESCRIPTION
I was following the shading examples and noticed that a '3' was missing from 'vec' was missing. 