### PR TITLE
Fixed http request example that was not working

### DIFF
--- a/tutorials/networking/http_request_class.rst
+++ b/tutorials/networking/http_request_class.rst
@@ -28,12 +28,12 @@ Below is all the code we need to make it work. The URL points to an online API m
     extends CanvasLayer
 
     func _ready():
-        pass
+        $HTTPRequest.connect("request_completed", self, "_on_request_completed")
 
     func _on_Button_pressed():
         $HTTPRequest.request("http://www.mocky.io/v2/5185415ba171ea3a00704eed")
 
-    func _on_HTTPRequest_request_completed( result, response_code, headers, body ):
+    func _on_request_completed(result, response_code, headers, body):
         var json = JSON.parse(body.get_string_from_utf8())
         print(json.result)
 


### PR DESCRIPTION
Previously in the example signal function "_on_HTTPRequest_request_completed" was not registered, therefore had no effect. I added signal (request_completed) registration in the code snippet.

Also, this example helps users understand that you can register multiple different http request signals in one script