### PR TITLE
Made export template name match the default for Linux

### DIFF
--- a/getting_started/editor/command_line_tutorial.rst
+++ b/getting_started/editor/command_line_tutorial.rst
@@ -135,7 +135,7 @@ that is headless (server build, no video) is ideal for this.
 
 ::
 
-    user@host:~/newgame$ godot --export "Linux X11" /var/builds/project
+    user@host:~/newgame$ godot --export "Linux/X11" /var/builds/project
     user@host:~/newgame$ godot --export Android /var/builds/project.apk
 
 The platform names recognized by the ``--export`` switch are the same as


### PR DESCRIPTION
The default export template name for Linux appears to be `Linux/X11` and not `Linux X11`

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
