### PR TITLE
Remove unused code (Exporting Dodge the Creeps doc)

### DIFF
--- a/getting_started/step_by_step/exporting.rst
+++ b/getting_started/step_by_step/exporting.rst
@@ -94,10 +94,8 @@ changed:
         if velocity.length() > 0:
             velocity = velocity.normalized() * speed
             $AnimatedSprite.play()
-            $Trail.emitting = true
         else:
             $AnimatedSprite.stop()
-            $Trail.emitting = false
 
         position += velocity * delta
         # We don't need to clamp the player's position


### PR DESCRIPTION
Removes left-over sample code in the Exporting section related to particle effects which were removed from the Dodge the Creeps 3.1 documents and the demo project scripts.

