### PR TITLE
Fixed hyperlinks

### DIFF
--- a/development/cpp/custom_audiostreams.rst
+++ b/development/cpp/custom_audiostreams.rst
@@ -1,4 +1,4 @@
-.. _custom_audiostreams:
+.. _doc_custom_audiostreams:
 
 Custom AudioStreams
 ===================

--- a/development/cpp/custom_godot_servers.rst
+++ b/development/cpp/custom_godot_servers.rst
@@ -1,4 +1,4 @@
-.. _custom_godot_servers:
+.. _doc_custom_godot_servers:
 
 Custom Godot Servers
 ====================

--- a/development/cpp/custom_resource_format_loaders.rst
+++ b/development/cpp/custom_resource_format_loaders.rst
@@ -1,4 +1,4 @@
-.. _custom_resource_format_loaders:
+.. _doc_custom_resource_format_loaders:
 
 Custom Resource Format Loaders
 ==============================


### PR DESCRIPTION
pervious commits were missing a _doc header

:ref: doc_guide instead of guide

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
