### PR TITLE
Added new gotcha regarding snake_case for certain api methods

### DIFF
--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -212,9 +212,11 @@ take a look over the official
 - Attached C# scripts should refer to a class that has a class name
   that matches the file name.
 - There are some methods such as ``Get()``/``Set()``, ``Call()``/``CallDeferred()`` 
-  and signal connection method ``Connect()`` that rely on godot's snake_case api naming conventions. 
-  So when using ``CallDeffered("AddChild")``, ``AddChild`` will not work here because the api is expecting the snake_case version 
-  ``add_child``. However, you can use any custom properties or methods without this snake_case limitation.
+  and signal connection method ``Connect()`` that rely on Godot's ``snake_case`` API
+  naming conventions. 
+  So when using e.g. ``CallDeferred("AddChild")``, ``AddChild`` will not work because
+  the API is expecting the original ``snake_case`` version ``add_child``. However, you
+  can use any custom properties or methods without this limitation.
 
 Performance of C# in Godot
 --------------------------

--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -211,6 +211,10 @@ take a look over the official
   `#20271 <https://github.com/godotengine/godot/issues/20271>`_).
 - Attached C# scripts should refer to a class that has a class name
   that matches the file name.
+- There are some methods such as ``Get()``/``Set()``, ``Call()``/``CallDeferred()`` 
+  and signal connection method ``Connect()`` that rely on godot's snake_case api naming conventions. 
+  So when using ``CallDeffered("AddChild")``, ``AddChild`` will not work here because the api is expecting the snake_case version 
+  ``add_child``. However, you can use any custom properties or methods without this snake_case limitation.
 
 Performance of C# in Godot
 --------------------------


### PR DESCRIPTION
This explains a gotcha that people commonly get confused with regarding api methods and predefined properties, methods and signals. For instance: https://github.com/godotengine/godot/issues/34015