### PR TITLE
Minor tutorial fixes for 3.1

### DIFF
--- a/getting_started/scripting/gdscript/static_typing.rst
+++ b/getting_started/scripting/gdscript/static_typing.rst
@@ -211,7 +211,7 @@ Define the return type of a function with the arrow ->
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To define the return type of a function, write a dash and a right angle
-bracket ``->`` after it’s declaration, followed by the return type:
+bracket ``->`` after its declaration, followed by the return type:
 
 ::
 

--- a/tutorials/2d/custom_drawing_in_2d.rst
+++ b/tutorials/2d/custom_drawing_in_2d.rst
@@ -345,8 +345,6 @@ is 361°, then it is actually 1°. If you don't wrap these values, the script wi
 work correctly, but the angle values will grow bigger and bigger over time until
 they reach the maximum integer value Godot can manage (``2^31 - 1``).
 When this happens, Godot may crash or produce unexpected behavior.
-Since Godot doesn't provide a ``wrap()`` function, we'll create it here, as
-it is relatively simple.
 
 Finally, we must not forget to call the ``update()`` function, which automatically
 calls ``_draw()``. This way, you can control when you want to refresh the frame.
@@ -354,19 +352,14 @@ calls ``_draw()``. This way, you can control when you want to refresh the frame.
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    func wrap(value, min_val, max_val):
-        var f1 = value - min_val
-        var f2 = max_val - min_val
-        return fmod(f1, f2) + min_val
-
     func _process(delta):
         angle_from += rotation_angle
         angle_to += rotation_angle
 
         # We only wrap angles when both of them are bigger than 360.
         if angle_from > 360 and angle_to > 360:
-            angle_from = wrap(angle_from, 0, 360)
-            angle_to = wrap(angle_to, 0, 360)
+            angle_from = wrapf(angle_from, 0, 360)
+            angle_to = wrapf(angle_to, 0, 360)
         update()
 
  .. code-tab:: csharp

--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -225,15 +225,15 @@ For example, here is the code for an "Asteroids" style spaceship:
 
     func _integrate_forces(state):
         if Input.is_action_pressed("ui_up"):
-            set_applied_force(thrust.rotated(rotation))
+            applied_force = thrust.rotated(rotation)
         else:
-            set_applied_force(Vector2())
+            applied_force = Vector2()
         var rotation_dir = 0
         if Input.is_action_pressed("ui_right"):
             rotation_dir += 1
         if Input.is_action_pressed("ui_left"):
             rotation_dir -= 1
-        set_applied_torque(rotation_dir * torque)
+        applied_torque = rotation_dir * torque
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
Just a few minor edits/corrections:

* "it's" -> "its" in Typed GDScript
* Remove erroneous "GDScript doesn't have `wrap()`" statement in 2D Custom Drawing - Fixes #2241
* Update RigidBody2D code in Physics Introduction to use properties.