### PR TITLE
JDK 9 causes gradelw build to fail.

### DIFF
--- a/development/compiling/compiling_for_android.rst
+++ b/development/compiling/compiling_for_android.rst
@@ -28,7 +28,7 @@ For compiling under Windows, Linux or macOS, the following is required:
 -  Android build tools version 19.1
 -  Android NDK r13 or later
 -  Gradle (will be downloaded and installed automatically if missing)
--  JDK 6 or later (either OpenJDK or Oracle JDK) - JDK 9 is untested as of now
+-  JDK 6 or later (either OpenJDK or Oracle JDK) - JDK 9 does not work with Gradle at this time.
 
 Setting up the buildsystem
 --------------------------


### PR DESCRIPTION
Fixing documentation.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
