### PR TITLE
Added play() to the enemy sprite

### DIFF
--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -592,6 +592,7 @@ choose one of the three animation types:
 
     func _ready():
         $AnimatedSprite.animation = mob_types[randi() % mob_types.size()]
+        $AnimatedSprite.play()
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
Following the tutorial, the sprites for the enemies were never set to play.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
