### PR TITLE
Update two outdated statements in the modules and plugins docs

### DIFF
--- a/development/cpp/custom_modules_in_cpp.rst
+++ b/development/cpp/custom_modules_in_cpp.rst
@@ -12,8 +12,9 @@ functionality at every level without modifying the core, which can be
 split for use and reuse in different modules.
 
 Modules are located in the ``modules/`` subdirectory of the build system.
-By default, two modules exist, GDScript (which, yes, is not part of the
-core engine), and the GridMap. As many new modules as desired can be
+By default, many different modules exist, such as GDScript (which, yes,
+is not part of the base engine), the Mono runtime, a regular expressions
+module, and others. As many new modules as desired can be
 created and combined, and the SCons build system will take care of it
 transparently.
 

--- a/development/plugins/making_plugins.rst
+++ b/development/plugins/making_plugins.rst
@@ -3,11 +3,6 @@
 Making Plugins
 ==============
 
-.. Remove this warning when 2.1 is release
-
-*Important:* This tutorial applies only to the upcoming version 2.1.
-
-
 About Plugins
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
This specifically fixes two things:

- Removes the notice in `development/plugins/making_plugins.rst` that the tutorial in question only applies to 2.1 (which has since been released, but the notice was never removed).

- Updates a paragraph in `development/cpp/custom_modules_in_cpp.rst` mentioning that only 2 modules exist by default - way more exist nowadays than that, so it felt appropriate to reflect that.

(Not sure if this should be split/squashed...)