### PR TITLE
Corrected function/variable cases for C# examples

### DIFF
--- a/getting_started/scripting/c_sharp/c_sharp_differences.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_differences.rst
@@ -27,7 +27,7 @@ Math
 
 Math functions like ``abs``, ``acos``, ``asin``, ``atan`` and ``atan2`` are
 located under ``Mathf`` as ``Abs``, ``Acos``, ``Asin``, ``Atan`` and ``Atan2``, instead of in global scope.
-``Pi`` is ``Mathf.Pi``
+``PI`` is ``Mathf.Pi``
 
 Random
 ------

--- a/getting_started/scripting/c_sharp/c_sharp_differences.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_differences.rst
@@ -26,8 +26,8 @@ Math
 ----
 
 Math functions like ``abs``, ``acos``, ``asin``, ``atan`` and ``atan2`` are
-located under ``Mathf`` instead of in global scope.
-``PI`` is ``Mathf.PI``
+located under ``Mathf`` as ``Abs``, ``Acos``, ``Asin``, ``Atan`` and ``Atan2``, instead of in global scope.
+``Pi`` is ``Mathf.Pi``
 
 Random
 ------

--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -803,13 +803,13 @@ Add the following code:
         AddChild(mobInstance);
 
         // Set the mob's direction perpendicular to the path direction.
-        var direction = mobSpawnLocation.Rotation + Mathf.PI / 2;
+        var direction = mobSpawnLocation.Rotation + Mathf.Pi / 2;
 
         // Set the mob's position to a random location.
         mobInstance.Position = mobSpawnLocation.Position;
 
         // Add some randomness to the direction.
-        direction += RandRand(-Mathf.PI / 4, Mathf.PI / 4);
+        direction += RandRand(-Mathf.Pi / 4, Mathf.Pi / 4);
         mobInstance.Rotation = direction;
 
         // Choose the velocity.

--- a/tutorials/math/matrices_and_transforms.rst
+++ b/tutorials/math/matrices_and_transforms.rst
@@ -233,7 +233,7 @@ Rotating Transform2D is done by using the "rotated" function:
  .. code-tab:: csharp
 
     var m = Transform2D.Identity;
-    m = m.Rotated(Mathf.PI / 2); // rotate 90°
+    m = m.Rotated(Mathf.Pi / 2); // rotate 90°
 
 .. image:: img/tutomat12.png
 
@@ -255,7 +255,7 @@ the origin:
 
     // Move 2 units to the right
     var m = Transform2D.Identity;
-    m = m.Rotated(Mathf.PI / 2); // rotate 90°
+    m = m.Rotated(Mathf.Pi / 2); // rotate 90°
     m[2] += new Vector2(2, 0);
 
 .. image:: img/tutomat13.png
@@ -279,7 +279,7 @@ method:
 
     // Move 2 units towards where the basis is oriented
     var m = Transform2D.Identity;
-    m = m.Rotated(Mathf.PI / 2); // rotate 90°
+    m = m.Rotated(Mathf.Pi / 2); // rotate 90°
     m = m.Translated(new Vector2(2, 0));
 
 .. image:: img/tutomat14.png
@@ -699,7 +699,7 @@ that can point to any direction, but length must be one (1.0).
 
     // rotate in Y axis
     var m3 = Basis.Identity;
-    m3 = m3.Rotated(new Vector3(0, 1, 0), Mathf.PI / 2);
+    m3 = m3.Rotated(new Vector3(0, 1, 0), Mathf.Pi / 2);
 
 Transform
 ---------


### PR DESCRIPTION
This commit corrects a few charecter cases in relation to
[godot/modules/mono/glue/cs_files/Mathf.cs](https://github.com/godotengine/godot/blob/master/modules/mono/glue/cs_files/Mathf.cs). The documentation currently states
Pi is defined as `Mathf.PI`, while it's actually `Mathf.Pi`.

The same mistake was found and fixed for some misc. arithmetical functions.