### PR TITLE
3.0 Docs Update

### DIFF
--- a/getting_started/step_by_step/scripting.rst
+++ b/getting_started/step_by_step/scripting.rst
@@ -259,7 +259,7 @@ Next, write a function which will be called when the button is pressed:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    func _on_button_pressed():  
+    func _on_Button_pressed():  
         get_node("Label").text = "HELLO!"
 
  .. code-tab:: csharp
@@ -293,7 +293,7 @@ The final script should look like this:
 
     extends Panel
 
-    func _on_button_pressed():
+    func _on_Button_pressed():
         get_node("Label").text = "HELLO!"
 
     func _ready():

--- a/index.rst
+++ b/index.rst
@@ -3,12 +3,13 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Godot Docs – *master* branch
-============================
+Godot Docs – *3.0* branch
+=========================
 
-.. attention:: This is the documentation for the unstable (master) branch.
-               Looking for the documentation of the current **stable** branch?
-               `Have a look here <http://docs.godotengine.org/en/stable>`_.
+.. tip:: This is the documentation for the stable 3.0 branch.
+         Looking for the documentation of the current **development** branch?
+         `Have a look here <http://docs.godotengine.org/en/latest>`_.
+         For the stable 2.1 branch, `it's here <http://docs.godotengine.org/en/2.1>`_.
 
 Welcome to the official documentation of Godot Engine, the free and open source
 community-driven 2D and 3D game engine! If you are new to this documentation,


### PR DESCRIPTION
Updated the docs to fix one of the method names which causes an error.

In Godot 3.0 (not sure if in earlier versions) the function name is `_on_Button_pressed` not `_on_button_pressed`. The latter throws an error with method not found.

In the Docs it reads:

By default, the method name will contain the emitting node’s name (“Button” in this case), resulting in “_on_[EmitterNode]_[signal_name]”.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1` or `3.0`) if your changes only apply to that specific version of Godot.
-->
