### PR TITLE
Adds a breadcrumb template to manage hiding 'Edit on Github' link.

### DIFF
--- a/_templates/breadcrumbs.html
+++ b/_templates/breadcrumbs.html
@@ -1,0 +1,7 @@
+{%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
+
+{% block breadcrumbs_aside %}
+{% if not meta or meta.get('github_url') != 'hide' %}
+{{ super() }}
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
To work, requires adding a meta the very beginning of files that have to hide this link:
`:github_url: hide`

This will thus also require a small adding in makerst.py on godotengine/godot.

For  the record, all credits goes to this kind person: https://github.com/sphinx-doc/sphinx/issues/2386#issuecomment-478403897