### PR TITLE
Add a line length guideline to the GDScript style guide

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_styleguide.rst
+++ b/getting_started/scripting/gdscript/gdscript_styleguide.rst
@@ -86,6 +86,13 @@ Surround functions and class definitions with two blank lines:
 
 Use one blank line inside functions to separate logical sections.
 
+Line length
+~~~~~~~~~~~
+
+Try to keep lines under 80 characters. This ensures greater readability on small
+displays and splitted editors (such as side-by-side diffs). It's OK to go over
+by a few characters, but a line should never exceed 100 characters.
+
 One statement per line
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
From consensus in the issue and Discord, a soft limit of 80 characters per line seems to be the way to go.

In the future, we should also document multiline wrapping using parentheses and backslashes and make a recommendation. My vote goes for recommending parentheses whenever possible, as they're less error-prone compared to backslashes :slightly_smiling_face:

This closes #2567.