### PR TITLE
Clarify Particles2D spread parameter

### DIFF
--- a/tutorials/2d/particle_systems_2d.rst
+++ b/tutorials/2d/particle_systems_2d.rst
@@ -199,7 +199,8 @@ Spread
 
 This parameter is the angle in degrees which will be randomly added in
 either direction to the base ``Direction``. A spread of ``180`` will emit
-in all directions (+/- 180).
+in all directions (+/- 180). For spread to do anything the "Initial Velocity"
+parameter must be greater than 0.
 
 .. image:: img/paranim3.gif
 


### PR DESCRIPTION
Clarifies that for the spread property to work the initial velocity property must be greater than 0. Closes #2878 