### PR TITLE
Add reference to documentation translation

### DIFF
--- a/about/introduction.rst
+++ b/about/introduction.rst
@@ -54,7 +54,9 @@ open source `Sphinx <http://www.sphinx-doc.org>`_ and `ReadTheDocs
 
 .. note:: You can contribute to Godot's documentation by opening issue tickets
           or sending patches via pull requests on its GitHub
-          `source repository <https://github.com/godotengine/godot-docs>`_.
+          `source repository <https://github.com/godotengine/godot-docs>`_, or
+          translating it into your language on `Hosted Weblate
+          <https://hosted.weblate.org/projects/godot-engine/godot-docs/>`_.
 
 All the contents are under the permissive Creative Commons Attribution 3.0
 (`CC-BY 3.0 <https://creativecommons.org/licenses/by/3.0/>`_) license, with


### PR DESCRIPTION
In Introduction, the reader is pointed to godotengine/godot-docs if they want to contribute, but there is no reference to the newly established translation system. Readers of a translated version will likely want to contribute to the translation as well.

This commit adds a reference to point people towards Hosted Weblate if they want to contribute to the translation.