### PR TITLE
Fixed cross product formula in vector math tutorial

### DIFF
--- a/tutorials/vector_math.rst
+++ b/tutorials/vector_math.rst
@@ -674,9 +674,9 @@ The formula for the cross product is:
 ::
 
     var c = Vector3()
-    c.x = (a.y + b.z) - (a.z + b.y)
-    c.y = (a.z + b.x) - (a.x + b.z)
-    c.z = (a.x + b.y) - (a.y + b.x)
+    c.x = (a.y * b.z) - (a.z * b.y)
+    c.y = (a.z * b.x) - (a.x * b.z)
+    c.z = (a.x * b.y) - (a.y * b.x)
 
 This can be simplified, in Godot, to:
 


### PR DESCRIPTION
According to the previous version of the vector math tutorial, this is the formula for the cross product:

    var c = Vector3()
    c.x = (a.y + b.z) - (a.z + b.y)
    c.y = (a.z + b.x) - (a.x + b.z)
    c.z = (a.x + b.y) - (a.y + b.x)

As you can see, the components are being added, but they should be [multiplied instead](http://tutorial.math.lamar.edu/Classes/CalcII/CrossProduct.aspx).
This pull request changes the above section to look like this:

    var c = Vector3()
    c.x = (a.y * b.z) - (a.z * b.y)
    c.y = (a.z * b.x) - (a.x * b.z)
    c.z = (a.x * b.y) - (a.y * b.x)
