### PR TITLE
Improve introduction of 2D transforms

### DIFF
--- a/tutorials/2d/2d_transforms.rst
+++ b/tutorials/2d/2d_transforms.rst
@@ -6,10 +6,9 @@ Viewport and canvas transforms
 Introduction
 ------------
 
-This tutorial is created after a topic that is a little dark for most
-users and explains all the 2D transforms going on for nodes from the
-moment they draw their content locally to the time they are drawn into
-the screen.
+This is an overview of the 2D transforms going on for nodes from the
+moment they draw their content locally to the time they are drawn onto
+the screen. This overview discusses very low level details of the engine.
 
 Canvas transform
 ----------------


### PR DESCRIPTION
Removed the odd wording intended to imply that the document is discussing very low level details.