### PR TITLE
Adding build debug instructions for c#

### DIFF
--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -161,10 +161,20 @@ located in the project root:
     </Project>
 
 
+Whenever packages are added or modified, run nuget restore in the root of the
+project directory, to ensure that the nuget packages will be available for msbuild
+(the tool used by godot to build mono projects) to use, run::
+
+  $ msbuild /t:restore
+
+
 Debugging Failing Godot Builds
 ------------------------------
 
 If you find that your mono project is failing to build, you can debug more closely
 by running the following on the command line, in the root of your project::
 
-    $ msbuild
+  $ msbuild
+
+This prints detailed output on why the build failed. Note that as mentioned
+in the above section, you need to run msbuild /t:restore separately.

--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -165,6 +165,6 @@ Debugging Failing Godot Builds
 ------------------------------
 
 If you find that your mono project is failing to build, you can debug more closely
-by running the following on the command line, in the root of your project.
+by running the following on the command line, in the root of your project::
 
     $ msbuild

--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -162,8 +162,8 @@ located in the project root:
 
 
 Whenever packages are added or modified, run nuget restore in the root of the
-project directory, to ensure that the nuget packages will be available for msbuild
-(the tool used by godot to build mono projects) to use, run::
+project directory, to ensure that the nuget packages will be available for
+msbuild to use, run::
 
   $ msbuild /t:restore
 

--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -161,6 +161,10 @@ located in the project root:
     </Project>
 
 
-Then using the dotnet command line to restore package, in the project root::
+Debugging Failing Godot Builds
+------------------------------
 
-    $ dotnet restore
+If you find that your mono project is failing to build, you can debug more closely
+by running the following on the command line, in the root of your project.
+
+    $ msbuild

--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -166,15 +166,3 @@ project directory, to ensure that the nuget packages will be available for
 msbuild to use, run::
 
   $ msbuild /t:restore
-
-
-Debugging Failing Godot Builds
-------------------------------
-
-If you find that your mono project is failing to build, you can debug more closely
-by running the following on the command line, in the root of your project::
-
-  $ msbuild
-
-This prints detailed output on why the build failed. Note that as mentioned
-in the above section, you need to run msbuild /t:restore separately.


### PR DESCRIPTION
This corrects the command line tool to use for debugging c# builds to msbuild, instead of dotnet.

Also clarifies the usage of the command.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
