### PR TITLE
change debug to release_debug

### DIFF
--- a/development/compiling/compiling_with_mono.rst
+++ b/development/compiling/compiling_with_mono.rst
@@ -153,7 +153,7 @@ Export templates
 
 The name of the data directory for an export template differs based on the
 configuration it was built with. The format is
-``data.mono.<platform>.<bits>.<target>``, e.g. ``data.mono.x11.32.debug`` or
+``data.mono.<platform>.<bits>.<target>``, e.g. ``data.mono.x11.32.release_debug`` or
 ``data.mono.windows.64.release``.
 
 This directory must be placed with its original name next to the Godot export

--- a/development/compiling/compiling_with_mono.rst
+++ b/development/compiling/compiling_with_mono.rst
@@ -120,7 +120,7 @@ Example (Windows)
     # Editor
     scons p=windows target=release_debug tools=yes module_mono_enabled=yes
     # Export templates
-    scons p=windows target=debug tools=no module_mono_enabled=yes
+    scons p=windows target=release_debug tools=no module_mono_enabled=yes
     scons p=windows target=release tools=no module_mono_enabled=yes
 
 Example (X11)
@@ -136,7 +136,7 @@ Example (X11)
     # Editor
     scons p=x11 target=release_debug tools=yes module_mono_enabled=yes
     # Export templates
-    scons p=x11 target=debug tools=no module_mono_enabled=yes
+    scons p=x11 target=release_debug tools=no module_mono_enabled=yes
     scons p=x11 target=release tools=no module_mono_enabled=yes
 
 .. _compiling_with_mono_data_directory:


### PR DESCRIPTION
Mono build: The docs were advising to use `target=debug` instead of `target=release_debug` for debug templates. This PR is addressing that.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
