### PR TITLE
Use scale and rect2 right position

### DIFF
--- a/tutorials/step_by_step/simple_2d_game.rst
+++ b/tutorials/step_by_step/simple_2d_game.rst
@@ -90,6 +90,7 @@ the dimensions of the screen and the pad:
     func _ready():
         screen_size = get_viewport_rect().size
         pad_size = get_node("left").get_texture().get_size()
+        pad_size *= get_node("left").get_scale()
         set_process(true)
 
 Then, some variables used for in-game processing will be added:
@@ -120,8 +121,8 @@ must be added.
 ::
 
         var ball_pos = get_node("ball").get_pos()
-        var left_rect = Rect2( get_node("left").get_pos() - pad_size/2, pad_size )
-        var right_rect = Rect2( get_node("right").get_pos() - pad_size/2, pad_size )
+        var left_rect = Rect2( get_node("left").get_pos(), pad_size )
+        var right_rect = Rect2( get_node("right").get_pos(), pad_size )
 
 Since the ball position was obtained, integrating it should be simple:
 


### PR DESCRIPTION
I suggested two mods. The first is related to the pad_size, taking in account the scale, in case of someone adjust it. The second correction is the Rect2 object position object, that does not need a pad_size correction factor.
