### PR TITLE
Add clarification on how to connect C# signals in the editor

### DIFF
--- a/getting_started/scripting/c_sharp/c_sharp_features.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_features.rst
@@ -94,7 +94,7 @@ Declaring a signal in C# is done with the ``[Signal]`` attribute on a delegate.
     delegate void MySignalWithArguments(string foo, int bar);
 
 These signals can then be connected either in the editor or from code with ``Connect``.
-If you want to connect a signal in the editor, you need to (re)build the project assemblies to see the new signal. This build can be manually triggered by clicking the word “Mono” at the bottom of the editor window to reveal the Mono Panel, then clicking the “Build Project” button. 
+If you want to connect a signal in the editor, you need to (re)build the project assemblies to see the new signal. This build can be manually triggered by clicking the “Build” button at the top right corner of the editor window. 
 
 .. code-block:: csharp
 

--- a/getting_started/scripting/c_sharp/c_sharp_features.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_features.rst
@@ -94,6 +94,7 @@ Declaring a signal in C# is done with the ``[Signal]`` attribute on a delegate.
     delegate void MySignalWithArguments(string foo, int bar);
 
 These signals can then be connected either in the editor or from code with ``Connect``.
+If you want to connect a signal in the editor, you need to (re)build the project assemblies to see the new signal. This build can be manually triggered by clicking the word “Mono” at the bottom of the editor window to reveal the Mono Panel, then clicking the “Build Project” button. 
 
 .. code-block:: csharp
 


### PR DESCRIPTION
The doc does not mention how to connect a C# signal in the editor. Had a lot of trouble figuring out why I could not see my newly added signal.

Copied most of the explanation from the [Your first game](https://docs.godotengine.org/en/3.1/getting_started/step_by_step/your_first_game.html) doc which mentions this problem:

> If you’re using C#, you need to (re)build the project assemblies whenever you want to see new export variables or signals. This build can be manually triggered by clicking the word “Mono” at the bottom of the editor window to reveal the Mono Panel, then clicking the “Build Project” button.