### PR TITLE
Clarify how to use MultiMesh.set_instance_color.

### DIFF
--- a/classes/class_multimesh.rst
+++ b/classes/class_multimesh.rst
@@ -210,7 +210,9 @@ Return the transform of a specific instance.
 
 - void **set_instance_color** **(** :ref:`int<class_int>` instance, :ref:`Color<class_Color>` color **)**
 
-Set the color of a specific instance.
+Set the color of a specific instance. For the color to take effect, ensure that
+:ref:`color_format<class_MultiMesh_property_color_format>` is set on the MultiMesh and
+:ref:`vertex_color_use_as_albedo<class_SpatialMaterial_property_vertex_color_use_as_albedo>` is set on the material.
 
 .. _class_MultiMesh_method_set_instance_custom_data:
 


### PR DESCRIPTION
Just calling set_instance_color will do nothing unless you have set
color_format and vertex_color_use_as_albedo. This is really confusing,
and I only discovered my error by finding
https://github.com/godotengine/godot/issues/10217 from another confused
user.

The docs should call out these requirements.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
