### PR TITLE
Remove duplicate line from scripting tutorial

### DIFF
--- a/getting_started/step_by_step/scripting.rst
+++ b/getting_started/step_by_step/scripting.rst
@@ -290,9 +290,6 @@ The final script should look like this:
     func _on_Button_pressed():
         get_node("Label").text = "HELLO!"
 
-    func _on_button_pressed():
-        get_node("Label").text = "HELLO!"
-
  .. code-tab:: csharp
 
     using Godot;


### PR DESCRIPTION
The "final code" box contained the functions `_on_Button_pressed` and `_on_button_pressed`, even though only the former was mentioned earlier in the tutorial.
The C# code didn't contain a duplicate function, so I'm reasonably sure this was a mistake.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
