### PR TITLE
Fixed wrong result in class_float.rst

### DIFF
--- a/classes/class_float.rst
+++ b/classes/class_float.rst
@@ -49,5 +49,5 @@ Cast an :ref:`int<class_int>` value to a floating point value, ``float(1)`` will
 
 - :ref:`float<class_float>` **float** **(** :ref:`String<class_String>` from **)**
 
-Cast a :ref:`String<class_String>` value to a floating point value. This method accepts float value strings like `` '1.23' `` and exponential notation strings for its parameter so calling `` float('1e3') `` will return 1000.0 and calling `` float('1e-3') `` will return -0.001.
+Cast a :ref:`String<class_String>` value to a floating point value. This method accepts float value strings like `` '1.23' `` and exponential notation strings for its parameter so calling `` float('1e3') `` will return 1000.0 and calling `` float('1e-3') `` will return 0.001.
 


### PR DESCRIPTION
In the float-string parser documentation 1e-3 should return 0.001 and not -0.001.