### PR TITLE
Add minimal details required to successfully Export to Android

### DIFF
--- a/getting_started/workflow/export/exporting_for_android.rst
+++ b/getting_started/workflow/export/exporting_for_android.rst
@@ -1,6 +1,5 @@
 .. _doc_exporting_for_android:
 
-**This page covers the basics** for Android export.  For a more comprehensive walkthrough (*using Godot 3.1*), please [see this excelent tutorial](https://godotlearn.com/godot-3-1-how-to-export-for-android/).
 
 Exporting for Android
 =====================
@@ -122,3 +121,10 @@ and ARMv8 is usually sufficient to cover most devices in use today.
 You can optimize the size further by compiling an Android export template with
 only the features you need. See :ref:`doc_optimizing_for_size` for more
 information.
+
+Further reading
+---------------
+
+- Article covering the Android export process [at GodotLearn.com](https://godotlearn.com/godot-3-1-how-to-export-for-android/) (*Uses Godot v3.1*).
+
+

--- a/getting_started/workflow/export/exporting_for_android.rst
+++ b/getting_started/workflow/export/exporting_for_android.rst
@@ -1,26 +1,25 @@
 .. _doc_exporting_for_android:
 
-
 Exporting for Android
 =====================
 
-Exporting for Android has fewer requirements than compiling Godot for it. The
-following steps detail what is needed to setup the SDK and the engine.
+Exporting for Android has fewer requirements than compiling Godot for it.
+The following steps detail what is needed to setup the SDK and the engine.
 
 Download the Android SDK
 ------------------------
 
 Download and install the Android SDK from
-https://developer.android.com/studio/
+`developer.android.com <https://developer.android.com/studio/>`__.
 
-- You need to run Android Studio once to complete the setup.
+If you install Android Studio, you need to run it once to complete the SDK setup.
 
 Install OpenJDK or Oracle JDK
 -----------------------------
 
 Download and install  `OpenJDK <https://github.com/ojdkbuild/ojdkbuild>`__ or `Oracle JDK <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`__. Versions below JDK 8 may not work; some users have reported issues with the jarsigner (used to sign the APKs) in JDK 7.
 
-- If you install OpenJDK, choose ``1.8``. Don't choose the ``openjdk-jre`` files as that only contains the JRE, not the JDK which is required here.
+If you install OpenJDK, choose ``1.8``. Don't choose the ``openjdk-jre`` files as that only contains the JRE, not the JDK which is required here.
 
 Create a debug.keystore
 -----------------------
@@ -31,22 +30,18 @@ projects, ant or eclipse probably generated one for you (on Linux and
 macOS, you can find it in the ``~/.android`` directory).
 
 If you can't find it or need to generate one, the keytool command from
-the JDK can be used for this purpose:
-
-::
+the JDK can be used for this purpose::
 
     keytool -keyalg RSA -genkeypair -alias androiddebugkey -keypass android -keystore debug.keystore -storepass android -dname "CN=Android Debug,O=Android,C=US" -validity 9999
 
-- This will create a ``debug.keystore`` file in your current directory. You should move it to a memorable location such as ``%USERPROFILE%\.android\``, because you will need it's location in a later step.
-  - see this Q&A for more info on the KeyTool process: https://godotengine.org/qa/21349/jdk-android-file-missing?show=21399#a21399
+This will create a ``debug.keystore`` file in your current directory. You should move it to a memorable location such as ``%USERPROFILE%\.android\``, because you will need its location in a later step. For more information on ``keytool`` usage, see `this Q&A article <https://godotengine.org/qa/21349/jdk-android-file-missing>`__.
 
 Make sure you have adb
 ----------------------
 
-Android Debug Bridge (adb) is the command line tool used to communicate with
+Android Debug Bridge (``adb``) is the command line tool used to communicate with
 Android devices. It's installed with the SDK, but you may need to install one
 (any) of the Android API levels for it to be installed in the SDK directory.
-
 
 Setting it up in Godot
 ----------------------
@@ -63,11 +58,13 @@ Scroll down to the section where the Android settings are located:
 
 In that screen, the path to 3 files needs to be set:
 
--  The *adb* executable (adb.exe on Windows)
+- The ``adb`` executable (``adb.exe`` on Windows)
   - It can usually be found at ``%LOCALAPPDATA%\Android\Sdk\platform-tools\adb.exe``.
--  The *jarsigner* executable (from JDK 6 or 8)
-  - On Windows, OpenJDK installs to ``%PROGRAMFILES%\ojdkbuild\java-1.8.0-openjdk-1.8.0.232-2\bin``. The exact path may vary depending on the OpenJDK update you've installed.
--  The debug *keystore*
+
+- The ``jarsigner`` executable (from JDK 6 or 8)
+  - On Windows, OpenJDK installs to a dir like ``%PROGRAMFILES%\ojdkbuild\java-1.8.0-openjdk-1.8.0.232-2\bin``. The exact path may vary depending on the OpenJDK update you've installed.
+
+- The debug ``.keystore`` file
   - It can be found in the folder where you put the ``debug.keystore`` file you created above.
 
 Once that is configured, everything is ready to export to Android!
@@ -121,10 +118,3 @@ and ARMv8 is usually sufficient to cover most devices in use today.
 You can optimize the size further by compiling an Android export template with
 only the features you need. See :ref:`doc_optimizing_for_size` for more
 information.
-
-Further reading
----------------
-
-- Article covering the Android export process [at GodotLearn.com](https://godotlearn.com/godot-3-1-how-to-export-for-android/) (*Uses Godot v3.1*).
-
-

--- a/getting_started/workflow/export/exporting_for_android.rst
+++ b/getting_started/workflow/export/exporting_for_android.rst
@@ -38,7 +38,7 @@ the JDK can be used for this purpose:
 
     keytool -keyalg RSA -genkeypair -alias androiddebugkey -keypass android -keystore debug.keystore -storepass android -dname "CN=Android Debug,O=Android,C=US" -validity 9999
 
-- this will create a ```debug.keystore-``` file in your current directory.  you should move it to ```%userprofile%/.android/```
+- This will create a ``debug.keystore`` file in your current directory. You should move it to ``%USERPROFILE%\.android\``.
   - see this Q&A for more info on the KeyTool process: https://godotengine.org/qa/21349/jdk-android-file-missing?show=21399#a21399
 
 Make sure you have adb

--- a/getting_started/workflow/export/exporting_for_android.rst
+++ b/getting_started/workflow/export/exporting_for_android.rst
@@ -12,10 +12,14 @@ Download the Android SDK
 Download and install the Android SDK from
 https://developer.android.com/studio/
 
+- You need to run Android Studio once to complete the setup.
+
 Install OpenJDK or Oracle JDK
 -----------------------------
 
 Download and install  `OpenJDK <https://github.com/ojdkbuild/ojdkbuild>`__ or `Oracle JDK <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`__. Versions below JDK 8 may not work; some users have reported issues with the jarsigner (used to sign the APKs) in JDK 7.
+
+- If you install OpenJDK, choose ```1.8```. and choose do not choose the ```openjdk-jre``` files as that is only the JRE, not the JDK.
 
 Create a debug.keystore
 -----------------------
@@ -32,12 +36,16 @@ the JDK can be used for this purpose:
 
     keytool -keyalg RSA -genkeypair -alias androiddebugkey -keypass android -keystore debug.keystore -storepass android -dname "CN=Android Debug,O=Android,C=US" -validity 9999
 
+- this will create a ```debug.keystore-``` file in your current directory.  you should move it to ```%userprofile%/.android/```
+  - see this Q&A for more info on the KeyTool process: https://godotengine.org/qa/21349/jdk-android-file-missing?show=21399#a21399
+
 Make sure you have adb
 ----------------------
 
 Android Debug Bridge (adb) is the command line tool used to communicate with
 Android devices. It's installed with the SDK, but you may need to install one
 (any) of the Android API levels for it to be installed in the SDK directory.
+
 
 Setting it up in Godot
 ----------------------
@@ -55,8 +63,11 @@ Scroll down to the section where the Android settings are located:
 In that screen, the path to 3 files needs to be set:
 
 -  The *adb* executable (adb.exe on Windows)
+  - This will usually be found at ```%appdata%/../local/Android/Sdk/platform-tools/adb.exe```
 -  The *jarsigner* executable (from JDK 6 or 8)
+  - on windows, OpenJDK installs to ```%programfiles%/ojdkbuild\java-1.8.0-openjdk-1.8.0.232-2\bin```
 -  The debug *keystore*
+  - where you put the ```debug.keystore``` file you created above
 
 Once that is configured, everything is ready to export to Android!
 

--- a/getting_started/workflow/export/exporting_for_android.rst
+++ b/getting_started/workflow/export/exporting_for_android.rst
@@ -1,5 +1,7 @@
 .. _doc_exporting_for_android:
 
+**This page covers the basics** for Android export.  For a more comprehensive walkthrough (*using Godot 3.1*), please [see this excelent tutorial](https://godotlearn.com/godot-3-1-how-to-export-for-android/).
+
 Exporting for Android
 =====================
 

--- a/getting_started/workflow/export/exporting_for_android.rst
+++ b/getting_started/workflow/export/exporting_for_android.rst
@@ -67,7 +67,7 @@ In that screen, the path to 3 files needs to be set:
 -  The *adb* executable (adb.exe on Windows)
   - It can usually be found at ``%LOCALAPPDATA%\Android\Sdk\platform-tools\adb.exe``.
 -  The *jarsigner* executable (from JDK 6 or 8)
-  - on windows, OpenJDK installs to ```%programfiles%/ojdkbuild\java-1.8.0-openjdk-1.8.0.232-2\bin```
+  - On Windows, OpenJDK installs to ``%PROGRAMFILES%\ojdkbuild\java-1.8.0-openjdk-1.8.0.232-2\bin``. The exact path may vary depending on the OpenJDK update you've installed.
 -  The debug *keystore*
   - It can be found in the folder where you put the ``debug.keystore`` file you created above.
 

--- a/getting_started/workflow/export/exporting_for_android.rst
+++ b/getting_started/workflow/export/exporting_for_android.rst
@@ -21,7 +21,7 @@ Install OpenJDK or Oracle JDK
 
 Download and install  `OpenJDK <https://github.com/ojdkbuild/ojdkbuild>`__ or `Oracle JDK <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`__. Versions below JDK 8 may not work; some users have reported issues with the jarsigner (used to sign the APKs) in JDK 7.
 
-- If you install OpenJDK, choose ```1.8```. and choose do not choose the ```openjdk-jre``` files as that is only the JRE, not the JDK.
+- If you install OpenJDK, choose ``1.8``. Don't choose the ``openjdk-jre`` files as that only contains the JRE, not the JDK which is required here.
 
 Create a debug.keystore
 -----------------------

--- a/getting_started/workflow/export/exporting_for_android.rst
+++ b/getting_started/workflow/export/exporting_for_android.rst
@@ -69,7 +69,7 @@ In that screen, the path to 3 files needs to be set:
 -  The *jarsigner* executable (from JDK 6 or 8)
   - on windows, OpenJDK installs to ```%programfiles%/ojdkbuild\java-1.8.0-openjdk-1.8.0.232-2\bin```
 -  The debug *keystore*
-  - where you put the ```debug.keystore``` file you created above
+  - It can be found in the folder where you put the ``debug.keystore`` file you created above.
 
 Once that is configured, everything is ready to export to Android!
 

--- a/getting_started/workflow/export/exporting_for_android.rst
+++ b/getting_started/workflow/export/exporting_for_android.rst
@@ -65,7 +65,7 @@ Scroll down to the section where the Android settings are located:
 In that screen, the path to 3 files needs to be set:
 
 -  The *adb* executable (adb.exe on Windows)
-  - This will usually be found at ```%appdata%/../local/Android/Sdk/platform-tools/adb.exe```
+  - It can usually be found at ``%LOCALAPPDATA%\Android\Sdk\platform-tools\adb.exe``.
 -  The *jarsigner* executable (from JDK 6 or 8)
   - on windows, OpenJDK installs to ```%programfiles%/ojdkbuild\java-1.8.0-openjdk-1.8.0.232-2\bin```
 -  The debug *keystore*

--- a/getting_started/workflow/export/exporting_for_android.rst
+++ b/getting_started/workflow/export/exporting_for_android.rst
@@ -38,7 +38,7 @@ the JDK can be used for this purpose:
 
     keytool -keyalg RSA -genkeypair -alias androiddebugkey -keypass android -keystore debug.keystore -storepass android -dname "CN=Android Debug,O=Android,C=US" -validity 9999
 
-- This will create a ``debug.keystore`` file in your current directory. You should move it to ``%USERPROFILE%\.android\``.
+- This will create a ``debug.keystore`` file in your current directory. You should move it to a memorable location such as ``%USERPROFILE%\.android\``, because you will need it's location in a later step.
   - see this Q&A for more info on the KeyTool process: https://godotengine.org/qa/21349/jdk-android-file-missing?show=21399#a21399
 
 Make sure you have adb


### PR DESCRIPTION
clarify android export workflows, based on:  https://godotengine.org/qa/21349/jdk-android-file-missing?show=21399#a21399

verified works with godot mono 3.2b6 , exporting to samsung galaxy tab a (2019, Android 9).

