### PR TITLE
Update custom_godot_servers.rst

### DIFF
--- a/development/cpp/custom_godot_servers.rst
+++ b/development/cpp/custom_godot_servers.rst
@@ -384,7 +384,7 @@ The dummy class binds singleton methods to GDScript. In most cases, the dummy cl
 
 Binding Signals
 
-It is possible to emit signals to GDScript but calling the GDScript dummy object.
+It is possible to emit signals to GDScript by calling the GDScript dummy object.
 
 .. code:: cpp
 


### PR DESCRIPTION
"but" doesn't seem correct in this context. I wonder how I missed this word.
Before: It is possible to emit signals to GDScript but calling the GDScript dummy object.
After: It is possible to emit signals to GDScript by calling the GDScript dummy object.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
