### PR TITLE
Don't reinstall dependencies if they are already installed.

### DIFF
--- a/development/compiling/compiling_for_x11.rst
+++ b/development/compiling/compiling_for_x11.rst
@@ -35,8 +35,8 @@ Distro-specific one-liners
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **Arch Linux**   | ::                                                                                                        |
 |                  |                                                                                                           |
-|                  |     pacman -S scons pkgconf gcc libxcursor libxinerama libxi libxrandr mesa glu libglvnd alsa-lib \       |
-|                  |         pulseaudio yasm                                                                                   |
+|                  |     pacman -S --needed scons pkgconf gcc libxcursor libxinerama libxi libxrandr mesa glu libglvnd \       |
+|                  |         alsa-lib pulseaudio yasm                                                                          |
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **Debian** /     | ::                                                                                                        |
 | **Ubuntu**       |                                                                                                           |


### PR DESCRIPTION
Arch Linux's `pacman -S` re-installs packages that are already installed,
unless the option `--needed` is provided.

A user that wants to build Godot probably doesn't want to reinstall their
GCC compiler and all the other stuff listed in the command.
