### PR TITLE
alsa-lib-devel was missing in Solus oneliner

### DIFF
--- a/development/compiling/compiling_for_x11.rst
+++ b/development/compiling/compiling_for_x11.rst
@@ -72,7 +72,7 @@ Distro-specific oneliners
 | **Solus**      | ::                                                                                                        |
 |                |                                                                                                           |
 |                |     sudo eopkg install -c system.devel scons libxcursor-devel libxinerama-devel libxi-devel \             |
-|                |         libxrandr-devel mesalib-devel libglu alsa-lib pulseaudio pulseaudio-devel yasm                    |
+|                |         libxrandr-devel mesalib-devel libglu alsa-lib-devel pulseaudio-devel yasm                         |
 +----------------+-----------------------------------------------------------------------------------------------------------+
 
 Compiling


### PR DESCRIPTION
Can't compile without it.