### PR TITLE
Clarify the location of the "Layout" menu

### DIFF
--- a/getting_started/step_by_step/ui_main_menu.rst
+++ b/getting_started/step_by_step/ui_main_menu.rst
@@ -137,8 +137,8 @@ define the margins' size. Scroll down the ``Control`` class, to the
 -  Margin Left: *120*
 -  Margin Bottom: *80*
 
-We want the container to fit the window. In the Viewport, open the
-``Layout`` menu and select the last option, ``Full Rect``.
+We want the container to fit the window. In the toolbar above the Viewport, 
+open the ``Layout`` menu and select the last option, ``Full Rect``.
 
 Add the UI sprites
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
I spent a good 15 minutes looking for the "Layout" menu. Most of that is my own fault but here's a small edit that I think would be slightly more clarifying (using the same terminology from the "Introduction to Godot's editor" page)