### PR TITLE
More fixes for typos in vertex displacement tutorial

### DIFF
--- a/tutorials/3d/vertex_displacement_with_shaders.rst
+++ b/tutorials/3d/vertex_displacement_with_shaders.rst
@@ -194,11 +194,11 @@ we increase the frequency each level, decrease the amplitude, and calculate a ne
     float amplitude = 0.5;
     float frequency = 3.0;
     for (int i = 0; i < 6; i++){
-      h += noise(x * frequency) * amplitude;
+      height += noise(x * frequency) * amplitude;
       amplitude *= 0.5;
       frequency *= 2.0;
     }
-    return h;
+    return height;
   }
 
 We can now use this noise function in place of ``cos`` and ``sin`` in the previous section. 


### PR DESCRIPTION
Fixes issue #1627. Issue was misnamed variable in the fbm function. Funny enough I just updated the code for this same function in #1614 and somehow failed to see this typo. Should be good now.