### PR TITLE
Fix GDScript#signals ref in Unity to Godot page

### DIFF
--- a/getting_started/editor/unity_to_godot.rst
+++ b/getting_started/editor/unity_to_godot.rst
@@ -237,7 +237,7 @@ This is explained in :ref:`this page <doc_scripting_continued>`.
 But there's more! Certain nodes throw signals when certain actions happen.
 You can connect these signals to call a specific function when they happen.
 Note that you can define your own signals and send them whenever you want.
-This feature is documented `here <gdscript.html#signals>`_.
+This feature is documented `here <../scripting/gdscript/gdscript_basics.html#signals>`_.
 
 Using Godot in C++
 ------------------


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->

I was writing some things on the Unity to Godot page and accidentally clicked on this link that coincidentally was broken. :sweat_smile:

Also applicable to 3.0