### PR TITLE
Edit note on call_deferred() in Singletons (AutoLoad)

### DIFF
--- a/getting_started/step_by_step/singletons_autoload.rst
+++ b/getting_started/step_by_step/singletons_autoload.rst
@@ -224,11 +224,10 @@ current scene and replace it with the requested one.
         GetTree().SetCurrentScene(CurrentScene);
     }
 
-As mentioned in the comments above, we need to avoid the situation of deleting
-the current scene while it is still being used (i.e. its code is still running),
-so using :ref:`Object.call_deferred() <class_Object_method_call_deferred>`
-is required at this point. The result is that the second function will run
-at a later time when any code from the current scene has completed.
+Using :ref:`Object.call_deferred() <class_Object_method_call_deferred>`,
+the second function will only run once all code from the current scene has
+completed. Do not delete the current scene while it is still being used
+(i.e. its code is still running).
 
 Finally, we need to fill the empty callback functions in the two scenes:
 

--- a/getting_started/step_by_step/singletons_autoload.rst
+++ b/getting_started/step_by_step/singletons_autoload.rst
@@ -226,8 +226,8 @@ current scene and replace it with the requested one.
 
 Using :ref:`Object.call_deferred() <class_Object_method_call_deferred>`,
 the second function will only run once all code from the current scene has
-completed. Do not delete the current scene while it is still being used
-(i.e. its code is still running).
+completed. Thus, the current scene will not be removed while it is
+still being used (i.e. its code is still running).
 
 Finally, we need to fill the empty callback functions in the two scenes:
 


### PR DESCRIPTION
- Rewrote the paragraph to be less wordy and more concise.
- Moved "Object.call_deferred()" to the beginning  of the sentence to emphasize it.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
