### PR TITLE
Various small fixes for the docs

### DIFF
--- a/about/faq.rst
+++ b/about/faq.rst
@@ -37,13 +37,13 @@ Which platforms are supported by Godot?
 
 * Windows
 * Mac OS X
-* X11 (Linux, *BSD)
+* X11 (Linux, \*BSD)
 
 **For exporting your games:**
 
 * Windows (and UWP)
 * Mac OS X
-* X11 (Linux, *BSD)
+* X11 (Linux, \*BSD)
 * Android
 * iOS
 * Web
@@ -60,7 +60,7 @@ Which languages are supported in Godot?
 ---------------------------------------
 
 The officially supported languages for Godot are GDScript, Visual Scripting, C# and C++.
-See the subcategories for each language in the :ref:`toc-learn-scripting` section.
+See the subcategories for each language in the :ref:`scripting <toc-learn-scripting>` section.
 
 Note that C# and Visual Scripting support is comparatively young and GDScript still has
 some advantages as outlined below.
@@ -72,7 +72,7 @@ Work is currently underway, for example, on unofficial bindings for Godot
 to `Python <https://github.com/touilleMan/godot-python>`_ and `Nim <https://github.com/pragmagic/godot-nim>`_.
 
 GDScript? Why use a custom scripting language instead of my language of choice?
------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 
 The short answer is that we think the additional complexity both on your side
 (when first learning Godot and GDScript) as well as our side (maintenance)
@@ -222,9 +222,8 @@ And that's it! Your game should work in multiple resolutions.
 
 If there really is a desire to make your game also work on ancient
 devices with tiny screens (less than 300 pixels in width), you can use
-the :ref:`export option <doc_exporting_images>` to shrink
-images, and set that build to be used for certain screen sizes in the
-App Store or Google Play.
+the export option to shrink images, and set that build to be used for
+certain screen sizes in the App Store or Google Play.
 
 I have a great idea that will make Godot better. What do you think?
 -------------------------------------------------------------------
@@ -286,7 +285,7 @@ discussing any idea. Be specific and concrete.
 Bonus points for bringing screenshots, concrete numbers, test cases or example projects (if applicable).
 
 How can I support Godot development or contribute?
------------------------------------------
+--------------------------------------------------
 
 See :ref:`doc_ways_to_contribute`.
 

--- a/community/contributing/pr_workflow.rst
+++ b/community/contributing/pr_workflow.rst
@@ -111,6 +111,7 @@ We will start by setting up a reference ot the original repository that we forke
 
     $ git remote add upstream https://github.com/godotengine/godot
     $ git fetch upstream
+
 This will create a reference named *upstream* pointing to the original
 godotengine/godot repository. This will be useful when you want to pull new
 commits from its *master* branch to update your fork. You have another

--- a/community/contributing/updating_the_class_reference.rst
+++ b/community/contributing/updating_the_class_reference.rst
@@ -173,7 +173,7 @@ Our job is to add the missing text between these marks:
 -  <member></member>
 -  <signal></signal>
 
-Write in a clear and simple language. Always follow the :ref:`class_reference_styleguide` to keep your descriptions short and easy to read. **Do not leave empty lines** in the descriptions: each line in the XML file will result in a new paragraph. 
+Write in a clear and simple language. Always follow the :ref:`writing guidelines <doc_docs_writing_guidelines>` to keep your descriptions short and easy to read. **Do not leave empty lines** in the descriptions: each line in the XML file will result in a new paragraph. 
 
 Here's how a class looks like in XML:
 

--- a/development/cpp/configuring_an_ide.rst
+++ b/development/cpp/configuring_an_ide.rst
@@ -4,7 +4,7 @@ Configuring an IDE
 ==================
 
 We assume that you already `cloned <https://github.com/godotengine/godot>`_
-and :ref:`compiled <toc-compiling>` Godot.
+and :ref:`compiled <toc-devel-compiling>` Godot.
 
 Kdevelop
 --------

--- a/development/cpp/variant_class.rst
+++ b/development/cpp/variant_class.rst
@@ -40,7 +40,7 @@ References:
 -  `core/variant.h <https://github.com/godotengine/godot/blob/master/core/variant.h>`__
 
 Containers: Dictionary and Array
---------------------
+--------------------------------
 
 Both are implemented using variants. A Dictionary can match any datatype
 used as key to any other datatype. An Array just holds an array of

