### PR TITLE
Typo in viewports.rst

### DIFF
--- a/tutorials/viewports/viewports.rst
+++ b/tutorials/viewports/viewports.rst
@@ -7,7 +7,7 @@ Introduction
 ------------
 
 Godot has a small but very useful feature called viewports. Viewports
-are, as they name implies, rectangles where the world is drawn. They
+are, as the name implies, rectangles where the world is drawn. They
 have three main uses, but can flexibly adapted to a lot more. All this
 is done via the :ref:`Viewport <class_Viewport>` node.
 


### PR DESCRIPTION
`as they name implies`
changed to
`as the name implies`