### PR TITLE
Fix reference to Scene tab in the 'Design a title screen' page

### DIFF
--- a/getting_started/step_by_step/ui_main_menu.rst
+++ b/getting_started/step_by_step/ui_main_menu.rst
@@ -167,7 +167,7 @@ browser opens and lets you pick a sprite to load into the texture slot.
 Repeat the operation for all ``TextureRect`` nodes. You should have the
 logo, the illustration, the three menu options and the version note,
 each as a separate node. Then, double click on each of the nodes in the
-Inspector to rename them
+Scene tab to rename them.
 
 .. figure:: img/ui_main_menu_6_texturerect_nodes.png
 


### PR DESCRIPTION
On line 170 of the 'Design a title screen page', the use of Inspector is mistakenly used to refer to what should be the Scene tab. Additionally, the sentence is also missing a closing full stop.

> Then, double click on each of the nodes in the Inspector to rename them

should be

> Then, double click on each of the nodes in the Scene tab to rename them.


