### PR TITLE
Add note about shader function performance in GLES2

### DIFF
--- a/tutorials/misc/gles2_gles3_differences.rst
+++ b/tutorials/misc/gles2_gles3_differences.rst
@@ -158,6 +158,8 @@ For a complete list of built-in GLSL functions see the :ref:`Shading Language do
 | vec_type **fwidth** ( vec_type p )                                                          |                                                  |
 +---------------------------------------------------------------------------------------------+--------------------------------------------------+
 
+.. note:: Functions not in GLES2's GLSL were added with Godots own shader standard library. These functions may perform worse in GLES2 compared to GLES3.
+
 ``textureSize()`` workaround
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Adds a note in the GLES2 vs GLES3 page that some shader functions were added to GLES2 with Godot's own shader library. And they may perform worse in GLES2 compared to GLES3.
