### PR TITLE
Update broken links

### DIFF
--- a/development/cpp/core_types.rst
+++ b/development/cpp/core_types.rst
@@ -132,7 +132,7 @@ References:
 ~~~~~~~~~~~
 
 -  `core/os/memory.h <https://github.com/godotengine/godot/blob/master/core/os/memory.h>`__
--  `core/dvector.h <https://github.com/godotengine/godot/blob/master/core/dvector.h>`__
+-  `core/pool_vector.h <https://github.com/godotengine/godot/blob/master/core/pool_vector.cpp>`__
 
 Containers
 ----------

--- a/development/cpp/core_types.rst
+++ b/development/cpp/core_types.rst
@@ -197,7 +197,7 @@ is fast.
 References:
 ~~~~~~~~~~~
 
--  `core/string_db.h <https://github.com/godotengine/godot/blob/master/core/string_db.h>`__
+-  `core/string_name.h <https://github.com/godotengine/godot/blob/master/core/string_name.h>`__
 
 Math types
 ----------


### PR DESCRIPTION
There is a reference to core/dvector.h file insead of core/pool_vector.h, and a reference to core/string_db.h instead of core/string_name.h