### PR TITLE
Updated vector turning math

### DIFF
--- a/tutorials/vector_math.rst
+++ b/tutorials/vector_math.rst
@@ -166,10 +166,12 @@ Example:
 ::
 
     var v = Vector2(0,1)
+    
     # rotate right (clockwise)
-    var v_right = Vector2(-v.y, v.x)
-    # rotate left (counter-clockwise)
     var v_right = Vector2(v.y, -v.x)
+    
+    # rotate left (counter-clockwise)
+    var v_left = Vector2(-v.y, v.x)
 
 This is a handy trick that is often of use. It is impossible to do with
 3D vectors, because there are an infinite amount of perpendicular


### PR DESCRIPTION
The code example for how to turn a vector 90 degrees in either direction was wrong. The coordinates of the left vector were set to the "v_right" vector and vice-versa. Also, the two distinct vectors were named "v_right".