### PR TITLE
Update the MinGW Arch Linux package to point to the AUR

### DIFF
--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -151,29 +151,29 @@ If you are a Linux or macOS user, you need to install
 and 64-bit variants. The package names may differ based on your distribution,
 here are some known ones:
 
-+---------------+--------------------------------------------------------------+
-| **Arch**      | ::                                                           |
-|               |                                                              |
-|               |     pacman -S mingw-w64-gcc                                  |
-+---------------+--------------------------------------------------------------+
-| **Debian** /  | ::                                                           |
-| **Ubuntu**    |                                                              |
-|               |     apt install mingw-w64                                    |
-+---------------+--------------------------------------------------------------+
-| **Fedora**    | ::                                                           |
-|               |                                                              |
-|               |     dnf install mingw64-gcc-c++ mingw64-winpthreads-static \ |
-|               |                 mingw32-gcc-c++ mingw32-winpthreads-static   |
-+---------------+--------------------------------------------------------------+
-| **macOS**     | ::                                                           |
-|               |                                                              |
-|               |     brew install mingw-w64                                   |
-+---------------+--------------------------------------------------------------+
-| **Mageia**    | ::                                                           |
-|               |                                                              |
-|               |     urpmi mingw64-gcc-c++ mingw64-winpthreads-static \       |
-|               |           mingw32-gcc-c++ mingw32-winpthreads-static         |
-+---------------+--------------------------------------------------------------+
++----------------+--------------------------------------------------------------+
+| **Arch Linux** | Install `mingw-w64-gcc from the AUR`_.                       |
++----------------+--------------------------------------------------------------+
+| **Debian** /   | ::                                                           |
+| **Ubuntu**     |                                                              |
+|                |     apt install mingw-w64                                    |
++----------------+--------------------------------------------------------------+
+| **Fedora**     | ::                                                           |
+|                |                                                              |
+|                |     dnf install mingw64-gcc-c++ mingw64-winpthreads-static \ |
+|                |                 mingw32-gcc-c++ mingw32-winpthreads-static   |
++----------------+--------------------------------------------------------------+
+| **macOS**      | ::                                                           |
+|                |                                                              |
+|                |     brew install mingw-w64                                   |
++----------------+--------------------------------------------------------------+
+| **Mageia**     | ::                                                           |
+|                |                                                              |
+|                |     urpmi mingw64-gcc-c++ mingw64-winpthreads-static \       |
+|                |           mingw32-gcc-c++ mingw32-winpthreads-static         |
++----------------+--------------------------------------------------------------+
+
+.. _mingw-w64-gcc from the AUR: https://aur.archlinux.org/packages/mingw-w64-gcc/
 
 Before attempting the compilation, SCons will check for
 the following binaries in your ``PATH`` environment variable::


### PR DESCRIPTION
MinGW is no longer part of the official repositories. The AUR must now be used to install MinGW.

(There are multiple AUR helpers out there, so I can't write a copy-pastable command directly.)

This closes #2157.