### PR TITLE
Fixed a typo in a code example

### DIFF
--- a/getting_started/step_by_step/scripting.rst
+++ b/getting_started/step_by_step/scripting.rst
@@ -238,7 +238,7 @@ the following underneath the ``_ready()`` function:
 
     public override void _Ready()
     {
-        GetNode("Button")
+        GetNode("Button");
     }
 
 Next, write a function which will be called when the button is pressed:


### PR DESCRIPTION
I added a semi-colon to an example, without it the code would crash. Probably a typo.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
