### PR TITLE
Remove old GDScript functions in Scripting Continued

### DIFF
--- a/getting_started/step_by_step/scripting_continued.rst
+++ b/getting_started/step_by_step/scripting_continued.rst
@@ -221,15 +221,6 @@ follows, can be applied to nodes:
         # This is called every physics frame.
         pass
 
-    func _paused():
-        # Called when game is paused. After this call, the node will not receive
-        # any more process callbacks.
-        pass
-
-    func _unpaused():
-        # Called when game is unpaused.
-        pass
-
  .. code-tab:: csharp
  
     public override void _EnterTree()


### PR DESCRIPTION
As far as I can tell `func _paused():` and `func _unpaused():` no longer exist in GDScript, so I've removed them from the Scripting Continued page.