### PR TITLE
Rename all occurrences of Mac OS X to macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ __pycache__
 .vscode/
 *.mo
 
-# Finder (MacOS) makes these automatically.
+# Finder (macOS) makes these automatically.
 .DS_Store
 
 # And Windows keeps creating these.

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -13,16 +13,16 @@ In short:
 * You are free to download and use Godot for any purpose, personal, non-profit, commercial, or otherwise;
 * You are free to modify, distribute, redistribute, and remix Godot to your heart's content, for any reason, both non-commercially and commercially.
 
-All the contents of this accompanying documentation are published under 
-the permissive Creative Commons Attribution 3.0 (`CC-BY 3.0 <https://creativecommons.org/licenses/by/3.0/>`_) license, with attribution 
+All the contents of this accompanying documentation are published under
+the permissive Creative Commons Attribution 3.0 (`CC-BY 3.0 <https://creativecommons.org/licenses/by/3.0/>`_) license, with attribution
 to "Juan Linietsky, Ariel Manzur and the Godot Engine community."
 
-Logos and icons are generally under the same Creative Commons license. Note 
-that some third-party libraries included with Godot's source code may have 
+Logos and icons are generally under the same Creative Commons license. Note
+that some third-party libraries included with Godot's source code may have
 different licenses.
 
-For full details, look at the `COPYRIGHT.txt <https://github.com/godotengine/godot/blob/master/COPYRIGHT.txt>`_ as well 
-as the `LICENSE.txt <https://github.com/godotengine/godot/blob/master/LICENSE.txt>`_ and `LOGO_LICENSE.txt <https://github.com/godotengine/godot/blob/master/LOGO_LICENSE.md>`_ files 
+For full details, look at the `COPYRIGHT.txt <https://github.com/godotengine/godot/blob/master/COPYRIGHT.txt>`_ as well
+as the `LICENSE.txt <https://github.com/godotengine/godot/blob/master/LICENSE.txt>`_ and `LOGO_LICENSE.txt <https://github.com/godotengine/godot/blob/master/LOGO_LICENSE.md>`_ files
 in the Godot repository.
 
 Also see `the license page on the Godot website <https://godotengine.org/license>`_.
@@ -33,13 +33,13 @@ Which platforms are supported by Godot?
 **For the editor:**
 
 * Windows
-* Mac OS X
+* macOS
 * X11 (Linux, \*BSD)
 
 **For exporting your games:**
 
 * Windows (and UWP)
-* Mac OS X
+* macOS
 * X11 (Linux, \*BSD)
 * Android
 * iOS
@@ -48,74 +48,74 @@ Which platforms are supported by Godot?
 Both 32- and 64-bit binaries are supported where it makes sense, with 64
 being the default.
 
-Some users also report building and using Godot successfully on ARM-based 
+Some users also report building and using Godot successfully on ARM-based
 systems with Linux, like the Raspberry Pi.
 
-Additionally, there is some unofficial third-party work being done on building 
-for some consoles. However, none of this is included in the default build 
+Additionally, there is some unofficial third-party work being done on building
+for some consoles. However, none of this is included in the default build
 scripts or export templates at this time.
 
-For more on this, see the sections on :ref:`exporting <toc-learn-workflow-export>` 
+For more on this, see the sections on :ref:`exporting <toc-learn-workflow-export>`
 and :ref:`compiling Godot yourself <toc-devel-compiling>`.
 
 Which programming languages are supported in Godot?
 ---------------------------------------------------
 
-The officially supported languages for Godot are GDScript, Visual Scripting, 
-C#, and C++. See the subcategories for each language in the 
+The officially supported languages for Godot are GDScript, Visual Scripting,
+C#, and C++. See the subcategories for each language in the
 :ref:`scripting <toc-learn-scripting>` section.
 
-If you are just starting out with either Godot or game development in general, 
-GDScript is the recommended language to learn and use since it is native to Godot. 
-While scripting languages tend to be less performant than lower-level languages in 
-the long run, for prototyping, developing Minimum Viable Products (MVPs), and 
-focusing on Time-To-Market (TTM), GDScript will provide a fast, friendly, and capable 
+If you are just starting out with either Godot or game development in general,
+GDScript is the recommended language to learn and use since it is native to Godot.
+While scripting languages tend to be less performant than lower-level languages in
+the long run, for prototyping, developing Minimum Viable Products (MVPs), and
+focusing on Time-To-Market (TTM), GDScript will provide a fast, friendly, and capable
 way of developing your games.
 
