### PR TITLE
Incorrect syntax highlighting for languages other than GDScript.

### DIFF
--- a/community/contributing/code_style_guidelines.rst
+++ b/community/contributing/code_style_guidelines.rst
@@ -149,7 +149,7 @@ ones, the following rules should be followed:
 
 Example:
 
-.. code:: cpp
+.. code-block:: cpp
 
     /*************************************************************************/
     /*  my_new_file.h                                                        */
@@ -194,7 +194,7 @@ Example:
 
     #endif // MY_NEW_FILE_H
 
-.. code:: cpp
+.. code-block:: cpp
 
     /*************************************************************************/
     /*  my_new_file.cpp                                                      */

--- a/community/contributing/updating_the_class_reference.rst
+++ b/community/contributing/updating_the_class_reference.rst
@@ -182,7 +182,7 @@ Write in a clear and simple language. Always follow the :ref:`writing guidelines
 
 Here's how a class looks like in XML:
 
-.. code:: xml
+.. code-block:: xml
 
     <class name="Node2D" inherits="CanvasItem" category="Core">
         <brief_description>
@@ -255,7 +255,7 @@ Godot's class reference supports BBcode-like tags. They add nice formatting to t
 
 Use ``[codeblock]`` for pre-formatted code blocks. Inside ``[codeblock]``, always use **four spaces** for indentation (the parser will delete tabs). Example:
 
-.. code:: xml
+.. code-block:: xml
 
     [codeblock]
     func _ready():

--- a/development/cpp/binding_to_external_libraries.rst
+++ b/development/cpp/binding_to_external_libraries.rst
@@ -19,7 +19,7 @@ To bind to an external library, set up a module directory similar to the Summato
 
 Next, you will create a header file with a simple TTS class:
 
-.. code:: cpp
+.. code-block:: cpp
 
     /* tts.h */
 
@@ -44,7 +44,7 @@ Next, you will create a header file with a simple TTS class:
 
 And then you'll add the cpp file.
 
-.. code:: cpp
+.. code-block:: cpp
 
     /* tts.cpp */
 
@@ -77,7 +77,7 @@ need to be created:
 
 With the following contents:
 
-.. code:: cpp
+.. code-block:: cpp
 
     /* register_types.h */
 
@@ -85,7 +85,7 @@ With the following contents:
     void unregister_tts_types();
     /* yes, the word in the middle must be the same as the module folder name */
 
-.. code:: cpp
+.. code-block:: cpp
 
     /* register_types.cpp */
 
@@ -105,7 +105,7 @@ With the following contents:
 Next, you need to create a ``SCsub`` file so the build system compiles
 this module:
 
-.. code:: python
+.. code-block:: python
 
     # SCsub
 
@@ -157,7 +157,7 @@ can link to them instead by adding them as submodules (from within the modules/t
 To add include directories for the compiler to look at you can append it to the
 environment's paths:
 
-.. code:: python
+.. code-block:: python
 
     env_tts.Append(CPPPATH=["speech_tools/include", "festival/src/include"]) # this is a path relative to /modules/tts/
     # http://www.cstr.ed.ac.uk/projects/festival/manual/festival_28.html#SEC132 <-- Festival library documentation
@@ -169,7 +169,7 @@ If you want to add custom compiler flags when building your module, you need to 
 `env` first, so it won't add those flags to whole Godot build (which can cause errors).
 Example `SCsub` with custom flags:
 
-.. code:: python
+.. code-block:: python
 
     # SCsub
 

--- a/development/cpp/core_types.rst
+++ b/development/cpp/core_types.rst
@@ -107,18 +107,18 @@ For dynamic memory, the PoolVector<> template is provided. PoolVector is a
 standard vector class, and is very similar to vector in the C++ standard library.
 To create a PoolVector buffer, use this:
 
-.. code:: cpp
+.. code-block:: cpp
 
     PoolVector<int> data;
 
 PoolVector can be accessed using the [] operator and a few helpers exist for this:
 
-.. code:: cpp
+.. code-block:: cpp
 
     PoolVector<int>::Read r = data.read()
     int someint = r[4]
 
-.. code:: cpp
+.. code-block:: cpp
 
     PoolVector<int>::Write w = data.write()
     w[4] = 22;
@@ -149,7 +149,7 @@ in C++ are often inlined and make the binary size much fatter, both in
 debug symbols and code. List, Set and Map can be iterated using
 pointers, like this:
 
-.. code:: cpp
+.. code-block:: cpp
 
     for(List<int>::Element *E=somelist.front();E;E=E->next()) {
         print_line(E->get()); // print the element

--- a/development/cpp/core_types.rst
+++ b/development/cpp/core_types.rst
@@ -79,7 +79,7 @@ should not be used. Instead, a few other ones are provided.
 
 For C-style allocation, Godot provides a few macros:
 
-.. code:: cpp
+.. code-block:: none
 
     memalloc()
     memrealloc()
@@ -90,7 +90,7 @@ library.
 
 For C++-style allocation, special macros are provided:
 
-.. code:: cpp
+.. code-block:: none
 
     memnew( Class / Class(args) )
     memdelete( instance )
@@ -152,7 +152,7 @@ pointers, like this:
 .. code:: cpp
 
     for(List<int>::Element *E=somelist.front();E;E=E->next()) {
-        print_line(E->get()); //print the element
+        print_line(E->get()); // print the element
     }
 
 The Vector<> class also has a few nice features:

--- a/development/cpp/custom_audiostreams.rst
+++ b/development/cpp/custom_audiostreams.rst
@@ -45,7 +45,7 @@ ResourceLoader. ResourceLoader loads once and references the same
 object regardless how many times ``load`` is called on a specific resource.
 Therefore, playback state must be self contained in AudioStreamPlayback.
 
-.. code:: cpp
+.. code-block:: cpp
 
 	/* audiostream_mytone.h */
 
@@ -76,7 +76,7 @@ Therefore, playback state must be self contained in AudioStreamPlayback.
 		static void _bind_methods();
 	};
 
-.. code:: cpp
+.. code-block:: cpp
 
 	/* audiostream_mytone.cpp */
 
@@ -126,7 +126,7 @@ AudioStreamPlayer uses ``mix`` callback to obtain PCM data. The callback must ma
 
 Since AudioStreamPlayback is controlled by the audio thread, i/o and dynamic memory allocation are forbidden.
 
-.. code:: cpp
+.. code-block:: cpp
 
 	/*  audiostreamplayer_mytone.h */
 
@@ -164,7 +164,7 @@ Since AudioStreamPlayback is controlled by the audio thread, i/o and dynamic mem
 		~AudioStreamPlaybackMyTone();
 	};
 
-.. code:: cpp
+.. code-block:: cpp
 
 	/* audiostreamplayer_mytone.cpp */
 
@@ -238,7 +238,7 @@ Godot provides cubic interpolation for audio resampling.
 Instead of overloading ``mix``, AudioStreamPlaybackResampled uses ``_mix_internal`` to
 query AudioFrames and ``get_stream_sampling_rate`` to query current mix rate.
 
-.. code:: cpp
+.. code-block:: cpp
 
 	#include "core/reference.h"
 	#include "core/resource.h"
@@ -279,7 +279,7 @@ query AudioFrames and ``get_stream_sampling_rate`` to query current mix rate.
 		~AudioStreamPlaybackResampledMyTone();
 	};
 
-.. code:: cpp
+.. code-block:: cpp
 
 	#include "mytone_audiostream_resampled.h"
 

--- a/development/cpp/custom_godot_servers.rst
+++ b/development/cpp/custom_godot_servers.rst
@@ -481,7 +481,7 @@ Summing it up
 
 Here is the GDScript sample code:
 
-.. code::
+::
 
     extends Node
 

--- a/development/cpp/custom_godot_servers.rst
+++ b/development/cpp/custom_godot_servers.rst
@@ -38,7 +38,7 @@ Creating a Godot server
 At minimum, a server must have a static instance, a sleep timer, a thread loop,
 an initialization state and a cleanup procedure.
 
-.. code:: cpp
+.. code-block:: cpp
 
 	#ifndef HILBERT_HOTEL_H
 	#define HILBERT_HOTEL_H
@@ -92,7 +92,7 @@ an initialization state and a cleanup procedure.
 
 	#endif
 
-.. code:: cpp
+.. code-block:: cpp
 
 	#include "hilbert_hotel.h"
 
@@ -236,7 +236,7 @@ an initialization state and a cleanup procedure.
 		singleton = this;
 	}
 
-.. code:: cpp
+.. code-block:: cpp
 
 	/* prime_225.h */
 
@@ -278,7 +278,7 @@ Godot servers implement a mediator pattern. All data types inherit ``RID_Data``.
 RID_Owner maintains a list of RIDs. In practice, RIDs are similar to writing
 object-oriented C code.
 
-.. code:: cpp
+.. code-block:: cpp
 
 	class InfiniteBus : public RID_Data {
 		RID self;
@@ -332,7 +332,7 @@ class must be created to reference the proper Godot server.
 In ``register_server_types()``, ``Engine::get_singleton()->add_singleton``
 is used to register the dummy class in GDScript.
 
-.. code:: cpp
+.. code-block:: cpp
 
 	/* register_types.cpp */
 
@@ -365,7 +365,7 @@ is used to register the dummy class in GDScript.
 		}
 	}
 
-.. code:: cpp
+.. code-block:: cpp
 
 	/* register_types.h */
 
@@ -380,7 +380,7 @@ Bind methods
 
 The dummy class binds singleton methods to GDScript. In most cases, the dummy class methods wraps around.
 
-.. code:: cpp
+.. code-block:: cpp
 
 	Variant _HilbertHotel::get_bus_info(RID id) {
 		return HilbertHotel::get_singleton()->get_bus_info(id);
@@ -390,13 +390,13 @@ Binding Signals
 
 It is possible to emit signals to GDScript by calling the GDScript dummy object.
 
-.. code:: cpp
+.. code-block:: cpp
 
 	void HilbertHotel::_emit_occupy_room(uint64_t room, RID rid) {
 		_HilbertHotel::get_singleton()->_occupy_room(room, rid);
 	}
 
-.. code:: cpp
+.. code-block:: cpp
 
 	class _HilbertHotel : public Object {
 		GDCLASS(_HilbertHotel, Object);
@@ -423,7 +423,7 @@ It is possible to emit signals to GDScript by calling the GDScript dummy object.
 
 	#endif
 
-.. code:: cpp
+.. code-block:: cpp
 
 	_HilbertHotel *_HilbertHotel::singleton = NULL;
 	_HilbertHotel *_HilbertHotel::get_singleton() { return singleton; }

--- a/development/cpp/custom_modules_in_cpp.rst
+++ b/development/cpp/custom_modules_in_cpp.rst
@@ -54,7 +54,7 @@ located):
 
 Inside we will create a simple summator class:
 
-.. code:: cpp
+.. code-block:: cpp
 
     /* summator.h */
 
@@ -83,7 +83,7 @@ Inside we will create a simple summator class:
 
 And then the cpp file.
 
-.. code:: cpp
+.. code-block:: cpp
 
     /* summator.cpp */
 
@@ -121,7 +121,7 @@ need to be created:
 
 With the following contents:
 
-.. code:: cpp
+.. code-block:: cpp
 
     /* register_types.h */
 
@@ -129,7 +129,7 @@ With the following contents:
     void unregister_summator_types();
     /* yes, the word in the middle must be the same as the module folder name */
 
-.. code:: cpp
+.. code-block:: cpp
 
     /* register_types.cpp */
 
@@ -149,7 +149,7 @@ With the following contents:
 Next, we need to create a ``SCsub`` file so the build system compiles
 this module:
 
-.. code:: python
+.. code-block:: python
 
     # SCsub
 
@@ -160,7 +160,7 @@ this module:
 With multiple sources, you can also add each file individually to a Python
 string list:
 
-.. code:: python
+.. code-block:: python
 
     src_list = ["summator.cpp", "other.cpp", "etc.cpp"]
     env.add_source_files(env.modules_sources, src_list)
@@ -172,7 +172,7 @@ with Godot by default for examples.
 To add include directories for the compiler to look at you can append it to the
 environment's paths:
 
-.. code:: python
+.. code-block:: python
 
     env.Append(CPPPATH=["mylib/include"]) # this is a relative path
     env.Append(CPPPATH=["#myotherlib/include"]) # this is an 'absolute' path
@@ -181,7 +181,7 @@ If you want to add custom compiler flags when building your module, you need to 
 `env` first, so it won't add those flags to whole Godot build (which can cause errors).
 Example `SCsub` with custom flags:
 
-.. code:: python
+.. code-block:: python
 
     # SCsub
 
@@ -195,7 +195,7 @@ Example `SCsub` with custom flags:
 And finally, the configuration file for the module, this is a simple
 python script that must be named ``config.py``:
 
-.. code:: python
+.. code-block:: python
 
     # config.py
 
@@ -266,7 +266,7 @@ long and costly part.
 The solution to avoid such a cost is to build our own module as a shared
 library that will be dynamically loaded when starting our game's binary.
 
-.. code:: python
+.. code-block:: python
 
     # SCsub
 
@@ -314,7 +314,7 @@ module as shared library (for development) or as a part of the Godot binary
 (for release). To do that we can define a custom flag to be passed to SCons
 using the `ARGUMENT` command:
 
-.. code:: python
+.. code-block:: python
 
     # SCsub
 
@@ -367,7 +367,7 @@ There are several steps in order to setup custom docs for the module:
 
 2. Append the following code snippet to ``config.py``:
 
-   .. code:: python
+   .. code-block:: python
 
        def get_doc_classes():
            return [
@@ -438,7 +438,7 @@ Once you've created your icon(s), proceed with the following steps:
 If you'd like to store your icons somewhere else within your module,
 add the following code snippet to ``config.py`` to override the default path:
 
-   .. code:: python
+   .. code-block:: python
 
        def get_icons_path():
            return "path/to/icons"

--- a/development/cpp/custom_resource_format_loaders.rst
+++ b/development/cpp/custom_resource_format_loaders.rst
@@ -252,7 +252,7 @@ Loading it on GDScript
 ----------------------
 
 
-.. code::
+.. code-block:: json
 
     {
       "savefilename" : "demo.mjson",

--- a/development/cpp/custom_resource_format_loaders.rst
+++ b/development/cpp/custom_resource_format_loaders.rst
@@ -55,7 +55,7 @@ resources with the ``load`` function. To load a resource, ``load`` must
 read and handle data serialization.
 
 
-.. code:: cpp
+.. code-block:: cpp
 
 	#ifndef MY_JSON_LOADER_H
 	#define MY_JSON_LOADER_H
@@ -74,7 +74,7 @@ read and handle data serialization.
 	};
 	#endif // MY_JSON_LOADER_H
 
-.. code:: cpp
+.. code-block:: cpp
 
 	#include "my_json_loader.h"
 	#include "my_json.h"
@@ -115,7 +115,7 @@ understand additional binary formats such as machine learning models.
 
 Here is an example of how to create a custom datatype
 
-.. code:: cpp
+.. code-block:: cpp
 
 	#ifndef MY_JSON_H
 	#define MY_JSON_H
@@ -179,7 +179,7 @@ Therefore, Godot call translations are required.
 For example, here is the code for translating ``FileAccess``
 calls into ``std::istream``.
 
-.. code:: cpp
+.. code-block:: cpp
 
 	#include <istream>
 	#include <streambuf>
@@ -223,7 +223,7 @@ Godot registers ``ResourcesFormatLoader`` with a ``ResourceLoader``
 handler. The handler selects the proper loader automatically
 when ``load`` is called.
 
-.. code:: cpp
+.. code-block:: cpp
 
 	/* register_types.cpp */
 	#include "register_types.h"
@@ -250,7 +250,6 @@ References
 
 Loading it on GDScript
 ----------------------
-
 
 .. code-block:: json
 

--- a/development/cpp/custom_resource_format_loaders.rst
+++ b/development/cpp/custom_resource_format_loaders.rst
@@ -265,7 +265,7 @@ Loading it on GDScript
       ]
     }
 
-.. code::
+::
 
     extends Node
 

--- a/development/cpp/introduction_to_godot_development.rst
+++ b/development/cpp/introduction_to_godot_development.rst
@@ -26,7 +26,7 @@ project. To launch a project directly, you need to run the editor by
 passing the ``-e`` argument to Godot Engine's binary from within your
 project's folder. Typically:
 
-.. code:: bash
+.. code-block:: none
 
     $ cd ~/myproject
     $ gdb godot
@@ -34,7 +34,7 @@ project's folder. Typically:
 
 Or:
 
-.. code:: bash
+.. code-block:: none
 
     $ gdb godot
     > run -e --path ~/myproject

--- a/development/cpp/object_class.rst
+++ b/development/cpp/object_class.rst
@@ -11,7 +11,7 @@ inherit directly or indirectly from it. Objects provide reflection and
 editable properties, and declaring them is a matter of using a single
 macro like this.
 
-.. code:: cpp
+.. code-block:: cpp
 
     class CustomObject : public Object {
 
@@ -20,7 +20,7 @@ macro like this.
 
 This makes Objects gain a lot of functionality, like for example
 
-.. code:: cpp
+.. code-block:: cpp
 
     obj = memnew(CustomObject);
     print_line("Object class: ", obj->get_class()); // print object class
@@ -41,7 +41,7 @@ their methods properties and integer constants.
 
 Classes are registered by calling:
 
-.. code:: cpp
+.. code-block:: cpp
 
     ClassDB::register_class<MyCustomClass>()
 
@@ -50,7 +50,7 @@ creating them again when deserializing.
 
 Registering as virtual is the same but it can't be instanced.
 
-.. code:: cpp
+.. code-block:: cpp
 
     ClassDB::register_virtual_class<MyCustomClass>()
 
@@ -64,13 +64,13 @@ virtual automatically.
 Inside ``_bind_methods``, there are a couple of things that can be done.
 Registering functions is one:
 
-.. code:: cpp
+.. code-block:: cpp
 
     ClassDB::register_method(D_METHOD("methodname", "arg1name", "arg2name"), &MyCustomMethod);
 
 Default values for arguments can be passed in reverse order:
 
-.. code:: cpp
+.. code-block:: cpp
 
     ClassDB::register_method(D_METHOD("methodname", "arg1name", "arg2name"), &MyCustomType::method, DEFVAL(-1)); // default value for arg2name
 
@@ -95,7 +95,7 @@ Constants
 
 Classes often have enums such as:
 
-.. code:: cpp
+.. code-block:: cpp
 
     enum SomeMode {
        MODE_FIRST,
@@ -105,13 +105,13 @@ Classes often have enums such as:
 For these to work when binding to methods, the enum must be declared
 convertible to int, for this a macro is provided:
 
-.. code:: cpp
+.. code-block:: cpp
 
     VARIANT_ENUM_CAST(MyClass::SomeMode); // now functions that take SomeMode can be bound.
 
 The constants can also be bound inside ``_bind_methods``, by using:
 
-.. code:: cpp
+.. code-block:: cpp
 
     BIND_CONSTANT(MODE_FIRST);
     BIND_CONSTANT(MODE_SECOND);
@@ -127,13 +127,13 @@ Objects export properties, properties are useful for the following:
 Properties are usually defined by the PropertyInfo() class. Usually
 constructed as:
 
-.. code:: cpp
+.. code-block:: cpp
 
     PropertyInfo(type, name, hint, hint_string, usage_flags)
 
 For example:
 
-.. code:: cpp
+.. code-block:: cpp
 
     PropertyInfo(Variant::INT, "amount", PROPERTY_HINT_RANGE, "0,49,1", PROPERTY_USAGE_EDITOR)
 
@@ -143,7 +143,7 @@ from 0 to 49 in steps of 1 (integers). It is only usable for the editor
 
 Another example:
 
-.. code:: cpp
+.. code-block:: cpp
 
     PropertyInfo(Variant::STRING, "modes", PROPERTY_HINT_ENUM, "Enabled,Disabled,Turbo")
 
@@ -163,7 +163,7 @@ impossible unless using operator [].
 From ``_bind_methods()``, properties can be created and bound as long as
 set/get functions exist. Example:
 
-.. code:: cpp
+.. code-block:: cpp
 
     ADD_PROPERTY(PropertyInfo(Variant::INT, "amount"), "set_amount", "get_amount")
 
@@ -180,7 +180,7 @@ they are NOT virtual, DO NOT make them virtual, they are called for
 every override and the previous ones are not invalidated (multilevel
 call).
 
-.. code:: cpp
+.. code-block:: cpp
 
     void _get_property_info(List<PropertyInfo> *r_props); // return list of properties
     bool _get(const StringName &p_property, Variant &r_value) const; // return true if property was found
@@ -195,7 +195,7 @@ Dynamic casting
 Godot provides dynamic casting between Object-derived classes, for
 example:
 
-.. code:: cpp
+.. code-block:: cpp
 
     void somefunc(Object *some_obj) {
 
@@ -213,7 +213,7 @@ Signals
 Objects can have a set of signals defined (similar to Delegates in other
 languages). Connecting to them is rather easy:
 
-.. code:: cpp
+.. code-block:: cpp
 
     obj->connect(<signal>, target_instance, target_method)
     // for example:
@@ -225,7 +225,7 @@ The method ``_node_entered_tree`` must be registered to the class using
 Adding signals to a class is done in ``_bind_methods``, using the
 ``ADD_SIGNAL`` macro, for example:
 
-.. code:: cpp
+.. code-block:: cpp
 
     ADD_SIGNAL(MethodInfo("been_killed"))
 
@@ -236,7 +236,7 @@ References
 reference count. It is the base for reference counted object types.
 Declaring them must be done using Ref<> template. For example:
 
-.. code:: cpp
+.. code-block:: cpp
 
     class MyReference: public Reference {
         GDCLASS(MyReference, Reference);
@@ -273,7 +273,7 @@ Resource loading
 
 Resources can be loaded with the ResourceLoader API, like this:
 
-.. code:: cpp
+.. code-block:: cpp
 
     Ref<Resource> res = ResourceLoader::load("res://someresource.res")
 
@@ -294,7 +294,7 @@ Resource saving
 
 Saving a resource can be done with the resource saver API:
 
-.. code:: cpp
+.. code-block:: cpp
 
     ResourceSaver::save("res://someresource.res", instance)
 

--- a/development/editor/creating_icons.rst
+++ b/development/editor/creating_icons.rst
@@ -16,7 +16,7 @@ For instance, you can use the open-source `Inkscape <https://inkscape.org/>`_ ed
 
 Clone the ``godot-design`` repository containing all the original editor icons:
 
