### PR TITLE
Adding Animation to the Mob Scene

### DIFF
--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -608,6 +608,21 @@ choose one of the three animation types:
           the scene. We're going to use ``randomize()`` in our ``Main`` scene,
           so we won't need it here. ``randi() % n`` is the standard way to get
           a random integer between ``0`` and ``n-1``.
+          
+Also we will add a ``_process(delta)`` function below to animate our mob.          
+.. tabs::
+ .. code-tab:: gdscript GDScript
+
+    func _process(delta):
+	$AnimatedSprite.play()
+
+ .. code-tab:: csharp
+
+    public override void _Process(float delta)
+    {
+          var animatedSprite = GetNode<AnimatedSprite>("AnimatedSprite");
+          animatedSprite.Play();
+    }
 
 The last piece is to make the mobs delete themselves when they leave the
 screen. Connect the ``screen_exited()`` signal of the ``Visibility``


### PR DESCRIPTION
Current Tutorial does not instruct to enable animation in the mob scene. I realized it after noticing the difference between my completed game and the example picture included at the beginning of the Tutorial.
Adding a simple function to the mob scene solved my problem and the enemy mob now had animated motion. 
func _process(delta):
	$AnimatedSprite.play()
This can be verified here on my personal repository. 
Project Link - https://github.com/aviraljanveja/Godot/tree/master/DodgeGame
Please find the directory : Godot/DodgeGame/Play/Dodge Game.exe. alternatively: Godot/DodgeGame/project.godot.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
