### PR TITLE
Updated certificate importing instructions for Mono v6

### DIFF
--- a/development/compiling/compiling_with_mono.rst
+++ b/development/compiling/compiling_with_mono.rst
@@ -23,7 +23,7 @@ from the Mono command line prompt, or from the regular command prompt if you add
 
     cert-sync --user cacert.pem
 
-Alternatively, you can do this with the following command, though it won't work for Mono v6 or newer ::
+Alternatively, you can use the following command, though it's deprecated and may only work up to Mono v5 ::
 
     mozroots --import --sync
 

--- a/development/compiling/compiling_with_mono.rst
+++ b/development/compiling/compiling_with_mono.rst
@@ -23,7 +23,7 @@ from the Mono command line prompt, or from the regular command prompt if you add
 
     cert-sync --user cacert.pem
 
-Aternatively, you can do this with the following command, though it won't work for Mono v6 or newer ::
+Alternatively, you can do this with the following command, though it won't work for Mono v6 or newer ::
 
     mozroots --import --sync
 

--- a/development/compiling/compiling_with_mono.rst
+++ b/development/compiling/compiling_with_mono.rst
@@ -23,7 +23,7 @@ from the Mono command line prompt, or from the regular command prompt if you add
 
     cert-sync --user cacert.pem
 
-Alternatively, you can use the following command, though it's deprecated and may only work up to Mono v5 ::
+Alternatively, you can use the following command, though it's deprecated and may not work ::
 
     mozroots --import --sync
 

--- a/development/compiling/compiling_with_mono.rst
+++ b/development/compiling/compiling_with_mono.rst
@@ -14,8 +14,16 @@ Requirements
 - pkg-config
 
 You may need to import necessary certificates for NuGet to perform HTTPS
-requests. You can do this with the following command (on Windows, you can run it
-from the Mono command line prompt)::
+requests.
+
+First you have to download **curl**'s CA (Certificate Autorities) certificate bundle: https://curl.haxx.se/ca/cacert.pem
+
+Then you run the following command to import it (on Windows, you can run it
+from the Mono command line prompt, or from the regular command prompt if you added the Mono installation's bin directory to the PATH environemnt variable)::
+
+    cert-sync --user cacert.pem
+
+Aternatively, you can do this with the following command, though it won't work for Mono v6 or newer ::
 
     mozroots --import --sync
 

--- a/development/compiling/compiling_with_mono.rst
+++ b/development/compiling/compiling_with_mono.rst
@@ -23,7 +23,7 @@ from the Mono command line prompt, or from the regular command prompt if you add
     curl -LO https://curl.haxx.se/ca/cacert.pem
     cert-sync --user cacert.pem
 
-Alternatively, you can use the following command, though it's deprecated and may not work correctly ::
+Alternatively, you can use the following command, though it's deprecated and may not work correctly::
 
     mozroots --import --sync
 

--- a/development/compiling/compiling_with_mono.rst
+++ b/development/compiling/compiling_with_mono.rst
@@ -23,7 +23,7 @@ from the Mono command line prompt, or from the regular command prompt if you add
     curl -LO https://curl.haxx.se/ca/cacert.pem
     cert-sync --user cacert.pem
 
-Alternatively, you can use the following command, though it's deprecated and may not work ::
+Alternatively, you can use the following command, though it's deprecated and may not work correctly ::
 
     mozroots --import --sync
 

--- a/development/compiling/compiling_with_mono.rst
+++ b/development/compiling/compiling_with_mono.rst
@@ -18,7 +18,7 @@ requests.
 
 The recommended method is to use **curl**'s CA (Certificate Autorities) certificate bundle.
 
-Run the following commands to download and import it
+Run the following commands to download and import it.
 On Windows, you can run it from the Mono command line prompt. If Mono's \\bin directory is present in the PATH environment variable, you can use the regular command prompt for that::
     curl -LO https://curl.haxx.se/ca/cacert.pem
     cert-sync --user cacert.pem

--- a/development/compiling/compiling_with_mono.rst
+++ b/development/compiling/compiling_with_mono.rst
@@ -16,11 +16,11 @@ Requirements
 You may need to import necessary certificates for NuGet to perform HTTPS
 requests.
 
-First you have to download **curl**'s CA (Certificate Autorities) certificate bundle: https://curl.haxx.se/ca/cacert.pem
+The recommended method is to use **curl**'s CA (Certificate Autorities) certificate bundle.
 
-Then you run the following command to import it (on Windows, you can run it
+Run the following commands to download and import it (on Windows, you can run it
 from the Mono command line prompt, or from the regular command prompt if you added the Mono installation's bin directory to the PATH environemnt variable)::
-
+    curl -LO https://curl.haxx.se/ca/cacert.pem
     cert-sync --user cacert.pem
 
 Alternatively, you can use the following command, though it's deprecated and may not work ::

--- a/development/compiling/compiling_with_mono.rst
+++ b/development/compiling/compiling_with_mono.rst
@@ -18,8 +18,8 @@ requests.
 
 The recommended method is to use **curl**'s CA (Certificate Autorities) certificate bundle.
 
-Run the following commands to download and import it (on Windows, you can run it
-from the Mono command line prompt, or from the regular command prompt if you added the Mono installation's bin directory to the PATH environemnt variable)::
+Run the following commands to download and import it
+On Windows, you can run it from the Mono command line prompt. If Mono's \\bin directory is present in the PATH environment variable, you can use the regular command prompt for that::
     curl -LO https://curl.haxx.se/ca/cacert.pem
     cert-sync --user cacert.pem
 

--- a/development/compiling/compiling_with_mono.rst
+++ b/development/compiling/compiling_with_mono.rst
@@ -19,7 +19,8 @@ requests.
 The recommended method is to use **curl**'s CA (Certificate Autorities) certificate bundle.
 
 Run the following commands to download and import it.
-On Windows, you can run it from the Mono command line prompt. If Mono's \\bin directory is present in the PATH environment variable, you can use the regular command prompt for that::
+On Windows, you can run it from the Mono command line prompt (or the regular prompt if you added Mono's ``bin`` directory to your ``PATH`` environment variable)::
+
     curl -LO https://curl.haxx.se/ca/cacert.pem
     cert-sync --user cacert.pem
 


### PR DESCRIPTION
Fixed "Compiling with Mono "

*Bugsquad edit:* Fixes godotengine/godot#32284.