### PR TITLE
Add C# tabs to the first scripting tutorial page.

### DIFF
--- a/learning/step_by_step/scripting.rst
+++ b/learning/step_by_step/scripting.rst
@@ -262,7 +262,9 @@ The final script should look basically like this:
 
     using Godot;
 
-    public class SayHello : Panel
+    // IMPORTANT: the name of the class MUST match the filename exactly.
+    // this is case sensitive!
+    public class sayhello : Panel
     {
         public void _OnButtonPressed()
         {

--- a/learning/step_by_step/scripting.rst
+++ b/learning/step_by_step/scripting.rst
@@ -200,9 +200,14 @@ node that owns the script.
 In our case, because the button and the label are siblings under the panel
 where the script is attached, you can fetch the button as follows:
 
-::
+.. tabs::
+ .. code-tab:: gdscript GDScript
 
     get_node("Button")
+
+ .. code-tab:: csharp
+
+    GetNode("Button")
 
 Next, write a function which will be called when the button is pressed:
 
@@ -214,7 +219,11 @@ Next, write a function which will be called when the button is pressed:
 
  .. code-tab:: csharp
 
-   // i dont know how this is supposed to be in C#
+    public void _OnButtonPressed()
+    {
+        var label = (Label)GetNode("Label");
+        label.Text = "HELLO!";
+    }
 
  .. group-tab:: VS
 
@@ -223,14 +232,23 @@ Next, write a function which will be called when the button is pressed:
 Finally, connect the button's "pressed" signal to that callback in _ready(), by
 using :ref:`Object.connect() <class_Object_connect>`.
 
-::
+.. tabs::
+ .. code-tab:: gdscript GDScript
 
     func _ready():
         get_node("Button").connect("pressed",self,"_on_button_pressed")
 
+ .. code-tab:: csharp
+
+    public override void _Ready()
+    {
+        GetNode("Button").Connect("pressed", this, nameof(_OnButtonPressed));
+    }
+
 The final script should look basically like this:
 
-::
+.. tabs::
+ .. code-tab:: gdscript GDScript
 
     extends Panel
 
@@ -239,6 +257,25 @@ The final script should look basically like this:
 
     func _ready():
         get_node("Button").connect("pressed",self,"_on_button_pressed")
+
+ .. code-tab:: csharp
+
+    using Godot;
+
+    public class SayHello : Panel
+    {
+        public void _OnButtonPressed()
+        {
+            var label = (Label)GetNode("Label");
+            label.Text = "HELLO!";
+        }
+
+        public override void _Ready()
+        {
+            GetNode("Button").Connect("pressed", this, nameof(_OnButtonPressed));
+        }
+    }
+
 
 Run the scene and press the button. You should get the following result:
 
@@ -251,10 +288,17 @@ works. For some given node, get_node(path) searches its immediate children.
 In the above code, this means that *Button* must be a child of *Panel*. If
 *Button* were instead a child of *Label*, the code to obtain it would be:
 
-::
+.. tabs::
+ .. code-tab:: gdscript GDScript
 
     # not for this case
     # but just in case
     get_node("Label/Button") 
+
+ .. code-tab:: csharp
+
+    // not for this case
+    // but just in case
+    GetNode("Label/Button")
 
 Also, remember that nodes are referenced by name, not by type.


### PR DESCRIPTION
Here's a screenshot (slightly out of date):
![](https://cdn.discordapp.com/attachments/354924561143169025/382245662156128258/unknown.png)

By the way, the lack of VS tabs isn't an issue. The tab system seems to handle it well.