### PR TITLE
Added ClangFormat to IDE beautifier plugin list

### DIFF
--- a/community/contributing/code_style_guidelines.rst
+++ b/community/contributing/code_style_guidelines.rst
@@ -114,6 +114,7 @@ Here is a non-exhaustive list of beautifier plugins for some IDEs:
 
 - Qt Creator: `Beautifier plugin <http://doc.qt.io/qtcreator/creator-beautifier.html>`__
 - Visual Studio Code: `Clang-Format <https://marketplace.visualstudio.com/items?itemName=xaver.clang-format>`__
+- Visual Studio: `ClangFormat <https://marketplace.visualstudio.com/items?itemName=LLVMExtensions.ClangFormat>`__
 - vim: `vim-clang-format <https://github.com/rhysd/vim-clang-format>`__
 
 (Pull requests welcome to extend this list with tested plugins.)


### PR DESCRIPTION
Just adding another supported beautifier plugin to the list, this one for Visual Studio (none are currently listed for Visual Studio).

I am currently using this plugin, and it is the only one that I could find that is compatible with the latest Visual Studio releases.