### PR TITLE
State the auto-import for Vehicles and Wheels

### DIFF
--- a/getting_started/workflow/assets/importing_scenes.rst
+++ b/getting_started/workflow/assets/importing_scenes.rst
@@ -323,6 +323,16 @@ Create navigation (-navmesh)
 A mesh node with this suffix will be converted to a navigation mesh. Original Mesh node will be
 removed.
 
+Create a VehicleBody (-vehicle)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A mesh node with this suffix will be imported as a child to a VehicleBody node.
+
+Create a VehicleWheel (-wheel)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A mesh node with this suffix will be imported as a child to a VehicleWheel node.
+
 Rigid Body (-rigid)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/getting_started/workflow/assets/importing_scenes.rst
+++ b/getting_started/workflow/assets/importing_scenes.rst
@@ -324,14 +324,14 @@ A mesh node with this suffix will be converted to a navigation mesh. Original Me
 removed.
 
 Create a VehicleBody (-vehicle)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A mesh node with this suffix will be imported as a child to a VehicleBody node.
+A mesh node with this suffix will be imported as a child to a :ref:`VehicleBody <class_VehicleBody>` node.
 
 Create a VehicleWheel (-wheel)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A mesh node with this suffix will be imported as a child to a VehicleWheel node.
+A mesh node with this suffix will be imported as a child to a :ref:`VehicleWheel <class_VehicleWheel>` node.
 
 Rigid Body (-rigid)
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The Godot Importer will treat meshes with names suffixed as -vehicle and -wheel differently and will apply some automatic behavior which was not previously stated in the documentation.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
