### PR TITLE
Add vim/gvim to a list of external editor flags

### DIFF
--- a/getting_started/editor/external_editor.rst
+++ b/getting_started/editor/external_editor.rst
@@ -37,5 +37,7 @@ Some example Exec Flags for various editors include:
 +---------------------+-----------------------------------------------------+
 | Visual Studio Code  | {project} -\-goto {file}:{line}:{col}               |
 +---------------------+-----------------------------------------------------+
+| Vim (gVim)          | "+call cursor({line}, {col})" {file}                |
++---------------------+-----------------------------------------------------+
 
 .. note:: For Visual Studio Code you will have to point to the "code.cmd" file.


### PR DESCRIPTION
Sidenote: Even though the flags work both for vim and gvim, it probably makes more sense to use gvim, because the way Godot launches the editor won't work with normal vim since it doesn't have a terminal to live in.