-Note that C# support is still relatively new, and as such, you may encounter some 
-issues along the way. Our friendly and hard-working development community is always 
-ready to tackle new problems as they arise, but since this is an open-source project, 
-we recommend that you first do some due diligence yourself. Searching through 
-discussions on `open issues <https://github.com/godotengine/godot/issues>`_ is a 
-great way to start your troubleshooting. 
+Note that C# support is still relatively new, and as such, you may encounter some
+issues along the way. Our friendly and hard-working development community is always
+ready to tackle new problems as they arise, but since this is an open-source project,
+we recommend that you first do some due diligence yourself. Searching through
+discussions on `open issues <https://github.com/godotengine/godot/issues>`_ is a
+great way to start your troubleshooting.
 
-As for new languages, support is possible via third parties using the GDNative / 
-NativeScript / PluginScript facilities. (See question about plugins below.) 
+As for new languages, support is possible via third parties using the GDNative /
+NativeScript / PluginScript facilities. (See question about plugins below.)
 Work is currently underway, for example, on unofficial bindings for Godot
 to `Python <https://github.com/touilleMan/godot-python>`_ and `Nim <https://github.com/pragmagic/godot-nim>`_.
 
 What is GDScript and why should I use it?
 -----------------------------------------
 
-GDScript is Godot's integrated scripting language. It was built from the ground 
-up to maximize Godot's potential in the least amount of code, affording both novice 
-and expert developers alike to capitalize on Godot's strengths as fast as possible. 
-If you've ever written anything in a language like Python before then you'll feel 
-right at home. For examples, history, and a complete overview of the power GDScript 
+GDScript is Godot's integrated scripting language. It was built from the ground
+up to maximize Godot's potential in the least amount of code, affording both novice
+and expert developers alike to capitalize on Godot's strengths as fast as possible.
+If you've ever written anything in a language like Python before then you'll feel
+right at home. For examples, history, and a complete overview of the power GDScript
 offers you, check out the `GDScript scripting guide <gdscript_basics>`_.
 
-There are several reasons to use GDScript--especially when you are prototyping, in 
-alpha/beta stages of your project, or are not creating the next AAA title--but the 
-most salient reason is the overall **reduction of complexity.** 
+There are several reasons to use GDScript--especially when you are prototyping, in
+alpha/beta stages of your project, or are not creating the next AAA title--but the
+most salient reason is the overall **reduction of complexity.**
 
-The original intent of creating a tightly integrated, custom scripting language for 
-Godot was two-fold: first, it reduces the amount of time necessary to get up and running 
-with Godot, giving developers a rapid way of exposing themselves to the engine with a 
-focus on productivity; second, it reduces the overall burden of maintenance, attenuates 
-the dimensionality of issues, and allows the developers of the engine to focus on squashing 
-bugs and improving features related to the engine core--rather than spending a lot of time 
-trying to get a small set of incremental features working across a large set of languages. 
+The original intent of creating a tightly integrated, custom scripting language for
+Godot was two-fold: first, it reduces the amount of time necessary to get up and running
+with Godot, giving developers a rapid way of exposing themselves to the engine with a
+focus on productivity; second, it reduces the overall burden of maintenance, attenuates
+the dimensionality of issues, and allows the developers of the engine to focus on squashing
+bugs and improving features related to the engine core--rather than spending a lot of time
+trying to get a small set of incremental features working across a large set of languages.
 
-Since Godot is an open-source project, it was imperative from the start to prioritize a 
+Since Godot is an open-source project, it was imperative from the start to prioritize a
 more integrated and seamless experience over attracting additional users by supporting
-more familiar programming languages--especially when supporting those more familiar 
-languages would result in a worse experience. We understand if you would rather use 
-another language in Godot (see list of supported options above). That being said, if 
-you haven't given GDScript a try, try it for **three days**. Just like Godot, 
-once you see how powerful it is and rapid your development becomes, we think GDScript 
-will grow on you. 
+more familiar programming languages--especially when supporting those more familiar
+languages would result in a worse experience. We understand if you would rather use
+another language in Godot (see list of supported options above). That being said, if
+you haven't given GDScript a try, try it for **three days**. Just like Godot,
+once you see how powerful it is and rapid your development becomes, we think GDScript
+will grow on you.
 
