### PR TITLE
Fixes a bug in the example code in object type. Ref<MyReference> myre…

### DIFF
--- a/development/cpp/object_class.rst
+++ b/development/cpp/object_class.rst
@@ -242,7 +242,7 @@ Declaring them must be done using Ref<> template. For example:
         GDCLASS(MyReference, Reference);
     };
 
-    Ref<MyReference> myref = memnew(MyReference);
+    Ref<MyReference> myref(memnew(MyReference));
 
 ``myref`` is reference counted. It will be freed when no more Ref<>
 templates point to it.


### PR DESCRIPTION
…f = Ref<MyReference>(memnew(MyReference));

The statement is a compile error which emits  use of overloaded operator '=' is ambiguous (with operand types 'Ref<FuncRef>' and 'FuncRef *')

This commit uses neikeq suggestion of Ref<MyReference> myref(memnew(MyReference));

Fixes #506