### PR TITLE
Corrected physics Introduction using move()

### DIFF
--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -246,7 +246,7 @@ They have two main uses:
    etc). As an example, the 2d/platformer demo uses them for moving
    platforms.
 -  **Kinematic Characters**: KinematicBody2D also has an API for moving
-   objects (the ``move()`` function) while performing collision tests. This
+   objects (the ``move_and_slide()`` function) while performing collision tests. This
    makes them really useful to implement characters that collide against
    a world, but that don't require advanced physics. There is a tutorial
    about it :ref:`doc_kinematic_character_2d`.


### PR DESCRIPTION
In the [Physics Introduction](https://godot.readthedocs.io/en/stable/classes/class_viewport.html) page of the docs, it is incorrectly reported that KinematicBody2D uses move(), when in fact it uses move_and_slide() as of version 3.0. This does not apply to earlier versions of Godot.