### PR TITLE
Fix the style used in an outdated example

### DIFF
--- a/community/contributing/docs_writing_guidelines.rst
+++ b/community/contributing/docs_writing_guidelines.rst
@@ -342,7 +342,7 @@ Also surround boolean values, variable names and methods with ``[code][/code]``.
 ::
 
     Timer.autostart
-    If [code]true[/code] the timer will automatically start when it enters the scene tree. Default value: [code]false[/code].
+    If [code]true[/code], the timer will automatically start when entering the scene tree.
 
 
 Use ``[code]`` around arguments


### PR DESCRIPTION
The `If true` example doesn't follow the documentation style (missing comma after `If [code]true[/code]` and it includes the default value). This updates it to that property's current documentation.