### PR TITLE
Incorrect Code Sample Scene Extension

### DIFF
--- a/learning/step_by_step/singletons_autoload.rst
+++ b/learning/step_by_step/singletons_autoload.rst
@@ -167,7 +167,7 @@ and scene_b.gd:
     #add to scene_a.gd
 
     func _on_goto_scene_pressed():
-            get_node("/root/global").goto_scene("res://scene_b.tscn")
+            get_node("/root/global").goto_scene("res://scene_b.scn")
 
 and
 
@@ -176,7 +176,7 @@ and
     #add to scene_b.gd
 
     func _on_goto_scene_pressed():
-            get_node("/root/global").goto_scene("res://scene_a.tscn")
+            get_node("/root/global").goto_scene("res://scene_a.scn")
 
 Now if you run the project, you can switch between both scenes by pressing
 the button!


### PR DESCRIPTION
The scene extension of the [example scenes](http://docs.godotengine.org/en/latest/_downloads/autoload.zip) were created using '.scn' instead of '.tscn'. The sample code incorrectly referred to the '.tscn' extension resulting in a crash.

