### PR TITLE
Fix a function name in GDNative C tutorial

### DIFF
--- a/tutorials/plugins/gdnative/gdnative-c-example.rst
+++ b/tutorials/plugins/gdnative/gdnative-c-example.rst
@@ -429,7 +429,7 @@ globally will be accessible from any instance of your object you create. If
 time a script accesses the library.
 
 If *Singleton* is enabled, our library is automatically loaded and a function
-called ``godot_singleton_init`` is called. We'll leave that for another
+called ``godot_gdnative_singleton`` is called. We'll leave that for another
 tutorial.
 
 The *Symbol Prefix* is a prefix for our core functions, such as ``godot_`` in


### PR DESCRIPTION
The function it referred to as `godot_singleton_init` is actually called [`godot_gdnative_singleton`](https://github.com/godotengine/godot/blob/1d9233c3882afe888b9396f7f2aac917d4dcac4d/modules/gdnative/register_types.cpp#L276).