### PR TITLE
Grammar fix: "it's" -> "its"

### DIFF
--- a/tutorials/optimization/using_servers.rst
+++ b/tutorials/optimization/using_servers.rst
@@ -3,7 +3,7 @@
 Optimization Using Servers
 ==========================
 
-Engines like Godot provide increased ease of use thanks to it's high level constructs and features. 
+Engines like Godot provide increased ease of use thanks to its high level constructs and features. 
 Most of them are accessed and used via the :ref:`Scene System<doc_scene_tree>`. Using nodes and 
 resources simplifies project organization and asset management in complex games.
 


### PR DESCRIPTION
Because apparent intended wording is not "...thanks to [it is] high level constructs...".