### PR TITLE
index: Localize Weblate badge on i18n instances

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -110,3 +110,11 @@ gettext_compact = False
 # Exclude class reference when marked with tag i18n.
 if is_i18n:
     exclude_patterns = ['classes']
+    # Couldn't find a way to retrieve variables nor do advanced string
+    # concat from reST, so had to hardcode this in the "epilog" added to
+    # all pages. This is used in index.rst to display the Weblate badge.
+    rst_epilog = """
+.. |weblate_widget| image:: https://hosted.weblate.org/widgets/godot-engine/{weblate_locale}/godot-docs/287x66-white.png
+    :alt: Translation status
+    :target: https://hosted.weblate.org/engage/godot-engine/{weblate_locale}/?utm_source=widget
+""".format(weblate_locale = language)

--- a/index.rst
+++ b/index.rst
@@ -51,10 +51,17 @@ in the top left corner.
           ``#godotengine-doc`` channel on `irc.freenode.net
           <http://webchat.freenode.net/?channels=#godotengine-doc>`_!
 
-.. image:: https://hosted.weblate.org/widgets/godot-engine/-/godot-docs/287x66-white.png
-    :alt: Translation state
-    :align: center
-    :target: https://hosted.weblate.org/engage/godot-engine/?utm_source=widget
+.. only:: not i18n
+
+  .. image:: https://hosted.weblate.org/widgets/godot-engine/-/godot-docs/287x66-white.png
+      :alt: Translation status
+      :align: center
+      :target: https://hosted.weblate.org/engage/godot-engine/?utm_source=widget
+
+.. only:: i18n
+
+  .. centered:: |weblate_widget|
+
 
 The main documentation for the site is organized into the following sections:
 


### PR DESCRIPTION
It will now show the translation status for the used language instead
of the overall completion for all languages.
The badge widget's text is also in the used language.

The drawback is that to do this I had to inject the localized image
directive in the `rst_epilog` for all pages, even though we only need
it for the index.