### PR TITLE
Fix Scons not finding library using Linux

### DIFF
--- a/tutorials/plugins/gdnative/files/cpp_example/SConstruct
+++ b/tutorials/plugins/gdnative/files/cpp_example/SConstruct
@@ -7,6 +7,11 @@ bits = ARGUMENTS.get("bits", 64)
 
 final_lib_path = 'demo/bin/'
 
+# Linux has "debug" in library names, if they are compiled in debug mode
+# An example name for a debug library is: libgodot-cpp.linux.debug.64.a
+# In release mode, the library is named libgodot-cpp.linux.64.a
+linux_debug_suffix = ''
+
 # This makes sure to keep the session environment variables on windows, 
 # that way you can run scons in a vs 2017 prompt and it will find all the required tools
 env = Environment()
@@ -26,8 +31,9 @@ if platform == "osx":
 
 elif platform == "linux":
     env.Append(CCFLAGS = ['-fPIC', '-g','-O3', '-std=c++14'])
-
     final_lib_path = final_lib_path + 'x11/'
+    if target == 'debug':
+        linux_debug_suffix = '.debug'
 
 elif platform == "windows":
     if target == "debug":
@@ -39,7 +45,7 @@ elif platform == "windows":
 
 env.Append(CPPPATH=['.', 'src/', "godot-cpp/godot_headers/", 'godot-cpp/include/', 'godot-cpp/include/core/', 'godot-cpp/include/gen/'])
 env.Append(LIBPATH="godot-cpp/bin")
-env.Append(LIBS=["godot-cpp" + "." + platform + "." + str(bits)])
+env.Append(LIBS=["godot-cpp" + "." + platform + linux_debug_suffix + "." + str(bits)])
 
 sources = []
 add_sources(sources, "src")

--- a/tutorials/plugins/gdnative/gdnative-cpp-example.rst
+++ b/tutorials/plugins/gdnative/gdnative-cpp-example.rst
@@ -286,7 +286,7 @@ and ``demo``, then run:
 
 .. code-block:: none
 
-    scons platform=<platform>
+    scons platform=<platform> target=debug
 
 You should now be able to find the module in ``demo/bin/<platform>``.
 

--- a/tutorials/plugins/gdnative/gdnative-cpp-example.rst
+++ b/tutorials/plugins/gdnative/gdnative-cpp-example.rst
@@ -286,7 +286,7 @@ and ``demo``, then run:
 
 .. code-block:: none
 
-    scons platform=<platform> target=debug
+    scons platform=<platform>
 
 You should now be able to find the module in ``demo/bin/<platform>``.
 


### PR DESCRIPTION
Because libraries built with Linux contain ".debug" in their filename
Scons would not find the library to compile the Cpp GDNative example ([source](https://old.reddit.com/r/godot/comments/9l5h7k/hitting_erros_while_doing_the_cpp_native_tutorial/)).

Fixes this error and updates the tutorial accordingly.
".debug" in the library name is omitted when compiling in release mode.