### PR TITLE
Fixed typo in title of fish tutorial

### DIFF
--- a/tutorials/3d/vertex_animation/animating_thousands_of_fish.rst
+++ b/tutorials/3d/vertex_animation/animating_thousands_of_fish.rst
@@ -1,7 +1,7 @@
 .. _doc_animating_thousands_of_fish:
 
-Animating thousands of fish with MeshInstance
-=============================================
+Animating thousands of fish with MultiMeshInstance
+==================================================
 
 This tutorial explores a technique used in the game `ABZU <https://www.gdcvault.com/play/1024409/Creating-the-Art-of-ABZ>`_ 
 for rendering and animating thousands of fish using vertex animation and 


### PR DESCRIPTION
The tutorial uses a MultiMeshInstance, not a MeshInstance. 

PR should be made in 3.1 and master
