### PR TITLE
set_script() detailing what happens to variables

### DIFF
--- a/classes/class_object.rst
+++ b/classes/class_object.rst
@@ -587,6 +587,8 @@ Adds or changes a given entry in the object's metadata. Metadata are serialized,
 
 Assigns a script to the object. Each object can have a single script assigned to it, which are used to extend its functionality.
 
+The object's old variables will be lost and new variables will be initialized from the new script.
+
 ----
 
 .. _class_Object_method_to_string:


### PR DESCRIPTION
Makes it clear to the reader that this is a clean replacement; no old variables will remain. I didn't know what would happen until I tested it.

It also seems somewhat significant to write this down because I think this is the only other way (other than writing ``var``) to initialize new variables on an existing node. Please correct me if I'm wrong, I've been looking for a way to initialize a new variable.