### PR TITLE
Removed double function from GDScript example

### DIFF
--- a/getting_started/step_by_step/scripting.rst
+++ b/getting_started/step_by_step/scripting.rst
@@ -290,9 +290,6 @@ The final script should look like this:
     func _on_Button_pressed():
         get_node("Label").text = "HELLO!"
 
-    func _on_button_pressed():
-        get_node("Label").text = "HELLO!"
-
  .. code-tab:: csharp
 
     using Godot;


### PR DESCRIPTION
_on_Button_pressed() function was doubled in final GDScript example.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
