### PR TITLE
get_skidinfo() misleading definition

### DIFF
--- a/classes/class_vehiclewheel.rst
+++ b/classes/class_vehiclewheel.rst
@@ -207,7 +207,7 @@ Method Descriptions
 
 - :ref:`float<class_float>` **get_skidinfo** **(** **)** const
 
-Returns a value between 0.0 and 1.0 that indicates whether this wheel is skidding. 0.0 is not skidding, 1.0 means the wheel has lost grip.
+Returns a value between 0.0 and 1.0 that indicates whether this wheel is skidding. 0.0 is skidding (the wheel has lost grip), 1.0 means not skidding.
 
 .. _class_VehicleWheel_method_is_in_contact:
 


### PR DESCRIPTION
It seems (please correct me if you understand it otherwise) that the description for the `get_skidinfo()` function is the inverse of what actually happens. I have run some simple tests, and looks like setting low  `Friction Slip`  (e.g. try 1 or 2) causes more skidding and returns smaller values for `get_skidinfo()`, while when the `Friction Slip` is increased, the car skids less and values printed to the console increase (get closer to 1.0). So it seems that a value of 0 means skidding, while a value of 1.0 means no skidding (the description says the exact opposite to this, from what I understood).

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
