### PR TITLE
Small consistency fixes for the VR tutorial pages

### DIFF
--- a/tutorials/vr/vr_starter_tutorial/index.rst
+++ b/tutorials/vr/vr_starter_tutorial/index.rst
@@ -1,5 +1,5 @@
-VR Starer tutorial
-==================
+VR starter tutorial
+===================
 
 .. toctree::
    :maxdepth: 1

--- a/tutorials/vr/vr_starter_tutorial/vr_starter_tutorial_part_one.rst
+++ b/tutorials/vr/vr_starter_tutorial/vr_starter_tutorial_part_one.rst
@@ -1,7 +1,7 @@
 .. _doc_vr_starter_tutorial_part_one:
 
-VR Starter Tutorial Part One
-============================
+VR starter tutorial part 1
+==========================
 
 Introduction
 ------------

--- a/tutorials/vr/vr_starter_tutorial/vr_starter_tutorial_part_two.rst
+++ b/tutorials/vr/vr_starter_tutorial/vr_starter_tutorial_part_two.rst
@@ -1,7 +1,7 @@
 .. _doc_vr_starter_tutorial_part_two:
 
-VR Starter Tutorial Part Two
-============================
+VR starter tutorial part 2
+==========================
 
 Introduction
 ------------
@@ -523,7 +523,7 @@ and the collision force is the ``collision_force`` variable we calculated.
 
 _________________
 
-Once all of the :ref:`Raycast <class_Raycast>`s in the ``raycast`` variable have been iterated over, we then play the shotgun shot sound by calling the ``play`` function on the ``shotgun_fire_sound`` variable.
+Once all of the :ref:`Raycast <class_Raycast>`\s in the ``raycast`` variable have been iterated over, we then play the shotgun shot sound by calling the ``play`` function on the ``shotgun_fire_sound`` variable.
 
 Finally, we check to see if the shotgun is being held by a VR controller by checking to see if the ``controller`` variable is not equal to ``null``. If it is not equal to ``null``,
 we then set the ``rumble`` property of the VR controller to ``0.25``, so there is a slight rumble when the shotgun fires.


### PR DESCRIPTION
- Fixed typo: "Starer" -> "Starter"
- Made the titles only capitalized at the beginning, like everywhere else.
- Made the numbers in the titles be actual digits, like in the FPS tutorial.
- Fixed error in a reference due to the use of a plural.