### PR TITLE
Change example signal name to animation_finished

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_basics.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics.rst
@@ -1486,7 +1486,7 @@ signal is received, execution will recommence. Here are some examples::
     yield(get_tree(), "idle_frame")
 
     # Resume execution when animation is done playing.
-    yield(get_node("AnimationPlayer"), "finished")
+    yield(get_node("AnimationPlayer"), "animation_finished")
 
     # Wait 5 seconds, then resume execution.
     yield(get_tree().create_timer(5.0), "timeout")


### PR DESCRIPTION
The AnimationPlayer signal used to demonstrate the yield function is called "animation_finished".

