### PR TITLE
Update FreeBSD dependencies in "Compiling for X11"

### DIFF
--- a/development/compiling/compiling_for_x11.rst
+++ b/development/compiling/compiling_for_x11.rst
@@ -45,8 +45,9 @@ Distro-specific oneliners
 +----------------+-----------------------------------------------------------------------------------------------------------+
 | **FreeBSD**    | ::                                                                                                        |
 |                |                                                                                                           |
-|                |     sudo pkg install scons pkgconf xorg-libraries libXcursor libXrandr libXi xineramaproto libglapi \     |
-|                |         libGLU yasm                                                                                       |
+|                |     sudo pkg install scons pkgconf xorg-libraries libXcursor libXrandr libXi xorgproto libGLU alsa-lib \  |
+|                |         pulseaudio yasm                                                                                   |
+|                |                                                                                                           |
 +----------------+-----------------------------------------------------------------------------------------------------------+
 | **Gentoo**     | ::                                                                                                        |
 |                |                                                                                                           |


### PR DESCRIPTION
`xineramaproto` is now `xorgproto` in recent FreeBSD versions. `libglapi` no longer seems to be available, but Godot still builds if you omit it.

This also adds `alsa-lib` and `pulseaudio` which are required to build editor and export template binaries.

Tested on FreeBSD 12.0 and 11.2.