### PR TITLE
Update examples of proprietary tools

### DIFF
--- a/getting_started/step_by_step/godot_design_philosophy.rst
+++ b/getting_started/step_by_step/godot_design_philosophy.rst
@@ -114,7 +114,7 @@ For the most part, they’re developed from the ground up by contributors.
 
 Anyone can plug in proprietary tools for the needs of their projects —
 they just won’t ship with the engine. This may include Google AdMob,
-or an FBX model importer. Any of these can come as
+or FMOD. Any of these can come as
 third-party plugins instead.
 
 On the other hand, an open codebase means you can **learn from and extend

--- a/getting_started/step_by_step/godot_design_philosophy.rst
+++ b/getting_started/step_by_step/godot_design_philosophy.rst
@@ -113,8 +113,8 @@ This means all the technologies that ship with it have to be Free
 For the most part, they’re developed from the ground up by contributors.
 
 Anyone can plug in proprietary tools for the needs of their projects —
-they just won’t ship with the engine. This may include NVIDIA PhysX,
-Google AdMob, or an FBX model importer. Any of these can come as
+they just won’t ship with the engine. This may include Google AdMob,
+or an FBX model importer. Any of these can come as
 third-party plugins instead.
 
 On the other hand, an open codebase means you can **learn from and extend


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->

As of Dec 3, 2018, NVIDIA PhysX is open-source. Thus it should be removed as an example of a proprietary tool from the design philosophy page