### PR TITLE
Fix bug in Creeps tutorial where creeps don't animate

### DIFF
--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -592,6 +592,7 @@ choose one of the three animation types:
 
     func _ready():
         $AnimatedSprite.animation = mob_types[randi() % mob_types.size()]
+        $AnimatedSprite.play()
 
  .. code-tab:: csharp
 
@@ -600,7 +601,9 @@ choose one of the three animation types:
 
     public override void _Ready()
     {
-        GetNode<AnimatedSprite>("AnimatedSprite").Animation = _mobTypes[_random.Next(0, _mobTypes.Length)];
+        var animatedSprite = GetNode<AnimatedSprite>("AnimatedSprite");
+        animatedSprite.Animation = _mobTypes[_random.Next(0, _mobTypes.Length)];
+        animatedSprite.Play();
     }
 
 .. note:: You must use ``randomize()`` if you want


### PR DESCRIPTION
In the Dodge the Creeps tutorial, we need to add a call to "Play()" for the creeps' animations to actually play.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
