### PR TITLE
Update "Exporting for PC" to remove outdated information

### DIFF
--- a/getting_started/workflow/export/exporting_for_pc.rst
+++ b/getting_started/workflow/export/exporting_for_pc.rst
@@ -4,14 +4,11 @@ Exporting for PC
 ================
 
 The simplest way to distribute a game for PC is to copy the executables
-(godot.exe on windows, godot on the rest), zip the folder and send it to
-someone else. However, this is often not desired.
+(godot.exe on Windows, godot on the rest), compress the folder and send it
+to someone else. However, this is often not desired.
 
 Godot offers a more elegant approach for PC distribution when using the
-export system. When exporting for PC (Linux, Windows, Mac), the exporter
-takes all the project files and creates a "data.pck" file. This file is
+export system. When exporting for PC (Linux, Windows, macOS), the exporter
+takes all the project files and creates a ``data.pck`` file. This file is
 bundled with a specially optimized binary that is smaller, faster and
-lacks tools and debugger.
-
-Optionally, the files can be bundled inside the executable, though this
-does not always works properly.
+does not contain the editor and debugger.


### PR DESCRIPTION
As of Godot 3.0, it is no longer possible to bundle project data inside the executable.

This page should be completed with more information eventually (such as linking to resources for creating Windows installers), but this should do for now.