### PR TITLE
Typo with the Animation introduction referring to the wrong target node class

### DIFF
--- a/tutorials/animation/introduction_2d.rst
+++ b/tutorials/animation/introduction_2d.rst
@@ -381,7 +381,7 @@ one.
 .. image:: img/animation_method_options.png
 
 When Godot reaches the keyframe, Godot calls the
-:ref:`class_AnimationPlayer` node's "play" function and the stream
+:ref:`class_AudioStreamPlayer` node's "play" function and the stream
 plays.
 
 You can change its position by dragging it on the timeline, you can also


### PR DESCRIPTION
Not much to say here. I've got another PR coming up which is probably slightly more interesting, but found this in the meantime