### PR TITLE
Add note about parameter limit in C++ modules

### DIFF
--- a/development/cpp/custom_modules_in_cpp.rst
+++ b/development/cpp/custom_modules_in_cpp.rst
@@ -224,6 +224,10 @@ You can then zip it and share the module with everyone else. When
 building for every platform (instructions in the previous sections),
 your module will be included.
 
+.. note:: There is a paramter limit of 5 in C++ modules for things such
+          as subclasses. This can be raised to 13 by including the header
+          file ``core/method_bind_ext.gen.inc``.
+
 Using the module
 ----------------
 


### PR DESCRIPTION
Adds a note in the C++ module page about the parameter limit of 5 and how to raise it. I don't work with C++ normally so if there's a better way to phrase it please tell me. Closes #2450 