### PR TITLE
Add proper extends / method calls to inspector plugins tutorial

### DIFF
--- a/tutorials/plugins/editor/inspector_plugins.rst
+++ b/tutorials/plugins/editor/inspector_plugins.rst
@@ -49,6 +49,7 @@ Here is an editor for editing integers
  .. code-tab:: gdscript GDScript
     
     # MyEditor.gd 
+    extends EditorProperty
     class_name MyEditor
 
     var updating = false
@@ -57,7 +58,7 @@ Here is an editor for editing integers
         if (updating):
             return
 
-        emit_changed( get_property(), value )
+        emit_changed( get_edited_property(), value )
 
     func update_property():
         var new_value = get_edited_object()[ get_edited_property() ]


### PR DESCRIPTION
Couple small changes which made the example work for me.
Note that this also required that I expose the `EditorSpinSlider` to GDScript which over here: https://github.com/godotengine/godot/pull/32944