### PR TITLE
Spelling error in documentation for PR workflow

### DIFF
--- a/community/contributing/pr_workflow.rst
+++ b/community/contributing/pr_workflow.rst
@@ -353,7 +353,7 @@ Mastering the PR workflow: the rebase
 -------------------------------------
 
 On the situation outlined above, your fellow contributors who are particularly
-pedantic regarding the Git history might ask your to *rebase* your branch to
+pedantic regarding the Git history might ask you to *rebase* your branch to
 *squash* or *meld* the last two commits together (i.e. the two related to the
 project manager), as the second commit basically fixes an issue in the first one.
 


### PR DESCRIPTION
There is a spelling/grammar error in the PR workflow documentation.

`the Git history might ask your to` should be `the Git history might ask you to`

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
