### PR TITLE
Fix references in best_practices/scenes_versus_scripts.rst

### DIFF
--- a/getting_started/workflow/best_practices/scenes_versus_scripts.rst
+++ b/getting_started/workflow/best_practices/scenes_versus_scripts.rst
@@ -95,7 +95,7 @@ name.
 
 There are two systems for registering types...
 
-- `Custom Types <doc_making_plugins>`
+- :ref:`Custom Types <doc_making_plugins>`
 
    - Editor-only. Typenames are not accessible at runtime.
 
@@ -112,7 +112,7 @@ There are two systems for registering types...
 
    - Set up using :ref:`EditorPlugin.add_custom_type <class_EditorPlugin_method_add_custom_type>`.
 
-- `Script Classes <https://godot.readthedocs.io/en/latest/getting_started/step_by_step/scripting_continued.html#register-scripts-as-classes>`_
+- :ref:`Script Classes <doc_scripting_continued_class_name>`
 
    - Editor and runtime accessible.
 


### PR DESCRIPTION
This fixes the broken markup for the first reference, and also changes the second reference from an absolute URL to a `:ref:` (which will work locally & after the next version release).

https://docs.godotengine.org/en/latest/getting_started/workflow/best_practices/scenes_versus_scripts.html#named-types

![Screenshot_20190325_143020](https://user-images.githubusercontent.com/426784/54944728-8b7cf400-4f0a-11e9-9c00-ac65eea87e8d.png)