-More information about getting comfortable with GDScript or dynamically typed 
+More information about getting comfortable with GDScript or dynamically typed
 languages can be found in the :ref:`doc_gdscript_more_efficiently` tutorial.
 
 What were the motivations behind creating GDScript?
@@ -139,7 +139,7 @@ The main reasons for creating a custom scripting language for Godot were:
    completion, live editing, etc. (all of them). This is well
    supported by GDScript.
 
-GDScript was designed to curtail the issues above and more. 
+GDScript was designed to curtail the issues above and more.
 
 What type of 3D model formats does Godot support?
 -------------------------------------------------
@@ -152,41 +152,41 @@ As of Godot 3.0, glTF is supported.
 
 FBX SDK has a `restrictive license <https://www.blender.org/bf/Autodesk_FBX_License.rtf>`_,
 that is incompatible with the `open license <https://opensource.org/licenses/MIT>`_
-provided by Godot. That being said, FBX support could still be provided by third parties 
+provided by Godot. That being said, FBX support could still be provided by third parties
 as a plugin. (See Plugins question above.)
 
 Will [Insert closed SDK such as PhysX, GameWorks, etc.] be supported in Godot?
 ------------------------------------------------------------------------------
 
-The aim of Godot is to create a free and open-source MIT-licensed engine that 
-is modular and extendable. There are no plans for the core engine development 
-community to support any third-party, closed-source/proprietary SDKs, as integrating 
-with these would go against Godot's ethos. 
+The aim of Godot is to create a free and open-source MIT-licensed engine that
+is modular and extendable. There are no plans for the core engine development
+community to support any third-party, closed-source/proprietary SDKs, as integrating
+with these would go against Godot's ethos.
 
-That said, because Godot is open-source and modular, nothing prevents you or 
-anyone else interested in adding those libraries as a module and shipping your 
+That said, because Godot is open-source and modular, nothing prevents you or
+anyone else interested in adding those libraries as a module and shipping your
 game with them--as either open- or closed-source.
 
-To see how support for your SDK of choice could still be provided, look at the 
+To see how support for your SDK of choice could still be provided, look at the
 Plugins question above.
 
-If you know of a third-party SDK that is not supported by Godot but that offers 
+If you know of a third-party SDK that is not supported by Godot but that offers
 free and open-source integration, consider starting the integration work yourself.
-Godot is not owned by one person; it belongs to the community, and it grows along 
-with ambitious community contributors like you. 
+Godot is not owned by one person; it belongs to the community, and it grows along
+with ambitious community contributors like you.
 
 How should assets be created to handle multiple resolutions and aspect ratios?
 ------------------------------------------------------------------------------
 
-This question pops up often and it's probably thanks to the misunderstanding 
+This question pops up often and it's probably thanks to the misunderstanding
 created by Apple when they originally doubled the resolution of their devices.
-It made people think that having the same assets in different resolutions was a 
-good idea, so many continued towards that path. That originally worked to a 
-point and only for Apple devices, but then several Android and Apple devices 
-with different resolutions and aspect ratios were created, with a very wide 
+It made people think that having the same assets in different resolutions was a
+good idea, so many continued towards that path. That originally worked to a
+point and only for Apple devices, but then several Android and Apple devices
+with different resolutions and aspect ratios were created, with a very wide
 range of sizes and DPIs.
 
-The most common and proper way to achieve this is to, instead, use a single 
+The most common and proper way to achieve this is to, instead, use a single
 base resolution for the game and only handle different screen aspect ratios.
 This is mostly needed for 2D, as in 3D it's just a matter of Camera XFov or YFov.
 
@@ -218,11 +218,11 @@ devices with tiny screens (fewer than 300 pixels in width), you can use
 the export option to shrink images, and set that build to be used for
 certain screen sizes in the App Store or Google Play.
 
-How can I extend Godot? 
+How can I extend Godot?
 -----------------------
 
-For extending Godot, like creating Godot Editor plugins or adding support 
-for additional languages, take a look at :ref:`EditorPlugins <doc_making_plugins>` 
+For extending Godot, like creating Godot Editor plugins or adding support
+for additional languages, take a look at :ref:`EditorPlugins <doc_making_plugins>`
 and tool scripts.
 
 Also see the official blog posts on these topics:
