### PR TITLE
Fix MSBuild Information

### DIFF
--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -24,13 +24,11 @@ A good starting point for checking its capabilities is the `Compatibility <http:
 Setup C# for Godot
 ------------------
 
-To use C# in Godot you must have `Mono <http://www.mono-project.com/download/>`_ installed (at least version 5.2).
+To use C# in Godot you must have `Mono <http://www.mono-project.com/download/>`_ installed (at least version 5.2), as well 
+as MSBuild (at least version 15.0) which should come with the Mono installation. 
 
 Additionally, your Godot version must have Mono support enabled, so take care to download the **Mono version** of Godot.
 If you are building Godot from source, make sure to follow the steps to include Mono support in your build outlined on the  :ref:`doc_compiling_with_mono` page.
-
-Windows users also need MS Build 15.0, which comes bundled with Visual Studio 2017,
-or can be downloaded separately with `build tools for Visual Studio 2017 <https://www.visualstudio.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15#>`_.
 
 Configuring an external editor
 ------------------------------


### PR DESCRIPTION
Fix the MSBuild Information so it doesn't say only windows users need it. The page was originally like that because that's what the C# blog post said, however that information is now outdated.