### PR TITLE
Update updating_the_class_reference.rst

### DIFF
--- a/community/contributing/updating_the_class_reference.rst
+++ b/community/contributing/updating_the_class_reference.rst
@@ -25,7 +25,7 @@ There are 5 steps to update the class reference (full guide below):
 4. Commit your changes and push them to your fork
 5. Make a pull request on the Godot repository
 
-.. warning:: always use these XML files to edit the API reference. Do not edit the generated .rST files :ref:`in the online documentation <toc-class-ref>`, hosted in the `godot-docs <https://github.com/godotengine/godot-docs>`_ repository.
+.. warning:: Always use these XML files to edit the API reference. Do not edit the generated .rST files :ref:`in the online documentation <toc-class-ref>`, hosted in the `godot-docs <https://github.com/godotengine/godot-docs>`_ repository.
 
 Get started with GitHub
 -----------------------


### PR DESCRIPTION
Capitilized start of a Warning

Pull Requests should use the master branch by default.

Only make Pull Requests against other branches (e.g. 2.1 or 3.0) if your changes only apply to that specific version of Godot.