-   .. code:: bash
+   .. code-block:: bash
 
        git clone https://github.com/godotengine/godot-design
 
@@ -58,7 +58,7 @@ optimized before being added to the engine, to do so:
 
 2. Run the ``optimize.py`` script. You must have the ``scour`` package installed:
 
-   .. code:: bash
+   .. code-block:: bash
 
        pip install scour
        cd godot-design/engine/icons && ./optimize.py

--- a/getting_started/editor/command_line_tutorial.rst
+++ b/getting_started/editor/command_line_tutorial.rst
@@ -285,7 +285,7 @@ The script must inherit from SceneTree or MainLoop.
 
 Here is a simple example of how it works:
 
-.. code:: python
+.. code-block:: python
 
     #sayhello.gd
     extends SceneTree

--- a/getting_started/scripting/cross_language_scripting.rst
+++ b/getting_started/scripting/cross_language_scripting.rst
@@ -75,7 +75,7 @@ Using C# from GDScript doesn't need much work. Once loaded
 (see :ref:`doc_gdscript_classes_as_resources`) the script can be instantiated
 with :ref:`new() <class_CSharpScript_method_new>`.
 
-.. code-block:: gdscript
+::
 
     var my_csharp_script = load("res://path_to_cs_file.cs")
     var my_csharp_node = my_csharp_script.new()
