### PR TITLE
Added missing references for some functions

### DIFF
--- a/tutorials/io/saving_games.rst
+++ b/tutorials/io/saving_games.rst
@@ -120,7 +120,8 @@ Saving and reading data
 
 As covered in the :ref:`doc_filesystem` tutorial, we'll need to open a file
 and write to it and then later, read from it. Now that we have a way to
-call our groups and get their relevant data, let's use to_json() to
+call our groups and get their relevant data, let's use :ref:`to_json()
+<class_@GDScript_method_to_json>` to
 convert it into an easily stored string and store them in a file. Doing
 it this way ensures that each line is its own object, so we have an easy
 way to pull the data out of the file as well.
@@ -265,6 +266,8 @@ heavily customized based on the needs of an individual project.
 This implementation assumes no Persist objects are children of other
 Persist objects. Otherwise, invalid paths would be created. To 
 accommodate nested Persist objects, consider saving objects in stages. 
-Load parent objects first so they are available for the add_child() 
+Load parent objects first so they are available for the :ref:`add_child()
+<class_node_method_add_child>` 
 call when child objects are loaded. You will also need a way to link 
-children to parents as the NodePath will likely be invalid.
+children to parents as the :ref:`NodePath
+<class_nodepath>` will likely be invalid.


### PR DESCRIPTION
I've added some missing references for some functions to better interact with the docs.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
