### PR TITLE
'vertex_array' Vector3 correction (proc geom gen tutorial)

### DIFF
--- a/tutorials/content/procedural_geometry.rst
+++ b/tutorials/content/procedural_geometry.rst
@@ -111,19 +111,19 @@ Similar code as before, but draw a square using indices:
 
     normal_array[0] = Vector3(0, 0, 1)
     uv_array[0] = Vector2(0, 0)
-    vertex_array[0] = Vector3(-1, -1)
+    vertex_array[0] = Vector3(-1, -1, 0)
 
     normal_array[1] = Vector3(0, 0, 1)
     uv_array[1] = Vector2(0,1)
-    vertex_array[1] = Vector3(-1, 1)
+    vertex_array[1] = Vector3(-1, 1, 0)
 
     normal_array[2] = Vector3(0, 0, 1)
     uv_array[2] = Vector2(1, 1)
-    vertex_array[2] = Vector3(1, 1)
+    vertex_array[2] = Vector3(1, 1, 0)
 
     normal_array[3] = Vector3(0, 0, 1)
     uv_array[3] = Vector2(1, 0)
-    vertex_array[3] = Vector3(1, -1)
+    vertex_array[3] = Vector3(1, -1, 0)
 
     # Indices are optional in Godot, but if they exist they are used.
     index_array[0] = 0


### PR DESCRIPTION
The `vertex_array` variable is defined as a Vector3, but it only contains 2 elements (I assume this is a mistake). So I have added the third element (being 0) to complete the size (i.e. make it a 3-component vector). These vertex vectors should now define the coordinates of a triangle in 3D space.