@@ -230,34 +230,34 @@ Also see the official blog posts on these topics:
 * `A look at the GDNative architecture <https://godotengine.org/article/look-gdnative-architecture>`_
 * `GDNative is here! <https://godotengine.org/article/dlscript-here>`_
 
-You can also take a look at the GDScript implementation, the Godot modules, 
+You can also take a look at the GDScript implementation, the Godot modules,
 as well as the `unofficial Python support <https://github.com/touilleMan/godot-python>`_ for Godot.
-This would be a good starting point to see how another third-party library 
-integrates with Godot. 
+This would be a good starting point to see how another third-party library
+integrates with Godot.
 
 I would like to contribute! How can I get started?
 --------------------------------------------------
 
-Awesome! As an open-source project, Godot thrives off of the innovation and 
-ambition of developers like you. 
+Awesome! As an open-source project, Godot thrives off of the innovation and
+ambition of developers like you.
 
 The first place to get started is in the `issues <https://github.com/godotengine/godot/issues>`_.
-Find an issue that resonates with you, then proceed to the `How to Contribute <https://github.com/godotengine/godot/blob/master/CONTRIBUTING.md#contributing-pull-requests>`_ 
+Find an issue that resonates with you, then proceed to the `How to Contribute <https://github.com/godotengine/godot/blob/master/CONTRIBUTING.md#contributing-pull-requests>`_
 guide to learn how to fork, modify, and submit a Pull Request (PR) with your changes.
 
 I have a great idea for Godot. How can I share it?
 --------------------------------------------------
 
-It might be tempting to want to bring ideas to Godot, like ones that 
+It might be tempting to want to bring ideas to Godot, like ones that
 result in massive core changes, some sort of mimicry of what another
-game engine does, or alternative workflows that you'd like built into 
-the editor. These are great and we are thankful to have such motivated 
-people want to contribute, but Godot's focus is and always will be the 
-core functionality as outlined in the `Roadmap <https://github.com/godotengine/godot-roadmap/blob/master/ROADMAP.md>`_, 
-`squashing bugs and addressing issues <https://github.com/godotengine/godot/issues>`_, 
-and conversations between Godot community members. 
+game engine does, or alternative workflows that you'd like built into
+the editor. These are great and we are thankful to have such motivated
+people want to contribute, but Godot's focus is and always will be the
+core functionality as outlined in the `Roadmap <https://github.com/godotengine/godot-roadmap/blob/master/ROADMAP.md>`_,
+`squashing bugs and addressing issues <https://github.com/godotengine/godot/issues>`_,
+and conversations between Godot community members.
 
