### PR TITLE
Fixed usage of -path flag when debugging

### DIFF
--- a/development/cpp/introduction_to_godot_development.rst
+++ b/development/cpp/introduction_to_godot_development.rst
@@ -37,4 +37,4 @@ Or:
 .. code:: bash
 
     $ gdb godot
-    > run -e -path ~/myproject
+    > run -e -path ~/myproject/project.godot

--- a/development/cpp/introduction_to_godot_development.rst
+++ b/development/cpp/introduction_to_godot_development.rst
@@ -37,4 +37,4 @@ Or:
 .. code:: bash
 
     $ gdb godot
-    > run -e --path ~/myproject/
+    > run -e --path ~/myproject

--- a/development/cpp/introduction_to_godot_development.rst
+++ b/development/cpp/introduction_to_godot_development.rst
@@ -37,4 +37,4 @@ Or:
 .. code:: bash
 
     $ gdb godot
-    > run -e -path ~/myproject/project.godot
+    > run -e --path ~/myproject/


### PR DESCRIPTION
When attempting to debug godot, I ran into an error when trying to use the -path flag to open up my project. It seems that the way you supply your project using the -path flag has changed and you need to also add in 'project.godot' to the end or else you will get an error.
