### PR TITLE
Add mac-specific and vscode-specific considerations

### DIFF
--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -24,14 +24,24 @@ A good starting point for checking its capabilities is the `Compatibility <http:
 Setup C# for Godot
 ------------------
 
-To use C# in Godot you must have `Mono <http://www.mono-project.com/download/>`_ installed. Godot 3.0.2 requires Mono 5.4, 3.0.3 requires Mono 5.12 on all platforms.
+Download and install the `Mono <http://www.mono-project.com/download/>`_ SDK. 
+
+If you are using Godot 3.0.2, you must use Mono 5.4.
+
+Godot 3.0.3+ requires Mono 5.12 on all platforms.
+
+.. note:: To download Mono v5.12+ on a Mac, locate the "Stable Channel" link from the `Mono Downloads Page <http://www.mono-project.com/download/>`_. The Visual Studio channel is an earlier version of Mono and will not work with Godot 3.0.3+. 
+
 You also need MSBuild (at least version 15.0) which should come with the Mono installation.
 
-.. note:: For instructions on installing older versions of Mono on Linux see `this page <http://www.mono-project.com/docs/getting-started/install/linux/#accessing-older-releases>`_.
+.. note:: For instructions on installing older versions of Mono on Linux, see `this page <http://www.mono-project.com/docs/getting-started/install/linux/#accessing-older-releases>`_.
         Older versions of Mono for MacOS and Windows can be found `here <https://download.mono-project.com/archive/>`_.
 
-Additionally, your Godot version must have Mono support enabled, so take care to download the **Mono version** of Godot.
-If you are building Godot from source, make sure to follow the steps to include Mono support in your build outlined on the  :ref:`doc_compiling_with_mono` page.
+Additionally, your Godot version must have Mono support enabled, so ensure you download the **Mono version** of Godot.
+
+If you are building Godot from source, make sure to follow the steps to include Mono support in your build outlined on the :ref:`doc_compiling_with_mono` page.
+
+In summary, you must have installed 1) the correct Mono SDK version for your Godot version, and 2) The Mono version of Godot.
 
 Configuring an external editor
 ------------------------------
@@ -43,6 +53,8 @@ debugging and other features useful when working with C#.
 To set it up, in Godot click on ``Editor``, then ``Editor Settings``. Scroll
 down to the bottom, to the ``Mono`` settings. Under Mono click on ``Editor``,
 and on that page choose your external editor of choice.
+
+.. note:: If you are using Visual Studio Code, ensure you download and install the .NET tools extension. Without this, Godot will crash when trying to create a new C# project or edit a C# script. 
 
 Creating a C# script
 --------------------


### PR DESCRIPTION
Setting up Godot for development on a Mac was very frustrating for a few people and me. We spent way too long trying to figure out why it wasn't working, only to realize that the latest mono stable release is a gray button instead of the bright blue button on the Mono download page. Additionally trying to use `brew` or anything else to install Mono will not get you the version you need. 

I updated to docs to just point out the version discrepancies that I ran into inadvertently. This should help future Mac users not pull their hair out trying to get started with Godot and C#.