### PR TITLE
Fix incorrectly formatted note in "GDNative C++ example" page

### DIFF
--- a/tutorials/networking/high_level_multiplayer.rst
+++ b/tutorials/networking/high_level_multiplayer.rst
@@ -379,7 +379,7 @@ To clarify, here is an example of how this looks in the
 
 
 Master and puppet keywords
-^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. FIXME: Clarify the equivalents to the GDScript keywords in C# and Visual Script.
 

--- a/tutorials/plugins/gdnative/gdnative-cpp-example.rst
+++ b/tutorials/plugins/gdnative/gdnative-cpp-example.rst
@@ -290,9 +290,11 @@ and ``demo``, then run:
 
 You should now be able to find the module in ``demo/bin/<platform>``.
 
-.. note:: Here, we've compiled both godot-cpp and our gdexample library
-as debug builds. For optimized builds, you should compile them using
-the ``target=release`` switch.
+.. note::
+
+    Here, we've compiled both godot-cpp and our gdexample library
+    as debug builds. For optimized builds, you should compile them using
+    the ``target=release`` switch.
 
 Using the GDNative module
 -------------------------


### PR DESCRIPTION
Also fixed an incorrect underline, seems that the slaves forgot to add a "^" while leaving.