### PR TITLE
Clean instancing page recap

### DIFF
--- a/getting_started/step_by_step/instancing_continued.rst
+++ b/getting_started/step_by_step/instancing_continued.rst
@@ -9,8 +9,7 @@ Recap
 Instancing has many handy uses. At a glance, with instancing you have:
 
 -  The ability to subdivide scenes and make them easier to manage.
--  A more flexible alternative to prefabs you might know from Unity (and much more powerful given that
-   instances can be nested).
+-  A tool to manage and edit multiple node instances at once.
 -  A way to organize and embed complex game flows or even UIs (in Godot, UI
    Elements are nodes, too).
 


### PR DESCRIPTION
Recaps usually highlight what was learned in the previous section. Unity wasn't mentioned in the previous section. The ability to mass edit nodes was mentioned, but wasn't included in the recap. Also, as of Unity 2018.3, nested prefabs are a core concept. I figured removing this line would help remove "informational dependencies" that need to be updated, and keep the section focused.