### PR TITLE
Update build instructions to mention support for Python  3.5 and later

### DIFF
--- a/about/introduction.rst
+++ b/about/introduction.rst
@@ -28,7 +28,7 @@ if you need a quick writeup about Godot Engine.
     and 3D games from a unified interface. It provides a comprehensive set of
     common tools, so that users can focus on making games without having to
     reinvent the wheel. Games can be exported in one click to a number of
-    platforms, including the major desktop platforms (Linux, Mac OSX, Windows)
+    platforms, including the major desktop platforms (Linux, macOS, Windows)
     as well as mobile (Android, iOS) and web-based (HTML5) platforms.
 
     Godot is completely free and open source under the very permissive MIT

--- a/development/compiling/batch_building_templates.rst
+++ b/development/compiling/batch_building_templates.rst
@@ -13,7 +13,7 @@ yourself, this might be of use.
 
 ::
 
-    #This script is intended to run on Linux or OSX. Cygwin might work.
+    #This script is intended to run on Linux or macOS. Cygwin might work.
 
     # if this flag is set, build is tagged as release in the version
     # echo $IS_RELEASE_BUILD
@@ -32,7 +32,7 @@ yourself, this might be of use.
 
     scons -j 4 p=windows target=release tools=no bits=32
     cp bin/godot.windows.opt.32.exe templates/windows_32_release.exe
-    upx templates/windows_32_release.exe 
+    upx templates/windows_32_release.exe
     scons -j 4 p=windows target=release_debug tools=no bits=32
     cp bin/godot.windows.opt.debug.32.exe templates/windows_32_debug.exe
     upx templates/windows_32_debug.exe
@@ -41,7 +41,7 @@ yourself, this might be of use.
 
     scons -j 4 p=windows target=release tools=no bits=64
     cp bin/godot.windows.opt.64.exe templates/windows_64_release.exe
-    x86_64-w64-mingw32-strip templates/windows_64_release.exe 
+    x86_64-w64-mingw32-strip templates/windows_64_release.exe
     scons -j 4 p=windows target=release_debug tools=no bits=64
     cp bin/godot.windows.opt.debug.64.exe templates/windows_64_debug.exe
     x86_64-w64-mingw32-strip templates/windows_64_debug.exe
@@ -83,7 +83,7 @@ yourself, this might be of use.
     mkdir -p platform/android/java/libs/armeabi
     mkdir -p platform/android/java/libs/x86
 
-    #Android Release 
+    #Android Release
 
     scons -j 4 p=android target=release
     cp bin/libgodot.android.opt.so platform/android/java/libs/armeabi/libgodot_android.so
@@ -100,15 +100,15 @@ yourself, this might be of use.
     # EMScripten
 
     scons -j 4 p=javascript target=release
-    cp bin/godot.javascript.opt.html godot.html 
-    cp bin/godot.javascript.opt.js godot.js 
+    cp bin/godot.javascript.opt.html godot.html
+    cp bin/godot.javascript.opt.js godot.js
     cp tools/html_fs/filesystem.js .
     zip javascript_release.zip godot.html godot.js filesystem.js
     mv javascript_release.zip templates/
 
     scons -j 4 p=javascript target=release_debug
     cp bin/godot.javascript.opt.debug.html godot.html
-    cp bin/godot.javascript.opt.debug.js godot.js 
+    cp bin/godot.javascript.opt.debug.js godot.js
     cp tools/html_fs/filesystem.js .
     zip javascript_debug.zip godot.html godot.js filesystem.js
     mv javascript_debug.zip templates/

--- a/development/compiling/compiling_for_android.rst
+++ b/development/compiling/compiling_for_android.rst
@@ -19,12 +19,12 @@ export template.
 Requirements
 ------------
 
-For compiling under Windows, Linux or OSX, the following is required:
+For compiling under Windows, Linux or macOS, the following is required:
 
--  Python 2.7+ (3.0 is untested as of now)
+-  Python 2.7+ or Python 3.5+
 -  SCons build system
 -  [Windows only] PyWin32 (optional, for parallel compilation)
--  Android SDK version 23.0.3 [Note: Please install all Tools and Extras of sdk manager]
+-  Android SDK version 23.0.3 [Note: Please install all tools and extras of the SDK Manager]
 -  Android build tools version 19.1
 -  Android NDK r13 or later
 -  Gradle (will be downloaded and installed automatically if missing)
@@ -44,11 +44,11 @@ To set those environment variables on Windows, press Windows+R, type
 pane, then click on **Environment variables** on the window that
 appears.
 
-To set those environment variables on Unix (e.g. Linux, Mac OSX), use
+To set those environment variables on Unix (e.g. Linux, macOS), use
 ``export ANDROID_HOME=/path/to/android-sdk`` and
 ``export ANDROID_NDK_ROOT=/path/to/android-ndk``.
