### PR TITLE
Change ambiguous section titles

### DIFF
--- a/development/cpp/index.rst
+++ b/development/cpp/index.rst
@@ -1,4 +1,4 @@
-Engine development 
+Engine development
 ==================
 
 .. toctree::

--- a/development/cpp/index.rst
+++ b/development/cpp/index.rst
@@ -1,5 +1,5 @@
-Developing in C++
-=================
+Engine development 
+==================
 
 .. toctree::
    :maxdepth: 1

--- a/learning/scripting/gdscript/gdscript_advanced.rst
+++ b/learning/scripting/gdscript/gdscript_advanced.rst
@@ -1,7 +1,7 @@
 .. _doc_gdscript_more_efficiently:
 
-GDScript more efficiently
-=========================
+GDScript: An introduction to dynamic languages
+==============================================
 
 About
 -----


### PR DESCRIPTION
Changes "Developing in C++" to "Engine development", and "GDScript more efficiently" to "GDScript: An introduction to dynamic languages".

Admittedly, the latter is a bit wordy (and thus open to suggestions), but it was similarly deemed to be a bit inaccurate/confusing (see #63), but the issue was kind of left in the dust.

Closes #933, #63.
  