--- a/getting_started/step_by_step/godot_design_philosophy.rst
+++ b/getting_started/step_by_step/godot_design_philosophy.rst
@@ -1,3 +1,5 @@
+.. _doc_godot_design_philosophy:
+
 Godot’s design philosophy
 =========================
 

--- a/getting_started/step_by_step/instancing.rst
+++ b/getting_started/step_by_step/instancing.rst
@@ -4,7 +4,7 @@ Instancing
 ==========
 
 Introduction
----------
+------------
 
 Creating a single scene and adding nodes into it might work for small
 projects, but as a project grows in size and complexity, the number of nodes

--- a/getting_started/step_by_step/intro_to_the_editor_interface.rst
+++ b/getting_started/step_by_step/intro_to_the_editor_interface.rst
@@ -1,3 +1,5 @@
+.. _doc_intro_to_the_editor_interface:
+
 Introduction to Godot’s editor
 ==============================
 

--- a/getting_started/step_by_step/scripting.rst
+++ b/getting_started/step_by_step/scripting.rst
@@ -39,7 +39,7 @@ typed languages), go for GDScript!
 VisualScript
 ~~~~~~~~~~~~~
 
-Beginning 3.0, Godot offers :ref:`visualscript<Visual Scripting>`. This is a
+Beginning 3.0, Godot offers :ref:`Visual Scripting<doc_what_is_visual_script>`. This is a
 somewhat typical implementation of blocks and connections language, but
 adapted to how Godot works. 
 

--- a/getting_started/step_by_step/ui_code_a_life_bar.rst
+++ b/getting_started/step_by_step/ui_code_a_life_bar.rst
@@ -1,3 +1,5 @@
+.. _doc_ui_code_a_life_bar:
+
 Control the game's UI with code
 ===============================
 
@@ -17,12 +19,7 @@ You will learn:
 
 -  How to **connect** a character to a GUI with signals
 -  How to **control** a GUI with GDscript
--  How to **animate** a life bar with the `Tween <#>`__ node
-
-
-.. warning::
-
-   This tutorial relies on a recent build of Godot 3's master branch. You will find some differences with Godot 3 alpha 1, and some more changes might happen in Godot 3 beta. We'll adapt the page after the beta release.
+-  How to **animate** a life bar with the :ref:`Tween <class_Tween>` node
 
 
 If you want to learn how to set up the interface instead, check out the
@@ -30,7 +27,6 @@ step-by-step UI tutorials:
 
 -  Create a main menu screen
 -  Create a game user interface
-
 
 
 When you code a game, you want to build the core gameplay first: the

--- a/getting_started/step_by_step/ui_game_user_interface.rst
+++ b/getting_started/step_by_step/ui_game_user_interface.rst
@@ -1,3 +1,5 @@
+.. _doc_ui_game_user_interface:
+
 Design the GUI
 ==============
 

--- a/getting_started/step_by_step/ui_main_menu.rst
+++ b/getting_started/step_by_step/ui_main_menu.rst
@@ -1,6 +1,7 @@
-=======================
- Design a title screen
-=======================
+.. _doc_ui_main_menu:
+
+Design a title screen
+=====================
 
 In the next two tutorials, you will build two responsive UI (user interface)
 scenes step-by-step using the engine's UI system:
@@ -294,4 +295,4 @@ You can change the scale mode in the project settings: click the Project menu ->
 Settings. In the window's left column, look for the Display category.
 Click on the Window sub-category. On the right side of the window,
 you'll find a Stretch section. The three settings, Mode, Aspect, and
-Shrink, control the screen size. For more information, see `:ref:'Project Settings<doc_multiple_resolutions>'`__.
+Shrink, control the screen size. For more information, see :ref:`doc_multiple_resolutions`.

--- a/getting_started/workflow/assets/importing_images.rst
+++ b/getting_started/workflow/assets/importing_images.rst
@@ -25,7 +25,7 @@ Import options are vast:
 .. image:: img/image_import1.png
 
 Compression:
--------------
+------------
 
 Images are one of the largest assets in a game. To handle them efficiently, they need to be compressed.
 Godot offers several compression methods, depending on the use case.
@@ -145,7 +145,7 @@ An alternative to fix darkened borders is to use premultiplied alpha. By enablin
 Keep in mind that a material will need to be created that uses the PREMULT ALPHA blend mode on canvas items that need it.
 
 HDR as SRGB
