### PR TITLE
Fix flags formatting in external editors doc

### DIFF
--- a/getting_started/editor/external_editor.rst
+++ b/getting_started/editor/external_editor.rst
@@ -3,25 +3,27 @@
 Using an external text editor
 ==============================
 
-Godot can be used with an external text editor, such as Sublime Text or Visual Studio Code. To select an external text editor via the Godot editor menu:
+Godot can be used with an external text editor, such as Sublime Text or Visual Studio Code.
+To enable an external text editor, browse to the relevant editor settings via:
 ``Editor -> Editor Settings -> Text Editor -> External``
 
 .. image:: img/editor_settings.png
 
 There are two fields: the executable path and command line flags. The flags
-allow you to better integrate the editor with Godot. Godot will replace the
-following inside the flags parameter:
+allow you to integrate the editor with Godot, passing it the file path to open
+and other relevant arguments. Godot will replace the following placeholders in
+the flags string:
 
 +---------------------+-----------------------------------------------------+
 | Field in Exec Flags | Is replaced with                                    |
 +=====================+=====================================================+
-| {project}           | The absolute path to the project directory          |
+| ``{project}``       | The absolute path to the project directory          |
 +---------------------+-----------------------------------------------------+
-| {file}              | The absolute path to the file                       |
+| ``{file}``          | The absolute path to the file                       |
 +---------------------+-----------------------------------------------------+
-| {col}               | The column number of the error                      |
+| ``{col}``           | The column number of the error                      |
 +---------------------+-----------------------------------------------------+
-| {line}              | The line number of the error                        |
+| ``{line}``          | The line number of the error                        |
 +---------------------+-----------------------------------------------------+
 
 Some example Exec Flags for various editors include:
@@ -29,15 +31,15 @@ Some example Exec Flags for various editors include:
 +---------------------+-----------------------------------------------------+
 | Editor              | Exec Flags                                          |
 +=====================+=====================================================+
-| Geany/Kate          | {file} -\-line {line} -\-column {col}               |
+| Geany/Kate          | ``{file} --line {line} --column {col}``             |
 +---------------------+-----------------------------------------------------+
-| Atom/Sublime Text   | {file}:{line}                                       |
+| Atom/Sublime Text   | ``{file}:{line}``                                   |
 +---------------------+-----------------------------------------------------+
-| JetBrains Rider     | -\-line {line} {file}                               |
+| JetBrains Rider     | ``--line {line} {file}``                            |
 +---------------------+-----------------------------------------------------+
-| Visual Studio Code  | {project} -\-goto {file}:{line}:{col}               |
+| Visual Studio Code  | ``{project} --goto {file}:{line}:{col}``            |
 +---------------------+-----------------------------------------------------+
-| Vim (gVim)          | "+call cursor({line}, {col})" {file}                |
+| Vim (gVim)          | ``"+call cursor({line}, {col})" {file}``            |
 +---------------------+-----------------------------------------------------+
 
-.. note:: For Visual Studio Code you will have to point to the "code.cmd" file.
+.. note:: For Visual Studio Code you will have to point to the ``code.cmd`` file.


### PR DESCRIPTION
Fixes #2336.

The escapes were not sufficient to prevent rendering those `--` as `‒`.