### PR TITLE
Grammar fix

### DIFF
--- a/getting_started/step_by_step/ui_code_a_life_bar.rst
+++ b/getting_started/step_by_step/ui_code_a_life_bar.rst
@@ -219,7 +219,7 @@ of information. And you will update the state of your connected node
 With this in mind let's connect the ``GUI`` to the ``Player``. Click on
 the ``Player`` node in the scene dock to select it. Head down to the
 Inspector and click on the Node tab. This is the place to connect nodes
-to listen the one you selected.
+to listen to the one you selected.
 
 The first section lists custom signals defined in ``Player.gd``:
 


### PR DESCRIPTION
Added "to."
This could also be re-written as "This is where we connect nodes to listen to the node we selected."

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
