### PR TITLE
Fix wrong type on replacing callback's types example

### DIFF
--- a/getting_started/scripting/gdscript/static_typing.rst
+++ b/getting_started/scripting/gdscript/static_typing.rst
@@ -288,7 +288,7 @@ And the same callback, with type hints:
     func _on_area_entered(area: CollisionObject2D) -> void:
         pass
 
-You’re free to replace, e.g. the ``PhysicsBody2D``, with your own type,
+You’re free to replace, e.g. the ``CollisionObject2D``, with your own type,
 to cast parameters automatically:
 
 ::


### PR DESCRIPTION
I think the type on the example was wrong, in the callback, and after the example, it is mentioned `CollisionBody2D`, but in the fixed sentence it is `PhysicsBody2D`