### PR TITLE
Add Alpine Linux dependencies oneliner in Compiling for X11

### DIFF
--- a/development/compiling/compiling_for_x11.rst
+++ b/development/compiling/compiling_for_x11.rst
@@ -27,53 +27,58 @@ required:
 
 Distro-specific oneliners
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-+----------------+-----------------------------------------------------------------------------------------------------------+
-| **Arch Linux** | ::                                                                                                        |
-|                |                                                                                                           |
-|                |     pacman -S scons pkgconf gcc libxcursor libxinerama libxi libxrandr mesa glu alsa-lib pulseaudio yasm  |
-+----------------+-----------------------------------------------------------------------------------------------------------+
-| **Debian** /   | ::                                                                                                        |
-| **Ubuntu**     |                                                                                                           |
-|                |     sudo apt-get install build-essential scons pkg-config libx11-dev libxcursor-dev libxinerama-dev \     |
-|                |         libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm   |
-+----------------+-----------------------------------------------------------------------------------------------------------+
-| **Fedora**     | ::                                                                                                        |
-|                |                                                                                                           |
-|                |     sudo dnf install scons pkgconfig libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel \    |
-|                |         libXi-devel mesa-libGL-devel mesa-libGLU-devel alsa-lib-devel pulseaudio-libs-devel \             |
-|                |         libudev-devel yasm                                                                                |
-+----------------+-----------------------------------------------------------------------------------------------------------+
-| **FreeBSD**    | ::                                                                                                        |
-|                |                                                                                                           |
-|                |     sudo pkg install scons pkgconf xorg-libraries libXcursor libXrandr libXi xorgproto libGLU alsa-lib \  |
-|                |         pulseaudio yasm                                                                                   |
-|                |                                                                                                           |
-+----------------+-----------------------------------------------------------------------------------------------------------+
-| **Gentoo**     | ::                                                                                                        |
-|                |                                                                                                           |
-|                |     emerge -an dev-util/scons x11-libs/libX11 x11-libs/libXcursor x11-libs/libXinerama x11-libs/libXi \   |
-|                |         media-libs/mesa media-libs/glu media-libs/alsa-lib media-sound/pulseaudio dev-lang/yasm           |
-+----------------+-----------------------------------------------------------------------------------------------------------+
-| **Mageia**     | ::                                                                                                        |
-|                |                                                                                                           |
-|                |     urpmi scons task-c++-devel pkgconfig "pkgconfig(alsa)" "pkgconfig(glu)" "pkgconfig(libpulse)" \       |
-|                |         "pkgconfig(udev)" "pkgconfig(x11)" "pkgconfig(xcursor)" "pkgconfig(xinerama)" "pkgconfig(xi)" \   |
-|                |         "pkgconfig(xrandr)" yasm                                                                          |
-+----------------+-----------------------------------------------------------------------------------------------------------+
-| **OpenBSD**    | ::                                                                                                        |
-|                |                                                                                                           |
-|                |     pkg_add python scons llvm yasm                                                                        |
-+----------------+-----------------------------------------------------------------------------------------------------------+
-| **openSUSE**   | ::                                                                                                        |
-|                |                                                                                                           |
-|                |     sudo zypper install scons pkgconfig libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel \ |
-|                |             libXi-devel Mesa-libGL-devel alsa-devel libpulse-devel libudev-devel libGLU1 yasm             |
-+----------------+-----------------------------------------------------------------------------------------------------------+
-| **Solus**      | ::                                                                                                        |
-|                |                                                                                                           |
-|                |     sudo eopkg install -c system.devel scons libxcursor-devel libxinerama-devel libxi-devel \             |
-|                |         libxrandr-devel mesalib-devel libglu alsa-lib-devel pulseaudio-devel yasm                         |
-+----------------+-----------------------------------------------------------------------------------------------------------+
++------------------+-----------------------------------------------------------------------------------------------------------+
+| **Alpine Linux** | ::                                                                                                        |
+|                  |                                                                                                           |
+|                  |     apk add scons pkgconf gcc g++ libx11-dev libxcursor-dev libxinerama-dev libxi-dev libxrandr-dev \     |
+|                  |         libexecinfo-dev                                                                                   |
++------------------+-----------------------------------------------------------------------------------------------------------+
+| **Arch Linux**   | ::                                                                                                        |
+|                  |                                                                                                           |
+|                  |     pacman -S scons pkgconf gcc libxcursor libxinerama libxi libxrandr mesa glu alsa-lib pulseaudio yasm  |
++------------------+-----------------------------------------------------------------------------------------------------------+
+| **Debian** /     | ::                                                                                                        |
+| **Ubuntu**       |                                                                                                           |
+|                  |     sudo apt-get install build-essential scons pkg-config libx11-dev libxcursor-dev libxinerama-dev \     |
+|                  |         libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm   |
++------------------+-----------------------------------------------------------------------------------------------------------+
+| **Fedora**       | ::                                                                                                        |
+|                  |                                                                                                           |
+|                  |     sudo dnf install scons pkgconfig libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel \    |
+|                  |         libXi-devel mesa-libGL-devel mesa-libGLU-devel alsa-lib-devel pulseaudio-libs-devel \             |
+|                  |         libudev-devel yasm                                                                                |
++------------------+-----------------------------------------------------------------------------------------------------------+
+| **FreeBSD**      | ::                                                                                                        |
+|                  |                                                                                                           |
+|                  |     sudo pkg install scons pkgconf xorg-libraries libXcursor libXrandr libXi xorgproto libGLU alsa-lib \  |
+|                  |         pulseaudio yasm                                                                                   |
+|                  |                                                                                                           |
++------------------+-----------------------------------------------------------------------------------------------------------+
+| **Gentoo**       | ::                                                                                                        |
+|                  |                                                                                                           |
+|                  |     emerge -an dev-util/scons x11-libs/libX11 x11-libs/libXcursor x11-libs/libXinerama x11-libs/libXi \   |
+|                  |         media-libs/mesa media-libs/glu media-libs/alsa-lib media-sound/pulseaudio dev-lang/yasm           |
++------------------+-----------------------------------------------------------------------------------------------------------+
+| **Mageia**       | ::                                                                                                        |
+|                  |                                                                                                           |
+|                  |     urpmi scons task-c++-devel pkgconfig "pkgconfig(alsa)" "pkgconfig(glu)" "pkgconfig(libpulse)" \       |
+|                  |         "pkgconfig(udev)" "pkgconfig(x11)" "pkgconfig(xcursor)" "pkgconfig(xinerama)" "pkgconfig(xi)" \   |
+|                  |         "pkgconfig(xrandr)" yasm                                                                          |
++------------------+-----------------------------------------------------------------------------------------------------------+
+| **OpenBSD**      | ::                                                                                                        |
+|                  |                                                                                                           |
+|                  |     pkg_add python scons llvm yasm                                                                        |
++------------------+-----------------------------------------------------------------------------------------------------------+
+| **openSUSE**     | ::                                                                                                        |
+|                  |                                                                                                           |
+|                  |     sudo zypper install scons pkgconfig libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel \ |
+|                  |             libXi-devel Mesa-libGL-devel alsa-devel libpulse-devel libudev-devel libGLU1 yasm             |
++------------------+-----------------------------------------------------------------------------------------------------------+
+| **Solus**        | ::                                                                                                        |
+|                  |                                                                                                           |
+|                  |     sudo eopkg install -c system.devel scons libxcursor-devel libxinerama-devel libxi-devel \             |
+|                  |         libxrandr-devel mesalib-devel libglu alsa-lib-devel pulseaudio-devel yasm                         |
++------------------+-----------------------------------------------------------------------------------------------------------+
 
 Compiling
 ---------


### PR DESCRIPTION
This adds an installation oneliner for [Alpine Linux](https://www.alpinelinux.org/). This distribution is popular in containers, so it can serve as a basis for Dockerfiles or similar.