### PR TITLE
Fixed incorrect documentation for MacOS compiling

### DIFF
--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -37,7 +37,7 @@ built with `scons p=osx target=release_debug`:
 
     user@host:~/godot$ cp -r misc/dist/osx_tools.app ./Godot.app
     user@host:~/godot$ mkdir -p Godot.app/Contents/MacOS
-    user@host:~/godot$ cp bin/godot.osx.opt.tools.64 Godot.app/Contents/MacOS/Godot
+    user@host:~/godot$ cp bin/godot.osx.tools.64 Godot.app/Contents/MacOS/Godot
     user@host:~/godot$ chmod +x Godot.app/Contents/MacOS/Godot
     
 Compiling for 32 and 64-bit


### PR DESCRIPTION
Line 40 contained a typo, referring to `godot.osx.opt.tools.64` instead of `godot.osx.tools.64`.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->