### PR TITLE
Correct API mention is_networking_server -> is_network_server

### DIFF
--- a/tutorials/networking/high_level_multiplayer.rst
+++ b/tutorials/networking/high_level_multiplayer.rst
@@ -105,7 +105,7 @@ Checking whether the tree is initialized as a server or client:
 
 ::
 
-    get_tree().is_networking_server()
+    get_tree().is_network_server()
 
 Terminating the networking feature:
 


### PR DESCRIPTION
In the tutorial for the high level multiplayer, it mentions the API is_networking_server. The API is actually is_network_server. This PR corrects that mistake.