### PR TITLE
Clean up after 5c74f49.

### DIFF
--- a/learning/features/index.rst
+++ b/learning/features/index.rst
@@ -13,7 +13,6 @@ Engine features
    viewports/index
    inputs/index
    animation/index
-   lighting/index
    shading/index
    networking/index
    platform/index

--- a/learning/features/physics/kinematic_character_2d.rst
+++ b/learning/features/physics/kinematic_character_2d.rst
@@ -45,7 +45,7 @@ necessarily simpler under the hood, but well hidden and presented as a
 nice and simple API).
 
 Physics process
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 To manage the logic of a kinematic body or character, it is always
 advised to use physics process, because it's called before physics step and its execution is


### PR DESCRIPTION
learning/features/index.rst:4: WARNING: toctree contains reference to nonexisting document 'learning/features/lighting/index'
learning/features/physics/kinematic_character_2d.rst:48: WARNING: Title underline too short.