### PR TITLE
Improve One-click deploy documentation

### DIFF
--- a/getting_started/workflow/export/one-click_deploy.rst
+++ b/getting_started/workflow/export/one-click_deploy.rst
@@ -6,28 +6,26 @@ One-click deploy
 Sounds good, what is it?
 ------------------------
 
-This feature will pop up automatically once a platform is properly
-configured and a supported device is connected to the computer. Since
-things can go wrong at many levels (platform may not be configured
-correctly, SDK may be incorrectly installed, device may be improperly
-configured, kitty ate the USB cable, etc.), it's good to let the user
+This feature will pop up automatically once a platform is properly configured
+and a supported device is connected to the computer. Since things can go wrong
+at many levels (platform may not be configured correctly, SDK may be incorrectly
+installed, device may be improperly configured, etc.), it's good to let the user
 know that it exists.
 
-Some platforms (at the time of this writing, only Android and Blackberry
-10) can detect when a USB device is connected to the computer, and offer
-the user to automatically export, install and run the project (in debug
-mode) on the device. This feature is called, in industry buzz-words,
-"One Click Deploy" (though, it's technically two clicks...).
+Some platforms (at the time of this writing, only Android) can detect when a USB
+device is connected to the computer, and offer the user to automatically export,
+install and run the project (in debug mode) on the device. This feature is
+called, in industry buzzwords, "One-Click Deploy".
 
 Steps for one-click deploy
 --------------------------
 
 #. Configure target platform.
 #. Configure device (make sure it's in developer mode, likes the
-   computer, usb cable is plugged, usb is recognized, etc.).
-#. Connect the device..
+   computer, USB cable is plugged, USB is recognized, etc.).
+#. Connect the device...
 #. And voilà!
 
 .. image:: img/oneclick.png
 
-Click once.. and deploy!
+Click once... and deploy!


### PR DESCRIPTION
- Shorten text to be more concise
- Remove references to BlackBerry 10, whose support was removed a long time ago

Note that I didn't mention the current support for one-click deploy with the HTML5 platform, since it may be removed soon until https://github.com/godotengine/godot/issues/16245 is implemented.