### PR TITLE
Update ui_introduction_to_the_ui_system.rst

### DIFF
--- a/getting_started/step_by_step/ui_introduction_to_the_ui_system.rst
+++ b/getting_started/step_by_step/ui_introduction_to_the_ui_system.rst
@@ -250,7 +250,7 @@ Every control node has Size Flags. They tell containers how the UI
 elements should scale. If you add the "Fill" flag to the Horizontal or
 Vertical property, the node's bounding box will take all the space it
 can, but it'll respect its siblings and retain its size. If there are 3
-TextureFrame nodes in an HBoxContainer, with the "Fill" flags on both
+TextureRect nodes in an HBoxContainer, with the "Fill" flags on both
 axes, they'll each take up to a third of the available space, but no
 more. The container will take over the node and resize it automatically.
 


### PR DESCRIPTION
There's no TextureFrame class in Godot 3. I think it should be TextureRect.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
