### PR TITLE
Last line gets read twice

### DIFF
--- a/learning/features/misc/saving_games.rst
+++ b/learning/features/misc/saving_games.rst
@@ -122,8 +122,8 @@ load function:
         # Load the file line by line and process that dictionary to restore the object it represents
         var currentline = {} # dict.parse_json() requires a declared dict.
         savegame.open("user://savegame.save", File.READ)
+        currentline.parse_json(savegame.get_line())
         while (!savegame.eof_reached()):
-            currentline.parse_json(savegame.get_line())
             # First we need to create the object and add it to the tree and set its position.
             var newobject = load(currentline["filename"]).instance()
             get_node(currentline["parent"]).add_child(newobject)
@@ -133,6 +133,7 @@ load function:
                 if (i == "filename" or i == "parent" or i == "posx" or i == "posy"):
                     continue
                 newobject.set(i, currentline[i])
+            currentline.parse_json(savegame.get_line())
         savegame.close()
 
 And now we can save and load an arbitrary number of objects laid out


### PR DESCRIPTION
because savegame.get_line() will consume the line, but eof_reached will only be reached when trying to read the next line the code inside the while gets called twice for the last line.

Which wouldn't be a problem, except currentline.parse_json(null) does not alter currentline.

I think an even better way would be

```
while (!savegame.eof_reached()):
    var line = savegame.get_line()
    if not line:
        continue

     currentline.parse_json(line)
     # Remaining code here
```