### PR TITLE
Added C# samples to "making plugins" doc

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -103,7 +103,7 @@ structure:
     using System;
 
     [Tool]
-    public class NoHeroTools : EditorPlugin
+    public class CustomNode : EditorPlugin
     {
         public override void _EnterTree()
         {

--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -36,8 +36,11 @@ You should end up with a directory structure like this:
 
 Now, open the script editor, click the **File** menu, choose **New TextFile**,
 then navigate to the plugin folder and name the file ``plugin.cfg``.
-Add the following structure to ``plugin.cfg``::
+Add the following structure to ``plugin.cfg``:
 
+.. tabs::
+ .. code-tab:: gdscript GDScript
+ 
     [plugin]
 
     name="My Custom Node"
@@ -45,6 +48,16 @@ Add the following structure to ``plugin.cfg``::
     author="Your Name Here"
     version="1.0.0"
     script="custom_node.gd"
+
+ .. code-tab:: csharp
+ 
+    [plugin]
+
+    name="My Custom Node"
+    description="A custom node made to extend the Godot Engine."
+    author="Your Name Here"
+    version="1.0.0"
+    script="CustomNode.cs"
 
 This is a simple INI file with metadata about your plugin. You need to set
 the name and description so people can understand what it does. Don't forget
@@ -69,8 +82,9 @@ default GDScript template from your file and replace it with the following
 structure:
 
 .. _doc_making_plugins_template_code:
-.. code-block:: python
-
+.. tabs::
+ .. code-tab:: gdscript GDScript
+ 
     tool
     extends EditorPlugin
 
@@ -81,6 +95,27 @@ structure:
     func _exit_tree():
         # Clean-up of the plugin goes here
         pass
+
+ .. code-tab:: csharp
+ 
+    #if TOOLS
+    using Godot;
+    using System;
+
+    [Tool]
+    public class NoHeroTools : EditorPlugin
+    {
+        public override void _EnterTree()
+        {
+            // Initialization of the plugin goes here
+        }
+
+        public override void _ExitTree()
+        {
+            // Initialization of the plugin goes here
+        }
+    }
+    #endif
 
 This is a good template to use when creating new plugins.
 
@@ -103,8 +138,11 @@ the ``tool`` keyword, it can be added so the script runs in the editor.
 For this tutorial, we'll create a simple button that prints a message when
 clicked. For that, we'll need a simple script that extends from
 :ref:`class_Button`. It could also extend
-:ref:`class_BaseButton` if you prefer::
+:ref:`class_BaseButton` if you prefer:
 
+.. tabs::
+ .. code-tab:: gdscript GDScript
+ 
     tool
     extends Button
 
@@ -114,7 +152,26 @@ clicked. For that, we'll need a simple script that extends from
     func clicked():
         print("You clicked me!")
 
-That's it for our basic button. You can save this as ``button.gd`` inside the
+ .. code-tab:: csharp
+ 
+    using Godot;
+    using System;
+
+    [Tool]
+    public class MyButton : Button
+    {
+        public override void _EnterTree()
+        {
+            Connect("pressed", this, "clicked");
+        }
+
+        public void clicked()
+        {
+            GD.Print("You clicked me!");
+        }
+    }
+
+That's it for our basic button. You can save this as ``my_button.gd`` inside the
 plugin folder. You'll also need a 16×16 icon to show in the scene tree. If you
 don't have one, you can grab the default one from the engine and save it in your
 `addons/my_custom_node` folder as `icon.png`, or use the default Godot logo
@@ -123,20 +180,50 @@ don't have one, you can grab the default one from the engine and save it in your
 .. image:: img/making_plugins-custom_node_icon.png
 
 Now, we need to add it as a custom type so it shows on the **Create New Node**
-dialog. For that, change the ``custom_node.gd`` script to the following::
+dialog. For that, change the ``custom_node.gd`` script to the following:
 
+.. tabs::
+ .. code-tab:: gdscript GDScript
+ 
     tool
     extends EditorPlugin
 
     func _enter_tree():
         # Initialization of the plugin goes here
         # Add the new type with a name, a parent type, a script and an icon
-        add_custom_type("MyButton", "Button", preload("button.gd"), preload("icon.png"))
+        add_custom_type("MyButton", "Button", preload("my_button.gd"), preload("icon.png"))
 
     func _exit_tree():
         # Clean-up of the plugin goes here
         # Always remember to remove it from the engine when deactivated
         remove_custom_type("MyButton")
+
+ .. code-tab:: csharp
+ 
+    #if TOOLS
+    using Godot;
+    using System;
+
+    [Tool]
+    public class CustomNode : EditorPlugin
+    {
+        public override void _EnterTree()
+        {
+            // Initialization of the plugin goes here
+            // Add the new type with a name, a parent type, a script and an icon
+            var script = GD.Load<Script>("addons/MyButton.cs");
+            var texture = GD.Load<Texture>("icon.png");
+            AddCustomType("MyButton", "Button", script, texture);
+        }
+
+        public override void _ExitTree()
+        {
+            // Clean-up of the plugin goes here
+            // Always remember to remove it from the engine when deactivated
+            RemoveCustomType("MyButton");
+        }
+    }
+    #endif
 
 With that done, the plugin should already be available in the plugin list in the
 **Project Settings**, so activate it as explained in `Checking the results`_.
@@ -160,8 +247,11 @@ based on Control, so they are created in a way similar to usual GUI scenes.
 
 Creating a custom dock is done just like a custom node. Create a new
 ``plugin.cfg`` file in the ``addons/my_custom_dock`` folder, then
-add the following content to it::
+add the following content to it:
 
+.. tabs::
+ .. code-tab:: gdscript GDScript
+ 
     [plugin]
 
     name="My Custom Dock"
@@ -169,6 +259,16 @@ add the following content to it::
     author="Your Name Here"
     version="1.0"
     script="custom_dock.gd"
+
+ .. code-tab:: csharp
+ 
+    [plugin]
+
+    name="My Custom Dock"
+    description="A custom dock made so I can learn how to make plugins."
+    author="Your Name Here"
+    version="1.0"
+    script="CustomDock.cs"
 
 Then create the script ``custom_dock.gd`` in the same folder. Fill it with the
 :ref:`template we've seen before <doc_making_plugins_template_code>` to get a
@@ -194,8 +294,11 @@ then add it as a dock in the editor. For this, you can rely on the function
 You need to select a dock position and define the control to add
 (which is the scene you just created). Don't forget to
 **remove the dock** when the plugin is deactivated.
-The script could look like this::
+The script could look like this:
 
+.. tabs::
+ .. code-tab:: gdscript GDScript
+ 
     tool
     extends EditorPlugin
 
@@ -217,6 +320,34 @@ The script could look like this::
         remove_control_from_docks(dock)
          # Erase the control from the memory
         dock.free()
+
+ .. code-tab:: csharp
+ 
+    #if TOOLS
+    using Godot;
+    using System;
+
+    [Tool]
+    public class CustomDock : EditorPlugin
+    {
+        Control dock;
+    
+        public override void _EnterTree()
+        {
+            dock = (Control)GD.Load<PackedScene>("addons/my_custom_dock/my_dock.tscn").Instance();
+            AddControlToDock(DockSlot.LeftUl, dock);
+        }
+
+        public override void _ExitTree()
+        {
+            // Clean-up of the plugin goes here
+            // Remove the dock
+            RemoveControlFromDocks(dock);
+            // Erase the control from the memory
+            dock.Free();
+        }
+    }
+    #endif
 
 Note that, while the dock will initially appear at its specified position,
 the user can freely change its position and save the resulting layout.


### PR DESCRIPTION
I added C# samples to https://docs.godotengine.org/en/3.1/tutorials/plugins/editor/making_plugins.html

I have not found any tool that supported previewing.
```
.. tabs::
 .. code-tab:: gdscript GDScript
   code
 .. code-tab:: csharp
   more code
```
So I just hope everything is formatted correctly