-Where /path/to/android-sdk and /path/to/android-ndk is the path where Android Sdk 
-and Android Ndk are placed on you PC.
+Where /path/to/android-sdk and /path/to/android-ndk is the path where Android SDK
+and Android NDK are placed on your PC.
 
 Toolchain
 ~~~~~~~~~
@@ -77,8 +77,8 @@ the following arguments:
     C:\godot> scons platform=android target=release
     C:\godot> cd platform/android/java
     C:\godot\platform\android\java> gradlew build
-    
-(on Linux/OSX, execute the `gradlew` script with `./gradlew build`)
+
+(on Linux or macOS, execute the `gradlew` script with `./gradlew build`)
 
 The resulting APK is in:
 
@@ -93,7 +93,7 @@ The resulting APK is in:
     C:\godot> scons platform=android target=release_debug
     C:\godot> cd platform/android/java
     C:\godot\platform\android\java> gradlew build
-    
+
 The resulting APK is in:
 
 ::
@@ -122,7 +122,7 @@ with Gradle. For example for the release template:
     C:\godot> scons platform=android target=release android_arch=x86
     C:\godot> cd platform/android/java
     C:\godot\platform\android\java> gradlew build
-    
+
 
 This will create a fat binary that works in both platforms, but will add
 about 6 megabytes to the APK.
@@ -155,7 +155,7 @@ The templates folder can be located in:
 
 -  Windows: ``C:\Users\[username]\AppData\Roaming\Godot\templates``
 -  Linux: ``/home/[username]/.godot/templates``
--  Mac OSX: ``/users/[username]/.godot/templates``
+-  macOS: ``/users/[username]/.godot/templates``
 
 .. TODO: Move these paths to a common reference page
 
@@ -210,21 +210,21 @@ In any case, ``adb logcat`` should also show the cause of the error.
 Compilation fails
 ~~~~~~~~~~~~~~~~~
 
-On Linux systems with Kernel version 4.3 or newer, compilation may fail 
+On Linux systems with Kernel version 4.3 or newer, compilation may fail
 with the error "pthread_create failed: Resource temporarily unavailable."
 
-This is because of a change in the way Linux limits thread creation. But 
-you can change those limits through the command line. Please read this 
+This is because of a change in the way Linux limits thread creation. But
+you can change those limits through the command line. Please read this
 section thoroughly before beginning.
 
-First open a terminal, then begin compilation as usual (it may be a good 
-idea to run a --clean first). While compiling enter the following in 
+First open a terminal, then begin compilation as usual (it may be a good
+idea to run a --clean first). While compiling enter the following in
 your terminal:
 
 ::
 
     user@host:~/$ top -b -n 1 | grep scons
-    
+
 The output should list a scons process, with its PID as the first number
 in the output. For example the PID 1077 in the output shown below:
 
@@ -246,11 +246,10 @@ You can increase those limits with the command:
 
     user@host:~/$ prlimit --pid=1077 --nproc=60000:60500
 
-Obviously you should substitute the scons PID output by top and a limits 
-that you think suitable. These are in the form --nproc=soft:hard where 
-soft must be lesser than or equal to hard. See the man page for more 
+Obviously you should substitute the scons PID output by top and a limits
+that you think suitable. These are in the form --nproc=soft:hard where
+soft must be lesser than or equal to hard. See the man page for more
 information.
 
-If all went well, and you entered the prlimit command while scons was 
+If all went well, and you entered the prlimit command while scons was
 running, then your compilation should continue without the error.
-

--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -11,7 +11,7 @@ Requirements
 For compiling under Linux or other Unix variants, the following is
 required:
 
--  Python 2.7+ (3.0 is untested as of now)
+-  Python 2.7+ or Python 3.5+
 -  SCons build system
 -  Xcode (or the more lightweight Command Line Tools for Xcode)
 

--- a/development/compiling/compiling_for_web.rst
+++ b/development/compiling/compiling_for_web.rst
@@ -10,8 +10,8 @@ Requirements
 
 To compile export templates for the Web, the following is required:
 
--  `Emscripten <http://emscripten.org/>`__: The easiest way to install it, if it's not up to date in your Linux package manager, is to use the `Emscripten SDK <http://emscripten.org/>`__ (Install in a path without spaces, i.e. not on "Program Files")
--  `Python 2.7+ <https://www.python.org/>`__ (3.0 is untested as of now)
+-  `Emscripten <http://emscripten.org/>`__: The easiest way to install it, if it's not up to date in your Linux package manager, is to use the `Emscripten SDK <http://emscripten.org/>`__ (Install in a path without spaces, i.e. not in "Program Files")
+-  `Python 2.7+ or Python 3.5+ <https://www.python.org/>`__
 -  `SCons <http://www.scons.org>`__ build system
 
 Building export templates
@@ -23,7 +23,7 @@ installation directory of Emscripten:
 -  If you installed Emscripten via the Emscripten SDK, you will declare the variable with a path to your downloaded folder::
 
     export EMSCRIPTEN_ROOT=~/emsdk/emscripten/master
