### PR TITLE
Document 'for' treatment of a bare number as a 'range()'

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_basics.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics.rst
@@ -842,6 +842,12 @@ in the loop variable.
     for c in "Hello":
         print(c) # Iterate through all characters in a String, print every letter on new line.
 
+    for i in 3:
+        statement # Similar to range(3)
+
+    for i in 2.2:
+        statement # Similar to range(ceil(2.2))
+
 match
 ^^^^^
 


### PR DESCRIPTION
I couldn't find these shortcuts documented. I think they're described correctly here but this is just based on observation of the behavior, not from digging into the GDScript compiler.
