### PR TITLE
C# style guide: Clarify inserting space after commas to not do so at the end of lines

### DIFF
--- a/getting_started/scripting/c_sharp/c_sharp_style_guide.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_style_guide.rst
@@ -141,7 +141,7 @@ Insert a space:
 * Between an opening parenthesis and ``if``, ``for``, ``foreach``, ``catch``, ``while``, ``lock`` or ``using`` keywords.
 * Before and within a single line accessor block.
 * Between accessors in a single line accessor block.
-* After a comma.
+* After a comma which is not at the end of a line.
 * After a semicolon in a ``for`` statement.
 * After a colon in a single line ``case`` statement.
 * Around a colon in a type declaration.


### PR DESCRIPTION
For example, we don't want to insert a space here: https://github.com/godotengine/godot/blob/master/modules/mono/glue/Managed/Files/Vector3.cs#L22 @neikeq 