-    
+
 -  If you installed Emscripten via your package manager, you can know the path with the ``em-config`` command::
 
     em-config EMSCRIPTEN_ROOT
@@ -31,7 +31,7 @@ installation directory of Emscripten:
    So you will declare the variable as for example::
 
     export EMSCRIPTEN_ROOT=/usr/lib/emscripten
-    
+
 The Emscripten variables are defined in the ``~/.emscripten`` file, so this is an alternative way to check. Erase this file if you want to reinstall Emscripten with a fresh new method.
 
 If you are on Windows and used Emscripten SDK, start a regular prompt or the Emscripten Command Prompt.

--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -15,8 +15,7 @@ For compiling under Windows, the following is required:
    (recommended), version 2013 (12.0) or later.
    **Make sure you read Installing Visual Studio caveats below or you
    will have to run/download the installer again.**
--  `Python 2.7+ <https://www.python.org/downloads/>`__ (3.0 is
-   untested as of now). Using the 32-bits installer is recommended.
+-  `Python 2.7+ or Python 3.5+ <https://www.python.org/downloads/>`__.
 -  `Pywin32 Python Extension <https://sourceforge.net/projects/pywin32/files/pywin32/>`__
    for parallel builds (which increase the build speed by a great factor).
 -  `SCons <http://www.scons.org>`__ build system.
@@ -26,14 +25,14 @@ Setting up SCons
 
 Python adds the interpreter (python.exe) to the path. It usually
 installs in ``C:\Python`` (or ``C:\Python[Version]``). SCons installs
-inside the Python install (typically in the ``Scripts`` folder) and 
-provides a batch file called "scons.bat".
+inside the Python install (typically in the ``Scripts`` folder) and
+provides a batch file called ``scons.bat``.
 The location of this file can be added to the path or it can simply be
 copied to ``C:\Python`` together with the interpreter executable.
 
 To check whether you have installed Python and SCons correctly, you can
-type ``python --version`` and ``scons --version`` into the standard
-Windows Command Prompt (cmd.exe).
+type ``python --version`` and ``scons --version`` into the
+Windows Command Prompt (``cmd.exe``).
 
 If commands above do not work, make sure you add Python to your PATH
 environment variable after installing it, and check again.
@@ -41,29 +40,28 @@ environment variable after installing it, and check again.
 Setting up Pywin32
 ------------------
 
-Pywin32 is required for -j (parallel) builds for multiple cores (for a
-32 bit Python version). If SCons is issuing a warning about Pywin32
-after parsing SConstruct build instructions, when beginning to build,
-you need to install it properly from the correct installer executable
-for your python version `located at Sourceforge. <https://sourceforge.net/projects/pywin32/files/pywin32/>`__
+Pywin32 is required for parallel builds using multiple CPU cores.
+If SCons is issuing a warning about Pywin32 after parsing SConstruct
+build instructions, when beginning to build, you need to install it properly
+from the correct installer executable for your Python version
+`located at Sourceforge. <https://sourceforge.net/projects/pywin32/files/pywin32/>`__
 
-For example, if you installed Python 2.7 32 bit version, you would want
-to install the latest version of Pywin32 (as of writting Build 220) that
-is built for the mentioned version of Python... That executable installer
-would be named "pywin32-220.win32-py2.7.exe".
+For example, if you installed a 32-bit version of Python 2.7, you would want
+to install the latest version of Pywin32 that is built for the mentioned version
+of Python. That executable installer would be named ``pywin32-221.win32-py2.7.exe``.
 
-Amd64 version of Pywin32 is for a 64 bit version of Python
-"pywin32-220.win-amd64-py2.7.exe". Change the "py" number to install for
-your version of python (check via ``python --version`` mentioned above).
+The ``amd64`` version of Pywin32 is for a 64-bit version of Python
+``pywin32-221.win-amd64-py2.7.exe``. Change the ``py`` number to install for
+your version of Python (check via ``python --version`` mentioned above).
 
 Installing Visual Studio caveats
 --------------------------------
 
-If installing VS 2015 or later, make sure to run **Custom** installation, not
+If installing Visual Studio 2015 or later, make sure to run **Custom** installation, not
 **Typical** and select C++ as language there (and any other things you might
 need). The installer does not install C++ by default. C++ was the
 `only language made optional <https://blogs.msdn.microsoft.com/vcblog/2015/07/24/setup-changes-in-visual-studio-2015-affecting-c-developers/>`__
-in VS2015.
+in Visual Studio 2015.
 
 If you have already made the mistake of installing a **Typical**,
 installation, rerun the executable installer you downloaded from
@@ -86,8 +84,8 @@ The tutorial will presume from now on that you placed the source into
 Compiling
 ---------
 
