### PR TITLE
Updated OS.get_unique_id() platform availability notice

### DIFF
--- a/tutorials/io/encrypting_save_games.rst
+++ b/tutorials/io/encrypting_save_games.rst
@@ -71,7 +71,7 @@ some unique user identifier, for example:
     f.StoreVar(gameState);
     f.Close();
 
-Note that ``OS.get_unique_id()`` only works on iOS and Android.
+Note that ``OS.get_unique_id()`` does not work on UWP or HTML5.
 
 That is all! Thank you for your cooperation, citizen.
 


### PR DESCRIPTION
In Godot 3.0, OS.get_unique_id() only supported iOS and Android, but in Godot 3.1 onwards, OS.get_unique_id() supports all platforms except for UWP and HTML5. This PR updates the docs to reflect that change made in Godot 3.1.
