### PR TITLE
Add a reference to pow to the description of exp.

### DIFF
--- a/classes/class_@gdscript.rst
+++ b/classes/class_@gdscript.rst
@@ -479,6 +479,8 @@ The natural exponential function. It raises the mathematical constant **e** to t
 
 **e** has an approximate value of 2.71828.
 
+For exponents to other bases use the method pow.
+
 ::
 
     a = exp(2) # Approximately 7.39


### PR DESCRIPTION
This might be especially usefull since godot script doesn't support ** or ^ as operators, so beginners (like me) might search for the exponential function, when what they really need is the pow function.

I would have liked to add a link to the pow function, but I don't really see how references work in this setup.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
