### PR TITLE
Warning+fix about compiling in Ubuntu >= 16.10

### DIFF
--- a/reference/compiling_for_x11.rst
+++ b/reference/compiling_for_x11.rst
@@ -79,6 +79,19 @@ If you wish to compile using Clang rather than GCC, use this command:
 ::
 
     user@host:~/godot$ scons platform=x11 use_llvm=yes
+    
+If you are using Ubuntu >=16.10, it includes GCC 6.2 as default,
+which could cause runtime issues.
+
+To force use of GCC 5, install gcc-5 and g++-5 with:
+::
+
+    sudo apt install gcc-5 g++-5
+
+then compile using:
+::
+
+    user@host:~/godot$ scons platform=x11 CC="/usr/bin/gcc-5" CXX="/usr/bin/g++-5"
 
 Building export templates
 -------------------------


### PR DESCRIPTION
Ubuntu 16.10 ships with GCC 6.2.0 as default, which currently causes issues. Added a warning and instructions to install and force usage of GCC 5.4.X at the moment of writing.
