### PR TITLE
Remove redundant adjective in introduction.rst

### DIFF
--- a/about/introduction.rst
+++ b/about/introduction.rst
@@ -83,7 +83,7 @@ relatively intuitive:
 - The :ref:`sec-general` section contains this introduction as well as
   information about the engine, its history, its licensing, authors, etc. It
   also contains the :ref:`doc_faq`.
-- The :ref:`sec-learn` section is the main *raison d'être* of this
+- The :ref:`sec-learn` section is the *raison d'être* of this
   documentation, as it contains all the necessary information on using the
   engine to make games. It starts with the :ref:`Step by step
   <toc-learn-step_by_step>` tutorial which should be the entry point for all


### PR DESCRIPTION
The adjective "main" before "*raison d'être*" in the second bullet of the last section (Organization of the documentation) is redundant. 

*raison d'être* means "the most important reason for something's existence", so to say "the main *raison d'être*" is to say "the main most important reason..."

I know this is pedantic, but I wanted to start contributing so I figured I'd tackle something easy the first time.