### PR TITLE
Add a list of supported external editors and update C# version info

### DIFF
--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -85,9 +85,9 @@ click on **Editor → Editor Settings** and scroll down to
 external editor of choice. Godot currently supports the following
 external editors:
 
-- VisualStudio for mac
+- Visual Studio Code
 - MonoDevelop
-- VisualStudio Code
+- Visual Studio for Mac
 - JetBrains Rider
 
 .. note:: If you are using Visual Studio Code, ensure you download and install

--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -19,8 +19,8 @@ and (re)visit the :ref:`Scripting section <doc_scripting>` of the
 step-by-step tutorial.
 
 C# is a high-level programming language developed by Microsoft. In Godot,
-it is implemented with the Mono 5.x .NET framework, including full support
-for C# 7.0. Mono is an open source implementation of Microsoft's .NET Framework
+it is implemented with the Mono 6.x .NET framework, including full support
+for C# 8.0. Mono is an open source implementation of Microsoft's .NET Framework
 based on the ECMA standards for C# and the Common Language Runtime.
 A good starting point for checking its capabilities is the
 `Compatibility <http://www.mono-project.com/docs/about-mono/compatibility/>`_
@@ -82,7 +82,13 @@ or MonoDevelop. These provide autocompletion, debugging, and other
 useful features for C#. To select an external editor in Godot, 
 click on **Editor → Editor Settings** and scroll down to
 **Mono**. Under **Mono**, click on **Editor**, and select your 
-external editor of choice.
+external editor of choice. Godot currently supports the following
+external editors:
+
+- VisualStudio for mac
+- MonoDevelop
+- VisualStudio Code
+- JetBrains Rider
 
 .. note:: If you are using Visual Studio Code, ensure you download and install
           the `C# extension <https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp>`_


### PR DESCRIPTION
Added a list of the external editors Godot supports, and updated the C# and mono version info for Godot 3.2.
