### PR TITLE
Fix capitalization of GDScript OS.get_unique_id()

### DIFF
--- a/tutorials/io/encrypting_save_games.rst
+++ b/tutorials/io/encrypting_save_games.rst
@@ -59,7 +59,7 @@ some unique user identifier is needed, for example:
  .. code-tab:: gdscript GDScript
 
     var f = File.new()
-    var err = f.open_encrypted_with_pass("user://savedata.bin", File.WRITE, OS.get_unique_ID())
+    var err = f.open_encrypted_with_pass("user://savedata.bin", File.WRITE, OS.get_unique_id())
     f.store_var(game_state)
     f.close()
 


### PR DESCRIPTION
OS.get_unique_ID() did not work for me in Godot 3.   OS.get_unique_id() did work, so I assume it is correct.
