### PR TITLE
*updated doc to reflect structure change

### DIFF
--- a/reference/compiling_for_osx.rst
+++ b/reference/compiling_for_osx.rst
@@ -34,7 +34,7 @@ located in ``tools/Godot.app``. Typically:
 
 ::
 
-    user@host:~/godot$ cp -r tools/Godot.app .
+    user@host:~/godot$ cp -r tools/dist/osx_tools.app ./Godot.app
     user@host:~/godot$ mkdir -p Godot.app/Contents/MacOS
     user@host:~/godot$ cp bin/godot.osx.opt.tools.64 Godot.app/Contents/MacOS/Godot
     user@host:~/godot$ chmod +x Godot.app/Contents/MacOS/Godot


### PR DESCRIPTION
Godot.app is no longer in tools. Now using osx_tools.app in tools/dist/