### PR TITLE
removed uneccesary comparator

### DIFF
--- a/tutorials/3d/fps_tutorial/part_two.rst
+++ b/tutorials/3d/fps_tutorial/part_two.rst
@@ -89,7 +89,7 @@ Add the following code to ``AnimationPlayer_Manager.gd``:
             return true
 
 
-        if has_animation(animation_name) == true:
+        if has_animation(animation_name):
             if current_state != null:
                 var possible_animations = states[current_state]
                 if animation_name in possible_animations:


### PR DESCRIPTION
Method `has_animation(param)` returns true if `param` is a valid animation and makes it uneccesary to check  `if boolean == true` 