### PR TITLE
Mentioned "Scene panel" by name

### DIFF
--- a/getting_started/step_by_step/intro_to_the_editor_interface.rst
+++ b/getting_started/step_by_step/intro_to_the_editor_interface.rst
@@ -79,8 +79,8 @@ your project files and assets.
 
 |image11|
 
-On the right side, you’ll find the **Scene dock**, which lists the active
-scene’s content and the **Inspector** in the bottom right corner.
+On the right side, you’ll find the **Scene dock**. This dock contains the **Scene panel** which lists the active
+scene’s content and the **Inspector panel** which allows the properties of the currently selected node to be edited.
 
 |image12|
 


### PR DESCRIPTION
The intro to the editor interface didn't mention the 'Scene panel' by name when it's introduced. I've fixed that.
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
