### PR TITLE
Fix file extension mismatch in 'Singletons (Autoload)' code samples

### DIFF
--- a/getting_started/step_by_step/singletons_autoload.rst
+++ b/getting_started/step_by_step/singletons_autoload.rst
@@ -167,7 +167,7 @@ and scene_b.gd:
     #add to scene_a.gd
 
     func _on_goto_scene_pressed():
-            get_node("/root/global").goto_scene("res://scene_b.tscn")
+            get_node("/root/global").goto_scene("res://scene_b.scn")
 
 and
 
@@ -176,7 +176,7 @@ and
     #add to scene_b.gd
 
     func _on_goto_scene_pressed():
-            get_node("/root/global").goto_scene("res://scene_a.tscn")
+            get_node("/root/global").goto_scene("res://scene_a.scn")
 
 Now if you run the project, you can switch between both scenes by pressing
 the button!


### PR DESCRIPTION
The code samples reference `tscn` scene files. However, they are `scn` in the template files (from `autoload.zip`). I changed the extensions in the samples to `scn` so they match the template files.