-~~~~~~~~~~~~
+~~~~~~~~~~~
 
 Some few HDR files are broken and contain SRGB color data. It is advised to not use them but, in the worst case, toggling this option on will make them look right.
 

--- a/tutorials/2d/canvas_layers.rst
+++ b/tutorials/2d/canvas_layers.rst
@@ -16,8 +16,8 @@ will be moved too.
 These nodes are placed as direct or indirect children to a
 :ref:`Viewport <class_Viewport>`, and will be displayed through it.
 
-Viewport has a property "canvas_transform"
-:ref:`Viewport.set_canvas_transform() <class_Viewport_set_canvas_transform>`,
+Viewport has the property
+:ref:`Viewport.canvas_transform <class_Viewport_canvas_transform>`,
 which allows to transform all the CanvasItem hierarchy by a custom
 :ref:`Transform2D <class_Transform2D>` transform. Nodes such as
 :ref:`Camera2D <class_Camera2D>`, work by changing that transform.
@@ -73,4 +73,4 @@ Even though there shouldn't be any performance limitation, it is not
 advised to use excessive amount of layers to arrange drawing order of
 nodes. The most optimal way will always be arranging them by tree order.
 2d nodes also have a property for controlling their drawing order
-(see :ref:`Node2D.set_z() <class_Node2D_set_z>`).
+(see :ref:`Node2D.z_index <class_Node2D_z_index>`).

--- a/tutorials/2d/using_tilemaps.rst
+++ b/tutorials/2d/using_tilemaps.rst
@@ -166,7 +166,7 @@ one that looks better for you:
 
 
 -  Disable filtering for either the tileset texture or the entire image