-SCons will not be able out of the box to compile from the standard
-Windows "Command Prompt" (cmd.exe) because SCons and Visual C++ compiler
+SCons will not be able out of the box to compile from the
+Windows Command Prompt (``cmd.exe``) because SCons and Visual C++ compiler
 will not be able to locate environment variables and executables they
 need for compilation.
 
@@ -114,9 +112,9 @@ automatically searched by the start menu search option:
    Win 7:
    C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Visual Studio 2015\Visual Studio Tools
    C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Visual Studio 2013\Visual Studio Tools
-   
-If you found the Developer Console, it will do for now to create a 32
-bit version of Godot, but if you want the 64 bit version, you might need
+
+If you found the Developer Console, it will do for now to create a 32-bit
+version of Godot, but if you want the 64-bit version, you might need
 to setup the prompts manually for easy access.
 
 If you don't see some of the shortcuts, "How the prompts actually work"
@@ -129,36 +127,36 @@ There is a few things you need to know about these consoles and the
 Visual C++ compiler.
 
 Your Visual Studio installation will ship with several Visual C++
-compilers, them being more or less identical, however each cl.exe
+compilers, them being more or less identical, however each ``cl.exe``
 (Visual C++ compiler) will compile Godot for a different architecture
-(32 or 64 bit, ARM compiler is not supported).
+(32-bit x86 or 64-bit x86; the ARM compiler is not supported).
 
-The **Developer Command Prompt** will build a 32 bit version of Godot by
-using the 32 bit Visual C++ compiler.
+The **Developer Command Prompt** will build a 32-bit version of Godot by
+using the 32-bit Visual C++ compiler.
 
 **Native Tools** Prompts (mentioned above) are used when you want the
-32bit cl.exe to compile a 32 bit executable (x86 Native Tools
-Command Prompt). For the 64 bit cl.exe, it will compile a 64 bit
+32-bit cl.exe to compile a 32-bit executable (x86 Native Tools
+Command Prompt). For the 64-bit cl.exe, it will compile a 64-bit
 executable (x64 Native Tools Command Prompt).
 
 The **Cross Tools** are used when your Windows is using one architecture
-(32 bit, for example) and you need to compile to a different
-architecture (64 bit). As you might be familiar, 32 bit Windows can not
-run 64 bit executables, but you still might need to compile for them.
+(32-bit, for example) and you need to compile to a different
+architecture (64-bit). As you might be familiar, 32-bit Windows can not
+run 64-bit executables, but you still might need to compile for them.
 
 For example:
 
-* "VS2013 x64 Cross Tools Command Prompt" will use a 32 bit cl.exe that
+* "VS2013 x64 Cross Tools Command Prompt" will use a 32-bit cl.exe that
   will compile a 64 bit application.
 
-* "VS2013 x86 Cross Tools Command Prompt" will use a 64 bit cl.exe that
-  will compile a 32 bit application. This one is useful if you are
-  running a 32 bit Windows.
+* "VS2013 x86 Cross Tools Command Prompt" will use a 64-bit cl.exe that
+  will compile a 32-bit application. This one is useful if you are
+  running a 32-bit Windows.
 
-On a 64 bit Windows, you can run any of above prompts and compilers
-(cl.exe executables) because 64 bit windows can run any 32 bit
-application. 32 bit Windows can not run 64 bit executables, so the
-Visual Studio installer will not even install shortcuts for some of
+On a 64-bit Windows, you can run any of above prompts and compilers
+(``cl.exe`` executables) because 64-bit Windows can run any 32-bit
+application. 32-bit Windows cannot run 64-bit executables, so the
+Visual Studio installer won't even install shortcuts for some of
 these prompts.
 
 Note that you need to choose the **Developer Console** or the correct
@@ -184,8 +182,7 @@ command to instruct SCons to run parallel builds like this:
     C:\godot> scons -j6 platform=windows
 
 In general, it is OK to have at least as many threads compiling Godot as
-you have cores in your CPU, if not one or two more, I use -j6
-(six threads) for my 4 core CPU, your mileage may vary. Feel free to add
+you have cores in your CPU, if not one or two more. Feel free to add the
 -j option to any SCons command you see below if you setup the
 "Pywin32 Python Extension".
 
@@ -196,7 +193,7 @@ compiler architecture the environment (the prompt) is setup for and will
 build a corresponding executable.
 
 This executable file contains the whole engine and runs without any
-dependencies. Executing it will bring up the project manager.
+dependencies. Executing it will bring up the Project Manager.
 
 How the prompts actually work
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -205,13 +202,13 @@ The Visual Studio command prompts are just shortcuts that call the
 standard Command Prompt and have it run a batch file before giving  you
 control. The batch file itself is called **vcvarsall.bat** and it sets up
 environment variables, including the PATH variable, so that the correct
-version of the compiler can be run.The Developer Command Prompt calls a
+version of the compiler can be run. The Developer Command Prompt calls a
 different file called **VsDevCmd.bat** but none of the other tools that
 this batch file enables are needed by Godot/SCons.
 
