### PR TITLE
Note that Command Line Tools for Xcode suffices

### DIFF
--- a/reference/compiling_for_osx.rst
+++ b/reference/compiling_for_osx.rst
@@ -13,7 +13,7 @@ required:
 
 -  Python 2.7+ (3.0 is untested as of now)
 -  SCons build system
--  XCode
+-  Xcode (or the more lightweight Command Line Tools for Xcode)
 
 Compiling
 ---------


### PR DESCRIPTION
Godot does not require the full Xcode package to build on macOS, only the Command Line Tools for Xcode, so this modifies the build instructions to make that clear.

----

At least, that *appears* to be the case to me, because I only have the latter on my machine, and Godot builds. If I'm incorrect, obviously this pull request should be rejected.