### PR TITLE
Add docs for getting the source code from GitHub

### DIFF
--- a/development/compiling/getting_source.rst
+++ b/development/compiling/getting_source.rst
@@ -1,0 +1,38 @@
+.. _doc_getting_source:
+
+Getting the source
+==================
+
+Downloading the Godot source code
+---------------------------------
+
+Before :ref:`getting into the SCons build system <doc_introduction_to_the_buildsystem>`
+and compiling Godot, you need to actually download the Godot source code.
+
+The source code is available on `GitHub <https://github.com/godotengine/godot>`__
+and while you can manually download it via the website, in general you want to
+do it via the ``git`` version control system.
+
+If you don't know much about ``git`` yet, there are a great number of
+`tutorials <https://git-scm.com/book>`__ available on various websites.
+
+In general, you need to install ``git`` and/or one of the various GUI clients.
+
+Afterwards, to get the latest development version of the Godot source code
+(the unstable ``master`` branch), you can use ``git clone``.
+
+If you are using the ``git`` command line client, this is done by entering
+the following in a terminal:
+
+::
+
+    git clone https://github.com/godotengine/godot.git
+
+For any stable release, visit the `release page <https://github.com/godotengine/godot/releases>`__
+and click on the link for the release you want.
+You can then download and extract the source from the download link on the page.
+
+There are also generally branches besides ``master`` for each major version.
+
+After downloading the Godot source code,
+you can :ref:`continue to compiling Godot <doc_introduction_to_the_buildsystem>`.

--- a/development/compiling/index.rst
+++ b/development/compiling/index.rst
@@ -5,6 +5,7 @@ Compiling
    :maxdepth: 1
    :name: toc-devel-compiling
 
+   getting_source
    introduction_to_the_buildsystem
    compiling_for_windows
    compiling_for_x11

--- a/development/compiling/introduction_to_the_buildsystem.rst
+++ b/development/compiling/introduction_to_the_buildsystem.rst
@@ -38,7 +38,7 @@ So, please try to keep an open mind and get at least a little familiar with it i
 build Godot yourself.
 
 Setup
-------------------
+-----
 Please refer to the documentation for :ref:`doc_compiling_for_android`, :ref:`doc_compiling_for_ios`, :ref:`doc_compiling_for_osx`, :ref:`doc_compiling_for_uwp`, :ref:`doc_compiling_for_web`, :ref:`doc_compiling_for_windows` and :ref:`doc_compiling_for_x11`.
 
 Note that for **Windows/Visual Studio**, you need to use ``x86_x64 Cross Tools Command Prompt for VS 2017`` or similar, depending on your install, instead of the standard Windows command prompt to enter the commands below.


### PR DESCRIPTION
Explains how to get the Godot source code from GitHub and some general setup.

Closes https://github.com/godotengine/godot-docs/pull/385.