### PR TITLE
Remove duplicate line from compiling_with_mono.rst

### DIFF
--- a/development/compiling/compiling_with_mono.rst
+++ b/development/compiling/compiling_with_mono.rst
@@ -12,7 +12,6 @@ Requirements
 - MSBuild
 - NuGet
 - pkg-config
-- NuGet
 
 You may need to import necessary certificates for NuGet to perform HTTPS requests. You can do this
 with the following command (on Windows, you can run it from the Mono command line prompt):


### PR DESCRIPTION
Removed line 15 because NuGet was already stated at line 13.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
