### PR TITLE
Add math/formula support in Sphinx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,16 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
+LATEXDEPS     = latex dvipng
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
 $(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
 endif
+
+# check for latex dependencies
+E := $(foreach exec, $(LATEXDEPS),\
+	$(if $(shell which $(exec)), some string,$(error The $(exec) command was not found. Make sure you have LaTeX installed and added to your PATH. If you don't have LaTeX installed, grab it from https://www.latex-project.org/get/)))
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ endif
 
 # check for latex dependencies
 E := $(foreach exec, $(LATEXDEPS),\
-	$(if $(shell which $(exec)), some string,$(error The $(exec) command was not found. Make sure you have LaTeX installed and added to your PATH. If you don't have LaTeX installed, grab it from https://www.latex-project.org/get/)))
+	$(if $(shell which $(exec)), some string,$(warning The $(exec) command was not found: math formulas will not be built. LaTeX is required for math formula support. If you don't have LaTeX installed, grab it from https://www.latex-project.org/get/)))
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4

--- a/conf.py
+++ b/conf.py
@@ -11,7 +11,7 @@ needs_sphinx = '1.3'
 
 # Sphinx extension module names and templates location
 sys.path.append(os.path.abspath('extensions'))
-extensions = ['gdscript', 'sphinx_tabs.tabs']
+extensions = ['gdscript', 'sphinx_tabs.tabs', 'sphinx.ext.imgmath']
 templates_path = ['_templates']
 
 # You can specify multiple suffix as a list of string: ['.rst', '.md']

--- a/learning/features/math/vector_math.rst
+++ b/learning/features/math/vector_math.rst
@@ -212,14 +212,17 @@ but is often misunderstood. Dot product is an operation on two vectors that
 returns a **scalar**. Unlike a vector, which contains both magnitude and
 direction, a scalar value has only magnitude.
 
-The formula for dot product takes two common
-forms:
+The formula for dot product takes two common forms:
 
-.. image:: img/vector_dot1.png
+.. math::
+    
+    A \cdot B = \left \| A \right \|\left \| B \right \|\cos \Theta
 
 and
 
-.. image:: img/vector_dot2.png
+.. math::
+    
+    A \cdot B = A_{x}B_{x} + A_{y}B_{y}
 
 However, in most cases it is easiest to use the built-in method. Note that
 the order of the two vectors does not matter:


### PR DESCRIPTION
This commit enables Sphinx's math support (http://www.sphinx-doc.org/en/stable/ext/math.html) and uses it to replace images for dot product in Vector Math tutorial.

Note build system requires `latex` and `dvipng` to be in the path. Currently Sphinx fails silently if they're not found and the raw formula isn't formatted. Should we add a check/warning in the Makefile?