### PR TITLE
Clarifying hint_albedo converts color space

### DIFF
--- a/tutorials/shading/shading_reference/shading_language.rst
+++ b/tutorials/shading/shading_reference/shading_language.rst
@@ -477,7 +477,7 @@ You can set uniforms in the editor in the material. Or you can set them through 
           must match *exactly* to the name of the uniform in the shader or else it will not be recognized.
 
 Any GLSL type except for *void* can be a uniform. Additionally, Godot provides optional shader hints
-to make the compiler understand for what the uniform is used. ``hint_albedo`` is required for proper sRGB->linear conversion, as Godot’s 3D engine renders in linear color space.
+to make the compiler understand for what the uniform is used.
 
 .. code-block:: glsl
 
@@ -486,6 +486,8 @@ to make the compiler understand for what the uniform is used. ``hint_albedo`` is
     uniform vec4 color : hint_color;
     uniform float amount : hint_range(0, 1);
     uniform vec4 other_color : hint_color = vec4(1.0);
+
+It's important to understand that textures that are supplied as color require hints for proper sRGB->linear conversion (i.e. ``hint_albedo``), as Godot’s 3D engine renders in linear color space.
 
 Full list of hints below:
 

--- a/tutorials/shading/shading_reference/shading_language.rst
+++ b/tutorials/shading/shading_reference/shading_language.rst
@@ -477,7 +477,7 @@ You can set uniforms in the editor in the material. Or you can set them through 
           must match *exactly* to the name of the uniform in the shader or else it will not be recognized.
 
 Any GLSL type except for *void* can be a uniform. Additionally, Godot provides optional shader hints
-to make the compiler understand for what the uniform is used.
+to make the compiler understand for what the uniform is used. ``hint_albedo`` is required for proper sRGB->linear conversion, as Godot’s 3D engine renders in linear color space.
 
 .. code-block:: glsl
 
@@ -534,10 +534,6 @@ to shaders, Godot converts the type automatically. Below is a table of the corre
 
 .. note:: Be careful when setting shader uniforms from GDScript, no error will be thrown if the
           type does not match. Your shader will just exhibit undefined behaviour.
-
-As Godot's 3D engine renders in linear color space, it's important to understand that textures
-that are supplied as color (i.e. albedo) need to be specified as such for proper sRGB->linear
-conversion.
 
 Uniforms can also be assigned default values:
 


### PR DESCRIPTION
Addressing: https://github.com/godotengine/godot/issues/24992 https://github.com/godotengine/godot/issues/11381

https://github.com/godotengine/godot/issues/26196
This guy's minimal reproduction project isn't using hint_albedo and the colors are messed up, I was looking at it to see how TextureArrays are used. (so +1 people who didn't know about this)

I find it funny they're called "hints" while they have special effects like converting color space. But putting that aside...

https://docs.godotengine.org/en/3.1/tutorials/shading/shading_reference/shading_language.html
http://docs.godotengine.org/en/3.0/tutorials/shading/shading_language.html

>As Godot’s 3D engine renders in linear color space, it’s important to understand that textures that are supplied as color (i.e. albedo) need to be specified as such for proper sRGB->linear conversion.

In 3.1 docs (compared to 3.0 docs) this part has been pushed down away from the hints section, thus losing context. Read it on its own and you will not even realize that it's talking about hints.


>Any GLSL type except for void can be a uniform. Additionally, Godot provides optional shader hints to make the compiler understand for what the uniform is used.

I take issue with this. "Optional" shader hints. They're optional so I can skip over these docs, right? And yet they are also _required_ at the same time. Therefore I would move the part about the "sRGB->linear conversion" to the part where it talks about it being optional, in order to clarify to the reader that they're not always optional.