-Since you are probably using VS2013 or VS2015, if you need to recreate
-them manually, use the below folders, or place
-them on the desktop/taskbar:
+Since you are probably using Visual Studio 2013 or 2015, if you need to
+recreate them manually, use the below folders, or place them on the
+desktop/taskbar:
 
 ::
 
@@ -225,8 +222,8 @@ Then copy one of these commands below for the corresponding tool you
 need into the "Path" and "Name" sections of the shortcut creation
 wizard, and fix the path to the batch file if needed.
 
-* VS2013 is in the "Microsoft Visual Studio 12.0" folder.
-* VS2015 is in the "Microsoft Visual Studio 14.0" folder.
+* Visual Studio 2013 is in the "Microsoft Visual Studio 12.0" folder.
+* Visual Studio 2015 is in the "Microsoft Visual Studio 14.0" folder.
 * etc.
 
 ::
@@ -250,44 +247,44 @@ After you create the shortcut, in the shortcut's properties, that you
 can access by right clicking with your mouse on the shortcut itself, you
 can choose the starting directory of the command prompt ("Start in"
 field).
-   
-Some of these shortcuts (namely the 64 bit compilers) seem to not be
+
+Some of these shortcuts (namely the 64-bit compilers) seem to not be
 available in the Express edition of Visual Studio or Visual C++. Before
-recreating the commands, make sure that cl.exe executables are present
+recreating the commands, make sure that ``cl.exe`` executables are present
 in one of these locations, they are the actual compilers for the
 arhitecture you want to build from the command prompt.
 
 ::
 
-    x86 (32bit) cl.exe
+    x86 (32-bit) cl.exe
     C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\cl.exe
 
-    x86 (32bit) cl.exe for crosscompiling to 64bit.
+    x86 (32-bit) cl.exe for cross-compiling for 64-bit Windows.
     C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\x86_amd64\cl.exe
 
-    x64 (64bit) cl.exe
+    x64 (64-bit) cl.exe
     C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\amd64\cl.exe
 
-    x64 (64bit) cl.exe for crosscompiling to 32bit.
+    x64 (64-bit) cl.exe for cross-compiling for 32-bit Windows.
     C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\amd64_x86\cl.exe
 
 
-In case you are wondering what these prompt shortcuts do, they call the
-standard cmd.exe with \\k option and have it run a batch file...
+In case you are wondering what these prompt shortcuts do, they call ``cmd.exe``
+with the ``\k`` option and have it run a Batch file.
 
 ::
 
    %comspec% - path to cmd.exe
    \k - keep alive option of the command prompt
    remainder - command to run via cmd.exe
-   
+
    cmd.exe \k(eep cmd.exe alive after commands behind this option run) ""runme.bat"" with_this_option
 
 How to run an automated build of Godot
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you need to just run the compilation process via a batch file or
-directly in the vanilla Windows Command Prompt you need to do the
+If you just need to run the compilation process via a Batch file or
+directly in the Windows Command Prompt you need to use the
 following command:
 
 ::
@@ -296,10 +293,10 @@ following command:
 
 with one of the following parameters:
 
-* x86 (32 bit cl.exe to compile for the 32 bit architecture)
-* amd64 (64 bit cl.exe to compile for the 64 bit architecture)
-* x86_amd64 (32 bit cl.exe to compile for the 64 bit architecture)
-* amd64_x86 (64 bit cl.exe to compile for the 32 bit architecture)
+* x86 (32-bit cl.exe to compile for the 32-bit architecture)
+* amd64 (64-bit cl.exe to compile for the 64-bit architecture)
+* x86_amd64 (32-bit cl.exe to compile for the 64-bit architecture)
+* amd64_x86 (64-bit cl.exe to compile for the 32-bit architecture)
 
 and after that one, you can run SCons:
 
@@ -307,14 +304,14 @@ and after that one, you can run SCons:
 
    scons platform=windows
 
-or  you can do them together:
+or you can run them together:
 
 ::
 
-   32 bit Godot
+   32-bit Godot
    "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86 && scons platform=windows
-   
-   64 bit Godot
+
+   64-bit Godot
    "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" amd64 && scons platform=windows
 
 Development in Visual Studio or other IDEs
@@ -325,7 +322,7 @@ in C++ is needed, for creating modules or extending the engine, working
 with an IDE is usually desirable.
 
 You can create a Visual Studio solution via SCons by running SCons with
-the vsproj=yes parameter, like this:
+the ``vsproj=yes`` parameter, like this:
 
 ::
 
@@ -333,7 +330,7 @@ the vsproj=yes parameter, like this:
 
 You will be able to open Godot's source in a Visual Studio solution now,
 and able to build Godot via the Visual Studio **Build** button. However,
-make sure that you have installed Pywin so that parallel (-j) builds
+make sure that you have installed Pywin32 so that parallel (-j) builds
 work properly.
 
 If you need to edit the compilation commands, they are located in
