### PR TITLE
Add link to tool docs in gdscript docs.

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_basics.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics.rst
@@ -1256,6 +1256,9 @@ placed at the top of the file::
     func _ready():
         print("Hello")
 
+
+See :ref:`doc_running_code_in_the_editor` for more information.
+
 .. warning:: Be cautious when freeing nodes with ``queue_free()`` or ``free()``
              in a tool script (especially the script's owner itself). As tool
              scripts run their code in the editor, misusing them may lead to


### PR DESCRIPTION
The gdscript_basics docs give a pretty sparse description of the tool
keyword. I ended up figuring out a lot of it on my own before I finally
realized there was a more detailed page hidden elsewhere in the docs.


<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->