### PR TITLE
Wrong case in signal declaration

### DIFF
--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -254,7 +254,7 @@ Here is the code for the player using signals to emit the bullet:
 
     extends Sprite
 
-    signal shoot(bullet, direction, location)
+    signal shoot(Bullet, direction, location)
 
     var Bullet = preload("res://Bullet.tscn")
 


### PR DESCRIPTION
Was typed as ">b<ullet" instead of "Bullet", which is very small but led to some compilation errors and newbie's confusion.
