### PR TITLE
Changed link to GPU intensive website.

### DIFF
--- a/tutorials/shading/your_first_shader/your_first_canvasitem_shader.rst
+++ b/tutorials/shading/your_first_shader/your_first_canvasitem_shader.rst
@@ -217,4 +217,4 @@ At their core, shaders do what you have seen so far, they compute ``VERTEX`` and
 up to you to dream up more complex mathematical strategies for assigning values to those variables. 
 
 For inspiration, take a look at some of the more advanced shader tutorials, and look at other sites
-like `Shadertoy <https://www.shadertoy.com>`_ and `The Book of Shaders <https://thebookofshaders.com>`_. 
+like `Shadertoy <https://www.shadertoy.com/results?query=&sort=popular&from=10&num=4>`_ and `The Book of Shaders <https://thebookofshaders.com>`_. 


### PR DESCRIPTION
There is known issue with heavy page load at www.shadertoy.com, which imposes GPU intensive shaders on main page: https://bugs.chromium.org/p/chromium/issues/detail?id=33620. It leads user's PC to go nuts even on second load. Bug is marked as "WontFix", which is unsettling.

I thought that it's quite exhaustive user experience, that distracts from reading documentation. So, I've placed link with reduced search results to avoid this inconsistency.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
