### PR TITLE
Changed dvector.h to pool_vector.h

### DIFF
--- a/development/cpp/core_types.rst
+++ b/development/cpp/core_types.rst
@@ -133,7 +133,7 @@ References:
 ~~~~~~~~~~~
 
 -  `core/os/memory.h <https://github.com/godotengine/godot/blob/master/core/os/memory.h>`__
--  `core/dvector.h <https://github.com/godotengine/godot/blob/master/core/dvector.h>`__
+-  `core/pool_vector.h <https://github.com/godotengine/godot/blob/master/core/pool_vector.h>`__
 
 Containers
 ----------


### PR DESCRIPTION
No such header named dvector.h exists.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
