### PR TITLE
General fixes for the new "Legal" page

### DIFF
--- a/tutorials/legal/complying_with_licenses.rst
+++ b/tutorials/legal/complying_with_licenses.rst
@@ -10,26 +10,25 @@ Godot is created and distributed under the `MIT License <https://opensource.org/
 
 The license is the legal requirement for you (or your company) to use and distribute the software (and derivative projects, including games made with it). Your game or project can have a different license, but it still needs to comply with the original one.
 
-  
-Requierments
+
+Requirements
 ------------
 
 In the case of the MIT license, the only requirement is to include the license text somewhere in your game or derivative project.
 
 This text reads as follows:
 
-::
+
 	Godot Engine
-	
+
 	Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.
 	Copyright (c) 2014-2019 Godot Engine contributors.
-	
-	Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal	in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-	
-	The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-	
-	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+	Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal	in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 Inclusion
@@ -42,18 +41,18 @@ Credits screen
 
 Include the above license text somewhere in the credits screen. It can be at the bottom after showing the rest of the credits. Most large studios use this approach with open source licenses.
 
-Licences screen
-^^^^^^^^^^^^^^
+Licenses screen
+^^^^^^^^^^^^^^^
 
 Some games have a special menu (often in the settings) to display licenses.
 
-Output Log
-^^^^^^^^^^^^^^
+Output log
+^^^^^^^^^^
 
 Just printing the licensing text using a print() function may be enough on platforms where a global output log is readable (as an example, mobile devices).
 
 Accompanying file
-^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^
 
 If the game is distributed on desktop operating systems, a file containing the license can be added to the software that is installed to the user PC.
 
@@ -72,16 +71,16 @@ FreeType
 
 Godot uses `FreeType <https://www.freetype.org/>`_ to render fonts. It's license requires attribution, so the following text must be included together with the Godot license:
 
-::
+
 	Portions of this software are copyright © <year> The FreeType Project (www.freetype.org).  All rights reserved.
 
 
 ENet
 ^^^^
 
-If the project being creater is a multiplayer game using the `ENet <http://enet.bespin.org/>`_ driver, ENet has similar licensing terms as Godot 
+If the project being creater is a multiplayer game using the `ENet <http://enet.bespin.org/>`_ driver, ENet has similar licensing terms as Godot
 
-::
+
 	Copyright (c) 2002-2016 Lee Salzman
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -95,7 +94,7 @@ MBedTLS
 
 If the is done with Godot 3.1 or above and it utilizes SSL (usually through HTTP requests), the `MBedTLS <https://tls.mbed.org>`_ Apache license needs to be complied by including the following text:
 
-::
+
 	MBedTLS is Copyright (C) 2013-2019 ARM
 
 	Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
@@ -105,5 +104,3 @@ If the is done with Godot 3.1 or above and it utilizes SSL (usually through HTTP
 	Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 Keep in mind that Godot 2.x and 3.0 use `OpenSSL <https://www.openssl.org>`_ instead.
-
-

--- a/tutorials/legal/index.rst
+++ b/tutorials/legal/index.rst
@@ -1,5 +1,5 @@
-VR
-==
+Legal
+=====
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
- Fixed title underlines.
- Fixed typos.
- Correctly place it in its own "Legal" section instead of "VR".
- Removed extraneous spaces.