### PR TITLE
Fix godot docs

### DIFF
--- a/getting_started/editor/unity_to_godot.rst
+++ b/getting_started/editor/unity_to_godot.rst
@@ -157,7 +157,7 @@ Design
 
 As you may know already, Unity supports C#. C# benefits from its integration with Visual Studio and other features, such as static typing.
 
-Godot provides its own scripting language, :ref:`GDScript <doc_scripting>` as well as support for :ref:`Visual Script <toc-learn-scripting-visual_script>` and :ref:`doc_c_sharp`. GDScript borrows its syntax from Python, but is not related to it. If you wonder about the reasoning for a custom scripting language, please read :ref:`GDScript <doc_gdscript>` and `FAQ <faq>`_ pages. GDScript is strongly attached to the Godot API, but it is really easy to learn: between one evening for an experienced programmer and a week for a complete beginner.
+Godot provides its own scripting language, :ref:`GDScript <doc_scripting>` as well as support for :ref:`Visual Script <toc-learn-scripting-visual_script>` and :ref:`C# <doc_c_sharp>`. GDScript borrows its syntax from Python, but is not related to it. If you wonder about the reasoning for a custom scripting language, please read :ref:`GDScript <doc_gdscript>` and `FAQ <faq>`_ pages. GDScript is strongly attached to the Godot API, but it is really easy to learn: between one evening for an experienced programmer and a week for a complete beginner.
 
 Unity allows you to attach as many scripts as you want to a GameObject. Each script adds a behaviour to the GameObject: for example, you can attach a script so that it reacts to the player's controls, and another that controls its specific game logic.
 

--- a/getting_started/step_by_step/ui_code_a_life_bar.rst
+++ b/getting_started/step_by_step/ui_code_a_life_bar.rst
@@ -337,8 +337,8 @@ float or an integer. We can use ``interpolate_property`` to animate a
 number, but not to animate text directly. We're going to use it to
 animate a new ``GUI`` variable named ``animated_health``.
 
-At the top of the script, define a new variable and name it
-``animated_health``. Navigate back to the ``update_health`` method and
+At the top of the script, define a new variable, name it
+``animated_health``, and set its value to 0. Navigate back to the ``update_health`` method and
 clear its content. Let's animate the ``animated_health`` value. Call the
 ``Tween`` node's ``interpolate_property`` method:
 


### PR DESCRIPTION
Fix couple of documentation errors:

**Control game's UI with code:** animated_health needs to be intialized to zero to avoid run time error.

**Unity to Godot:** C# Text is missing from link to C# as one of the scripting options. Link text was reading "introduction"