### PR TITLE
clarified section about adding icons to plugins

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -118,7 +118,7 @@ clicked. And for that we'll need a simple script that extends from
 
 That's it for our basic button. You can save this as ``button.gd`` inside the
 plugin folder. You'll also need a 16x16 icon to show in the scene tree. If you
-don't have one, you can grab the default one from the engine:
+don't have one, you can grab the default one from the engine, save it in your `addons/my_custom_node` folder as `icon.png` or you use the default Godot logo (`preload("res://icon.png")`).
 
 .. image:: img/making_plugins-custom_node_icon.png
 


### PR DESCRIPTION
The tutorial was expanded by a few words to make it clearer.
If one follows the tutorial literally the following error message is shown "Base type is not EditorPlugin" which just says "the icon cannot be found".