### PR TITLE
Mention the 32x32 image requirement in the custom mouse cursor tutorial

### DIFF
--- a/tutorials/inputs/custom_mouse_cursor.rst
+++ b/tutorials/inputs/custom_mouse_cursor.rst
@@ -20,7 +20,7 @@ Open project settings, go to Display>Mouse Cursor. You will see Custom Image and
 Custom Image is the desired image that you would like to set as the mouse cursor.
 Custom Hotspot is the point in the image that you would like to use as the cursor's detection point.
 
-.. note:: The custom image **must** be less than 256x256.
+.. note:: The custom image **must** be a 32x32. Any other size will not work.
 
 Using a script
 --------------


### PR DESCRIPTION
This restriction has been increased (to 256x256) in master, but 3.0 still requires 32x32.

Related to godotengine/godot#17018

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
