### PR TITLE
Fixed number of spaces in the indentation of C# basics page

### DIFF
--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -70,7 +70,7 @@ Example: If you created a script (e.g. ``Test.cs``) and delete it in Godot, comp
 You can for now simply open up the ``.csproj`` and look for the ``ItemGroup``, there should be a line included like the following:
 
 .. code-block:: xml
-   :emphasize-lines: 2
+    :emphasize-lines: 2
 
     <ItemGroup>
         <Compile Include="Test.cs" />``
@@ -152,12 +152,12 @@ can also be added manually by adding the package reference in the .csproj file
 located in the project root:
 
 .. code-block:: xml
-   :emphasize-lines: 2
+    :emphasize-lines: 2
 
         <ItemGroup>
             <PackageReference Include="Newtonsoft.Json" Version="11.0.2"/>
         </ItemGroup>
-      ...
+        ...
     </Project>
 
 


### PR DESCRIPTION
Related to #1475. Apologies.

This makes them 4 instead of 3 now.