### PR TITLE
Explain the need to set ANDROID_NDK_HOME env var

### DIFF
--- a/development/compiling/compiling_for_android.rst
+++ b/development/compiling/compiling_for_android.rst
@@ -56,9 +56,9 @@ with ``y``:
 
 Set the environment variable ``ANDROID_NDK_ROOT`` to point to the
 Android NDK. You also might need to set the variable ``ANDROID_NDK_HOME``
-to the same path, in particular if you are using custom Android modules,
+to the same path, especially if you are using custom Android modules,
 since some Gradle plugins rely on the NDK and use this variable to
-determine the location.
+determine its location.
 
 To set those environment variables on Windows, press **Windows + R**, type
 "control system", then click on **Advanced system settings** in the left

--- a/development/compiling/compiling_for_android.rst
+++ b/development/compiling/compiling_for_android.rst
@@ -55,7 +55,10 @@ with ``y``:
 
 
 Set the environment variable ``ANDROID_NDK_ROOT`` to point to the
-Android NDK.
+Android NDK. You also might need to set the variable ``ANDROID_NDK_HOME``
+to the same path, in particular if you are using custom Android modules,
+since some Gradle plugins rely on the NDK and use this variable to
+determine the location.
 
 To set those environment variables on Windows, press **Windows + R**, type
 "control system", then click on **Advanced system settings** in the left


### PR DESCRIPTION
When using custom modules, it's possible that the Gradle build fails if this is not set (or set incorrectly) and the cause it's not explicitly stated in the logs. So documenting this might save some trouble.