### PR TITLE
Added changes about use of Dynamic Typing

### DIFF
--- a/community/contributing/docs_writing_guidelines.rst
+++ b/community/contributing/docs_writing_guidelines.rst
@@ -274,6 +274,29 @@ element of a list with more than two elements.
 How to write methods and classes
 --------------------------------
 
+Dynamic vs Static typing
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Despite the addition of optional static typing, GDScript remains primarily 
+dynamic language. Unless you are specifily discussing static typing, you
+should only use dynamic typing in your code examples and snipets. 
+This will help reduce confusion to new users by promoting consistent look
+to the code examples they are exposed to. 
+
+**Don't** write using using static typing:
+
+::
+
+    var a := 5
+    var b: String = "My String"
+
+**Do** write code using dynamic typing:
+
+::
+
+    var a = 5
+    var b = "My String"
+
 Give an overview of the node in the brief description
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/community/contributing/docs_writing_guidelines.rst
+++ b/community/contributing/docs_writing_guidelines.rst
@@ -277,25 +277,43 @@ How to write methods and classes
 Dynamic vs Static typing
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Despite the addition of optional static typing, GDScript remains primarily 
-dynamic language. Unless you are specifily discussing static typing, you
-should only use dynamic typing in your code examples and snipets. 
-This will help reduce confusion to new users by promoting consistent look
-to the code examples they are exposed to. 
+GDScript aims to be concise and easy to learn. Optional static typing conflicts with this vision
+by making documentation more congested. To improve its accessibility for new users, please use 
+dynamic GDScript code samples where possible. The one exception is topics that explain 
+static typing concepts to users.
 
-**Don't** write using using static typing:
+**Don't** add a type hint with a colon or by casting:
 
 ::
 
     var a := 5
     var b: String = "My String"
+    var my_sprite : Sprite = $Sprite as Sprite
 
-**Do** write code using dynamic typing:
+
+**Do** write varibles with dynamic typing:
 
 ::
 
     var a = 5
     var b = "My String"
+    var my_sprite = $Sprite
+
+
+**Don't** write functions with inferred arguments or return types:
+
+::
+
+    func my_func(arg1 : int, arg2 : String = "") -> void:
+    return
+
+**Do** write functions using dynamic typing:
+
+::
+
+    func my_func(arg1, arg2 = ""):
+    return
+
 
 Give an overview of the node in the brief description
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/community/contributing/docs_writing_guidelines.rst
+++ b/community/contributing/docs_writing_guidelines.rst
@@ -286,35 +286,43 @@ static typing concepts to users.
 
 ::
 
-    const MyNode := preload("preload("res://my_node.gd")
-    var a := 5
-    var b: String = "My String"
-    var my_sprite := $Sprite as Sprite
+    const main_attack := preload("res://fire_attack.gd")
+    var hit_points := 5
+    var name: String = "Bob"
+    var body_sprite := $Sprite as Sprite
 
 
 **Do** write constants variables with dynamic typing:
 
 ::
 
-    const MyNode = preload("preload("res://my_node.gd")
-    var a = 5
-    var b = "My String"
-    var my_sprite = $Sprite
+    const main_attack = preload("res://fire_attack.gd")
+    var hit_points = 5
+    var name = "Bob"
+    var body_sprite = $Sprite
 
 
 **Don't** write functions with inferred arguments or return types:
 
 ::
 
-    func my_func(arg1 : int, arg2 : String = "") -> void:
-        pass
+    func choose(arguments: Array): 
+        #Chooses one of the arguments from array with equal chance
+        randomize()
+        var size := arguments.size()
+        var choice: int = randi() % size
+        return arguments[choice]
 
 **Do** write functions using dynamic typing:
 
 ::
 
-    func my_func(arg1, arg2 = ""):
-        pass
+    func choose(arguments:): 
+        #Chooses one of the arguments from array with equal chance
+        randomize()
+        var size = arguments.size()
+        var choice = randi() % size
+        return arguments[choice]
 
 
 Give an overview of the node in the brief description

--- a/community/contributing/docs_writing_guidelines.rst
+++ b/community/contributing/docs_writing_guidelines.rst
@@ -286,15 +286,17 @@ static typing concepts to users.
 
 ::
 
+    const MyNode := preload("preload("res://my_node.gd")
     var a := 5
     var b: String = "My String"
-    var my_sprite : Sprite = $Sprite as Sprite
+    var my_sprite := $Sprite as Sprite
 
 
-**Do** write varibles with dynamic typing:
+**Do** write constants variables with dynamic typing:
 
 ::
 
+    const MyNode = preload("preload("res://my_node.gd")
     var a = 5
     var b = "My String"
     var my_sprite = $Sprite
@@ -305,14 +307,14 @@ static typing concepts to users.
 ::
 
     func my_func(arg1 : int, arg2 : String = "") -> void:
-    return
+        pass
 
 **Do** write functions using dynamic typing:
 
 ::
 
     func my_func(arg1, arg2 = ""):
-    return
+        pass
 
 
 Give an overview of the node in the brief description

--- a/community/contributing/docs_writing_guidelines.rst
+++ b/community/contributing/docs_writing_guidelines.rst
@@ -307,7 +307,7 @@ static typing concepts to users.
 ::
 
     func choose(arguments: Array): 
-        #Chooses one of the arguments from array with equal chance
+        # Chooses one of the arguments from array with equal chance
         randomize()
         var size := arguments.size()
         var choice: int = randi() % size
@@ -318,7 +318,7 @@ static typing concepts to users.
 ::
 
     func choose(arguments:): 
-        #Chooses one of the arguments from array with equal chance
+        # Chooses one of the arguments from array with equal chance
         randomize()
         var size = arguments.size()
         var choice = randi() % size


### PR DESCRIPTION
I have added explanation directing doc contributors to only use Dynamic typed GDScript in their examples unless they are specifically discussing issues related to static typing.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
