### PR TITLE
Fix UI code a life bar documentation

### DIFF
--- a/getting_started/step_by_step/ui_code_a_life_bar.rst
+++ b/getting_started/step_by_step/ui_code_a_life_bar.rst
@@ -410,7 +410,7 @@ clear its content. Let's animate the ``animated_health`` value. Call the
  .. code-tab:: csharp
 
     // Add this to the top of your class.
-    private int _animatedHealth = 0;
+    private float _animatedHealth = 0;
 
     public void UpdateHealth(int health)
     {


### PR DESCRIPTION
In order for the following section to still be valid:

```
Play the game to see the bar animate smoothly. But the text displays
decimal number and looks like a mess
```

The variable should be set as a float instead of an int.