### PR TITLE
Update class_os.rst

### DIFF
--- a/classes/class_os.rst
+++ b/classes/class_os.rst
@@ -1320,7 +1320,9 @@ Sets the window title to the specified string.
 
 Requests the OS to open a resource with the most appropriate program. For example.
 
-``OS.shell_open("C:\\Users\name\Downloads")`` on Windows opens the file explorer at the downloads folders of the user.
+``OS.shell_open("C:\\Program Files")`` on Windows opens the file explorer at the Program Files directory.
+
+``OS.shell_open(OS.get_user_data_dir()+"/my_file.txt")`` opens ``user://my_file.txt`` using the default text editor.
 
 ``OS.shell_open("https://godotengine.org")`` opens the default web browser on the official Godot website.
 


### PR DESCRIPTION
The line that was edited had multiple flaws (at least two).
1) One could interpret the path as working for all users instead of the user named "name"
2) Only one of the backwards slashes were escaped

The first of these flaws would not be a big deal, and would not pose a big risk of being misunderstand, though the second flaw means it wouldn't even parse. **When typing "C:\\Users\name\Downloads" into the GDScript editor you get the following error message: "Parse Error: Invalid escape sequence".**

**My proposed PR fixes these flaws by instead leading to the Program Files** directory, and in addition it adds **a new example that works on all desktop platforms and illustrates that text files can be opened**, not just directories and URLs. I understand if including OS.get_user_data_dir() over-complicates it and am willing to change it. Nor am i sure if OS.get_user_data_dir()+"/my_file.txt" is the correct way to write it as Windows prefers backslashes while Linux and macOS uses forwards slashes?

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
