### PR TITLE
Fix description of get_modified_time

### DIFF
--- a/classes/class_file.rst
+++ b/classes/class_file.rst
@@ -308,7 +308,7 @@ Returns an MD5 String representing the file at the given path or an empty :ref:`
 
 - :ref:`int<class_int>` **get_modified_time** **(** :ref:`String<class_String>` file **)** const
 
-Returns the last time the ``file`` was modified in unix timestamp format or returns a :ref:`String<class_String>` "ERROR IN ``file``". This unix timestamp can be converted to datetime by using :ref:`OS.get_datetime_from_unix_time<class_OS_method_get_datetime_from_unix_time>`.
+Returns the last time the ``file`` was modified in unix timestamp format or 0 if the file does not exist. This unix timestamp can be converted to datetime by using :ref:`OS.get_datetime_from_unix_time<class_OS_method_get_datetime_from_unix_time>`.
 
 .. _class_File_method_get_pascal_string:
 


### PR DESCRIPTION
In Godot 3.1 get_modified_time() returns 0 for nonexistant files and not a String as the current documentation suggests. THis change reflects the current behaviour.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
