### PR TITLE
Update config example function signature

### DIFF
--- a/development/cpp/custom_modules_in_cpp.rst
+++ b/development/cpp/custom_modules_in_cpp.rst
@@ -199,7 +199,7 @@ python script that must be named ``config.py``:
 
     # config.py
 
-    def can_build(platform):
+    def can_build(env, platform):
         return True
 
     def configure(env):


### PR DESCRIPTION
The previous example caused godot to display the following warning:

`Warning: module 'module' uses a deprecated 'can_build' signature in its config.py file, it should be 'can_build(env, platform)'.`