-   loader (see the :ref:`doc_managing_image_files` asset pipeline tutorial).
+   loader (see the :ref:`doc_import_images` asset pipeline tutorial).
 -  Enable pixel snap (set: "Scene > Project Settings >
    Display/use_2d_pixel_snap" to true).
 -  Viewport Scaling can often help with shrinking the map (see the

--- a/tutorials/3d/3d_performance_and_limitations.rst
+++ b/tutorials/3d/3d_performance_and_limitations.rst
@@ -49,7 +49,7 @@ Reuse shaders and materials
 
 Godot renderer is a little different to what is out there. It's designed
 to minimize GPU state changes as much as possible.
-:ref:`FixedMaterial <class_FixedMaterial>`
+:ref:`class_SpatialMaterial`
 does a good job at reusing materials that need similar shaders but, if
 custom shaders are used, make sure to reuse them as much as possible.
 Godot's priorities will be like this:
@@ -59,7 +59,7 @@ Godot's priorities will be like this:
    of objects (in the hundreds or thousands) try reusing the materials
    or in the worst case use atlases.
 -  **Reusing Shaders**: If materials can't be reused, at least try to
-   re-use shaders (or FixedMaterials with different parameters but same
+   re-use shaders (or SpatialMaterials with different parameters but same
    configuration).
 
 If a scene has, for example, 20.000 objects with 20.000 different
@@ -182,7 +182,7 @@ Bake lighting
 
 Small lights are usually not a performance issue. Shadows a little more.
 In general, if several lights need to affect a scene, it's ideal to bake
-it (:ref:`doc_light_baking`). Baking can also improve the scene quality by
+it (:ref:`doc_baked_lightmaps`). Baking can also improve the scene quality by
 adding indirect light bounces.
 
 If working on mobile, baking to texture is recommended, since this

--- a/tutorials/3d/baked_lightmaps.rst
+++ b/tutorials/3d/baked_lightmaps.rst
@@ -1,7 +1,7 @@
 .. _doc_baked_lightmaps:
 
 Baked Lightmaps
-==========
+===============
 
 Introduction
 ------------
@@ -55,7 +55,7 @@ If you use external meshes on import, the size will be kept.
 Be wary that most unwrappers in 3D DCCs are not very quality oriented, as they are meant to work quick. You will mostly need to use seams or other techniques to create better unwrapping.
 
 Unwrap from within Godot
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Godot has an option to unwrap meshes and visualize the UV channels. It can be found in the Mesh menu:
 
@@ -87,7 +87,7 @@ In the mesh menu mentioned before, the UV2 texture coordinates can be visualized
 .. image:: img/baked_light_uvchannel.png
 
 Setting up the Scene
-----------------
+--------------------
 
 Before anything is done, a **BakedLight** Node needs to be added to a scene. This will enable light baking on all nodes (and sub-nodes) in that scene, even on instanced scenes. 
 
@@ -97,7 +97,7 @@ A sub-scene can be instanced several times, as this is supported by the baker an
 
 
 Configure Bounds
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 Lightmap needs an approximate volume of the area affected, because it uses it to transfer light to dynamic objects inside (more on that later). Just 
 cover the scene with the volume, as you do with GIProbe:
@@ -158,7 +158,7 @@ To begin the bake process, just push the big **Bake Lightmaps** button on top, w
 This can take from seconds to minutes (or hours) depending on scene size, bake method and quality selected.
 
 Configuring Bake
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 Several more options are present for baking:
 
@@ -174,7 +174,7 @@ Several more options are present for baking:
 
 
 Dynamic Objects
-----------------
+---------------
 
 In other engines or lightmapper implementations, you are required to manually place small objects called "lightprobes" all around the level to generate *capture* data. This is used to, then, transfer the light to dynamic objects that move around the scene.
 

--- a/tutorials/3d/lights_and_shadows.rst
+++ b/tutorials/3d/lights_and_shadows.rst
@@ -14,10 +14,10 @@ result. Light can come from several types of sources in a scene:
 -  Light Nodes: Directional, Omni and Spot.
 -  Ambient Light in the
    :ref:`Environment <class_Environment>`.
--  Baked Light (read :ref:`doc_light_baking`).
+-  Baked Light (read :ref:`doc_baked_lightmaps`).
 
 The emission color is a material property. You can read more about it
-in the :ref:`doc_fixed_materials` tutorial.
+in the :ref:`doc_spatial_material` tutorial.
 
 Light nodes
 -----------

--- a/tutorials/3d/reflection_probes.rst
+++ b/tutorials/3d/reflection_probes.rst
@@ -6,7 +6,7 @@ Reflection Probes
 Introduction
 ------------
 
-As stated in the :ref:`doc_spatial_materials`, objects can show reflected or diffuse light.
+As stated in the :ref:`doc_spatial_material`, objects can show reflected or diffuse light.
 Reflection Probes are used as a source of reflected and ambient light for objects inside their area of influence.
 
 A probe of this type captures the surroundings (as a sort of 360 degrees image), and stores versions

--- a/tutorials/animation/introduction_2d.rst
+++ b/tutorials/animation/introduction_2d.rst
@@ -343,7 +343,7 @@ Advanced: Call Func tracks
 
 Godot's animation engine doesn't stop here. If you're already
 comfortable with Godot's scripting language
-:doc:`/learning/scripting/index` and :doc:`/classes/index` you
+:ref:`doc_gdscript` and :doc:`/classes/index` you
 know that each node type is a class and has a bunch of callable
 functions.
 

--- a/tutorials/assetlib/what_is_assetlib.rst
+++ b/tutorials/assetlib/what_is_assetlib.rst
@@ -16,7 +16,7 @@ under non-free, proprietary licenses, limiting what you can do with them.
 
 The Asset Library is different - all assets are distributed free of charge, and under
 a host of open-source licenses (such as the MIT license, the GPL, and the Boost Software License).
-This makes the AssetLib more similar to the software repositories of a GNU/Linux distribution.
+This makes the AssetLib more similar to the software repositories of a Linux distribution.
 
 This set of pages will cover how to use the AssetLib (both from inside Godot, and on the
 website), how you can submit your own assets, and what the guidelines for submission are.

--- a/tutorials/gui/custom_gui_controls.rst
+++ b/tutorials/gui/custom_gui_controls.rst
@@ -25,8 +25,8 @@ Checking control size
 
 Unlike 2D nodes, "size" is very important with controls, as it helps to
 organize them in proper layouts. For this, the
-:ref:`Control.get_size() <class_Control_get_size>`
-method is provided. Checking it during _draw() is vital to ensure
+:ref:`Control.rect_size <class_Control_rect_size>`
+member variable is provided. Checking it during _draw() is vital to ensure
 everything is kept in-bounds.
 
 Checking focus
@@ -35,11 +35,11 @@ Checking focus
 Some controls (such as buttons or text editors) might provide input
 focus for keyboard or joypad input. Examples of this are entering text
 or pressing a button. This is controlled with the
-:ref:`Control.set_focus_mode() <class_Control_set_focus_mode>`
-function. When drawing, and if the control supports input focus, it is
+:ref:`Control.focus_mode <class_Control_focus_mode>`
+member variable. When drawing, and if the control supports input focus, it is
 always desired to show some sort of indicator (highight, box, etc) to
 indicate that this is the currently focused control. To check for this
-status, the :ref:`Control.has_focus() <class_Control_has_focus>`
+status, the :ref:`Control.has_focus() <class_Control_has_focus>` method
 exists. Example
 
 ::
@@ -94,7 +94,7 @@ when:
 -  The button was pressed over this control (control always
    captures input until button is released)
 -  Control provides keyboard/joypad focus via
-   :ref:`Control.set_focus_mode() <class_Control_set_focus_mode>`.
+   :ref:`Control.focus_mode <class_Control_focus_mode>`.
 
 This function is
 :ref:`Control._gui_input() <class_Control__gui_input>`.

--- a/tutorials/inputs/inputevent.rst
+++ b/tutorials/inputs/inputevent.rst
@@ -96,10 +96,10 @@ There are several types of InputEvent, described in the table below:
 | :ref:`InputEventMouseMotion <class_InputEventMouseMotion>`        | MOUSE_MOTION       | Contains motion information, such as    |
 |                                                                   |                    | relative, absolute positions and speed. |
 +-------------------------------------------------------------------+--------------------+-----------------------------------------+
-| :ref:`InputEventJoystickMotion <class_InputEventJoystickMotion>`  | JOYSTICK_MOTION    | Contains Joystick/Joypad analog axis    |
+| :ref:`InputEventJoypadMotion <class_InputEventJoypadMotion>`      | JOYSTICK_MOTION    | Contains Joystick/Joypad analog axis    |
 |                                                                   |                    | information.                            |
 +-------------------------------------------------------------------+--------------------+-----------------------------------------+
-| :ref:`InputEventJoystickButton <class_InputEventJoystickButton>`  | JOYSTICK_BUTTON    | Contains Joystick/Joypad button         |
+| :ref:`InputEventJoypadButton <class_InputEventJoypadButton>`      | JOYSTICK_BUTTON    | Contains Joystick/Joypad button         |
 |                                                                   |                    | information.                            |
 +-------------------------------------------------------------------+--------------------+-----------------------------------------+
 | :ref:`InputEventScreenTouch <class_InputEventScreenTouch>`        | SCREEN_TOUCH       | Contains multi-touch press/release      |

--- a/tutorials/math/matrices_and_transforms.rst
+++ b/tutorials/math/matrices_and_transforms.rst
@@ -109,7 +109,7 @@ the uses for the dot product. This was enough to obtain back the
 design coordinates for every point in the ship.
 
 So, what we have been working with so far (with X, Y and Origin) is an
-*Oriented Coordinate System\*. X an Y are the **Basis**, and \*Origin*
+*Oriented Coordinate System*. X an Y are the **Basis**, and *Origin*
 is the offset.
 
 Basis
@@ -143,29 +143,29 @@ depth, only its practical use. There is plenty of material for that,
 which should be a lot simpler to understand after completing this
 tutorial. We'll just explain how to use transforms.
 
-Matrix32
---------
+Transform2D
+-----------
 
-:ref:`Matrix32 <class_Matrix32>` is a 3x2 matrix. It has 3 Vector2 elements and
+:ref:`class_Transform2D` is a 3x2 matrix. It has 3 Vector2 elements and
 it's used for 2D. The "X" axis is the element 0, "Y" axis is the element 1 and
 "Origin" is element 2. It's not divided in basis/origin for convenience, due to
 its simplicity.
 
 ::
 
-    var m = Matrix32()
+    var m = Transform2D()
     var x = m[0] # 'X'
     var y = m[1] # 'Y'
     var o = m[2] # 'Origin'
     
 
-Most operations will be explained with this datatype (Matrix32), but the
+Most operations will be explained with this datatype (Transform2D), but the
 same logic applies to 3D.
 
 Identity
 --------
 
-By default, Matrix32 is created as an "identity" matrix. This means:
+By default, Transform2D is created as an "identity" matrix. This means:
 
 -  'X' Points right: Vector2(1,0)
 -  'Y' Points up (or down in pixels): Vector2(0,1)
@@ -184,11 +184,11 @@ Operations
 Rotation
 --------
 
-Rotating Matrix32 is done by using the "rotated" function:
+Rotating Transform2D is done by using the "rotated" function:
 
 ::
 
-    var m = Matrix32()
+    var m = Transform2D()
     m = m.rotated(PI/2) # rotate 90°
 
 .. image:: img/tutomat12.png
@@ -196,13 +196,13 @@ Rotating Matrix32 is done by using the "rotated" function:
 Translation
 -----------
 
-There are two ways to translate a Matrix32, the first one is just moving
+There are two ways to translate a Transform2D, the first one is just moving
 the origin:
 
 ::
 
     # Move 2 units to the right
-    var m = Matrix32()
+    var m = Transform2D()
     m = m.rotated(PI/2) # rotate 90°
     m[2]+=Vector2(2,0)
 
@@ -212,13 +212,13 @@ This will always work in global coordinates.
 
 If instead, translation is desired in *local* coordinates of the
 matrix (towards where the *basis* is oriented), there is the
-:ref:`Matrix32.translated() <class_Matrix32_translated>`
+:ref:`Transform2D.translated() <class_Transform2D_translated>`
 method:
 
 ::
 
     # Move 2 units towards where the basis is oriented
-    var m = Matrix32()
+    var m = Transform2D()
     m = m.rotated(PI/2) # rotate 90°
     m = m.translated( Vector2(2,0) )
 
@@ -234,7 +234,7 @@ the scale). It will leave the origin alone:
 ::
 
     # Make the basis twice its size.
-    var m = Matrix32()
+    var m = Transform2D()
     m = m.scaled( Vector2(2,2) )
 
 .. image:: img/tutomat15.png
@@ -298,7 +298,7 @@ Or pre-multiplication:
 Orthonormal matrices
 --------------------
 
-However, if the Matrix has been scaled (vectors are not unit length),
+However, if the matrix has been scaled (vectors are not unit length),
 or the basis vectors are not orthogonal (90°), the inverse transform
 will not work.
 
@@ -311,7 +311,7 @@ the position unchanged:
 ::
 
     # Does nothing, pos is unchanged
-    pos = Matrix32().xform(pos)
+    pos = Transform2D().xform(pos)
 
 Affine inverse
 --------------
@@ -393,7 +393,7 @@ Multiplying a matrix by identity, will result in the unchanged matrix:
 ::
 
     # B will be equal to A
-    B = A * Matrix32()
+    B = A * Transform2D()
 
 Matrix tips
 -----------

--- a/tutorials/misc/pausing_games.rst
+++ b/tutorials/misc/pausing_games.rst
@@ -19,13 +19,13 @@ Godot.
 How pausing works
 -----------------
 
-To set pause mode, the pause state must be set. This is done by calling
-:ref:`SceneTree.set_pause() <class_SceneTree_set_pause>`
-with a "true" argument:
+To set pause mode, the pause state must be set. This is done by assigning
+"true" to the :ref:`SceneTree.paused <class_SceneTree_paused>` member
+variable:
 
 ::
 
-    get_tree().set_pause(true)
+    get_tree().paused = true
 
 Doing so will have the following behavior:
 
@@ -81,8 +81,8 @@ enable the pause and show the pause screen.
 ::
 
     func _on_pause_button_pressed():
-        get_tree().set_pause(true)
-        get_node("pause_popup").show()
+        get_tree().paused = true
+        $pause_popup.show()
 
 To remove the pause, just do the opposite when the pause screen is
 closed:
@@ -90,7 +90,7 @@ closed:
 ::
 
     func _on_pause_popup_close_pressed():
-        get_node("pause_popup").hide()
-        get_tree().set_pause(false)
+        $pause_popup.hide()
+        get_tree().paused = false
 
 And that should be all!

--- a/tutorials/misc/saving_games.rst
+++ b/tutorials/misc/saving_games.rst
@@ -41,9 +41,9 @@ Serializing
 The next step is to serialize the data. This makes it much easier to
 read and store to disk. In this case, we're assuming each member of
 group Persist is an instanced node and thus has a path. GDScript
-has helper functions for this, such as :ref:`Dictionary.to_json()
-<class_Dictionary_to_json>` and :ref:`Dictionary.parse_json()
-<class_Dictionary_parse_json>`, so we will use a dictionary. Our node needs to
+has helper functions for this, such as :ref:`to_json()
+<class_@GDScript_to_json>` and :ref:`parse_json()
+<class_@GDScript_parse_json>`, so we will use a dictionary. Our node needs to
 contain a save function that returns this data. The save function will look
 like this:
 
@@ -96,7 +96,7 @@ way to pull the data out of the file as well.
         var savenodes = get_tree().get_nodes_in_group("Persist")
         for i in savenodes:
             var nodedata = i.save()
-            savegame.store_line(nodedata.to_json())
+            savegame.store_line(to_json(nodedata))
         savegame.close()
 
 Game saved! Loading is fairly simple as well. For that we'll read each
@@ -120,10 +120,9 @@ load function:
             i.queue_free()
 
         # Load the file line by line and process that dictionary to restore the object it represents
-        var currentline = {} # dict.parse_json() requires a declared dict.
         savegame.open("user://savegame.save", File.READ)
         while (!savegame.eof_reached()):
-            currentline.parse_json(savegame.get_line())
+            var currentLine = parse_json(savegame.get_line())
             # First we need to create the object and add it to the tree and set its position.
             var newobject = load(currentline["filename"]).instance()
             get_node(currentline["parent"]).add_child(newobject)

--- a/tutorials/physics/kinematic_character_2d.rst
+++ b/tutorials/physics/kinematic_character_2d.rst
@@ -96,7 +96,8 @@ Moving the Kinematic character
 
 Go back to the character scene, and open the script, the magic begins
 now! Kinematic body will do nothing by default, but it has a really
-useful function called :ref:`KinematicBody2D.move() <class_KinematicBody2D_move>`.
+useful function called
+:ref:`KinematicBody2D.move_and_collide() <class_KinematicBody2D_move_and_collide>`.
 This function takes a :ref:`Vector2 <class_Vector2>` as
 an argument, and tries to apply that motion to the kinematic body. If a
 collision happens, it stops right at the moment of the collision.
@@ -108,7 +109,7 @@ So, let's move our sprite downwards until it hits the floor:
     extends KinematicBody2D
 
     func _physics_process(delta):
-        move( Vector2(0,1) ) #move down 1 pixel per physics frame
+        move_and_collide(Vector2(0,1)) # Move down 1 pixel per physics frame
 
 The result is that the character will move, but stop right when
 hitting the floor. Pretty cool, huh?
@@ -128,7 +129,7 @@ little more like an actual game character:
         velocity.y += delta * GRAVITY
 
         var motion = velocity * delta
-        move( motion )
+        move_and_collide(motion)
 
 Now the character falls smoothly. Let's make it walk to the sides, left
 and right when touching the directional keys. Remember that the values

--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -299,8 +299,8 @@ changes outside that callback will not take place until the next frame.
     method will not be called (I.E. they act like a static body until a
     collision or a force is applied to them). To override this behavior you will
     need to keep the rigid body "awake" by creating a collision, applying a force to it
-    (e.g. :ref:`set_linear_velocity <class_RigidBody2D_set_linear_velocity>`)
-    or by disabling the `can_sleep` property (see :ref:`set_can_sleep <class_RigidBody2D_set_can_sleep>`).
+    (e.g. :ref:`linear_velocity <class_RigidBody2D_linear_velocity>`)
+    or by disabling the `can_sleep` property (see :ref:`can_sleep <class_RigidBody2D_can_sleep>`).
     Be aware that this can have an effect on performance.
 
 Contact reporting


### PR DESCRIPTION
- Fixed several title underline sizes.
- Fixed LOTS of undefined labels.
- Some miscellaneous fixes here and there (character escaping, etc).

There where some problems that I could not fix however:

- In the **Design a title screen** tutorial, there's no link for the download of the final menu, I suppose that this was made by @NathanLovato, correct?
- Undefined labels at **DCC-created models** and **Generated geometry** inside **Introduction to 3D** weren't fixed, because this sections are in need of some rewriting, which is beyond the scope of this pull.
- Undefined label in the **InputEvent** tutorial, as I'm not sure to where it should be redirecting.
- Undefined labels in the **Matrices and Transforms** tutorial, as Matrix3 is supposed to be Basis, but there is already a Basis section for something different in the page.
- Removal of a reference to an **Exporting images** guide that doesn't exist as far as I'm aware of.