### PR TITLE
Fix typo (`players` to `layers`)

### DIFF
--- a/getting_started/step_by_step/scripting_continued.rst
+++ b/getting_started/step_by_step/scripting_continued.rst
@@ -8,7 +8,7 @@ Processing
 
 Several actions in Godot are triggered by callbacks or virtual functions, 
 so there is no need to write code that runs all the time. Additionally, a 
-lot can be done with animation players.
+lot can be done with animation layers.
 
 However, it is still a very common case to have a script process on every
 frame. There are two types of processing: idle processing and physics


### PR DESCRIPTION
I'm not super familiar with Godot yet, but I'm guessing this should refer to `animation layers` not `animation players`. Feel free to reject otherwise :)