### PR TITLE
Fix punctuation in size_and_anchors

### DIFF
--- a/tutorials/gui/size_and_anchors.rst
+++ b/tutorials/gui/size_and_anchors.rst
@@ -12,7 +12,7 @@ Only TVs nowadays have a standard resolution and aspect ratio.
 Everything else, from computer monitors to tablets, portable consoles
 and mobile phones have different resolutions and aspect ratios.
 
-There are several ways to handle this, but for now let's just imagine
+There are several ways to handle this, but for now, let's just imagine
 that the screen resolution has changed and the controls need to be
 re-positioned. Some will need to follow the bottom of the screen, others
 the top of the screen, or maybe the right or left margins.
@@ -20,7 +20,7 @@ the top of the screen, or maybe the right or left margins.
 .. image:: img/anchors.png
 
 This is done by editing the *margin* properties of controls. Each
-control has four margins: left, right, bottom and top. By default all of
+control has four margins: left, right, bottom and top. By default, all of
 them represent a distance in pixels relative to the top-left corner of
 the parent control or (in case there is no parent control) the viewport.
 
@@ -32,7 +32,7 @@ corner of the parent control or viewport.
 
 .. image:: img/marginend.png
 
-Here the control is set to expand its bottom-right corner with that of
+Here, the control is set to expand its bottom-right corner with that of
 the parent, so when re-sizing the parent, the control will always cover
 it, leaving a 20 pixel margin:
 


### PR DESCRIPTION
Fix punctuation in size_and_anchors. 
I presume the illustrations are stragglers from an older version of Godot, the look of which I like quite a bit more. 
At any rate, the current version of Godot doesn't present its options in the manner set forth by this page; there seem to have been a number of minor changes done and  ``Grow Direction``  is what it pertains to now.