### PR TITLE
Document all comments that disable warnings

### DIFF
--- a/getting_started/scripting/gdscript/static_typing.rst
+++ b/getting_started/scripting/gdscript/static_typing.rst
@@ -327,7 +327,7 @@ script editor’s status bar. The example below has 3 warnings:
    warning system example
 
 To ignore specific warnings in one file, insert a special comment of the
-form ``#warning-ignore:warning-id``, or click on the ignore link to the
+form ``# warning-ignore:warning-id``, or click on the ignore link to the
 right of the warning’s description. Godot will add a comment above the
 corresponding line and the code won’t trigger the corresponding warning
 anymore:
@@ -336,6 +336,10 @@ anymore:
    :alt: warning system ignore example
 
    warning system ignore example
+
+You can also choose to ignore not just one but all warnings of a certain
+type in this file with ``# warning-ignore-all:warning-id``. To ignore all
+warnings of all types in a file add the comment ``# warnings-disable`` to it.
 
 Warnings won’t prevent the game from running, but you can turn them into
 errors if you’d like. This way your game won’t compile unless you fix


### PR DESCRIPTION
These are the 3 types that I found in the code:

- \# warning-ignore:id_of_warning
- \# warning-ignore-all:id_of_warning
- \# warnings-disable

I found them at https://github.com/godotengine/godot/blob/24e1039eb6fe32115e8d1a62a84965e9be19a2ed/modules/gdscript/gdscript_tokenizer.cpp#L558
If there are any more they should also be added.

Having these documented could help people that fight against the warning system - currently it seems quite common to disable warnings alltogether (from what I read on the different support channels).

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
