### PR TITLE
solution for no visual studio compiler found

### DIFF
--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -43,6 +43,8 @@ environment variable after installing it, then check again.
 You can do so by running the Python installer again and enabling the option
 to add Python to the ``PATH``.
 
+If you are not using MinGW, make sure SCons 3.1.1 is installed. Download `Scons 3.1.1 <https://scons.org/pages/download.html>`_, extract the zip file, and execute ``python setup.py install``.
+
 .. _doc_compiling_for_windows_install_vs:
 
 Installing Visual Studio caveats

--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -43,7 +43,7 @@ environment variable after installing it, then check again.
 You can do so by running the Python installer again and enabling the option
 to add Python to the ``PATH``.
 
-If you are not using MinGW, make sure SCons 3.1.1 is installed. Download `Scons 3.1.1 <https://scons.org/pages/download.html>`_, extract the zip file, and execute ``python setup.py install``.
+If you are not using MinGW, make sure SCons 3.1.1 is installed. Download `SCons 3.1.1 <https://scons.org/pages/download.html>`_, extract the zip file, and execute ``python setup.py install``.
 
 .. _doc_compiling_for_windows_install_vs:
 


### PR DESCRIPTION
Added solution for `warning: No version of Visual Studio compiler found`

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
