### PR TITLE
Change comment for `s.queue_free()`

### DIFF
--- a/getting_started/step_by_step/scripting_continued.rst
+++ b/getting_started/step_by_step/scripting_continued.rst
@@ -327,13 +327,13 @@ This erases the node safely during idle.
  .. code-tab:: gdscript GDScript
 
     func _someaction():
-        s.queue_free() # Immediately removes the node from the scene and frees it.
+        s.queue_free() # Removes the node from the scene and frees it when it becomse safe to do so.
 
  .. code-tab:: csharp
 
     public void _SomeAction()
     {
-        _sprite.QueueFree(); // Immediately removes the node from the scene and frees it.
+        _sprite.QueueFree(); // Removes the node from the scene and frees it when it becomse safe to do so.
     }
 
 Instancing scenes


### PR DESCRIPTION
In the previous section, we document `free` as being immediate, and here we contrast that with `queue_free`. However, each function has the same comment implying that both `free` and `queue_free` are immediate.

I believe the point of this documentation is to point out that `queue_free` is _not_ necessarily immediate and will wait until it is safe to free the node.
