### PR TITLE
Fix markup and navigation details in "Design a title screen" tutorial

### DIFF
--- a/getting_started/step_by_step/ui_main_menu.rst
+++ b/getting_started/step_by_step/ui_main_menu.rst
@@ -156,8 +156,8 @@ Start to type ``TextureRect`` to find the corresponding node and press
 enter. With the new node selected, press ``Meta+D`` five times to
 create five extra ``TextureRect`` instances.
 
-Click each of the nodes to select it. In the inspector, find the Texture
-property and click "[empty]" -> ``Load``. A file browser opens and lets
+Click each of the nodes to select it. In the inspector, find the ``Texture``
+property and click ``[empty]`` -> ``Load``. A file browser opens and lets
 you pick a sprite to load into the texture slot.
 
 .. figure:: img/ui_texturerect_load_texture.png

--- a/getting_started/step_by_step/ui_main_menu.rst
+++ b/getting_started/step_by_step/ui_main_menu.rst
@@ -22,7 +22,7 @@ read :doc:`ui_code_a_life_bar`
 Download the project files: :download:`ui_main_menu_design.zip
 <files/ui_main_menu_design.zip>` and extract the archive. Import the ``start/``
 project in Godot to follow this tutorial. The ``end/`` folder contains the
-final result. You'll find all the sprites in the ``start/assets/main_menu```
+final result. You'll find all the sprites in the ``start/assets/main_menu``
 folder.
 
 .. note:
@@ -156,9 +156,7 @@ Start to type ``TextureRect`` to find the corresponding node and press
 enter. With the new node selected, press ``Meta+D`` five times to
 create five extra ``TextureRect`` instances.
 
-Click each of the nodes to select it. In the inspector, click the ``…``
-Icon to the right of the Texture property, and click on ``Load``. A file
-browser opens and lets you pick a sprite to load into the texture slot.
+Click each of the nodes to select it. In the inspector, find the Texture property and click "[empty]" -> ``Load``. A file browser opens and lets you pick a sprite to load into the texture slot.
 
 .. figure:: img/ui_texturerect_load_texture.png
 

--- a/getting_started/step_by_step/ui_main_menu.rst
+++ b/getting_started/step_by_step/ui_main_menu.rst
@@ -156,7 +156,9 @@ Start to type ``TextureRect`` to find the corresponding node and press
 enter. With the new node selected, press ``Meta+D`` five times to
 create five extra ``TextureRect`` instances.
 
-Click each of the nodes to select it. In the inspector, find the Texture property and click "[empty]" -> ``Load``. A file browser opens and lets you pick a sprite to load into the texture slot.
+Click each of the nodes to select it. In the inspector, find the Texture
+property and click "[empty]" -> ``Load``. A file browser opens and lets
+you pick a sprite to load into the texture slot.
 
 .. figure:: img/ui_texturerect_load_texture.png
 


### PR DESCRIPTION
This pull request adds the following to  ```getting_started/step_by_step/ui_main_menu.rst```

* Markup fix for a sprite path
* Corrects a Texture property navigation detail