### PR TITLE
Adding information and guidelines about how to properly create a standard CSV translation file

### DIFF
--- a/getting_started/workflow/assets/importing_translations.rst
+++ b/getting_started/workflow/assets/importing_translations.rst
@@ -78,7 +78,8 @@ which should be the result of editing the above in a spreadsheet.
 When editing the plain text version, be sure to enclose any message
 that contains a comma with double quotes, so that the comma is not
 parsed as delimiter. Alternatively, you can select another delimiter
-in the import options.
+in the import options. Be sure to also escape any double quotes a
+message may contain by preceding them with another double quote.
 
 .. code-block:: none
 

--- a/getting_started/workflow/assets/importing_translations.rst
+++ b/getting_started/workflow/assets/importing_translations.rst
@@ -63,23 +63,27 @@ runtime by the matching translated string. Note that the case is important,
 The top-left cell is ignored and can be left empty or having any content.
 Here's an example:
 
-+---------+------------------+----------------+--------------+
-| keys    | en               | es             | ja           |
-+=========+==================+================+==============+
-| GREET   | Hello, friend!   | Hola, amigo!   | こんにちは   |
-+---------+------------------+----------------+--------------+
-| ASK     | How are you?     | Cómo está?     | 元気ですか   |
-+---------+------------------+----------------+--------------+
-| BYE     | Goodbye          | Adiós          | さようなら   |
-+---------+------------------+----------------+--------------+
++-------+-----------------------+------------------------+--------------------------+
+| keys  | en                    | es                     | ja                      |
++=======+=======================+========================+==========================+
+| GREET | Hello, friend!        | Hola, amigo!           | こんにちは                |
++-------+-----------------------+------------------------+--------------------------+
+| ASK   | How are you?          | Cómo está?             | 元気ですか                |
++-------+-----------------------+------------------------+--------------------------+
+| BYE   | Goodbye               | Adiós                  | さようなら                |
++-------+-----------------------+------------------------+--------------------------+
+| QUOTE | "Hello" said the man. | "Hola" dijo el hombre. | 「こんにちは」男は言いました |
++-------+-----------------------+------------------------+--------------------------+
 
 The same example is shown below as a comma-separated plain text file,
 which should be the result of editing the above in a spreadsheet.
-When editing the plain text version, be sure to enclose any message
-that contains a comma with double quotes, so that the comma is not
-parsed as delimiter. Alternatively, you can select another delimiter
-in the import options. Be sure to also escape any double quotes a
-message may contain by preceding them with another double quote.
+When editing the plain text version, be sure to enclose with double 
+quotes any message that contains commas, line breaks or double quotes,
+so that commas are not parsed as delimiters, line breaks don't create new
+entries and double quotes are not parsed as enclosing characters. Be sure
+to escape any double quotes a message may contain by preceding them with 
+another double quote. Alternatively, you can select another delimiter than
+comma in the import options.
 
 .. code-block:: none
 
@@ -87,6 +91,7 @@ message may contain by preceding them with another double quote.
     GREET,"Hello, friend!","Hola, amigo!",こんにちは
     ASK,How are you?,Cómo está?,元気ですか
     BYE,Goodbye,Adiós,さようなら
+    QUOTE,"""Hello"" said the man.","""Hola"" dijo el hombre.",「こんにちは」男は言いました
 
 CSV importer
 ------------


### PR DESCRIPTION
RFC-4180: "If double-quotes are used to enclose fields, then a double-quote appearing inside a field must be escaped by preceding it with another double quote."
I tried to escape it with backslash without knowing the special standards of CSV, it didn't work and I [opened an issue for nothing](https://github.com/godotengine/godot/issues/34949). I think it might be right to explain that directly in the docs so that no ones lack this information and ask for help about that again.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
