### PR TITLE
Subjectively improve tutorial on encrypting game saves

### DIFF
--- a/tutorials/io/encrypting_game_saves.rst
+++ b/tutorials/io/encrypting_game_saves.rst
@@ -8,12 +8,11 @@ Why?
 
 Most users that care whether a game save is encrypted will prefer no
 encryption at all. But there may be reasons to implement this feature
-anyway. Encrypting saves will curb cheating; this may not be fun for users
-but may be necessary in multiplayer games, games with microtransactions, or
-games that hide secrets to surprise the player. This method of save
-encryption is still able to be bypassed by a sufficiently savvy user
-because, since the encryption key is stored inside the game, the player can
-still decrypt and edit the file themselves.
+anyway. Encrypting can curb cheating and may be necessary in multiplayer
+games, games with microtransactions, or games that hide secrets to surprise
+the player. This method of save encryption is still able to be bypassed by
+a sufficiently savvy user because, since the encryption key is stored
+inside the game, the player can still decrypt and edit the file themselves.
 
 The only way to prevent this from being possible is to store the save data
 on a remote server, where players can only make authorized changes to their

--- a/tutorials/io/encrypting_game_saves.rst
+++ b/tutorials/io/encrypting_game_saves.rst
@@ -1,6 +1,6 @@
-.. _doc_encrypting_save_games:
+.. _doc_encrypting_game_saves:
 
-Encrypting save games
+Encrypting game saves
 =====================
 
 Why?

--- a/tutorials/io/encrypting_save_games.rst
+++ b/tutorials/io/encrypting_save_games.rst
@@ -6,28 +6,19 @@ Encrypting save games
 Why?
 ----
 
-Because the world today is not the world of yesterday. A capitalist
-oligarchy runs the world and forces us to consume in order to keep the
-gears of this rotten society on track. As such, the biggest market for
-video game consumption today is the mobile one. It is a market of poor
-souls forced to compulsively consume digital content in order to forget
-the misery of their everyday life, commute, or just any other brief
-free moment they have that they are not using to produce goods or
-services for the ruling class. These individuals need to keep focusing
-on their video games (because not doing so will fill them with
-tremendous existential angst), so they go as far as spending money on
-them to extend their experience, and their preferred way of doing so is
-through in-app purchases and virtual currency.
+Most users that care whether a game save is encrypted will prefer no
+encryption at all. But there may be reasons to implement this feature
+anyway. Encrypting saves will curb cheating; this may not be fun for users
+but may be necessary in multiplayer games, games with microtransactions, or
+games that hide secrets to surprise the player. This method of save
+encryption is still able to be bypassed by a sufficiently savvy user
+because, since the encryption key is stored inside the game, the player can
+still decrypt and edit the file themselves.
 
-But what if someone were to find a way to edit the saved games and
-assign the items and currency without effort? That would be terrible,
-because it would help players consume the content much faster, and therefore
-run out of it sooner than expected. If that happens, they will have
-nothing that avoids them to think, and the tremendous agony of realizing
-their own irrelevance would again take over their life.
-
-No, we definitely do not want that to happen, so let's see how to
-encrypt savegames and protect the world order.
+The only way to prevent this from being possible is to store the save data
+on a remote server, where players can only make authorized changes to their
+save data. If your game deals with real money, you need to be doing this
+anyway.
 
 How?
 ----
@@ -35,7 +26,9 @@ How?
 The class :ref:`File <class_File>` can open a file at a
 location and read/write data (integers, strings and variants).
 It also supports encryption.
-To create an encrypted file, a passphrase must be provided, like this:
+To create an encrypted file, a passphrase must be provided. If we just
+store the passphrase in plaintext in our code, it will look something
+like this:
 
 .. tabs::
  .. code-tab:: gdscript GDScript
@@ -52,9 +45,16 @@ To create an encrypted file, a passphrase must be provided, like this:
     f.StoreVar(gameState);
     f.Close();
 
-This will make the file unreadable to users, but will still not prevent
-them from sharing savefiles. To solve this, use the device unique id or
-some unique user identifier, for example:
+We could instead extract the passphrase string from a local or remote
+file, but all these methods are imperfect solutions as long as the save data
+is local.
+
+We have now curbed the reading/writing of the file by users. However, this
+does not prevent users from swapping savefiles. To solve this on
+iOS/Android, use OS.get_unique_id().
+
+This function only works on mobile, but another unique user identifier
+could be found for the desktop with some extra work.
 
 .. tabs::
  .. code-tab:: gdscript GDScript
@@ -71,13 +71,4 @@ some unique user identifier, for example:
     f.StoreVar(gameState);
     f.Close();
 
-Note that ``OS.get_unique_id()`` only works on iOS and Android.
 
-That is all! Thank you for your cooperation, citizen.
-
-.. note:: This method cannot really prevent players from editing their savegames
-          locally because, since the encryption key is stored inside the game, the player
-          can still decrypt and edit the file themselves. The only way to prevent this
-          from being possible is to store the save data on a remote server, where players
-          can only make authorized changes to their save data. If your game deals with
-          real money, you need to be doing this anyway.

--- a/tutorials/io/index.rst
+++ b/tutorials/io/index.rst
@@ -8,4 +8,4 @@ I/O
     background_loading
     data_paths
     saving_games
-    encrypting_save_games
+    encrypting_game_saves


### PR DESCRIPTION
This is subjective, but I felt the humor in the beginning of this tutorial on encrypting game saves was a bit long winded, out of place, and wouldn't be encouraging to the people who were trying to implement it, namely, mobile developers.

The tutorial was also called "encrypting save games", but "encrypting game saves" sounds more correct.