### PR TITLE
Mesh.PRIMITIVE_TRIANGLES correction in proc geometry tutorial

### DIFF
--- a/tutorials/content/procedural_geometry.rst
+++ b/tutorials/content/procedural_geometry.rst
@@ -21,7 +21,7 @@ Here is a simple example of how to use it to add a single triangle.
 
     var st = SurfaceTool.new()
 
-    st.begin(Mesh.PRIMITIVE_TRIANGLE)
+    st.begin(Mesh.PRIMITIVE_TRIANGLES)
 
     # Prepare attributes for add_vertex.
     st.add_normal(Vector3(0, 0, 1))
@@ -65,7 +65,7 @@ It's used similar to *SurfaceTool*.
         clear()
 
         # Begin draw.
-        begin(Mesh.PRIMITIVE_TRIANGLE)
+        begin(Mesh.PRIMITIVE_TRIANGLES)
 
         # Prepare attributes for add_vertex.
         set_normal( Vector3(0, 0, 1))


### PR DESCRIPTION
Lines 24 and 68 should be 'Mesh.PRIMITIVE_TRIANGLE**S**' and not 'Mesh.PRIMITIVE_TRIANGLE'

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
