### PR TITLE
update Sphinx build instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LATEXDEPS     = latex dvipng
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD make variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
 endif
 
 # check for latex dependencies

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ You can then build the HTML documentation from the root folder of this repositor
 make html
 ```
 
+or:
+
+```sh
+make SPHINXBUILD=~/.local/bin/sphinx-build html
+```
+
 The compilation might take some time as the `classes/` folder contains many files to parse.  
 You can then test the changes live by opening `_build/html/index.html` in your favourite browser.
 


### PR DESCRIPTION
Reason for PR:

Following [instructions](https://github.com/godotengine/godot-docs#building-with-sphinx) on Ubuntu 17.10 results in sadness:

```
todd@todd-ab28d3:~/repos/remote/brainsick-godot-docs$ make html
Makefile:13: *** The 'sphinx-build' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the 'sphinx-build' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/.  Stop.
```

Following instructions provided in error results in sadness:

```
todd@todd-ab28d3:~/repos/remote/brainsick-godot-docs$ env SPHINXBUILD=/home/todd/.local/bin/sphinx-build make html
Makefile:13: *** The 'sphinx-build' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the 'sphinx-build' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/.  Stop.
```

Foiled again!

You actually need to set the make variable SPHINXBUILD for this to work.

```
todd@todd-ab28d3:~/repos/remote/brainsick-godot-docs$ make SPHINXBUILD=/home/todd/.local/bin/sphinx-build html
Makefile:17: The latex command was not found: math formulas will not be built. LaTeX is required for math formula support. If you don't have LaTeX installed, grab it from https://www.latex-project.org/get/
Makefile:17: The dvipng command was not found: math formulas will not be built. LaTeX is required for math formula support. If you don't have LaTeX installed, grab it from https://www.latex-project.org/get/
/home/todd/.local/bin/sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v1.6.6
loading translations [en]... done
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 2 source files that are out of date
updating environment: 0 added, 2 changed, 0 removed
reading sources... [100%] learning/step_by_step/splash_screen                                                                               
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] learning/step_by_step/splash_screen                                                                                
/home/todd/repos/remote/brainsick-godot-docs/learning/step_by_step/splash_screen.rst:43: WARNING: undefined label: doc_importing_fonts (if the link has no caption the label must precede a section header)
generating indices... genindex
writing additional pages... search
copying images... [100%] learning/step_by_step/img/label.png                                                                                
copying downloadable files... [100%] learning/step_by_step/files/robisplash_assets.zip                                                      
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 1 warning.
Copying tabs assets... done

Build finished. The HTML pages are in _build/html.
```

Much rejoicing!
