### PR TITLE
Fix Sphinx Weblate widget warning

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -116,14 +116,20 @@ linkcheck_timeout = 10
 
 locale_dirs = ['../sphinx/po/']
 gettext_compact = False
+
+# Couldn't find a way to retrieve variables nor do advanced string
+# concat from reST, so had to hardcode this in the "epilog" added to
+# all pages. This is used in index.rst to display the Weblate badge.
+# On English pages, the badge points to the language-neutral engage page.
+rst_epilog = """
+.. |weblate_widget| image:: https://hosted.weblate.org/widgets/godot-engine/{image_locale}/godot-docs/287x66-white.png
+    :alt: Translation status
+    :target: https://hosted.weblate.org/engage/godot-engine{target_locale}/?utm_source=widget
+""".format(
+    image_locale='-' if language == 'en' else language,
+    target_locale='' if language == 'en' else '/' + language
+)
+
 # Exclude class reference when marked with tag i18n.
 if is_i18n:
     exclude_patterns = ['classes']
-    # Couldn't find a way to retrieve variables nor do advanced string
-    # concat from reST, so had to hardcode this in the "epilog" added to
-    # all pages. This is used in index.rst to display the Weblate badge.
-    rst_epilog = """
-.. |weblate_widget| image:: https://hosted.weblate.org/widgets/godot-engine/{weblate_locale}/godot-docs/287x66-white.png
-    :alt: Translation status
-    :target: https://hosted.weblate.org/engage/godot-engine/{weblate_locale}/?utm_source=widget
-""".format(weblate_locale = language)

--- a/index.rst
+++ b/index.rst
@@ -51,17 +51,7 @@ in the top left corner.
           ``#godotengine-doc`` channel on `irc.freenode.net
           <http://webchat.freenode.net/?channels=#godotengine-doc>`_!
 
-.. only:: not i18n
-
-  .. image:: https://hosted.weblate.org/widgets/godot-engine/-/godot-docs/287x66-white.png
-      :alt: Translation status
-      :align: center
-      :target: https://hosted.weblate.org/engage/godot-engine/?utm_source=widget
-
-.. only:: i18n
-
-  .. centered:: |weblate_widget|
-
+.. centered:: |weblate_widget|
 
 The main documentation for the site is organized into the following sections:
 


### PR DESCRIPTION
The `weblate_widget` substitution is now always defined. This also makes it possible to remove some duplication in `index.rst`.

This partially addresses #2664.