@@ -345,7 +342,7 @@ architectures (Win32/x64). They are equivalent.
 Cross-compiling for Windows from other operating systems
 --------------------------------------------------------
 
-If you are a Linux or Mac user, you need to install `MinGW-w64 <https://mingw-w64.org>`_,
+If you are a Linux or macOS user, you need to install `MinGW-w64 <https://mingw-w64.org>`_,
 which typically comes in 32-bit and 64-bit variants. The package names
 may differ based on your distro, here are some known ones:
 
@@ -381,7 +378,7 @@ the following binaries in your ``$PATH``:
 
 If the binaries are not located in the ``$PATH`` (e.g. ``/usr/bin``),
 you can define the following environment variables to give a hint to
-the buildsystem:
+the build system:
 
 ::
 

--- a/development/compiling/introduction_to_the_buildsystem.rst
+++ b/development/compiling/introduction_to_the_buildsystem.rst
@@ -133,7 +133,7 @@ build targets, and which will be explained below.
 Tools
 -----
 
-Tools are enabled by default in all PC targets (Linux, Windows, OSX),
+Tools are enabled by default in all PC targets (Linux, Windows, macOS),
 disabled for everything else. Disabling tools produces a binary that can
 run projects but that does not include the editor or the project
 manager.
@@ -220,7 +220,7 @@ To create those yourself, just follow the instructions detailed for each
 platform in this same tutorial section. Each platform explains how to
 create its own template.
 
-If you are developing for multiple platforms, OSX is definitely the most convenient
+If you are developing for multiple platforms, macOS is definitely the most convenient
 host platform for cross compilation, since you can cross-compile for
 almost every target (except for UWP). Linux and Windows come in second
 place, but Linux has the advantage of being the easier platform to set

--- a/development/cpp/configuring_an_ide.rst
+++ b/development/cpp/configuring_an_ide.rst
@@ -83,7 +83,7 @@ Importing the project
 -  Set the path to your Godot root directory and enter the project name.
 -  Here you can choose which folders and files will be visible to the project. C/C++ files
    are added automatically. Potentially useful additions: \*.py for buildsystem files, \*.java for Android development,
-   \*.mm for OSX. Click "Next".
+   \*.mm for macOS. Click "Next".
 -  Click *Finish*.
 -  Add a line containing ``.`` to *project_name.includes* to get working code completion.
 

--- a/learning/editor/unity_to_godot.rst
+++ b/learning/editor/unity_to_godot.rst
@@ -1,6 +1,6 @@
 .. _unity3D_to_godot:
 
-..    references : 
+..    references :
 ..    https://wiki.unrealengine.com/Unity3D_Developer's_Guide_to_Unreal_Engine_4
 ..    https://docs.unrealengine.com/latest/INT/GettingStarted/FromUnity/
 
@@ -17,14 +17,14 @@ Differences
 +===================+===================================================================================+================================================================================================================+
 | License           | Proprietary, closed, free license with revenue caps and usage restrictions        | MIT license, free and fully open source without any restriction                                                |
 +-------------------+-----------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------+
-| OS (editor)       | Windows, OSX, Linux (unofficial and unsupported)                                  | Windows, X11 (Linux, \*BSD), Haiku, OSX                                                                        |
+| OS (editor)       | Windows, macOS, Linux (unofficial and unsupported)                                | Windows, X11 (Linux, \*BSD), Haiku, macOS                                                                      |
 +-------------------+-----------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------+
-| OS (export)       | | Desktop: Windows, Linux/SteamOS, OSX                                            | | Desktop: Windows, X11, OSX                                                                                   |
-|                   | | Mobile: Android, iOS, Windows Phone, Tizen,                                     | | Mobile: Android, iOS, Blackberry (deprecated)                                                                |
-|                   | | Web: WebGL                                                                      | | Web: WebGL, HTML5 (via emscripten, broken)                                                                   |
-|                   | | Consoles: PS4, PS Vita, XBox One, XBox 360, WiiU, 3DS                           |                                                                                                                |
+| OS (export)       | | Desktop: Windows, Linux/SteamOS, macOS                                          | | Desktop: Windows, X11, macOS                                                                                 |
+|                   | | Mobile: Android, iOS, Windows Phone, Tizen,                                     | | Mobile: Android, iOS,                                                                                        |
+|                   | | Web: WebAssembly or asm.js                                                      | | Web: WebAssembly                                                                                             |
+|                   | | Consoles: PS4, PS Vita, Xbox One, Xbox 360, Wii U, Nintendo 3DS                 |                                                                                                                |
 |                   | | VR: Oculus Rift, SteamVR, Google Cardboard, Playstation VR, Gear VR, HoloLens   |                                                                                                                |
