### PR TITLE
Link to Built-in GDScript functions

### DIFF
--- a/getting_started/scripting/visual_script/nodes_purposes.rst
+++ b/getting_started/scripting/visual_script/nodes_purposes.rst
@@ -397,10 +397,8 @@ input and return an output. They are almost never sequenced.
 Built-In
 ^^^^^^^^
 
-There is a list of built-in helpers. The list is almost identical to the one from `GDScript`_. Most of them are mathematical functions, but others can be useful helpers. Make sure to take a look at the list
+There is a list of built-in helpers. The list is almost identical to the one from :ref:`GDScript<class_@GDScript>`. Most of them are mathematical functions, but others can be useful helpers. Make sure to take a look at the list
 at some point.
-
-.. _GDScript: https://docs.godotengine.org/en/3.1/classes/class_@gdscript.html
 
 By Type
 ^^^^^^^

--- a/getting_started/scripting/visual_script/nodes_purposes.rst
+++ b/getting_started/scripting/visual_script/nodes_purposes.rst
@@ -397,10 +397,10 @@ input and return an output. They are almost never sequenced.
 Built-In
 ^^^^^^^^
 
-There is a list of built-in helpers. The list is almost identical to the one from GDScript (@TODO, link to gdscript methods?).
-Most of them are mathematical functions, but others can be useful helpers. Make sure to take a look at the list
+There is a list of built-in helpers. The list is almost identical to the one from `GDScript`_. Most of them are mathematical functions, but others can be useful helpers. Make sure to take a look at the list
 at some point.
 
+.. _GDScript: https://docs.godotengine.org/en/3.1/classes/class_@gdscript.html
 
 By Type
 ^^^^^^^


### PR DESCRIPTION
In the tutorial:
https://docs.godotengine.org/en/3.1/getting_started/scripting/visual_script/nodes_purposes.html

Replaced (@TODO, link to gdscript methods?) with link to Built-in GDScript functions.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
