### PR TITLE
cpp custom module fix

### DIFF
--- a/development/cpp/custom_modules_in_cpp.rst
+++ b/development/cpp/custom_modules_in_cpp.rst
@@ -141,7 +141,7 @@ With the following contents:
 
     void register_summator_types() {
 
-            ClassDB::register_type<Summator>();
+            ClassDB::register_class<Summator>();
     }
 
     void unregister_summator_types() {


### PR DESCRIPTION
Changed a call from ClassDB::register_type<> to the appropriate ClassDB::register_class<>