### PR TITLE
Remove text for add_icon_item that describes a required argument as optional

### DIFF
--- a/classes/class_optionbutton.rst
+++ b/classes/class_optionbutton.rst
@@ -91,7 +91,7 @@ Member Function Description
 
 - void **add_icon_item** **(** :ref:`Texture<class_texture>` texture, :ref:`String<class_string>` label, :ref:`int<class_int>` id **)**
 
-Add an item, with a "texture" icon, text "label" and (optionally) id. If no "id" is passed, "id" becomes the item index. New items are appended at the end.
+Add an item, with a "texture" icon, text "label" and id. New items are appended at the end.
 
 .. _class_OptionButton_add_item:
 


### PR DESCRIPTION
With 3.0.1 this argument is required, and calling `add_icon_item` with only a `texture` and `label` raises:
```
Invalid call to function 'add_icon_item' in base 'OptionButton': Expected 3 arguments.
```

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
