### PR TITLE
Updated title underline in thread safe tutorial

### DIFF
--- a/tutorials/threads/thread_safe_apis.rst
+++ b/tutorials/threads/thread_safe_apis.rst
@@ -1,7 +1,7 @@
 .. _doc_thread_safe_apis:
 
 Thread Safe APIs
-=============
+================
 
 Threads
 -------


### PR DESCRIPTION
While building docs I consistently got a warning about the title in the thread safe tutorial. So I fixed it.