### PR TITLE
Fix mistakes in some recent tutorials changes

### DIFF
--- a/tutorials/3d/high_dynamic_range.rst
+++ b/tutorials/3d/high_dynamic_range.rst
@@ -25,7 +25,7 @@ in the game engine; there is only a potentially infinitely wide range of intensi
 values generated per frame of rendering.
 
 This means that some transformation of the scene light intensity, also known
-as _scene referred_ light ratios, need to be transformed and mapped to fit
+as scene-referred light ratios, need to be transformed and mapped to fit
 within the particular output range of the chosen display. This can be most
 easily understood if we consider virtually photographing our game engine scene
 through a virtual camera. Here, our virtual camera would apply a particular

--- a/tutorials/animation/introduction_2d.rst
+++ b/tutorials/animation/introduction_2d.rst
@@ -378,7 +378,7 @@ click the "Insert Key" option. This will bring up a list of methods
 that can be called for the AudioStreamPlayer node. Select the first
 one.
 
-.. image:: img/animation_method_list.png
+.. image:: img/animation_method_options.png
 
 When Godot reaches the keyframe, Godot calls the
 :ref:`class_AnimationPlayer` node's "play" function and the stream
@@ -387,7 +387,7 @@ plays.
 You can change its position by dragging it on the timeline, you can also
 click on the keyframe and use the keyframe settings in the inspector.
 
-.. img:: img/animation_call_method_keyframe.png
+.. image:: img/animation_call_method_keyframe.png
 
 .. |Play from beginning| image:: img/animation_play_from_beginning.png
 .. |Add Animation| image:: img/animation_add.png


### PR DESCRIPTION
- Fixed some images not appearing in "Introduction to the 2D animation features".
- Removed out of place formatting in "Light transport in game engines". @sobotka, what where you trying to do here?