### PR TITLE
Add yasm to scoop install.

### DIFF
--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -24,7 +24,7 @@ For compiling under Windows, the following is required:
 .. note:: If you have `Scoop <https://scoop.sh/>`_ installed, you can easily
           install MinGW and other dependencies using the following command::
 
-              scoop install gcc python scons make
+              scoop install gcc python scons yasm make
 
 .. note:: If you have `MSYS2 <https://www.msys2.org/>`_ installed, you can easily
           install MinGW and other dependencies using the following command::


### PR DESCRIPTION
Windows version of #1849. Helps avoid godotengine/godot#21719 when building on Windows.

