### PR TITLE
Delete repeated instructions in Your first game

### DIFF
--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -808,11 +808,6 @@ well as its position.
 Note that a new instance must be added to the scene using
 ``add_child()``.
 
-Now click on ``MobTimer`` in the scene window then head to inspector window,
-switch to node view then click on ``timeout()`` and connect the signal.
-
-Add the following code:
-
 .. tabs::
  .. code-tab:: gdscript GDScript
 


### PR DESCRIPTION
Deletes the repeated instructions in the your first game tutorial. Closes #2901 
