### PR TITLE
Copyedit of "getting_started/step_by_step/your_first_game"

### DIFF
--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -242,7 +242,7 @@ and use ``clamp()`` to prevent it from leaving the screen:
 
 .. tip:: *Clamping* a value means restricting it to a given range.
 
-Click "Play the edited scene" (``F6``) and confirm you can move the player
+Click "Play Scene" (``F6``) and confirm you can move the player
 around the screen in all directions.
 
 .. warning:: If you get an error in the "Debugger" panel that refers to a "null instance",
@@ -253,9 +253,9 @@ Choosing Animations
 ~~~~~~~~~~~~~~~~~~~
 
 Now that the player can move, we need to change which animation the
-AnimatedSprite is playing based on direction. We have a ``right``
+AnimatedSprite is playing based on direction. We have a "right"
 animation, which should be flipped horizontally using the ``flip_h``
-property for left movement, and an ``up`` animation, which should be
+property for left movement, and an "up" animation, which should be
 flipped vertically with ``flip_v`` for downward movement.
 Let's place this code at the end of our ``_process()`` function:
 
@@ -403,7 +403,7 @@ at the same speed). Set them to ``150`` and ``250`` in the Inspector. We
 also have an array containing the names of the three animations, which
 we'll use to select a random one.
 
-Now let's look at the rest of the script. In ``_ready()`` we will randomly 
+Now let's look at the rest of the script. In ``_ready()`` we randomly 
 choose one of the three animation types:
 
 ::
@@ -688,7 +688,7 @@ has been pressed.
 
 This function is called when we want to display a message
 temporarily, such as "Get Ready". On the ``MessageTimer``, set the
-``Wait Time`` to ``2`` and set 	the ``One Shot`` property to "On".
+``Wait Time`` to ``2`` and set the ``One Shot`` property to "On".
 
 ::
 

--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -81,7 +81,7 @@ are not selectable."
 Save the scene. Click Scene -> Save, or press ``Ctrl+S`` on Windows/Linux or ``Command+S`` on Mac.
 
 .. note:: For this project, we will be following the Godot naming
-          conventions. Classes (nodes) use ``CamelCase``, variables and
+          conventions. Classes (nodes) use ``PascalCase``, variables and
           functions use ``snake_case``, and constants use ``ALL_CAPS``.
 
 Sprite Animation


### PR DESCRIPTION
Checks for grammar and sentence structure at "[getting_started/step_by_step/your_first_game.html](https://godot.readthedocs.io/en/3.0/getting_started/step_by_step/your_first_game.html)".

This is a big tutorial, though there was less to correct than the previous ones. Much of the time I felt like I was copying what was written instead of understanding what exactly I am doing with the code I am writing down. A lot of it seemed like magic to me, which is perhaps due to my not fully understanding GDScript.

I ended up failing the tutorial and getting an error titled "Invalid call. Nonexistent function 'instance' in base 'Nil'", which isn't present on the completed version at https://github.com/kidscancode/Godot3_dodge/releases I don't know how to correct it, and I don't expect any support, though I've uploaded my project file for your inspection: 

[DodgeTheCreeps.zip](https://github.com/gemkibeju/godot-docs/files/1713996/DodgeTheCreeps.zip)

I've also noticed that "\n" doesn't break a line for my project even when I copy and paste the code from the example project, where it works just fine. Could this be an engine version difference from 2.0 to 3.0, or did I just misinterpret something?