### PR TITLE
Default to parallel builds in Sphinx for faster builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -j auto
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/make.bat
+++ b/make.bat
@@ -10,6 +10,7 @@ if "%SPHINXBUILD%" == "" (
 set SOURCEDIR=.
 set BUILDDIR=_build
 set SPHINXPROJ=Test
+set SPHINXOPTS=-j auto
 
 if "%1" == "" goto help
 


### PR DESCRIPTION
`-j auto` detects the number of CPU threads automatically.

This partially addresses #2779.