-Most developers in the Godot community will be more interested to learn 
+Most developers in the Godot community will be more interested to learn
 about things like:
 
 -  Your experience using the software and the problems you have (we
@@ -268,17 +268,17 @@ about things like:
 -  The parts of your workflow you would like to see optimized.
 -  Parts where you missed clear tutorials or where the documentation wasn't clear.
 
-Please don't feel like your ideas for Godot are unwelcome. Instead, 
-try to reformulate them as a problem first, so developers and the community 
+Please don't feel like your ideas for Godot are unwelcome. Instead,
+try to reformulate them as a problem first, so developers and the community
 have a functional foundation to ground your ideas on.
 
-A good way to approach sharing your ideas and problems with the community 
-is as a set of user stories. Explain what you are trying to do, what behavior 
-you expect to happen, and then what behavior actually happened. Framing problems 
-and ideas this way will help the whole community stay focused on improving 
-developer experiences as a whole. 
+A good way to approach sharing your ideas and problems with the community
+is as a set of user stories. Explain what you are trying to do, what behavior
+you expect to happen, and then what behavior actually happened. Framing problems
+and ideas this way will help the whole community stay focused on improving
+developer experiences as a whole.
 
-Bonus points for bringing screenshots, concrete numbers, test cases, or example 
+Bonus points for bringing screenshots, concrete numbers, test cases, or example
 projects (if applicable).
 
 How can I support Godot development or contribute?

--- a/community/contributing/bug_triage_guidelines.rst
+++ b/community/contributing/bug_triage_guidelines.rst
@@ -63,9 +63,9 @@ The following labels are currently defined in the Godot repository:
    it a great fit for junior contributors who need to become familiar with
    the code base.
 -  *Needs rebase*: the issue need a git rebase to be merged.
--  *Needs testing*: the issue/pull request could not be completely tested 
+-  *Needs testing*: the issue/pull request could not be completely tested
    and thus need further testing. This can mean that it needs to be tested
-   on different hardware/software configurations or even that the steps to 
+   on different hardware/software configurations or even that the steps to
    reproduce are not certain.
 -  *PR welcome / hero wanted!*: Contributions for issues with these labels are especially welcome.
    Note that this **doesn't** mean you can't work on issues without
@@ -95,7 +95,7 @@ feature request, or one that is not precise enough to be worked on.
 -  *Mono*: relates to the C# / Mono bindings.
 -  *Network*: relates to networking.
 -  *Physics*: relates to the physics engine (2D/3D).
--  *Plugin*: relates to problems encountered while writing plugins. 
+-  *Plugin*: relates to problems encountered while writing plugins.
 -  *Porting*: relates to some specific platforms.
 -  *Rendering*: relates to the 2D and 3D rendering engines.
 -  *VisualScript*: relates to issues with the visual scripting language.
@@ -107,9 +107,9 @@ can focus on the issues labelled with their team's topic.
 
 **Platforms:**
 
-*Android*, *HTML5*, *iOS*, *Linux*, *OS X*, *Windows*, *UWP*
+*Android*, *HTML5*, *iOS*, *Linux*, *macOS*, *Windows*, *UWP*
 
-By default, it is assumed that a given issue applies to all platforms. 
+By default, it is assumed that a given issue applies to all platforms.
 If one of the platform labels is used, it is then exclusive and the
 previous assumption doesn't stand anymore (so if it's a bug on e.g.
 Android and Linux exclusively, select those two platforms).

--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -1,7 +1,7 @@
 .. _doc_compiling_for_osx:
 
-Compiling for OSX
-=================
+Compiling for macOS
+===================
 
 .. highlight:: shell
 
@@ -30,7 +30,7 @@ runs without any dependencies. Executing it will bring up the project
 manager.
 
 To create an .app like in the official builds, you need to use the template
-located in ``misc/dist/osx_tools.app``. Typically, for a ".64" optimised binary 
+located in ``misc/dist/osx_tools.app``. Typically, for a ".64" optimised binary
 built with `scons p=osx target=release_debug`:
 
 ::
@@ -39,26 +39,26 @@ built with `scons p=osx target=release_debug`:
     user@host:~/godot$ mkdir -p Godot.app/Contents/MacOS
     user@host:~/godot$ cp bin/godot.osx.tools.64 Godot.app/Contents/MacOS/Godot
     user@host:~/godot$ chmod +x Godot.app/Contents/MacOS/Godot
-    
+
 Compiling for 32 and 64-bit
 ---------------------------
 
 All macOS versions after 10.6 are 64-bit exclusive, so the executable
-will be a ".64" file by default for most users. If you would like to 
-compile a ".fat" executable which contains both 32 and 64-bit code, 
+will be a ".64" file by default for most users. If you would like to
+compile a ".fat" executable which contains both 32 and 64-bit code,
 you can do so by specifying the bits in the scons command like so:
 
 ::
 
     user@host:~/godot$ scons platform=osx bits=fat
-    
+
 Cross-compiling
 ---------------
 
