### PR TITLE
Remove some dead links

### DIFF
--- a/getting_started/step_by_step/ui_introduction_to_the_ui_system.rst
+++ b/getting_started/step_by_step/ui_introduction_to_the_ui_system.rst
@@ -24,9 +24,6 @@ This guide will get you started with UI design. You will learn:
    containers
 -  The five most common containers
 
-To learn how to control the interface and connect it to other scripts,
-read `Build your first game UI in Godot <#>`__.
-
 Only use Control nodes when you design your interfaces. They have unique
 properties that allow them to work with one another. Other nodes like
 Node2D, Sprite, etc. will not work. You can still use some nodes that

--- a/getting_started/step_by_step/ui_introduction_to_the_ui_system.rst
+++ b/getting_started/step_by_step/ui_introduction_to_the_ui_system.rst
@@ -342,6 +342,4 @@ between the rows and columns respectively.
 
    A GridContainer with 2 columns. It sizes each column automatically.
 
-Godot's UI system is complex, and has a lot more to offer. To learn how
-to design more advanced interface, read `Design advanced UI with other
-Control nodes <img/#>`__.
+Godot's UI system is complex, and has a lot more to offer. Keep reading to learn more!

--- a/getting_started/step_by_step/ui_introduction_to_the_ui_system.rst
+++ b/getting_started/step_by_step/ui_introduction_to_the_ui_system.rst
@@ -48,10 +48,7 @@ The 5 most common UI elements
 -----------------------------
 
 Godot ships with dozens of Control nodes. A lot of them are here to help
-you build editor plugins and applications. To learn more about them,
-check the guide about `Advanced UI nodes and Themes <img/#>`__.
-
-For most games, you'll only need five types of UI elements, and a few
+you build editor plugins and applications. For most games, you'll only need five types of UI elements, and a few
 Containers. These five Control nodes are:
 
 1. Label: for displaying text


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->

Happened upon some dead links while browsing the docs, opted to remove them due to ...
- was not able to locate the page/section of the docs where they should (used to?) have been referring to. It may have been something which has since been refactored/removed.
- and feel that the step-by-step section of the docs should ...
  - limit the amount of links to a minimum so to not confuse the reader (ie. to avoid questions such as "do I need to read that part before I continue with this part?", "is that part just optional extra reading if in case I want to get more deep knowledge?" or "if I don't read that part now, will it be linked again at a later point in the document?"
  - and not link at all in cases where the target is also part of the step-by-step guide (since the intent is to have the reader eventually reach that anyway, step by step. Or if the linked information is relevant to the page on hand, it should be included in this page or relocated to a page prior to this page)