### PR TITLE
moved explanations of fragment shader passes

### DIFF
--- a/tutorials/shading/shading_reference/canvas_item_shader.rst
+++ b/tutorials/shading/shading_reference/canvas_item_shader.rst
@@ -191,7 +191,7 @@ When the shader is on a light pass, the ``AT_LIGHT_PASS`` variable will be ``tru
 Light built-ins
 ^^^^^^^^^^^^^^^
 
-The `light` shader runs for each fragment of each light source.
+The `light` processor function runs for each fragment of each light source.
 
 +-------------------------------------+-------------------------------------------------------------------------------+
 | Built-in                            | Description                                                                   |

--- a/tutorials/shading/shading_reference/canvas_item_shader.rst
+++ b/tutorials/shading/shading_reference/canvas_item_shader.rst
@@ -181,7 +181,7 @@ it to the ``NORMALMAP`` property. Godot will handle converting it for use in 2D 
 +----------------------------------+----------------------------------------------------------------+
 
 Light processor functions work differently in 2D than they do in 3D. In CanvasItem shaders, the 
-`fragment` shader is called once for the object being drawn, and then once for each light touching that 
+``fragment`` shader is called once for the object being drawn, and then once for each light touching that 
 object in the scene. Use render_mode ``unshaded`` if you do not want any light passes to occur
 for that object. Use render_mode ``light_only`` if you only want light passes to occur for
 that object; this can be useful when you only want the object visible where it is covered by light. 

--- a/tutorials/shading/shading_reference/canvas_item_shader.rst
+++ b/tutorials/shading/shading_reference/canvas_item_shader.rst
@@ -181,7 +181,7 @@ it to the ``NORMALMAP`` property. Godot will handle converting it for use in 2D 
 +----------------------------------+----------------------------------------------------------------+
 
 Light processor functions work differently in 2D than they do in 3D. In CanvasItem shaders, the 
-``fragment`` shader is called once for the object being drawn, and then once for each light touching that 
+shader is called once for the object being drawn, and then once for each light touching that 
 object in the scene. Use render_mode ``unshaded`` if you do not want any light passes to occur
 for that object. Use render_mode ``light_only`` if you only want light passes to occur for
 that object; this can be useful when you only want the object visible where it is covered by light. 

--- a/tutorials/shading/shading_reference/canvas_item_shader.rst
+++ b/tutorials/shading/shading_reference/canvas_item_shader.rst
@@ -180,16 +180,18 @@ it to the ``NORMALMAP`` property. Godot will handle converting it for use in 2D 
 | in sampler2D **SCREEN_TEXTURE**  | Screen texture, mipmaps contain gaussian blurred versions.     |
 +----------------------------------+----------------------------------------------------------------+
 
-Light built-ins
-^^^^^^^^^^^^^^^
-
 Light processor functions work differently in 2D than they do in 3D. In CanvasItem shaders, the 
-shader is called once for the object being drawn, and then once for each light touching that 
+`fragment` shader is called once for the object being drawn, and then once for each light touching that 
 object in the scene. Use render_mode ``unshaded`` if you do not want any light passes to occur
 for that object. Use render_mode ``light_only`` if you only want light passes to occur for
 that object; this can be useful when you only want the object visible where it is covered by light. 
 
 When the shader is on a light pass, the ``AT_LIGHT_PASS`` variable will be ``true``.
+
+Light built-ins
+^^^^^^^^^^^^^^^
+
+The `light` shader runs for each fragment of each light source.
 
 +-------------------------------------+-------------------------------------------------------------------------------+
 | Built-in                            | Description                                                                   |


### PR DESCRIPTION
Currently the [Light built-ins](https://docs.godotengine.org/en/3.1/tutorials/shading/shading_reference/canvas_item_shader.html#light-built-ins) section contains information that actually doesn't apply to the `light` shader, but rather the `fragment` shader. This is confusing, for instance the mentioned `AT_LIGHT_PASS` doesn't exist in the light shader, but in the fragment shader.

It would make more sense to me to move the paragraph into the fragment shader section above, serving as a transition to the light shader.


