### PR TITLE
Add file formatting to GDScript style guide

### DIFF
--- a/getting_started/scripting/c_sharp/c_sharp_style_guide.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_style_guide.rst
@@ -31,12 +31,16 @@ Formatting conventions
 ----------------------
 
 * Use line feed (**LF**) characters to break lines, not CRLF or CR.
+* Use one line feed character at the end of each file, except for `csproj` files.
 * Use **UTF-8** encoding without a `byte order mark <https://en.wikipedia.org/wiki/Byte_order_mark>`_.
 * Use **4 spaces** instead of tabs for indentation (which is referred to as "soft tabs").
 * Consider breaking a line into several if it's longer than 100 characters.
 
+Code structure
+--------------
+
 Line breaks and blank lines
----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For a general indentation rule, follow `the "Allman Style" <https://en.wikipedia.org/wiki/Indentation_style#Allman_style>`_
 which recommends placing the brace associated with a control statement on the next line, indented to
@@ -133,7 +137,7 @@ Avoid inserting a blank line:
     }
 
 Using spaces
-------------
+~~~~~~~~~~~~
 
 Insert a space:
 

--- a/getting_started/scripting/gdscript/gdscript_styleguide.rst
+++ b/getting_started/scripting/gdscript/gdscript_styleguide.rst
@@ -18,17 +18,18 @@ styleguide.
 .. note:: Godot's built-in script editor uses a lot of these conventions
           by default. Let it help you.
 
-Code structure
---------------
+Formatting conventions
+----------------------
 
-Indentation
-~~~~~~~~~~~
-
-Indent type: Tabs *(editor default)*
-
-Indent size: 4 *(editor default)*
+* Use line feed (**LF**) characters to break lines, not CRLF or CR. *(editor default)*
+* Use one line feed character at the end of each file. *(editor default)*
+* Use **UTF-8** encoding without a `byte order mark <https://en.wikipedia.org/wiki/Byte_order_mark>`_. *(editor default)*
+* Use **Tabs** instead of spaces for indentation. *(editor default)*
 
 Each indent level should be one greater than the block containing it.
+
+Code structure
+--------------
 
 **Good**:
 


### PR DESCRIPTION
Recommend LF, newline at end of file, UTF-8, no BOM, and tabs. The displayed size of tabs does not matter as it does not affect the saved files, so don't mention it.

Note: Newline at end of file is the editor default starting in 3.2, but not in 3.1.

Also slightly change the C# style guide for consistency.
