### PR TITLE
[Minor] Getting Started corrections

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_basics.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics.rst
@@ -1351,7 +1351,7 @@ initializers, but they must be constant expressions.
 
     export(Array, int) var ints = [1,2,3]
     export(Array, int, "Red", "Green", "Blue") var enums = [2, 1, 0]
-    export(Array, Array, float) var two_dimensional = [[1, 2], [3, 4]]
+    export(Array, Array, float) var two_dimensional = [[1.0, 2.0], [3.0, 4.0]]
 
     # You can omit the default value, but then it would be null if not assigned.
 

--- a/getting_started/step_by_step/scripting_continued.rst
+++ b/getting_started/step_by_step/scripting_continued.rst
@@ -33,7 +33,7 @@ This method will be called every time a frame is drawn:
         // Do something...
     }
 
-It's important to bear in mind that the frequecy with which ``_process()``
+It's important to bear in mind that the frequency with which ``_process()``
 will be called depends on how many frames per second (FPS) your application
 is running at. This rate can vary over time and devices.
 


### PR DESCRIPTION
1º - For some reason, even with the float type indicator in the export settings, it will display integer sliders for the array elements. Putting ".0" fixes that behavior.

2º - "frequecy" should be "frequency".