### PR TITLE
Fixes the canvas item vertex example

### DIFF
--- a/tutorials/shading/shading_language.rst
+++ b/tutorials/shading/shading_language.rst
@@ -987,7 +987,7 @@ happen later, though) with the following code, so it can be done manually:
 
 .. code-block:: glsl
 
-    shader_type spatial;
+    shader_type canvas_item;
     render_mode skip_vertex_transform;
 
     void vertex() {


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1` or `3.0`) if your changes only apply to that specific version of Godot.
-->
The `shader_type` should be `canvas_item` in the example.
