### PR TITLE
Fix link

### DIFF
--- a/getting_started/step_by_step/ui_game_user_interface.rst
+++ b/getting_started/step_by_step/ui_game_user_interface.rst
@@ -25,7 +25,7 @@ Breaking down the UI
 --------------------
 
 Let's break down the final UI and plan the containers we'll use. As in
-the `main menu tutorial <#>`__, it starts with a ``MarginContainer``.
+the :doc:`ui_main_menu`, it starts with a ``MarginContainer``.
 Then, we can see up to three columns:
 
 1. The life and energy counters on the left


### PR DESCRIPTION
The link for "main menu tutorial" was pointing at the current page instead of the tutorial.