### PR TITLE
Change call_deferred to set_deferred (Step by Step)

### DIFF
--- a/getting_started/step_by_step/exporting.rst
+++ b/getting_started/step_by_step/exporting.rst
@@ -117,7 +117,7 @@ changed:
     func _on_Player_body_entered( body ):
         hide()
         emit_signal("hit")
-        $CollisionShape2D.call_deferred("set_disabled", true)
+        $CollisionShape2D.set_deferred("disabled", true)
 
 Export templates
 ----------------

--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -459,7 +459,7 @@ Add this code to the function:
     func _on_Player_body_entered(body):
         hide()  # Player disappears after being hit.
         emit_signal("hit")
-        $CollisionShape2D.call_deferred("set_disabled", true)
+        $CollisionShape2D.set_deferred("disabled", true)
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
Changes  **call_deferred** method to **set_deferred**  for CollisionShape2D in  'Your First Game' and 'Exporting' pages, as per @akien-mga's suggestion  ( https://github.com/godotengine/godot-docs/pull/2303#discussion_r269552445 ) :


> It would be better to use `set_deferred("disabled", true)`. But that can be for another PR as I guess the other tutorial needs to be changed too.


