### PR TITLE
Your first game: enable CollisionShape2D again on player start

### DIFF
--- a/learning/step_by_step/your_first_game.rst
+++ b/learning/step_by_step/your_first_game.rst
@@ -323,7 +323,6 @@ the player when starting a new game.
     func start(pos):
         position = pos
         show()
-        monitoring = true
         $CollisionShape2D.disabled = false
 
 Enemy Scene

--- a/learning/step_by_step/your_first_game.rst
+++ b/learning/step_by_step/your_first_game.rst
@@ -324,6 +324,7 @@ the player when starting a new game.
         position = pos
         show()
         monitoring = true
+        $CollisionShape2D.disabled = false
 
 Enemy Scene
 -----------


### PR DESCRIPTION
Hey there!

While doing the 'Your first game' tutorial in the 'latest' docs I noticed that when restarting the game, the collision doesn't work anymore. 

I think a line is missing to re-able it.

I hope it works like this, let me know if something else needs updating.