### PR TITLE
add feedback support to docs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -85,3 +85,13 @@ latex_documents = [
   (master_doc, 'GodotEngine.tex', 'Godot Engine Documentation',
    'Juan Linietsky, Ariel Manzur and the Godot community', 'manual'),
 ]
+
+# -- Godot custom HTML feedback link --------------------------------------
+# https://docs.readthedocs.io/en/latest/guides/adding-custom-css.html
+# http://www.sphinx-doc.org/en/1.5.6/config.html#confval-html_static_path
+
+html_static_path = ['html_inc']
+
+def setup(app):
+    app.add_stylesheet('feedback/godot_feedback.css')
+    app.add_javascript('feedback/godot_feedback.js')

--- a/html_inc/feedback/godot_feedback.css
+++ b/html_inc/feedback/godot_feedback.css
@@ -1,0 +1,21 @@
+.godot-feedback {
+	background-color: #2980B9; /* from RTD theme */
+	color: white;
+	font-weight: bold;
+	margin-bottom: 20px;
+	padding: 15px;
+	text-align: center;
+	width: 100%;
+}
+
+.godot-feedback a,
+.godot-feedback a:link,
+.godot-feedback a:visited,
+.godot-feedback a:hover,
+.godot-feedback a:active {
+	border: 2px solid white;
+	color: white;
+	margin-left: 10px;
+	padding: 5px 10px;
+	text-decoration: none;
+}

--- a/html_inc/feedback/godot_feedback.js
+++ b/html_inc/feedback/godot_feedback.js
@@ -1,0 +1,23 @@
+$(document).ready(function() {
+	$('footer').prepend(
+		'<div class="godot-feedback">' +
+			'Is this page helpful? ' +
+				'<a id="gf-yes">Yes</a> ' +
+				'<a id="gf-no" target="_blank">No</a>' +
+		'</div>');
+	
+	var title = $('title').text();
+	title = '[FEEDBACK] ' + title;
+	
+	var yes_body = 'You folks are great!  Keep up the good work!';
+	$('#gf-yes').attr('href',
+		'mailto:docfeedback@godotengine.org' +
+			'?subject=' + encodeURIComponent(title) +
+			'&body=' + encodeURIComponent(yes_body));
+	
+	var no_body = 'When I do `$this`, it doesn\'t `$work`!';
+	$('#gf-no').attr('href', 
+		'https://github.com/godotengine/godot-docs/issues/new' +
+			'?title=' + encodeURIComponent(title) +
+			'&body=' + encodeURIComponent(no_body));
+});


### PR DESCRIPTION
A complete, albeit simplistic, implementation of the requested feedback loop, with a few creative liberties.

![image](https://user-images.githubusercontent.com/1111573/34860778-85948d2a-f725-11e7-85e9-d2bffd1cedad.png)

Yes (mailto):

![screenshot from 2018-01-13 15-13-20](https://user-images.githubusercontent.com/1111573/34910127-6be6756e-f874-11e7-9c35-6757c1217ac2.png)

No (issue):

![screenshot from 2018-01-13 15-14-54](https://user-images.githubusercontent.com/1111573/34910139-8fa5169a-f874-11e7-96a2-ac36aaf29244.png)
