### PR TITLE
Add robots.txt file to prevent indexing outdated docs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -91,6 +91,8 @@ html_logo = 'img/docs_logo.png'
 # These folders are copied to the documentation's HTML output
 html_static_path = ['_static']
 
+html_extra_path = ['robots.txt']
+
 # These paths are either relative to html_static_path
 # or fully qualified paths (eg. https://...)
 html_css_files = [

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,6 @@
+user-agent: *
+disallow: /*/3.1
+disallow: /*/3.0
+disallow: /*/2.0
+
+sitemap: https://docs.godotengine.org/sitemap.xml


### PR DESCRIPTION
Closes #2912

That should disable indexing for version 3.1, 3.0, and 2.0 on the docs, allowing search engines to only index stable and latest for all languages.

I did a test build, the file gets copied over to the build folder.

Once the change is live, you can use the webmaster console to see if it's working: https://support.google.com/webmasters/answer/6062598?hl=en&ref_topic=6061961