### PR TITLE
Fix broken lists

### DIFF
--- a/tutorials/2d/cutout_animation.rst
+++ b/tutorials/2d/cutout_animation.rst
@@ -180,7 +180,7 @@ Skeletons
 ~~~~~~~~~
 
 Godot doesn't actually support *true* Skeketons, but it does feature a
-helper to create "bones" between nodes. This is enough for most cases, 
+helper to create "bones" between nodes. This is enough for most cases,
 but the way it works is not completely obvious.
 
 
@@ -307,7 +307,7 @@ Simply do the following steps:
 4. Select "loc" and "rot" on the top menu.
 
 5. Push the key button. Keys will be inserted for everything, creating
-a default pose.
+   a default pose.
 
 .. image:: /img/tuto_cutout21.png
 

--- a/tutorials/2d/physics_introduction.rst
+++ b/tutorials/2d/physics_introduction.rst
@@ -308,7 +308,7 @@ Area2D
 Areas in Godot physics have three main roles:
 
 1. Override the space parameters for objects entering them (ie.
-gravity, gravity direction, gravity type, density, etc).
+   gravity, gravity direction, gravity type, density, etc).
 
 2. Monitor when rigid or kinematic bodies enter or exit the area.
 
@@ -420,7 +420,7 @@ server must be used directly. For this, the
 class must be used. To obtain it, the following steps must be taken:
 
 1. It must be used inside the ``_fixed_process()`` callback, or at
-``_integrate_forces()``
+   ``_integrate_forces()``
 
 2. The 2D RIDs for the space and physics server must be obtained.
 

--- a/tutorials/3d/3d_performance_and_limitations.rst
+++ b/tutorials/3d/3d_performance_and_limitations.rst
@@ -79,7 +79,7 @@ originally only rendered triangles, so all the vertices:
 
 1. Had to be transformed by the CPU (including clipping).
 
-1. Had to be sent to the GPU memory from the main RAM.
+2. Had to be sent to the GPU memory from the main RAM.
 
 Nowadays, all this is handled inside the GPU, so the performance is
 extremely high. 3D artists usually have the wrong feeling about


### PR DESCRIPTION
If you don't intent further lines in a list, this bullet point won't be an actual bullet point, but a separated paragraph:

![screenshot-20161030-182050](https://cloud.githubusercontent.com/assets/877229/19838348/abf218cc-9ecd-11e6-844e-c6c852c44770.png)

This PR fixes this for all lists in the docs, fix one numbering inside the rst files ... and additionally removes one trailing space (because - you know - my editor did it).