### PR TITLE
Update simple_2d_game.rst

### DIFF
--- a/learning/step_by_step/simple_2d_game.rst
+++ b/learning/step_by_step/simple_2d_game.rst
@@ -25,7 +25,8 @@ Scene setup
 To pay homage to the olden times, the game will be in 640x400 pixels
 resolution. This can be configured in the Project Settings (see
 :ref:`doc_scenes_and_nodes-configuring_the_project`) under the Scene/Project
-settings menu. The default background color should be set to black:
+settings menu. Set Stretch Mode in Display to 2d.
+The default background color should be set to black:
 
 .. image:: img/clearcolor.png
 


### PR DESCRIPTION
Without setting the Stretch Mode the game window was resulting in (1280, 800) on my MBP not sure if this is hardware specific or not.  This results in the game being pretty broken and I'm sure would be confusing to new users.

<img width="677" alt="gd" src="https://user-images.githubusercontent.com/690817/31586896-c79f0bfc-b1a5-11e7-9cbd-0eedb0c1347e.png">

You can see the window extends for many pixels after the divider Sprite ends.


Through Googling I was able to find the Stretch Mode setting and found that it _mostly_ fixed the issue, there is still about 100px height that is "outside" the game window where the ball will continue  before bouncing.

Not sure if this is the correct fix, just what worked for me.