### PR TITLE
fixing Arc polygon function example for GDScript

### DIFF
--- a/tutorials/2d/custom_drawing_in_2d.rst
+++ b/tutorials/2d/custom_drawing_in_2d.rst
@@ -246,7 +246,7 @@ We can take this a step further and not only write a function that draws the pla
         var colors = PoolColorArray([color])
     
         for i in range(nb_points+1):
-            var angle_point = deg2rad(angle_from + i * (angle_to - angle_from) / nb_points - 90
+            var angle_point = deg2rad(angle_from + i * (angle_to - angle_from) / nb_points - 90)
             points_arc.push_back(center + Vector2(cos(angle_point), sin(angle_point)) * radius)
         draw_polygon(points_arc, colors)
         


### PR DESCRIPTION
GDScript fixing an error in the example: Arc polygon function there is missing ")" on deg2rad.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
