### PR TITLE
Mention Linux binary compatibility limitations on "Compiling for X11"

### DIFF
--- a/development/compiling/compiling_for_x11.rst
+++ b/development/compiling/compiling_for_x11.rst
@@ -115,6 +115,14 @@ manager.
 Building export templates
 -------------------------
 
+.. warning:: Linux binaries usually won't run on distributions that are
+             older than the distribution they were built on. If you wish to
+             distribute binaries that work on most distributions,
+             you should build them on an old distribution such as Ubuntu 16.04.
+             You can use a virtual machine or a container to set up a suitable
+             build environment.
+
+
 To build X11 (Linux, \*BSD) export templates, run the build system with the
 following parameters:
 
@@ -132,14 +140,14 @@ following parameters:
     user@host:~/godot$ scons platform=x11 tools=no target=release bits=64
     user@host:~/godot$ scons platform=x11 tools=no target=release_debug bits=64
 
-Note that cross compiling for the opposite bits (64/32) as your host
+Note that cross-compiling for the opposite bits (64/32) as your host
 platform is not always straight-forward and might need a chroot environment.
 
 To create standard export templates, the resulting files must be copied to:
 
 ::
 
-    /home/[username]/.local/share/godot/templates/[gd-version]/
+    $HOME/.local/share/godot/templates/[gd-version]/
 
 and named like this (even for \*BSD which is seen as "Linux X11" by Godot):
 
@@ -157,5 +165,5 @@ here:
 .. image:: img/lintemplates.png
 
 You don't even need to copy them, you can just reference the resulting
-files in the bin/ directory of your Godot source folder, so the next
-time you build you automatically have the custom templates referenced.
+files in the ``bin/`` directory of your Godot source folder, so the next
+time you build, you automatically have the custom templates referenced.


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/29976.

This should probably be cherry-picked to the `3.1` branch as it's quite important for those who build their own templates :slightly_smiling_face:
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->