### PR TITLE
Update canvas_item's light built-in POSITION to FRAGCOORD

### DIFF
--- a/tutorials/shading/shading_language.rst
+++ b/tutorials/shading/shading_language.rst
@@ -1041,7 +1041,7 @@ Light Built-Ins
 +-------------------------------------+-------------------------------------------------------------------------------+
 | Built-In                            | Description                                                                   |
 +=====================================+===============================================================================+
-| in vec2 **POSITION**                | Fragment coordinate, pixel adjusted.                                          |
+| in vec2 **FRAGCOORD**               | Fragment coordinate, pixel adjusted.                                          |
 +-------------------------------------+-------------------------------------------------------------------------------+
 | in vec3 **NORMAL**                  | Input Normal. Although this value is passed in,                               |
 |                                     | **normal calculation still happens outside of this function**.                |


### PR DESCRIPTION
The built-in `in vec2 POSITION` has been renamed FRAGCOORD but this was missed in the light shader's documentation.