-It is possible to compile for OSX in a Linux environment (and maybe
+It is possible to compile for macOS in a Linux environment (and maybe
 also in Windows with Cygwin). For that you will need
 `OSXCross <https://github.com/tpoechtrager/osxcross>`__ to be able
-to use OSX as target. First, follow the instructions to install it:
+to use macOS as target. First, follow the instructions to install it:
 
 Clone the `OSXCross repository <https://github.com/tpoechtrager/osxcross>`
 somewhere on your machine (or download a zip file and extract it somewhere),

--- a/development/cpp/configuring_an_ide.rst
+++ b/development/cpp/configuring_an_ide.rst
@@ -77,19 +77,19 @@ Run configuration:
 Updating Sources after pulling latest commits
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-As a developer you usually want to frequently pull the latest commits 
-from the upstream git repository or a specific fork etc. However this 
-brings a little problem with it: as the development continues, source files 
-(and folders) are added or removed. These changes needs to be reflected in 
-your project files for Qt Creator too, so you continue to have a nice 
-experience coding in it. A simple way to check these things, is to right click 
+As a developer you usually want to frequently pull the latest commits
+from the upstream git repository or a specific fork etc. However this
+brings a little problem with it: as the development continues, source files
+(and folders) are added or removed. These changes needs to be reflected in
+your project files for Qt Creator too, so you continue to have a nice
+experience coding in it. A simple way to check these things, is to right click
 at your root folder in the "Projects View" and click on "Edit files..."
 
 .. image:: img/qtcreator-edit-files-menu.png
 
 Now a new dialog should appear that is similar in functionality to the one in the third step
 of the "Importing the project" section. Here now you can check whether you want to add/remove
-specific files and/or folders. You can chose by clicking with your mouse or just simply by 
+specific files and/or folders. You can chose by clicking with your mouse or just simply by
 clicking the "Apply Filter" button. A simple click on "Ok" and you're ready to continue your work.
 
 .. image:: img/qtcreator-edit-files-dialog.png
@@ -130,14 +130,14 @@ Add the following includes/imports:
     core/math/
     tools/
     drivers/
-    platform/x11/  // make that platform/osx/ if you're using OS X
+    platform/x11/  // make that platform/osx/ if you're using macOS
 
 .. image:: img/kdevelop_addincludes.png
 
 Apply the changes then switch to the "Custom Buildsystem" tab.
 Leave the build directory blank. Enable build tools and add ``scons``
 as the executable and add ``platform=x11 target=debug`` (``platform=osx``
-if you're on OS X).
+if you're on macOS).
 
 .. image:: img/kdevelop_buildconfig.png
 

--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -24,18 +24,18 @@ A good starting point for checking its capabilities is the `Compatibility <http:
 Setup C# for Godot
 ------------------
 
-Download and install the `Mono <http://www.mono-project.com/download/>`_ SDK. 
+Download and install the `Mono <http://www.mono-project.com/download/>`_ SDK.
 
 If you are using Godot 3.0.2, you must use Mono 5.4.
 
 Godot 3.0.3+ requires Mono 5.12 on all platforms.
 
-.. note:: To download Mono v5.12+ on a Mac, locate the "Stable Channel" link from the `Mono Downloads Page <http://www.mono-project.com/download/>`_. The Visual Studio channel is an earlier version of Mono and will not work with Godot 3.0.3+. 
+.. note:: To download Mono v5.12+ on a Mac, locate the "Stable Channel" link from the `Mono Downloads Page <http://www.mono-project.com/download/>`_. The Visual Studio channel is an earlier version of Mono and will not work with Godot 3.0.3+.
 
 You also need MSBuild (at least version 15.0) which should come with the Mono installation.
 
 .. note:: For instructions on installing older versions of Mono on Linux, see `this page <http://www.mono-project.com/docs/getting-started/install/linux/#accessing-older-releases>`_.
-        Older versions of Mono for MacOS and Windows can be found `here <https://download.mono-project.com/archive/>`_.
+        Older versions of Mono for macOS and Windows can be found `here <https://download.mono-project.com/archive/>`_.
 
 Additionally, your Godot version must have Mono support enabled, so ensure you download the **Mono version** of Godot.
 
@@ -54,7 +54,7 @@ To set it up, in Godot click on ``Editor``, then ``Editor Settings``. Scroll
 down to the bottom, to the ``Mono`` settings. Under Mono click on ``Editor``,
 and on that page choose your external editor of choice.
 
-.. note:: If you are using Visual Studio Code, ensure you download and install the .NET tools extension. Without this, Godot will crash when trying to create a new C# project or edit a C# script. 
+.. note:: If you are using Visual Studio Code, ensure you download and install the .NET tools extension. Without this, Godot will crash when trying to create a new C# project or edit a C# script.
 
 Creating a C# script
 --------------------

--- a/getting_started/step_by_step/exporting.rst
+++ b/getting_started/step_by_step/exporting.rst
@@ -172,10 +172,10 @@ folder. Choose a location *outside* of your project folder.
 
 Click "Save" and the engine will build the export files.
 
-.. note:: When exporting for MacOS, if you export on a MacOS computer, you'll
+.. note:: When exporting for macOS, if you export on a macOS computer, you'll
           end up with a `.dmg` file, while using Linux or Windows
           produces a `.zip`. In either case, the compressed file contains
-          a MacOS `.app` that you can double-click and run.
+          a macOS `.app` that you can double-click and run.
 
 .. note:: On Windows, if you want your exported executable to have a different
           icon than the default one, you need to change it manually. See:
@@ -237,7 +237,7 @@ iOS
 ~~~
 
 .. note:: In order to build your game for iOS, you must have a computer running
-          MacOS with Xcode installed.
+          macOS with Xcode installed.
 
 Before exporting, there are some settings that you *must* complete for the project
 to export successfully. First, the "App Store Team Id", which you can find by

--- a/tutorials/plugins/gdnative/gdnative-c-example.rst
+++ b/tutorials/plugins/gdnative/gdnative-c-example.rst
@@ -26,7 +26,7 @@ This example project also contains a SConstruct file that makes compiling a litt
     func get_data():
         return data
 
-We'll be writing separate tutorials on the other types of GDNative modules and explain what each of them is for as we go through them. 
+We'll be writing separate tutorials on the other types of GDNative modules and explain what each of them is for as we go through them.
 
 Prerequisites
 -------------
@@ -84,10 +84,10 @@ We're going to start by having a look at what our simple.c file contains. Now, f
 
 We'll be looking at the source code bit by bit so all the parts below should all be put together into one big file. I'll explain each section as we add it.
 
-The below code includes our header files that we need and then defines two pointers to two different structs. 
+The below code includes our header files that we need and then defines two pointers to two different structs.
 GDNative supports a large collection for functions for calling back into the main Godot executable. In order for your module to have access to these functions, GDNative provides your application with a struct containing pointers to all these functions.
 
-To keep this implementation modular and easily extendable, the core functions are available directly through the "core" API struct, but additional functions have their own "GDNative structs" that are accessible through extensions. 
+To keep this implementation modular and easily extendable, the core functions are available directly through the "core" API struct, but additional functions have their own "GDNative structs" that are accessible through extensions.
 
 In our example, we access one of these extension to gain access to the functions specifically needed for NativeScript.
 
@@ -170,7 +170,7 @@ The descriptions contain the function pointers to the functions themselves. The 
             attributes, get_data);
     }
 
