### PR TITLE
[iOS] Add commands for bundling camera and ARKit universal libs.

### DIFF
--- a/development/compiling/compiling_for_ios.rst
+++ b/development/compiling/compiling_for_ios.rst
@@ -51,7 +51,9 @@ All those steps can be performed with following commands:
 
     $ scons p=iphone tools=no target=release arch=arm
     $ scons p=iphone tools=no target=release arch=arm64
-    $ lipo bin/libgodot.iphone.opt.arm.a bin/libgodot.iphone.opt.arm64.a -output bin/godot.iphone.opt.universal.a
+    $ lipo -create bin/libgodot.iphone.opt.arm.a bin/libgodot.iphone.opt.arm64.a -output bin/libgodot.iphone.release.fat.a
+    $ lipo -create bin/libgodot_camera_module.iphone.opt.arm.a bin/libgodot_camera_module.iphone.opt.arm64.a -output bin/libgodot_camera_module.iphone.release.fat.a
+    $ lipo -create bin/libgodot_arkit_module.iphone.opt.arm.a bin/libgodot_arkit_module.iphone.opt.arm64.a -output bin/libgodot_arkit_module.iphone.release.fat.a
 
 If you also want to provide a simulator build (reduces the chance of any linker errors with dependencies), you'll need to build and lipo the ``x86_64`` architecture as well.
 
@@ -60,7 +62,9 @@ If you also want to provide a simulator build (reduces the chance of any linker 
     $ scons p=iphone tools=no target=release arch=arm
     $ scons p=iphone tools=no target=release arch=arm64
     $ scons p=iphone tools=no target=release arch=x86_64
-    $ lipo -create bin/libgodot.iphone.opt.arm.a bin/libgodot.iphone.opt.arm64.a bin/libgodot.iphone.opt.x86_64.a -output bin/godot.iphone.opt.universal.simulator.a
+    $ lipo -create bin/libgodot.iphone.opt.arm.a bin/libgodot.iphone.opt.arm64.a bin/libgodot.iphone.opt.x86_64.a -output bin/libgodot.iphone.release.fat.a
+    $ lipo -create bin/libgodot_camera_module.iphone.opt.arm.a bin/libgodot_camera_module.iphone.opt.arm64.a bin/libgodot_camera_module.iphone.opt.x86_64.a -output bin/libgodot_camera_module.iphone.release.fat.a
+    $ lipo -create bin/libgodot_arkit_module.iphone.opt.arm.a bin/libgodot_arkit_module.iphone.opt.arm64.a bin/libgodot_arkit_module.iphone.opt.x86_64.a -output bin/libgodot_arkit_module.iphone.release.fat.a
 
 Run
 ---

--- a/development/compiling/cross-compiling_for_ios_on_linux.rst
+++ b/development/compiling/cross-compiling_for_ios_on_linux.rst
@@ -154,6 +154,9 @@ you are in the root Godot source directory:
 
 ::
 
-    $ /path/to/iostoolchain/usr/bin/arm-apple-darwin11-lipo -create bin/godot.iphone.opt.debug.arm bin/godot.iphone.opt.debug.arm64 -output bin/godot.iphone.opt.debug.fat
+    $ /path/to/iostoolchain/usr/bin/arm-apple-darwin11-lipo -create bin/libgodot.iphone.opt.debug.arm.a bin/libgodot.iphone.opt.debug.arm64.a -output bin/libgodot.iphone.debug.fat.a
+    $ /path/to/iostoolchain/usr/bin/arm-apple-darwin11-lipo -create bin/libgodot_camera_module.iphone.opt.debug.arm.a bin/libgodot_camera_module.iphone.opt.debug.arm64.a -output bin/libgodot_camera_module.iphone.debug.fat.a
+    $ /path/to/iostoolchain/usr/bin/arm-apple-darwin11-lipo -create bin/libgodot_arkit_module.iphone.opt.debug.arm.a bin/libgodot_arkit_module.iphone.opt.debug.arm64.a -output bin/libgodot_arkit_module.iphone.debug.fat.a
 
-Then you will have an iOS fat binary in ``bin/godot.iphone.opt.debug.fat``.
+
+Then you will have iOS fat binaries in ``bin`` directory.


### PR DESCRIPTION
Adds commands to accommodate changes in the iOS export made in https://github.com/godotengine/godot/pull/33992, adds missing `-create` flag and changes output file names to match names used in export template.

*Update:* Same commands for cross build added.