### PR TITLE
Changed "scenes" to "nodes" for clarity

### DIFF
--- a/getting_started/step_by_step/scripting_continued.rst
+++ b/getting_started/step_by_step/scripting_continued.rst
@@ -89,7 +89,7 @@ There are two ways to do this. The first is from the UI, from the Groups button 
 
 .. image:: img/groups_in_nodes.png
 
-And the second way is from code. One example would be to tag scenes
+And the second way is from code. One example would be to tag nodes
 which are enemies:
 
 .. tabs::


### PR DESCRIPTION
In the scripting_continues step_by_step tutorial. This addresses issue #1986 

I figured this was the simplest change, plus it aligns with the language in the rest of the section. 

The user spotted the issue in the 3.0 branch, so it should be cherrypicked there as well.
