### PR TITLE
Renamed simple.gdns occurrences to Simple.gdns

### DIFF
--- a/tutorials/plugins/gdnative/gdnative-c-example.rst
+++ b/tutorials/plugins/gdnative/gdnative-c-example.rst
@@ -61,7 +61,7 @@ Let's start by writing our main code. Ideally, we want to end up with a file str
       + bin
         - libsimple.dll/so/dylib
         - libsimple.gdnlib
-        - simple.gdns
+        - Simple.gdns
       + src
         - .gdignore
         - simple.c
@@ -329,7 +329,7 @@ Now we can implement our main.gd code:
     extends Control
 
     # load the SIMPLE library
-    onready var data = preload("res://bin/simple.gdns").new()
+    onready var data = preload("res://bin/Simple.gdns").new()
 
     func _on_Button_pressed():
         $Label.text = "Data = " + data.get_data()


### PR DESCRIPTION
The tutorial was using both uppercase and lowercase names interchangeably that led me to errors.
In this PR, I went for the uppercase name `Simple.gdns` to match the 4th gif of the tutorial.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
