### PR TITLE
Fix "GDScript basics" link text to "GDScript" in tutorial

### DIFF
--- a/getting_started/step_by_step/scripting.rst
+++ b/getting_started/step_by_step/scripting.rst
@@ -7,7 +7,7 @@ Introduction
 ------------
 
 Before Godot 3.0, the only choice for scripting a game was to use
-:ref:`doc_gdscript`. Nowadays, Godot has four (yes, four!) official languages
+:ref:`GDScript<doc_gdscript>`. Nowadays, Godot has four (yes, four!) official languages
 and the ability to add extra scripting languages dynamically!
 
 This is great, mostly due to the large amount of flexibility provided, but
@@ -21,7 +21,7 @@ C# and C++ need to be edited in a separate IDE. If you are a big fan of statical
 GDScript
 ~~~~~~~~
 
-:ref:`doc_gdscript` is, as mentioned above, the main language used in Godot.
+:ref:`GDScript<doc_gdscript>` is, as mentioned above, the main language used in Godot.
 Using it has some positive points compared to other languages due
 to its high integration with Godot:
 
@@ -97,7 +97,7 @@ demonstrate:
 - Hooking up UI elements via signals.
 - Writing a script that can access other nodes in the scene.
 
-Before continuing, please make sure to read the :ref:`doc_gdscript` reference.
+Before continuing, please make sure to read the :ref:`GDScript<doc_gdscript>` reference.
 It's a language designed to be simple, and the reference is short, so it will not take more
 than a few minutes to get an overview of the concepts.
 


### PR DESCRIPTION
The text present in "Step by Step" section, under "Scripting", contains some references to "GDScript" as "GDScript basics". It might be some regression by changing the reference doc text. The doc in 3.0 it's all right.

At first, "overriding" (custom link text) doesn't look like a great way of doing it, because I have to do to 3 of them, but then I saw the pattern in class documentation, like: :ref:`bool<class_bool>`;

This pull request is to fix the regression by "overriding" the text in the reference.