-|                   | | TV: AndroidTV, Samsung SMARTTV, tvOS                                            |                                                                                                                |
+|                   | | TV: Android TV, Samsung SMART TV, tvOS                                          |                                                                                                                |
 +-------------------+-----------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------+
 | Scene system      | | Component/Scene (GameObject > Component)                                        | Scene tree and nodes, allowing scenes to be nested and/or inherit other scenes                                 |
 |                   | | Prefabs                                                                         |                                                                                                                |
@@ -58,12 +58,12 @@ Godot's Scene panel is similar to Unity's Hierarchy panel but, as each node has 
 
 The Inspector in Godot is more minimalist and designed to only show properties. Thanks to this, objects can export a much larger amount of useful parameters to the user, without having to hide functionality in language APIs. As a plus, Godot allows animating any of those properties visually, so changing colors, textures, enumerations or even links to resources in real-time is possible without involving code.
 
-Finally, the Toolbar at the top of the screen is similar in the sense that it allows controlling the project playback, but projects in Godot run in a separate window, as they don't execute inside the editor (but the tree and objects can still be explored in the debugger window). 
+Finally, the Toolbar at the top of the screen is similar in the sense that it allows controlling the project playback, but projects in Godot run in a separate window, as they don't execute inside the editor (but the tree and objects can still be explored in the debugger window).
 
 This approach has the disadvantage that the running game can't be explored from different angles (though this may be supported in the future, and displaying collision gizmos in the running game is already possible), but in exchange has several advantages:
 
 - Running the project and closing it is very fast (Unity has to save, run the project, close the project and then reload the previous state).
-- Live editing is a lot more useful, because changes done to the editor take effect immediately in the game, and are not lost (nor have to be synced) when the game is closed. This allows fantastic workflows, like creating levels while you play them. 
+- Live editing is a lot more useful, because changes done to the editor take effect immediately in the game, and are not lost (nor have to be synced) when the game is closed. This allows fantastic workflows, like creating levels while you play them.
 - The editor is more stable, because the game runs in a separate process.
 
 Finally, the top toolbar includes a menu for remote debugging. These options make it simple to deploy to a device (connected phone, tablet or browser via HTML5), and debug/live edit on it after the game was exported.
@@ -73,7 +73,7 @@ The scene system
 
 This is the most important difference between Unity and Godot, and actually the favourite feature of most Godot users.
 
-Unity's scene system consist in embedding all the required assets in a scene, and link them together by setting components and scripts to them. 
+Unity's scene system consist in embedding all the required assets in a scene, and link them together by setting components and scripts to them.
 
 Godot's scene system is different: it actually consists in a tree made of nodes. Each node serves a purpose: Sprite, Mesh, Light... Basically, this is similar to Unity scene system. However, each node can have multiple children, which make each a subscene of the main scene. This means you can compose a whole scene with different scenes, stored in different files.
 
@@ -101,7 +101,7 @@ There again, an enemy is a reusable element in other levels. It is almost the sa
 
 It is composed of Bricks (for platforms), Coins (for the player to grab) and a certain number of instances of the previous Enemy scene. These will be different, separate enemies, whose behaviour and appearance will be the same as defined in the Enemy scene. Each instance is then considered as a node in the Level scene tree. Of course, you can set different properties for each enemy node (to change its color for example).
 
-Finally, the main scene would then be composed of one root node with 2 children: a Player instance node, and a Level instance node. 
+Finally, the main scene would then be composed of one root node with 2 children: a Player instance node, and a Level instance node.
 The root node can be anything, generally a "root" type such as "Node" which is the most global type, or "Node2D" (root type of all 2D-related nodes), "Spatial" (root type of all 3D-related nodes) or "Control" (root type of all GUI-related nodes).
 
 
@@ -163,9 +163,9 @@ Unity allows you to attach as many scripts as you want to a GameObject. Each scr
 
 In Godot, you can only attach one script per node. You can use either an external GDScript file, or include it directly in the node. If you need to attach more scripts to one node, then you may consider 2 solutions, depending on your scene and on what you want to achieve:
 
-- either add a new node between your target node and its current parent, then add a script to this new node. 
+- either add a new node between your target node and its current parent, then add a script to this new node.
 - or, your can split your target node into multiple children and attach one script to each of them.
-  
+
 As you can see, it can be easy to turn a scene tree to a mess. This is why it is important to have a real reflection, and consider splitting a complicated scene into multiple, smaller branches.
 
 Connections : groups and signals
@@ -179,6 +179,6 @@ But there's more! Certain nodes throw signals when certain actions happen. You c
 Using Godot in C++
 ------------------
 
-Just for your information, Godot also allows you to develop your project directly in C++ by using its API, which is not possible with Unity at the moment. As an example, you can consider Godot Engine's editor as a "game" written in C++ using Godot API. 
+Just for your information, Godot also allows you to develop your project directly in C++ by using its API, which is not possible with Unity at the moment. As an example, you can consider Godot Engine's editor as a "game" written in C++ using Godot API.
 
 If you are interested in using Godot in C++, you may want to start reading the :ref:`Developing in C++ <doc_introduction_to_godot_development>` page.

