### PR TITLE
Plugin Tutorial _ExitTree c# example comment fix

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -110,7 +110,7 @@ like this:
 
         public override void _ExitTree()
         {
-            // Initialization of the plugin goes here
+            // Clean-up of the plugin goes here
         }
     }
     #endif


### PR DESCRIPTION
Should be "Clean-up of the plugin goes here"

