### PR TITLE
Mark Sphinx extensions as parallel-safe

### DIFF
--- a/extensions/gdscript.py
+++ b/extensions/gdscript.py
@@ -169,3 +169,8 @@ class GDScriptLexer(RegexLexer):
 
 def setup(sphinx):
     sphinx.add_lexer('gdscript', GDScriptLexer())
+
+    return {
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/extensions/sphinx_tabs/tabs.py
+++ b/extensions/sphinx_tabs/tabs.py
@@ -339,3 +339,8 @@ def setup(app):
                 app.add_javascript(path)
     app.connect('html-page-context', update_context)
     app.connect('build-finished', copy_assets)
+
+    return {
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }


### PR DESCRIPTION
This makes it possible to build the whole documentation in parallel by specifying the `-j <threads>` argument on the `sphinx-build` command line.

On an i7-6700K @ 4.4 GHz, building the documentation can be achieved in 3 minutes instead of 10 minutes with a single thread.

Testing on Windows would be welcome as well. If this works reliably, we could add `-j auto` to the `make html` command to benefit from parallel builds by default :slightly_smiling_face: