### PR TITLE
Fix FPS Tutorial move_and_slide

### DIFF
--- a/tutorials/3d/fps_tutorial/part_one.rst
+++ b/tutorials/3d/fps_tutorial/part_one.rst
@@ -145,7 +145,7 @@ Add the following code to ``Player.gd``:
     var vel = Vector3()
     const MAX_SPEED = 20
     const JUMP_SPEED = 18
-    const ACCEL= 4.5
+    const ACCEL = 4.5
 
     var dir = Vector3()
     
@@ -228,7 +228,7 @@ Add the following code to ``Player.gd``:
         hvel = hvel.linear_interpolate(target, accel*delta)
         vel.x = hvel.x
         vel.z = hvel.z
-        vel = move_and_slide(vel,Vector3(0,1,0), true, 0.05, 4, deg2rad(MAX_SLOPE_ANGLE))
+        vel = move_and_slide(vel,Vector3(0,1,0), 0.05, 4, deg2rad(MAX_SLOPE_ANGLE))
         
     func _input(event):
         if event is InputEventMouseMotion and Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:


### PR DESCRIPTION
Fixes the issue with move_and_slide in part one of the FPS tutorial. also fixes a minor spacing issue in the beginning of the code. Closes #1563 @TwistedTwigleg does this look good to you?
