### PR TITLE
Changled link to Shadertoy (mirror #3026)

### DIFF
--- a/tutorials/shading/migrating_to_godot_shader_language.rst
+++ b/tutorials/shading/migrating_to_godot_shader_language.rst
@@ -123,7 +123,7 @@ more information, see the :ref:`Shading Language <doc_shading_language>` referen
 Shadertoy
 ---------
 
-`Shadertoy <https://www.shadertoy.com>`_ is a website that makes it easy to write fragment shaders and
+`Shadertoy <https://www.shadertoy.com/results?query=&sort=popular&from=10&num=4>`_ is a website that makes it easy to write fragment shaders and
 create `pure magic <https://www.shadertoy.com/view/4tjGRh>`_.
 
 Shadertoy does not give the user full control over the shader. It handles all


### PR DESCRIPTION
#3026
There is known issue with heavy page load at www.shadertoy.com, which imposes GPU intensive shaders on main page: https://bugs.chromium.org/p/chromium/issues/detail?id=33620. It leads user's PC to go nuts even on second load.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
