### PR TITLE
Clarify exporting a PCK from the command-line

### DIFF
--- a/getting_started/workflow/export/exporting_projects.rst
+++ b/getting_started/workflow/export/exporting_projects.rst
@@ -149,12 +149,9 @@ called "Windows Desktop" and the template can be found.
 The output path is relative to the project path or absolute;
 it does not respect the directory the command was invoked from.
 
-You can also configure it to export only the PCK or ZIP file (allowing
-a single export to be used with multiple Godot executables). This
-takes place if:
-
- - the export preset is not marked as runnable,
- - the target name ends with ``.pck`` or ``.zip``.
+You can also configure it to export only the PCK or ZIP file, allowing
+a single export to be used with multiple Godot executables.
+This takes place if the target name ends with ``.pck`` or ``.zip``.
 
 It is often useful to combine the ``--export`` flag with the ``--path``
 flag, and to create a dedicated export preset for automated export:


### PR DESCRIPTION
The "Runnable" preset is actually used to define which presets can be run from an one-click deploy in the editor. It is currently only used for Android and HTML5.

From testing on commit https://github.com/godotengine/godot/commit/5441aaf768d6dd4c3d8465e6b340ae38ddc7db1d, the export preset's "Runnable" status has no bearing on whether a PCK file can be created or not.

Likewise, an executable project can still be exported from an export preset not marked as "Runnable".