### PR TITLE
Clarify the behavior of match and continue

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_basics.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics.rst
@@ -851,15 +851,15 @@ Basic syntax::
 
 1. Replace ``switch`` with ``match``.
 2. Remove ``case``.
-3. Remove any ``break``\ s. If you don't want to ``break`` by default, you can use ``continue`` for a fallthrough.
+3. Remove any ``break``\ s. If you don't want to ``break`` by default, you can use ``continue`` followed by a Multiple pattern for a fallthrough.
 4. Change ``default`` to a single underscore.
 
 
 **Control flow**:
 
 The patterns are matched from top to bottom.
-If a pattern matches, the corresponding block will be executed. After that, the execution continues below the ``match`` statement.
-If you want to have a fallthrough, you can use ``continue`` to stop execution in the current block and check the ones below it.
+If a pattern matches, the first corresponding block will be executed. After that, the execution continues below the ``match`` statement.
+If you want to have a fallthrough, you can use ``continue`` to stop execution in the current block and check for an additional match in the patterns below it.
 
 There are 6 pattern types:
 


### PR DESCRIPTION
I found the description of the fallthrough behavior of 'continue' to be misleading, since it doesn't behave the same way as any language's switch fallthrough that I'm aware of. Added details on how our 'continue' is different.