### PR TITLE
Added -j flag hint in compiling_for_x11.rst

### DIFF
--- a/development/compiling/compiling_for_x11.rst
+++ b/development/compiling/compiling_for_x11.rst
@@ -82,7 +82,11 @@ Start a terminal, go to the root dir of the engine source code and type:
 
 ::
 
-    user@host:~/godot$ scons platform=x11
+    user@host:~/godot$ scons -j8 platform=x11
+
+A good rule of thumb for the ``-j`` (*jobs*) flag, is to have at least as many
+threads compiling Godot as you have cores in your CPU, if not one or two more.
+Feel free to add the ``-j`` option to any SCons command you see below.
 
 If all goes well, the resulting binary executable will be placed in the
 "bin" subdirectory. This executable file contains the whole engine and


### PR DESCRIPTION
Added the `-j8` flag to the first `scons` command for faster compiling times. It tells how many jobs the compiler will use when compiling godot. Right now, it defaults to using just one job, which means that the computer is using just one of its cores, therefore making the compilation 2, 4, 6, 8 or more times slower depending on your cpu count.

I used 8 because it has more advantages to 6 and 8 core cpus than it has disadvantages to 4 or 2 cores (almost none). 6 is the value used in `compiling_for_windows.rst`, but it wastes 2 cores on 8 core cpus which are now more common.

It could also use this line for automatically detecting number of cores.

```bash
    user@host:~/godot$ scons -j $(python3 -c 'import multiprocessing as mp; print(int(mp.cpu_count() * 1.5))') platform=x11
```
As python is already a dependency, but the command seems too bloated.
(*snippet from https://stackoverflow.com/a/50594123/3358251*)