### PR TITLE
Add clarifying paragraph on encryption page

### DIFF
--- a/tutorials/io/encrypting_save_games.rst
+++ b/tutorials/io/encrypting_save_games.rst
@@ -29,6 +29,13 @@ their own irrelevance would again take over their life.
 No, we definitely do not want this to happen, so let's see how to
 encrypt savegames and protect the world order.
 
+(NOTE: This method can not really prevent players from editing their savegames
+locally, because since the encryption key is stored inside the game, the player
+can still decrypt and edit the file themselves. The only way to prevent this
+from being possible is to store the save data on a remote server where players
+can only make authorized changes to their save data. If your game deals with
+real money, you need to be doing this anyway.)
+
 How?
 ----
 

--- a/tutorials/io/encrypting_save_games.rst
+++ b/tutorials/io/encrypting_save_games.rst
@@ -29,13 +29,6 @@ their own irrelevance would again take over their life.
 No, we definitely do not want this to happen, so let's see how to
 encrypt savegames and protect the world order.
 
-(NOTE: This method can not really prevent players from editing their savegames
-locally, because since the encryption key is stored inside the game, the player
-can still decrypt and edit the file themselves. The only way to prevent this
-from being possible is to store the save data on a remote server where players
-can only make authorized changes to their save data. If your game deals with
-real money, you need to be doing this anyway.)
-
 How?
 ----
 
@@ -81,3 +74,10 @@ some unique user identifier, for example:
 Note that ``OS.get_unique_id()`` only works on iOS and Android.
 
 This is all! Thanks for your cooperation, citizen.
+
+.. note:: This method cannot really prevent players from editing their savegames
+          locally, because since the encryption key is stored inside the game, the player
+          can still decrypt and edit the file themselves. The only way to prevent this
+          from being possible is to store the save data on a remote server where players
+          can only make authorized changes to their save data. If your game deals with
+          real money, you need to be doing this anyway.


### PR DESCRIPTION
I wouldn't want to mislead people into thinking that encrypting and decrypting a save file locally on the player's computer can prevent editing and sharing of save files. It can't. The only way to prevent unauthorized editing and sharing of save data is to keep the save data on a remote server, and then running the game logic on that server instead of locally on the player's computer.