### PR TITLE
Remove extra letter from class_worldenvironment.rst

### DIFF
--- a/classes/class_worldenvironment.rst
+++ b/classes/class_worldenvironment.rst
@@ -14,7 +14,7 @@ WorldEnvironment
 Brief Description
 -----------------
 
-Default environment properties for the entire scene (post-processing effects, lightning and background settings).
+Default environment properties for the entire scene (post-processing effects, lighting and background settings).
 
 Properties
 ----------


### PR DESCRIPTION
I assume this node deals with [artificial] illumination, not atmo"spheric" electrical-discharges.