### PR TITLE
Improved description of apply_impulse to clarify the "position" vector

### DIFF
--- a/classes/class_rigidbody.rst
+++ b/classes/class_rigidbody.rst
@@ -202,7 +202,7 @@ Called during physics processing, allowing you to read and safely modify the sim
 
 - void **apply_impulse** **(** :ref:`Vector3<class_vector3>` position, :ref:`Vector3<class_vector3>` impulse **)**
 
-Apply a positioned impulse (which will be affected by the body mass and shape). This is the equivalent of hitting a billiard ball with a cue: a force that is applied once, and only once. Both the impulse and the offset from the body origin are in global coordinates.
+Apply a positioned impulse (which will be affected by the body mass and shape). This is the equivalent of hitting a billiard ball with a cue: a force that is applied once, and only once. Both the impulse and the position are in global coordinates, and the position is relative to the objects origin.
 
 .. _class_RigidBody_get_colliding_bodies:
 


### PR DESCRIPTION
Minor change to the documentation for apply_impulse, as to me the note on offset being relative was "hidden."