### PR TITLE
Add NuGet as a requirement for Mono compiling

### DIFF
--- a/development/compiling/compiling_with_mono.rst
+++ b/development/compiling/compiling_with_mono.rst
@@ -11,6 +11,7 @@ Requirements
 - Mono 5.12.0 or greater
 - MSBuild
 - pkg-config
+- NuGet
 
 Environment variables
 ---------------------


### PR DESCRIPTION
Compiling Godot Mono on x11 with the latest source needs NuGet to be intalled which is not a dependency of any current requirement.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
