### PR TITLE
Update outdated namespaces

### DIFF
--- a/getting_started/scripting/c_sharp/c_sharp_differences.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_differences.rst
@@ -260,7 +260,7 @@ Array
 =====================  ==============================================================
 GDScript               C#
 =====================  ==============================================================
-``Array``              ``Godot.Array``
+``Array``              ``Godot.Collections.Array``
 ``PoolIntArray``       ``int[]``
 ``PoolByteArray``      ``byte[]``
 ``PoolFloatArray``     ``float[]``
@@ -270,16 +270,16 @@ GDScript               C#
 ``PoolVector3Array``   ``Vector3[]``
 =====================  ==============================================================
 
-``Godot.Array<T>`` is a type-safe wrapper around ``Godot.Array``.
-Use the ``Godot.Array<T>(Godot.Array)`` constructor to create one.
+``Godot.Collections.Array<T>`` is a type-safe wrapper around ``Godot.Collections.Array``.
+Use the ``Godot.Collections.Array<T>(Godot.Collections.Array)`` constructor to create one.
 
 Dictionary
 ----------
 
-Use ``Godot.Dictionary``.
+Use ``Godot.Collections.Dictionary``.
 
-``Godot.Dictionary<T>`` is a type-safe wrapper around ``Godot.Dictionary``.
-Use the ``Godot.Dictionary<T>(Godot.Dictionary)`` constructor to create one.
+``Godot.Collections.Dictionary<T>`` is a type-safe wrapper around ``Godot.Collections.Dictionary``.
+Use the ``Godot.Collections.Dictionary<T>(Godot.Collections.Dictionary)`` constructor to create one.
 
 Variant
 -------


### PR DESCRIPTION
Updated Array and Dictionary namespaces from Godot to Godot.Collections

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
