### PR TITLE
MessageLabel and StartButton layout misplacement fixed

### DIFF
--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -872,19 +872,6 @@ ScoreLabel
 MessageLabel
 ~~~~~~~~~~~~
 
--  ``Layout``: "Center Bottom"
--  ``Margin``:
-
-   -  Left: ``-100``
-   -  Top: ``-200``
-   -  Right: ``100``
-   -  Bottom: ``-100``
-
--  Text: ``Dodge the Creeps!``
-
-StartButton
-~~~~~~~~~~~
-
 -  ``Layout``: "Center"
 -  ``Margin``:
 
@@ -892,6 +879,19 @@ StartButton
    -  Top: ``70``
    -  Right: ``60``
    -  Bottom: ``150``
+
+-  Text: ``Dodge the Creeps!``
+
+StartButton
+~~~~~~~~~~~
+
+-  ``Layout``: "Center Bottom"
+-  ``Margin``:
+
+   -  Left: ``-100``
+   -  Top: ``-200``
+   -  Right: ``100``
+   -  Bottom: ``-100``
 
 -  Text: ``Start``
 


### PR DESCRIPTION
Hello, pals!

Looks like layout and margin params for MessageLabel and StartButton were misplaced, because on the screenshot there's a MessageLabel shown in the middle of the screen and StartButton at the center bottom.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
