### PR TITLE
Fixed the example in custom_modules_in_cpp.rst

### DIFF
--- a/development/cpp/custom_modules_in_cpp.rst
+++ b/development/cpp/custom_modules_in_cpp.rst
@@ -60,7 +60,7 @@ Inside we will create a simple summator class:
     #ifndef SUMMATOR_H
     #define SUMMATOR_H
 
-    #include "reference.h"
+    #include "core/reference.h"
 
     class Summator : public Reference {
         GDCLASS(Summator, Reference);
@@ -137,7 +137,7 @@ With the following contents:
     /* register_types.cpp */
 
     #include "register_types.h"
-    #include "class_db.h"
+    #include "core/class_db.h"
     #include "summator.h"
 
     void register_summator_types() {


### PR DESCRIPTION
Judging by this include in other modules, it looks like "core/" must now be specified whereas it wasn't necessary for Godot 3.0.6.