### PR TITLE
Updated gles2 differences with built-in variables

### DIFF
--- a/tutorials/misc/gles2_gles3_differences.rst
+++ b/tutorials/misc/gles2_gles3_differences.rst
@@ -195,3 +195,23 @@ For a complete list of built-in GLSL functions see the :ref:`Shading Language do
 +------------------------------------------------------------------------+--------------------------------------------------+
 | vec_type **fwidth** ( vec_type )                                       |                                                  |
 +------------------------------------------------------------------------+--------------------------------------------------+
+
+Godot also provides many built-in variables and render modes. Some cannot be supported in GLES2. Below is a list of
+built-in variables and render modes that, when written to, will have no effect or could even cause issues when using 
+the GLES2 backend.
+
++----------------------------+
+| Variable / Render Mode     |
++============================+
+| ``ensure_correct_normals`` |
++----------------------------+
+| ``INSTANCE_ID``            |
++----------------------------+
+| ``DEPTH``                  |
++----------------------------+
+| ``ANISOTROPY``             |
++----------------------------+
+| ``ANISOTROPY_FLOW``        |
++----------------------------+
+| ``SSS_STRENGTH``           |
++----------------------------+


### PR DESCRIPTION
Address #2298 

This applies to 3.1 and master.

I think anisotropy is supposed to be in GLES2, there is code for it in scene.glsl, but it completely breaks rendering, and reduz has removed it from SpatialMaterial. There is a chance that the implementation is just bugged.