### PR TITLE
fix build errors with `make latexpdf`

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -11,7 +11,8 @@ needs_sphinx = '1.3'
 
 # Sphinx extension module names and templates location
 sys.path.append(os.path.abspath('extensions'))
-extensions = ['gdscript', 'sphinx_tabs.tabs', 'sphinx.ext.imgmath']
+extensions = ['gdscript', 'sphinx_tabs.tabs', 'sphinx.ext.imgmath', 'sphinx.ext.imgconverter']
+
 templates_path = ['_templates']
 
 # You can specify multiple suffix as a list of string: ['.rst', '.md']

--- a/extensions/sphinx_tabs/tabs.py
+++ b/extensions/sphinx_tabs/tabs.py
@@ -291,14 +291,16 @@ def copy_assets(app, exception):
     """ Copy asset files to the output """
     if 'getLogger' in dir(logging):
         log = logging.getLogger(__name__).info  # pylint: disable=no-member
+        warn = logging.getLogger(__name__).warning  # pylint: disable=no-member
     else:
         log = app.info
+        warn = app.warn
     builders = get_compatible_builders(app)
     if exception:
         return
     if app.builder.name not in builders:
         if not app.config['sphinx_tabs_nowarn']:
-            app.warn(
+            warn(
                 'Not copying tabs assets! Not compatible with %s builder' %
                 app.builder.name)
         return


### PR DESCRIPTION
This commit provides two small fixes.

Gif images are not supported by latexpdf (see [here](https://github.com/sphinx-doc/sphinx/issues/2852#issuecomment-239778182)). There are a handful of options
to resolve that issue, but the already-available imgconverter extension
takes care of converting them to supported image formats.

The pdf build was also failing due to the deprecated Sphinx `app.warn` used
in the sphinx_tabs extension. The `app.log` deprecation was already
handled in this function, and now `warn` is as well.

I do still need to force latexpdf to continue through errors due to poor support for Japanese unicode characters, but that may be something I can solve locally, I'm not sure. The resulting PDF is totally usable regardless.