### PR TITLE
Revert "Mention additional MinGW compilation troubleshooting tips"

### DIFF
--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -217,13 +217,6 @@ And for 32-bit::
     sudo update-alternatives --config i686-w64-mingw32-g++
     <choose i686-w64-mingw32-g++-posix from the list>
 
-.. note::
-
-    Using certain MinGW distributions (e.g. from Homebrew) may result in a build
-    error about ``sprintf_s`` or ``wcscpy_s`` when compiling Godot. If this is
-    the case, try passing
-    ``CXXFLAGS="-DMINGW_HAS_SECURE_API"`` at the end of the SCons command line.
-
 Creating Windows export templates
 ---------------------------------
 


### PR DESCRIPTION
This reverts commit d7cf5991ac6285febe8ce6f4bcdef87f67c93d83, which was merged through https://github.com/godotengine/godot-docs/pull/2842

This is because as per https://github.com/godotengine/godot/issues/33062, we embeded `-DMINGW_HAS_SECURE_API=1` into the build script instead of letting the users put this manually.

As suggested https://github.com/godotengine/godot/pull/33064#issuecomment-546348668,
I reverted this to prevent some confusion.