### PR TITLE
correct emscripten sdk download url

### DIFF
--- a/development/compiling/compiling_for_web.rst
+++ b/development/compiling/compiling_for_web.rst
@@ -12,7 +12,7 @@ To compile export templates for the Web, the following is required:
 
 -  `Emscripten 1.37.9+ <http://emscripten.org/>`__: If the version available
    per package manager is not recent enough, the best alternative is to install
-   using the `Emscripten SDK <http://kripken.github.io/emscripten-site/docs/gettng_started/downloads.html>`__
+   using the `Emscripten SDK <http://kripken.github.io/emscripten-site/docs/getting_started/downloads.html>`__
 -  `Python 2.7+ or Python 3.5+ <https://www.python.org/>`__
 -  `SCons <http://www.scons.org>`__ build system
 


### PR DESCRIPTION
correct emscripten sdk download url

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
