### PR TITLE
fix-7160-broken-code-blocks

### DIFF
--- a/tutorials/step_by_step/simple_2d_game.rst
+++ b/tutorials/step_by_step/simple_2d_game.rst
@@ -175,10 +175,8 @@ default, so a small adjustment of ``pad_size / 2`` must be added.
 
     func _process(delta):
         var ball_pos = get_node("ball").get_pos()
-        var left_rect = Rect2( get_node("left").get_pos() - pad_size*0.5,
-pad_size )
-        var right_rect = Rect2( get_node("right").get_pos() - pad_size*0.5,
-pad_size )
+        var left_rect = Rect2( get_node("left").get_pos() - pad_size*0.5, pad_size )
+        var right_rect = Rect2( get_node("right").get_pos() - pad_size*0.5, pad_size )
 
 Now, let's add some movement to the ball in the ``_process()`` function.
 Since the ball position is stored in the ``ball_pos`` variable,
@@ -200,8 +198,7 @@ the floor and the roof:
 ::
 
         # Flip when touching roof or floor
-        if ((ball_pos.y < 0 and direction.y < 0) or (ball_pos.y >
-screen_size.y and direction.y > 0)):
+        if ((ball_pos.y < 0 and direction.y < 0) or (ball_pos.y > screen_size.y and direction.y > 0)):
             direction.y = -direction.y
 
 Second, the pads: if one of the pads was touched, we need to invert the
@@ -212,8 +209,7 @@ speed a little.
 ::
 
         # Flip, change direction and increase speed when touching pads
-        if ((left_rect.has_point(ball_pos) and direction.x < 0) or
-(right_rect.has_point(ball_pos) and direction.x > 0)):
+        if ((left_rect.has_point(ball_pos) and direction.x < 0) or (right_rect.has_point(ball_pos) and direction.x > 0)):
             direction.x = -direction.x
             direction.y = randf()*2.0 - 1
             direction = direction.normalized()
@@ -248,8 +244,7 @@ is done using the Input class:
 
         if (left_pos.y > 0 and Input.is_action_pressed("left_move_up")):
             left_pos.y += -PAD_SPEED * delta
-        if (left_pos.y < screen_size.y and
-Input.is_action_pressed("left_move_down")):
+        if (left_pos.y < screen_size.y and Input.is_action_pressed("left_move_down")):
             left_pos.y += PAD_SPEED * delta
 
         get_node("left").set_pos(left_pos)
@@ -259,8 +254,7 @@ Input.is_action_pressed("left_move_down")):
 
         if (right_pos.y > 0 and Input.is_action_pressed("right_move_up")):
             right_pos.y += -PAD_SPEED * delta
-        if (right_pos.y < screen_size.y and
-Input.is_action_pressed("right_move_down")):
+        if (right_pos.y < screen_size.y and Input.is_action_pressed("right_move_down")):
             right_pos.y += PAD_SPEED * delta
 
         get_node("right").set_pos(right_pos)


### PR DESCRIPTION
some lines of code was broken in half by CRLF which then was detected as `end-of-code-block`.
Rest of code which was after mentioned CRLF was displayed as normal text outside of its code block.
