### PR TITLE
Added export enums in gdscript_basics.rst

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_basics.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics.rst
@@ -989,6 +989,12 @@ special export syntax is provided.
     # Editor will enumerate with string names
     export(String, "Rebecca", "Mary", "Leah") var character_name
 
+    # Named enum values
+    
+    # Editor will enumerate as THING_1, THING_2, ANOTHER_THING
+    enum NamedEnum {THING_1, THING_2, ANOTHER_THING = -1}
+    export (NamedEnum) var x
+
     # Strings as paths
 
     # String is a path to a file


### PR DESCRIPTION
This is a small update to the documentation, for exporting enums.
The feature works in 3.0.2.
