### PR TITLE
Fixed script error on Line 51

### DIFF
--- a/learning/step_by_step/scripting_continued.rst
+++ b/learning/step_by_step/scripting_continued.rst
@@ -48,7 +48,7 @@ with the following script:
 
     func _process(delta):
         accum += delta
-        text = (str(accum) # text is a built-in label property
+        text = (str(accum)) # text is a built-in label property
 
 Which will show a counter increasing each frame.
 

--- a/learning/step_by_step/scripting_continued.rst
+++ b/learning/step_by_step/scripting_continued.rst
@@ -48,7 +48,7 @@ with the following script:
 
     func _process(delta):
         accum += delta
-        text = (str(accum)) # text is a built-in label property
+        text = str(accum) # text is a built-in label property
 
 Which will show a counter increasing each frame.
 


### PR DESCRIPTION
Going through the step-by-step and found that L51:
    text = (str(accum) # text is a built-in label property
should be 
    text = (str(accum)) # text is a built-in label property.
Missing a parentheses.