### PR TITLE
Reinsert clamp in exporting docs

### DIFF
--- a/getting_started/step_by_step/exporting.rst
+++ b/getting_started/step_by_step/exporting.rst
@@ -104,7 +104,7 @@ changed:
         # We still need to clamp the player's position here because on devices that don't
         # match your game's aspect ratio, Godot will try to maintain it as much as possible 
         # by creating black borders, if necessary.
-        # Without clamp() the player would be able to move under those borders.
+        # Without clamp(), the player would be able to move under those borders.
         position.x = clamp(position.x, 0, screen_size.x)
         position.y = clamp(position.y, 0, screen_size.y)
 

--- a/getting_started/step_by_step/exporting.rst
+++ b/getting_started/step_by_step/exporting.rst
@@ -101,10 +101,8 @@ changed:
             $AnimatedSprite.stop()
 
         position += velocity * delta
-        # We don't need to clamp the player's position
-        # because you can't click outside the screen.
-        # position.x = clamp(position.x, 0, screensize.x)
-        # position.y = clamp(position.y, 0, screensize.y)
+        position.x = clamp(position.x, 0, screen_size.x)
+        position.y = clamp(position.y, 0, screen_size.y)
 
         if velocity.x != 0:
             $AnimatedSprite.animation = "right"

--- a/getting_started/step_by_step/exporting.rst
+++ b/getting_started/step_by_step/exporting.rst
@@ -104,7 +104,7 @@ changed:
         # We still need to clamp the player's position here because on devices that don't
         # match your game's aspect ratio, Godot will try to maintain it as much as possible 
         # by creating black borders, if necessary.
-        # Without clamp the player would be able to move under those borders.
+        # Without clamp() the player would be able to move under those borders.
         position.x = clamp(position.x, 0, screen_size.x)
         position.y = clamp(position.y, 0, screen_size.y)
 

--- a/getting_started/step_by_step/exporting.rst
+++ b/getting_started/step_by_step/exporting.rst
@@ -101,6 +101,10 @@ changed:
             $AnimatedSprite.stop()
 
         position += velocity * delta
+        # We still need to clamp the player's position here because on devices that don't
+        # match your game's aspect ratio, Godot will try to maintain it as much as possible 
+        # by creating black borders, if necessary.
+        # Without clamp the player would be able to move under those borders.
         position.x = clamp(position.x, 0, screen_size.x)
         position.y = clamp(position.y, 0, screen_size.y)
 


### PR DESCRIPTION
Before this change clamping the players position got removed with the following explanation:

> We don't need to clamp the player's position because you can't click outside the screen.

While it is true that the player cannot click outside the window, the player can still click outside the playable area. Because we set Aspect to "keep" in the Project Settings, Godot will create Black borders if the window (or phone screen) doesn't match the desired aspect ratio. A player can now click on either of the borders and because clamp got removed the Player node will move out of the playable area and hide in the black border.

This is why the clamp should not be removed.

Here is a demo of the bad behaivoir:

![ScreenRecording2020-01-03at15110](https://user-images.githubusercontent.com/21206831/71727870-e3eb0580-2e3b-11ea-801f-913ce4e08cd0.gif)

