### PR TITLE
Fixed build command for shared library summator

### DIFF
--- a/development/cpp/custom_modules_in_cpp.rst
+++ b/development/cpp/custom_modules_in_cpp.rst
@@ -338,7 +338,7 @@ shared module as target in the scons command:
 
 ::
 
-    user@host:~/godot$ scons summator_shared=yes bin/summator.x11.tools.64.so
+    user@host:~/godot$ scons summator_shared=yes platform=x11 bin/libsummator.x11.tools.64.so
 
 Writing custom documentation
 ----------------------------


### PR DESCRIPTION
I can't seem to get the example to work as is on Ubunto 16.04. With these changes it works perfectly as a shared library but without it I get complaints about x11. Then if platform=x11 is added I get:

[  0%] scons: *** Do not know how to make File target `bin/summator.x11.tools.64.so' (/home/simon/projects/godot/bin/summator.x11.tools.64.so).  Stop.

Very unfamiliar with c++/scons/godot, not sure if docs should be changed or if it is a bug. ( I am running off of godot master ) 

Thanks,

Simon