### PR TITLE
Fixed input event when the mouse's button left is pressed in 2d-movement tutorial

### DIFF
--- a/tutorials/2d/2d_movement.rst
+++ b/tutorials/2d/2d_movement.rst
@@ -291,7 +291,7 @@ on the screen will cause the player to move to the target location.
     var velocity = Vector2()
 
     func _input(event):
-        if event.is_action_pressed('click'):
+        if event.is_mouse_button_pressed(BUTTON_LEFT):
             target = get_global_mouse_position()
 
     func _physics_process(delta):


### PR DESCRIPTION
While I was completing this tutorial I noticed that **event.is_action_pressed('click')** doesn't work anymore, so I had to change it to **event.is_mouse_button_pressed(BUTTON_LEFT)**. 

I fixed it on GDScript, but it would be a good idea if someone could please check it out on C#.
