### PR TITLE
Update SConstruct to generate debug symbols on windows

### DIFF
--- a/tutorials/plugins/gdnative/files/cpp_example/SConstruct
+++ b/tutorials/plugins/gdnative/files/cpp_example/SConstruct
@@ -65,7 +65,8 @@ elif env['platform'] == "windows":
 
     env.Append(CCFLAGS = ['-DWIN32', '-D_WIN32', '-D_WINDOWS', '-W3', '-GR', '-D_CRT_SECURE_NO_WARNINGS'])
     if env['target'] in ('debug', 'd'):
-        env.Append(CCFLAGS = ['-EHsc', '-D_DEBUG', '-MDd'])
+        env.Append(CCFLAGS = ['-EHsc', '-D_DEBUG', '-MDd', '-ZI'])
+        env.Append(LINKFLAGS = ['-DEBUG'])
     else:
         env.Append(CCFLAGS = ['-O2', '-EHsc', '-DNDEBUG', '-MD'])
 


### PR DESCRIPTION
The SConstruct file from the 'GDNative C++ example' was generating debug symbols on OSX and linux, but not on windows.

I've tested this and a breakpoint I put in the gdexample.cpp will trigger with gdb attached to a godot instance run from the editor with this change. 