### PR TITLE
updated trailing stop after exclamation mark in...

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_styleguide.rst
+++ b/getting_started/scripting/gdscript/gdscript_styleguide.rst
@@ -135,7 +135,7 @@ Whitespace
 ~~~~~~~~~~
 
 Always use one space around operators and after commas. Avoid extra
-spaces in dictionary references and function calls, or to create "columns."
+spaces in dictionary references and function calls, or to create "columns".
 
 **Good**:
 


### PR DESCRIPTION
...text: Always use one space around operators and after commas. Avoid extra spaces in dictionary references and function calls, or to create "columns."

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
