### PR TITLE
Adding missing dependency for Solus Linux

### DIFF
--- a/development/compiling/compiling_for_x11.rst
+++ b/development/compiling/compiling_for_x11.rst
@@ -71,8 +71,8 @@ Distro-specific oneliners
 +---------------+------------------------------------------------------------------------------------------------------------+
 | **Solus**     | ::                                                                                                         |
 |               |                                                                                                            |
-|               |     sudo eopkg install scons libxcursor-devel libxinerama-devel libxrandr-devel mesalib libglu alsa-lib \  |
-|               |             pulseaudio freetype2-devel                                                                     |                                  
+|               |     sudo eopkg install -c system.devel scons libxcursor-devel libxinerama-devel libxrandr-devel mesalib \  |
+|               |         libglu alsa-lib pulseaudio freetype2-devel                                                         |                                  
 +---------------+------------------------------------------------------------------------------------------------------------+
 | **Ubuntu**    | ::                                                                                                         |
 |               |                                                                                                            |


### PR DESCRIPTION
Forgot to add the software compiler/compilation package (which includes g++ and other compilation utilities)