### PR TITLE
[Minor] Fix "it's" that should be "its"

### DIFF
--- a/development/cpp/configuring_an_ide.rst
+++ b/development/cpp/configuring_an_ide.rst
@@ -295,4 +295,4 @@ To create them:
 
 - You can now start Debug process again to test that everything works.
 
-- If the build phase fails, check console for hints. On Linux it's most likely that some dependencies are missing. Check :ref:`Compiling for X11 (Linux, \*BSD) <doc_compiling_for_x11>`
+- If the build phase fails, check the console for hints. On Linux it's most likely that some dependencies are missing. Check :ref:`Compiling for X11 (Linux, \*BSD) <doc_compiling_for_x11>`

--- a/development/cpp/custom_modules_in_cpp.rst
+++ b/development/cpp/custom_modules_in_cpp.rst
@@ -21,7 +21,7 @@ transparently.
 What for?
 ---------
 
-While it's recommended that most of a game is written in scripting (as
+While it's recommended that most of a game be written in scripting (as
 it is an enormous time saver), it's perfectly possible to use C++
 instead. Adding C++ modules can be useful in the following scenarios:
 

--- a/getting_started/workflow/best_practices/data_preferences.rst
+++ b/getting_started/workflow/best_practices/data_preferences.rst
@@ -173,7 +173,7 @@ The important detail here is the complexity of the Object's task. Every time
 it performs one of these multi-source queries, it runs through *several*
 iteration loops and HashMap lookups. What's more, the queries are linear-time
 operations dependent on the Object's inheritance hierarchy size. If the class
-the Object queries (it's current class) doesn't find anything, the request
+the Object queries (its current class) doesn't find anything, the request
 defers to the next base class, all the way up until the original Object class.
 While these are each fast operations in isolation, the fact that it must make
 so many checks is what makes them slower than both of the alternatives for

--- a/getting_started/workflow/export/android_custom_build.rst
+++ b/getting_started/workflow/export/android_custom_build.rst
@@ -59,7 +59,7 @@ This may appear a little confusing, but be sure to follow these instructions car
 
   C:\users\<yourusername>\Documents\android-sdk
 
-is often good enough. Unzip the *sdk zip file* you just downloaded there. The only thing in the directory you created in the previous step should be the *tools* folder with it's contents inside, like this:
+is often good enough. Unzip the *sdk zip file* you just downloaded there. The only thing in the directory you created in the previous step should be the *tools* folder with its contents inside, like this:
 
 ::
 

--- a/getting_started/workflow/export/android_custom_build.rst
+++ b/getting_started/workflow/export/android_custom_build.rst
@@ -9,7 +9,7 @@ an export template every time you export the project.
 
 There are some reasons why you may want to do this:
 
-* Modify the project before it's build
+* Modify the project before it's built
 * Add external SDKs that build with your project
 
 Configuring custom build is a more or less straightforward process, but it may take a while to get used to how the Android SDK works.

--- a/tutorials/3d/fps_tutorial/part_one.rst
+++ b/tutorials/3d/fps_tutorial/part_one.rst
@@ -618,7 +618,7 @@ _________
 
 Now let's look at ``process_movement``:
 
-First we ensure that ``dir`` does not have any movement on the ``Y`` axis by setting it's ``Y`` value to zero.
+First we ensure that ``dir`` does not have any movement on the ``Y`` axis by setting its ``Y`` value to zero.
 
 Next we normalize ``dir`` to ensure we're within a ``1`` radius unit circle. This makes it where we're moving at a constant speed regardless
 of whether the player is moving straight or diagonally. If we did not normalize, the player would move faster on the diagonal than when going straight.

--- a/tutorials/gui/gui_containers.rst
+++ b/tutorials/gui/gui_containers.rst
@@ -25,7 +25,7 @@ When a :ref:`Container <class_Container>`-derived node is used, all children :re
 own positioning ability. This means the *Container* will control their positioning and any attempt to manually alter these
 nodes will be either ignored or invalidated the next time their parent is resized.
 
-Likewise, when a *Container* derived node is resized, all it's children will be re-positioned according to it, 
+Likewise, when a *Container* derived node is resized, all its children will be re-positioned according to it, 
 with a behavior based on the type of container used:
 
    .. image:: img/container_example.gif

--- a/tutorials/legal/complying_with_licenses.rst
+++ b/tutorials/legal/complying_with_licenses.rst
@@ -69,7 +69,7 @@ Godot itself contains software written by `third parties <https://github.com/god
 FreeType
 ^^^^^^^^
 
-Godot uses `FreeType <https://www.freetype.org/>`_ to render fonts. It's license requires attribution, so the following text must be included together with the Godot license:
+Godot uses `FreeType <https://www.freetype.org/>`_ to render fonts. Its license requires attribution, so the following text must be included together with the Godot license:
 
 
 	Portions of this software are copyright © <year> The FreeType Project (www.freetype.org).  All rights reserved.

--- a/tutorials/shading/your_first_shader/your_second_spatial_shader.rst
+++ b/tutorials/shading/your_first_shader/your_second_spatial_shader.rst
@@ -83,8 +83,8 @@ a low ``METALLIC`` has a more equal representation of sky color and ``ALBEDO`` c
 .. note:: ``METALLIC`` should be close to ``0`` or ``1`` for proper PBR shading. Only set it between
           them for blending between materials.
 
-Water is not a metal, so we will set its ``METALLIC`` property to ``0.0``. But, water is also highly
-reflective, so we will set its ``ROUGHNESS`` property to by quite low as well.
+Water is not a metal, so we will set its ``METALLIC`` property to ``0.0``. Water is also highly
+reflective, so we will set its ``ROUGHNESS`` property to be quite low as well.
 
 .. code-block:: glsl
 

--- a/tutorials/shading/your_first_shader/your_second_spatial_shader.rst
+++ b/tutorials/shading/your_first_shader/your_second_spatial_shader.rst
@@ -83,8 +83,8 @@ a low ``METALLIC`` has a more equal representation of sky color and ``ALBEDO`` c
 .. note:: ``METALLIC`` should be close to ``0`` or ``1`` for proper PBR shading. Only set it between
           them for blending between materials.
 
-Water is not a metal, so we will set it's ``METALLIC`` property to ``0.0``. But, water is also highly
-reflective, so we will set it's ``ROUGHNESS`` property to by quite low as well.
+Water is not a metal, so we will set its ``METALLIC`` property to ``0.0``. But, water is also highly
+reflective, so we will set its ``ROUGHNESS`` property to by quite low as well.
 
 .. code-block:: glsl
 


### PR DESCRIPTION
I saw some "it's" that should have been "its", so I went over the whole doc. I actually found very few of those, so I guess I'm just overly pedant, but thought I'd send the patch anyway.

Cheers!