### PR TITLE
Document the support for transparent RGB colors in BBCode

### DIFF
--- a/learning/features/gui/bbcode_in_richtextlabel.rst
+++ b/learning/features/gui/bbcode_in_richtextlabel.rst
@@ -76,5 +76,8 @@ List of valid color names for the [color=<name>] tag:
 
 Hexadecimal color codes
 ~~~~~~~~~~~~~~~~~~~~~~~
- 
-Any valid 6-digit hexadecimal code is supported, e.g. ``[color=#ffffff]white[/color]``.
+
+For opaque RGB colors, any valid 6-digit hexadecimal code is supported, e.g. ``[color=#ffffff]white[/color]``.
+
+For transparent RGB colors, any 8-digit hexadecimal code can be used, e.g. ``[color=#88ffffff]translucent white[/color]``.
+In this case, note that the alpha channel is the **first** component of the color code, not the last one.


### PR DESCRIPTION
RichTextLabel supports ARGB color codes (in addition to RGB), but it wasn't documented.