@@ -116,7 +116,7 @@ Accessing C# fields from GDScript
 Accessing C# fields from GDScript is straightforward, you shouldn't have
 anything to worry about.
 
-.. code-block:: gdscript
+::
 
     print(my_csharp_node.str1) # bar
     my_csharp_node.str1 = "BAR"
@@ -160,7 +160,7 @@ marshalling process will do its best to cast your the arguments to match
 function signatures.
 If that's impossible you'll see the following error: ``Invalid call. Nonexistent function `FunctionName```.
 
-.. code-block:: gdscript
+::
 
     my_csharp_node.PrintNodeName(self) # myGDScriptNode
     # my_csharp_node.PrintNodeName() # This line will fail.

--- a/getting_started/scripting/gdscript/gdscript_advanced.rst
+++ b/getting_started/scripting/gdscript/gdscript_advanced.rst
@@ -57,7 +57,7 @@ assignment. Example:
 
 Static:
 
-.. code:: cpp
+.. code-block:: cpp
 
     int a; // Value uninitialized
     a = 5; // This is valid
@@ -79,7 +79,7 @@ different arguments, for example:
 
 Static:
 
-.. code:: cpp
+.. code-block:: cpp
 
     void print_value(int value) {
 
@@ -119,7 +119,7 @@ too. Some Examples:
 
 -  C++:
 
-.. code:: cpp
+.. code-block:: cpp
 
     void use_class(SomeClass *instance) {
 
@@ -135,7 +135,7 @@ too. Some Examples:
 
 -  Java:
 
-.. code:: java
+.. code-block:: java
 
     @Override
     public final void use_class(SomeClass instance) {
@@ -177,7 +177,7 @@ Arrays in dynamically typed languages can contain many different mixed
 datatypes inside and are always dynamic (can be resized at any time).
 Compare for example arrays in statically typed languages:
 
-.. code:: cpp
+.. code-block:: cpp
 
     int *array = new int[4]; // Create array
     array[0] = 10; // Initialize manually
@@ -319,7 +319,7 @@ For & while
 
 Iterating in some statically typed languages can be quite complex:
 
-.. code:: cpp
+.. code-block:: cpp
 
     const char* strings = new const char*[50];
 
@@ -370,7 +370,7 @@ The range() function can take 3 arguments:
 
 Some statically typed programming language examples:
 
-.. code:: cpp
+.. code-block:: cpp
 
     for (int i = 0; i < 10; i++) {}
 
@@ -474,7 +474,7 @@ As an example, imagine a situation where a big rock is falling down a
 tunnel, smashing everything on its way. The code for the rock, in a
 statically typed language would be something like:
 
-.. code:: cpp
+.. code-block:: cpp
 
     void BigRollingRock::on_object_hit(Smashable *entity) {
 

--- a/tutorials/platform/services_for_ios.rst
+++ b/tutorials/platform/services_for_ios.rst
@@ -25,7 +25,7 @@ locally (no internet connection, API incorrectly configured, etc). If
 the error value is 'OK', a response event will be produced and added to
 the 'pending events' queue. Example:
 
-.. code:: python
+.. code-block:: python
 
     func on_purchase_pressed():
         var result = InAppStore.purchase( { "product_id": "my_product" } )
@@ -428,7 +428,7 @@ you need inside a conditional block, you need to also define them as
 valid identifiers (local variable or class member). This is an example
 of how to work around this in a class:
 
-.. code:: python
+.. code-block:: python
 
     var GameCenter = null # define it as a class member
 

--- a/tutorials/plugins/android/android_plugin.rst
+++ b/tutorials/plugins/android/android_plugin.rst
@@ -168,7 +168,7 @@ any additional resources you have provided for the module will be in the
 
 A singleton object template follows:
 
-.. code:: java
+.. code-block:: java
 
     package org.godotengine.godot;
 
@@ -246,7 +246,7 @@ passed to Java.
 From Java, use the ``calldeferred`` function to communicate back with Godot.
 Java will most likely run in a separate thread, so calls are deferred:
 
-.. code:: java
+.. code-block:: java
 
     GodotLib.calldeferred(<instanceid>, "<function>", new Object[]{param1, param2, etc});
 

--- a/tutorials/plugins/android/android_plugin.rst
+++ b/tutorials/plugins/android/android_plugin.rst
@@ -65,7 +65,7 @@ Android directories
 
 Inside your plugin folder, you can use the standard folders as if they were from an Android Gradle project. Examples of this are:
 
-::
+.. code-block:: none
 
    src/ - For Java source code, same as in your Android project
    res/ - For resources
@@ -91,19 +91,19 @@ AndroidManifest.conf
 
 This file allows to insert bits of chunk into *AndroidManifest.xml*, the following are supported tags and are entirely optional:
 
-::
+.. code-block:: none
 
    [user_permissions]
 
 Any bit of text below this tag is inserted inside the <manifest> tag of the file. This is often used for permission tags.
 
-::
+.. code-block:: none
 
    [application]
 
 Any bit of text below this tag inside the <application> tag of the file. Many SDKs require this.
 
-::
+.. code-block:: none
 
    [application_attribs]
 
@@ -114,7 +114,7 @@ gradle.conf
 
 This file allows to insert bits of chunk into *build.gradle*, the following are supported and are entirely optional:
 
-::
+.. code-block:: none
 
    [buildscript_repositories]
 
@@ -122,21 +122,21 @@ This file allows to insert bits of chunk into *build.gradle*, the following are 
 Any bit of text below this tag is inserted inside the buildscript.repositories section of the build file.
 
 
-::
+.. code-block:: none
 
    [buildscript_dependencies]
 
 
 Any bit of text below this tag is inserted inside the buildscript.dependencies section of the build file.
 
-::
+.. code-block:: none
 
    [allprojects_repositories]
 
 
 Any bit of text below this tag is inserted inside the allprojects.repositories section of the build file.
 
-::
+.. code-block:: none
 
    [dependencies]
 
@@ -144,14 +144,14 @@ Any bit of text below this tag is inserted inside the allprojects.repositories s
 Any bit of text below this tag is inserted inside the dependencies section of the build file.
 
 
-::
+.. code-block:: none
 
    [android_defaultconfig]
 
 
 Any bit of text below this tag is inserted inside the android.defaultconfig section of the build file.
 
-::
+.. code-block:: none
 
    [global]
 
@@ -290,7 +290,7 @@ entire Java API from GDScript.
 
 It's simple to use and it's used like this:
 
-::
+.. code-block:: none
 
     class = JavaClassWrapper.wrap(<javaclass as text>)
 

--- a/tutorials/plugins/android/android_plugin.rst
+++ b/tutorials/plugins/android/android_plugin.rst
@@ -264,7 +264,7 @@ The module should include the full Java path. For our example: ``org/godotengine
 
 Then, from your script:
 
-.. code::
+::
 
     if Engine.has_singleton("MySingleton"):
         var singleton = Engine.get_singleton("MySingleton")


### PR DESCRIPTION
This pull request solves the problem I outlined in #3057.

As already mentioned in the issue the solution is to replace `code` directives with `code-block` directives.

I am still unsure as to why the `code` directive doesn't do the job, but `code-block` seems to be the correct directive since this project uses Sphinx.

I also changed a few minor things that I noticed while making the change, the commits should speak for themselves.