### PR TITLE
Added a clarification about the Godot-Blender-Exporter

### DIFF
--- a/getting_started/workflow/assets/escn_exporter/index.rst
+++ b/getting_started/workflow/assets/escn_exporter/index.rst
@@ -1,6 +1,9 @@
 Godot-Blender-Exporter
 ======================
 
+.. note:: This chapter relates to the blender plugin called "Godot-Blender-Exporter", 
+          which can be downloaded here: https://github.com/godotengine/godot-blender-exporter
+
 Details on exporting
 --------------------
 .. toctree::


### PR DESCRIPTION
After I had spent several hours trying to get the physics export to work using the method described in this chapter combined with the "better collada exporter" I finally understood that there is a plugin that is called Godot-Blender-Exporter.
Since it used to be the default to use the "better collada exporter" I didn't understand that the title of the page is a name, not a description. After all the better collada exporter is kind of a godot to blender exporter.
