### PR TITLE
Update gdscript_advanced.rst

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_advanced.rst
+++ b/getting_started/scripting/gdscript/gdscript_advanced.rst
@@ -300,6 +300,7 @@ states and quick structs:
 
     # Same example, lua-style support.
     # This syntax is a lot more readable and usable
+    # Like any GDScript identifier, keys written in this form cannot start with a digit.
 
     var d = {
         name = "John",


### PR DESCRIPTION
    # Same example, lua-style support.
    # This syntax is a lot more readable and usable
+ # Like any GDScript identifier, keys written in this form cannot start with a digit.


