### PR TITLE
Add warning to making-plugins reminding about tool keyword

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -72,6 +72,11 @@ EditorPlugin script for you. The script has two requirements that you cannot
 change: it must be a ``tool`` script, or else it will not load properly in the
 editor, and it must inherit from :ref:`class_EditorPlugin`.
 
+.. warning::
+    In addition to the EditorPlugin script, any other GDScript that your plugin uses
+    must *also* be a tool.  Any GDScript without ``tool`` imported into the editor
+    will act like an empty file!
+
 It's important to deal with initialization and clean-up of resources.
 A good practice is to use the virtual function
 :ref:`_enter_tree() <class_Node_method__enter_tree>` to initialize your plugin and


### PR DESCRIPTION
I've repeatedly forgotten that other scripts used in editor plugins
*also* need to have the `tool` keyword, otherwise it fails to correctly
run.

View of changes:

<img width="750" alt="Screen Shot 2020-01-01 at 2 46 16 PM" src="https://user-images.githubusercontent.com/760906/71647043-95a3fe00-2ca5-11ea-984a-a9f8191776af.png">

