### PR TITLE
Change case sensitive string to "waiting"

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_basics.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics.rst
@@ -531,7 +531,7 @@ To add a key to an existing dictionary, access it like an existing key and
 assign to it::
 
     var d = {} # Create an empty Dictionary.
-    d.waiting = 14 # Add String "Waiting" as a key and assign the value 14 to it.
+    d.waiting = 14 # Add String "waiting" as a key and assign the value 14 to it.
     d[4] = "hello" # Add integer 4 as a key and assign the String "hello" as its value.
     d["Godot"] = 3.01 # Add String "Godot" as a key and assign the value 3.01 to it.
 


### PR DESCRIPTION
Tiny change! 

But I believe keys are case sensitive, so the key added to dict `d` via `d.waiting =` would be `"waiting"` and not `"Waiting"`.