-Now, it's time to start working on the functions of our object. First, we define a structure that we use to store the member data of an instance of our GDNative class. 
+Now, it's time to start working on the functions of our object. First, we define a structure that we use to store the member data of an instance of our GDNative class.
 
 .. code:: C
 
@@ -184,7 +184,7 @@ This pointer will be passed to any of our functions related to our object as a p
 
 .. code:: C
 
-    void *simple_constructor(godot_object *p_instance, void *p_method_data) {        
+    void *simple_constructor(godot_object *p_instance, void *p_method_data) {
         user_data_struct *user_data = api->godot_alloc(sizeof(user_data_struct));
         strcpy(user_data->data, "World from GDNative!");
 
@@ -229,7 +229,7 @@ If you add a blank .gdignore file to the src folder, Godot will not try to impor
 
 Compiling
 ---------
-We now need to compile our source code. As mentioned our example project on GitHub contains a Scons configuration that does all the hard work for you but for our tutorial here we are going to call the compilers directly. 
+We now need to compile our source code. As mentioned our example project on GitHub contains a Scons configuration that does all the hard work for you but for our tutorial here we are going to call the compilers directly.
 
 Assuming you are sticking to the folder structure suggested above it is best to CD into the src subfolder in a terminal session and execute the commands from there. Make sure to create the bin folder before you proceed.
 
@@ -240,7 +240,7 @@ On Linux:
     clang -std=c11 -fPIC -c -I/PATH/TO/GODOT/HEADERS simple.c -o simple.os
     clang -shared simple.os -o ../bin/libsimple.so
 
-On Mac OS X:
+On macOS:
 
 .. code-block:: none
 


### PR DESCRIPTION
OS X was renamed to macOS with the release of macOS 10.12 in 2016.

There's quite a lot of whitespace I ended up trimming, we should add an EditorConfig file to make sure people don't accidentally add trailing whitespace :slightly_smiling_face: