### PR TITLE
Fix typo 'an weapon'->'a weapon'

### DIFF
--- a/getting_started/scripting/c_sharp/c_sharp_style_guide.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_style_guide.rst
@@ -248,7 +248,7 @@ or *'float fPower'*, for example. However, there's an exception about interfaces
 Lastly, consider choosing descriptive names and do not try to shorten them too much if it affects
 readability.
 
-For instance, if you want to write a code to find a nearby enemy and hit with an weapon, prefer
+For instance, if you want to write a code to find a nearby enemy and hit with a weapon, prefer
 
 .. code-block:: csharp
 


### PR DESCRIPTION
Fix typo 'an weapon' to 'a weapon' at  "godot-docs/getting_started/scripting/c_sharp/c_sharp_style_guide.rst" line 251.

