### PR TITLE
Mention VSync as a fix for Jittering

### DIFF
--- a/tutorials/misc/jitter_stutter.rst
+++ b/tutorials/misc/jitter_stutter.rst
@@ -49,15 +49,15 @@ framerate performance. Solving this is game specific and will require optimizati
 The second is more complicated, because it is often not associated to the engine or game but the underlying operating system.
 Here is some information regarding stutter on different OSs.
 
-VSync
-^^^^^
+Use VSync
+^^^^^^^^^
 
 A common cause of Jitter is when the game's framerate is out of step with the monitor's refresh rate.  Go to ``` Project Settings -->  Display --> Window``` and ensure that ```Vsync``` is enabled, and if you are on Windows, also ensure that ```Vsync Via Compositor``` is enabled.
 
 .. note::
 
     ```Vsync Via Compositor```, a Windows-specific setting, is not enabled by default.  
-    If you are on Windows and seeing Jitter, enabling this as a first step.
+    If you are on Windows and seeing Jitter, enable this as a first step.
 
 Windows
 ^^^^^^^

--- a/tutorials/misc/jitter_stutter.rst
+++ b/tutorials/misc/jitter_stutter.rst
@@ -49,6 +49,16 @@ framerate performance. Solving this is game specific and will require optimizati
 The second is more complicated, because it is often not associated to the engine or game but the underlying operating system.
 Here is some information regarding stutter on different OSs.
 
+VSync
+^^^^^
+
+A common cause of Jitter is when the game's framerate is out of step with the monitor's refresh rate.  Go to ``` Project Settings -->  Display --> Window``` and ensure that ```Vsync``` is enabled, and if you are on Windows, also ensure that ```Vsync Via Compositor``` is enabled.
+
+.. note::
+
+    ```Vsync Via Compositor```, a Windows-specific setting, is not enabled by default.  
+    If you are on Windows and seeing Jitter, enabling this as a first step.
+
 Windows
 ^^^^^^^
 

--- a/tutorials/misc/jitter_stutter.rst
+++ b/tutorials/misc/jitter_stutter.rst
@@ -52,7 +52,7 @@ Here is some information regarding stutter on different OSs.
 Use VSync
 ^^^^^^^^^
 
-A common cause of Jitter is when the game's framerate is out of step with the monitor's refresh rate.  Go to ``` Project Settings -->  Display --> Window``` and ensure that ```Vsync``` is enabled, and if you are on Windows, also ensure that ```Vsync Via Compositor``` is enabled.
+A common cause of Jitter is when the game's framerate is out of step with the monitor's refresh rate.  Go to ``` Project Settings -->  Display --> Window``` and ensure that ```Vsync``` is enabled, and if you are on Windows, also ensure that ```Vsync Via Compositor``` *(same location in settings)* is enabled.
 
 .. note::
 


### PR DESCRIPTION
**Anecdote**:  On my trivial prototype, I spent multiple hours trying to figure out why Multithreaded Rendering caused Jitter, while Single-Threaded rendering did not.   It turns out that Multithreaded causes VSync issues on my machine, and while VSync is enabled by default, it's Windows-Specific counterpart for non-fullscreen apps is not.  (Godot v3.2b5)

Documenting this is important otherwise people will waste a lot of time trying to figure this out and might end up thinking the rendering subsystem is buggy.

