### PR TITLE
Fix function name for emit in GDScript in docs

### DIFF
--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -184,7 +184,7 @@ To emit a signal via code, use the ``emit`` function:
     signal my_signal
 
     func _ready():
-        emit("my_signal")
+        emit_signal("my_signal")
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
Rename emit() to emit_signal() in documentation about signals since this is the right name.
Calling just emit() produces error
