### PR TITLE
Improve Data paths page and mention feature tags

### DIFF
--- a/tutorials/io/data_paths.rst
+++ b/tutorials/io/data_paths.rst
@@ -7,34 +7,36 @@ Path separators
 ---------------
 
 For the sake of supporting as many platforms as possible, Godot only
-accepts unix style path separators (``/``). These work everywhere,
-including Windows.
+accepts UNIX-style path separators (``/``). These work on all
+platforms including Windows.
 
-A path like: ``C:\Projects`` will become ``C:/Projects``.
+A path like ``C:\Projects`` will become ``C:/Projects``.
 
 Resource path
 -------------
 
-As mentioned before. Godot considers that a project exists at any
-given folder that contains an "project.godot" text file, even if such
+As mentioned before, Godot considers that a project exists in any
+given folder that contains a ``project.godot`` text file, even if such
 file is empty.
 
 Accessing project files can be done by opening any path with ``res://``
 as a base. For example, a texture located in the root of the project
-folder may be opened from the following path: ``res://sometexture.png``.
+folder may be opened from the following path: ``res://some_texture.png``.
 
-Userdata path (persistent data)
+User path (persistent data)
 -------------------------------
 
 While the project is running, it is a common scenario that the
 resource path will be read-only, due to it being inside a package,
-self contained executable, or system wide install location.
+self-contained executable, or system-wide install location.
 
 Storing persistent files in such scenarios should be done by using the
-``user://`` prefix, for example: ``user://gamesave.txt``.
+``user://`` prefix, for example: ``user://game_save.txt``.
 
-In some devices (for example, mobile ad consoles) this path is unique
-for the app. Under desktop operating systems, the engine uses the
-typical ``~/.local/share/godot/app_userdata/Name`` (check the project
-name under the settings) in macOS and Linux, and ``APPDATA/Name``
-for Windows.
+On some devices (for example, mobile and consoles), this path is unique
+to the project. On desktop operating systems, the engine uses the
+typical ``~/.local/share/godot/app_userdata/Name`` on macOS and Linux,
+and ``%APPDATA%/Name`` on Windows. ``Name`` is taken from the
+application name defined in the Project Settings, but it can be
+overriden on a per-platform basis using
+:ref:`feature tags <doc_feature_tags>`.


### PR DESCRIPTION
This adds a mention of feature tags which can be used to set per-OS user data paths; it can be desired if one wants to use a "slugified" name on Linux and a "title cased" name on Windows.