### PR TITLE
Add recommendation to disable sky contribution to spatial material doc toon diffuse mode explaination.

### DIFF
--- a/tutorials/3d/spatial_material.rst
+++ b/tutorials/3d/spatial_material.rst
@@ -138,7 +138,7 @@ default one is Burley. Other modes are also available:
 * **Lambert:** Is not affected by roughness.
 * **Lambert Wrap:** Extends Lambert to cover more than 90 degrees when roughness increases. Works great for hair and simulating cheap subsurface scattering. This implementation is energy conserving.
 * **Oren Nayar:** This implementation aims to take microsurfacing into account (via roughness). Works well for clay-like materials and some types of cloth.
-* **Toon:** Provides a hard cut for lighting, with smoothing affected by roughness.
+* **Toon:** Provides a hard cut for lighting, with smoothing affected by roughness. It is recommended you disable sky contribution from your environment's ambient light settings to achieve a better effect.
 
 .. image:: img/spatial_material6.png
 


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
