### PR TITLE
Back to lobby section had naming error in the remote function at rpc_id call.

### DIFF
--- a/tutorials/high_level_multiplayer.rst
+++ b/tutorials/high_level_multiplayer.rst
@@ -168,10 +168,10 @@ Let's get back to the lobby. Imagine that each player that connects to the serve
         # If I'm the server, let the new guy know about existing players
         if (get_tree().is_network_server()):
             # Send my info to new player
-            rpc_id(id, "register_info", 1, my_info)
+            rpc_id(id, "register_player", 1, my_info)
             # Send the info of existing players
             for peer_id in player_info:
-                rpc_id(id, "register_info", peer_id, players[peer_id])
+                rpc_id(id, "register_player", peer_id, players[peer_id])
 
         # Call function to update lobby UI here
 


### PR DESCRIPTION
At the remote func regisiter_player(). It contained rpc_id(id, "register_info", 1, my_info) where regisiter_info was wrong it should be _player instead of _info