### PR TITLE
Fix typo in gdscript_advanced.rst

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_advanced.rst
+++ b/getting_started/scripting/gdscript/gdscript_advanced.rst
@@ -293,7 +293,7 @@ easily with dictionaries. Here's a simple battleship game example:
 
 Dictionaries can also be used as data markup or quick structures. While
 GDScript dictionaries resemble python dictionaries, it also supports Lua
-style syntax an indexing, which makes it very useful for writing initial
+style syntax and indexing, which makes it very useful for writing initial
 states and quick structs:
 
 ::


### PR DESCRIPTION
Changed "an" to "and" in dictionary section.