--- a/learning/features/misc/data_paths.rst
+++ b/learning/features/misc/data_paths.rst
@@ -35,5 +35,5 @@ Storing persistent files in such scenarios should be done by using the
 
 In some devices (for example, mobile ad consoles) this path is unique
 for the app. Under desktop operating systems, the engine uses the
-typical ~/.Name (check the project name under the settings) in OSX and
+typical ~/.Name (check the project name under the settings) in macOS and
 Linux, and APPDATA/Name for Windows.

--- a/learning/step_by_step/filesystem.rst
+++ b/learning/step_by_step/filesystem.rst
@@ -41,7 +41,7 @@ Example of a file system contents:
     /enemy/enemy.gd
     /enemy/enemysprite.png
     /player/player.gd
-    
+
 project.godot
 -------------
 
@@ -98,14 +98,14 @@ Drawbacks
 There are some drawbacks to this simple file system design. The first issue is that
 moving assets around (renaming them or moving them from one path to another inside
 the project) will break existing references to these assets. These references will
-have to be re-defined to point at the new asset location. 
+have to be re-defined to point at the new asset location.
 
 To avoid this, do all your move, delete and rename operations from within Godot, on the FileSystem
 dock. Never move assets from outside Godot, or dependencies will have to be
 fixed manually (Godot detects this and helps you fix them anyway, but why
 going the hardest route?).
 
-The second is that under Windows and OSX file and path names are case insensitive.
+The second is that under Windows and macOS file and path names are case insensitive.
 If a developer working in a case insensitive host file system saves an asset as "myfile.PNG",
 but then references it as "myfile.png", it will work just fine on their platorm, but not
 on other platforms, such as Linux, Android, etc. This may also apply to exported binaries,

--- a/learning/workflow/export/exporting_for_android.rst
+++ b/learning/workflow/export/exporting_for_android.rst
@@ -24,8 +24,8 @@ Create a debug.keystore
 
 Android needs a debug keystore file to install to devices and distribute
 non-release APKs. If you have used the SDK before and have built
-projects, ant or eclipse probably generated one for you (In Linux and
-OSX, you can find it in the ~/.android folder).
+projects, ant or eclipse probably generated one for you (on Linux and
+macOS, you can find it in the ``~/.android`` directory).
 
 If you can't find it or need to generate one, the keytool command from
 the JDK can be used for this purpose:

--- a/learning/workflow/export/feature_tags.rst
+++ b/learning/workflow/export/feature_tags.rst
@@ -33,9 +33,9 @@ Here is a list of most feature tags in Godot. Keep in mind they are *case sensit
 +=================+========================================================+
 | **Android**     | Running on Android                                     |
 +-----------------+--------------------------------------------------------+
-| **JavaScript**  | Running on Javascript (HTML5)                          |
+| **JavaScript**  | Running on JavaScript (HTML5)                          |
 +-----------------+--------------------------------------------------------+
-| **OSX**         | Running on OSX                                         |
+| **OSX**         | Running on macOS                                       |
 +-----------------+--------------------------------------------------------+
 | **iOS**         | Running on iOS                                         |
 +-----------------+--------------------------------------------------------+
@@ -49,17 +49,17 @@ Here is a list of most feature tags in Godot. Keep in mind they are *case sensit
 +-----------------+--------------------------------------------------------+
 | **release**     | Running on release build                               |
 +-----------------+--------------------------------------------------------+
-| **32**          | Running on 32 bits build                               |
+| **32**          | Running on 32-bit build                                |
 +-----------------+--------------------------------------------------------+
-| **64**          | Running on 64 bits build                               |
+| **64**          | Running on 64-bit build                                |
 +-----------------+--------------------------------------------------------+
 | **mobile**      | Host OS is a mobile platform                           |
 +-----------------+--------------------------------------------------------+
-| **pc**          | Host OS is a PC                                        |
+| **pc**          | Host OS is a PC platform (desktop/laptop)              |
 +-----------------+--------------------------------------------------------+
-| **web**         | Hot OS is a web browser                                |
+| **web**         | Hot OS is a Web browser                                |
 +-----------------+--------------------------------------------------------+
-| **etc**         | Textures using ETC compression are supported           |
+| **etc**         | Textures using ETC1 compression are supported          |
 +-----------------+--------------------------------------------------------+
 | **etc2**        | Textures using ETC2 compression are supported          |
 +-----------------+--------------------------------------------------------+
@@ -104,5 +104,3 @@ Customizing Build
 
 Feature tags can be used to customize a build process too, by writing a custom **ExportPlugin**.
 They also are used to specify which shared library is loaded and exported in **GDNative**.
-
-


### PR DESCRIPTION
This also fixes grammar and wording in many areas of the documentation. For example, OS X has been renamed to macOS.