### PR TITLE
Removed duplicated function in button hooking GDScript example in

### DIFF
--- a/getting_started/step_by_step/scripting.rst
+++ b/getting_started/step_by_step/scripting.rst
@@ -290,9 +290,6 @@ The final script should look like this:
     func _on_Button_pressed():
         get_node("Label").text = "HELLO!"
 
-    func _on_button_pressed():
-        get_node("Label").text = "HELLO!"
-
  .. code-tab:: csharp
 
     using Godot;


### PR DESCRIPTION
step_by_step/scripting.rst
The final example at the mentioned tutorial had the function _on_Button_pressed as _on_button_pressed in the GDScript
example, this commit shall remove the duplicated function _on_button_pressed
Fixes #1556

Signed-off-by: Ibrahim Zidan <brahem@aotsw.com>

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
