### PR TITLE
Update overview_of_debugging_tools.rst

### DIFF
--- a/tutorials/debug/overview_of_debugging_tools.rst
+++ b/tutorials/debug/overview_of_debugging_tools.rst
@@ -100,7 +100,7 @@ When running your game, a bar will occur at the top of the ``Scene`` dock. You c
 
 .. image:: img/overview_remote.png
 
-.. note:: Some editor settings related to debugging can be find in the ``Editor Settings``, under Network>Debug and Debugger sections.
+.. note:: Some editor settings related to debugging can be found inside the ``Editor Settings``, under Network>Debug and Debugger sections.
 
 
 


### PR DESCRIPTION
Some editor settings related to debugging can be find in the ``Editor Settings``, under Network>Debug and Debugger sections.

+ Some editor settings related to debugging can be found inside the ``Editor Settings``, under Network>Debug and Debugger sections.
