### PR TITLE
Adding Weblate widget on homepage

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -27,9 +27,14 @@ in the top left corner.
           by letting us know!
 
           Submit an issue or pull request on the `GitHub repository
-          <https://github.com/godotengine/godot-docs/issues>`_, or discuss with
+          <https://github.com/godotengine/godot-docs/issues>`_, help us `translating present documentation <https://hosted.weblate.org/engage/godot-engine/>` into your language, or discuss with
           us on the ``#documentation`` channel on `Discord
           <https://godotengine.org/community>`_!
+
+.. image:: https://hosted.weblate.org/widgets/godot-engine/-/godot-docs/287x66-white.png
+    :alt: Translation state
+    :align: center
+    :target: https://hosted.weblate.org/engage/godot-engine/?utm_source=widget
 
 The main documentation for the site is organized into the following sections:
 


### PR DESCRIPTION
Translators may change widget image link to match their specific language progression state. Like https://hosted.weblate.org/widgets/godot-engine/fr/godot-docs/287x66-white.png
