### PR TITLE
Added Pineapple Works as another provider

### DIFF
--- a/tutorials/platform/consoles.rst
+++ b/tutorials/platform/consoles.rst
@@ -33,6 +33,8 @@ Following is the list of providers:
 
 * `Lone Wolf Technology <http://www.lonewolftechnology.com/>`_ offers
   Switch, PS4 and Xbox One porting and publishing of Godot games.
+* _`Pineapple Works <https://pineapple.works/>`_ offers 
+  Switch and Xbox One porting and publishing of Godot games.
 
 If your company offers porting and/or publishing services for Godot games,
 feel free to


### PR DESCRIPTION
Added Pineapple Works as another provider for both porting and publishing of Switch and Xbox One Godot games.


