### PR TITLE
Add VS2019 Support for C# Debugging (c_sharp_basics.rst)

### DIFF
--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -283,4 +283,4 @@ Configure VS2019 for Debugging
   - Set the ```Mono Debug Port``` to the port in Godot --> Project --> Project Settings --> Mono --> Debugger Agent
     - Also select ```Wait for Debugger``` in the Godot Mono options.  `This Godot Addon <https://godotengine.org/asset-library/asset/435>`_ may be helpful.
 5. Run the game in Godot.  It should hang at the Godot splash screen while it waits for your debugger to attach.
-6. In VS2019, open your project and choose Extensions -->Mono --> Attach to mono Debugger.
+6. In VS2019, open your project and choose Extensions -->Mono --> Attach to Mono Debugger.

--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -273,6 +273,7 @@ Profiling your C# code
 
 Configure VS2019 for Debugging
 -------------------------------
+
 1. Install VS2019 with ```.NET desktop development``` and ```Desktop development with C++``` workloads installed.
 2.  **Ensure that you do not have ```Xamarin``` installed** (do not choose ```Mobile development with .NET``` workload.  Xamarin changes the DLLs used by MonoDebugger, which breaks debugging.
 3. Install the `VSMonoDebugger extension <https://marketplace.visualstudio.com/items?itemName=GordianDotNet.VSMonoDebugger0d62>`_
@@ -283,4 +284,3 @@ Configure VS2019 for Debugging
     - Also select ```Wait for Debugger``` in the Godot Mono options.  `This Godot Addon <https://godotengine.org/asset-library/asset/435>`_ may be helpful.
 5. Run the game in Godot.  It should hang at the Godot splash screen while it waits for your debugger to attach.
 6. In VS2019, open your project and choose Extensions -->Mono --> Attach to mono Debugger.
-

--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -282,5 +282,5 @@ Configure VS2019 for Debugging
   - Leave ```Local Deploy Path``` blank
   - Set the ```Mono Debug Port``` to the port in Godot --> Project --> Project Settings --> Mono --> Debugger Agent
     - Also select ```Wait for Debugger``` in the Godot Mono options.  `This Godot Addon <https://godotengine.org/asset-library/asset/435>`_ may be helpful.
-5. Run the game in Godot.  It should hang at the Godot splash screen while it waits for your debugger to attach.
+5. Run the game in Godot. It should hang at the Godot splash screen while it waits for your debugger to attach.
 6. In VS2019, open your project and choose Extensions -->Mono --> Attach to Mono Debugger.

--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -283,4 +283,4 @@ Configure VS2019 for Debugging
   - Set the ```Mono Debug Port``` to the port in Godot --> Project --> Project Settings --> Mono --> Debugger Agent
     - Also select ```Wait for Debugger``` in the Godot Mono options.  `This Godot Addon <https://godotengine.org/asset-library/asset/435>`_ may be helpful.
 5. Run the game in Godot. It should hang at the Godot splash screen while it waits for your debugger to attach.
-6. In VS2019, open your project and choose Extensions -->Mono --> Attach to Mono Debugger.
+6. In VS2019, open your project and choose Extensions --> Mono --> Attach to Mono Debugger.

--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -274,7 +274,7 @@ Profiling your C# code
 Configure VS2019 for Debugging
 -------------------------------
 1. Install VS2019 with ```.NET desktop development``` and ```Desktop development with C++``` workloads installed.
-2.  **Ensure that you do not have ```Xamarin``` installed** (do not choose ```Mobile development with .NET``` workload.   Xamarin changes what dll's MonoDebugger uses, which breaks debugging.
+2.  **Ensure that you do not have ```Xamarin``` installed** (do not choose ```Mobile development with .NET``` workload.  Xamarin changes the DLLs used by MonoDebugger, which breaks debugging.
 3. Install the `VSMonoDebugger extension <https://marketplace.visualstudio.com/items?itemName=GordianDotNet.VSMonoDebugger0d62>`_
 4, In VS2019 --> Extensions --> Mono --> Settings:
   - Select ```Debug/Deploy to local Windows```
@@ -283,5 +283,4 @@ Configure VS2019 for Debugging
     - Also select ```Wait for Debugger``` in the Godot Mono options.  `This Godot Addon <https://godotengine.org/asset-library/asset/435>`_ may be helpful.
 5. Run the game in Godot.  It should hang at the Godot splash screen while it waits for your debugger to attach.
 6. In VS2019, open your project and choose Extensions -->Mono --> Attach to mono Debugger.
-
 

--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -85,6 +85,7 @@ click on **Editor → Editor Settings** and scroll down to
 external editor of choice. Godot currently supports the following
 external editors:
 
+- Visual Studio 2019
 - Visual Studio Code
 - MonoDevelop
 - Visual Studio for Mac
@@ -93,6 +94,10 @@ external editors:
 .. note:: If you are using Visual Studio Code, ensure you download and install
           the `C# extension <https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp>`_
           to enable features like syntax highlighting and IntelliSense.
+
+
+.. note:: If you are using Visual Studio 2019, you must follow the instructions found in the "Configure VS2019 for Debugging" section below.
+
 
 Creating a C# script
 --------------------
@@ -265,3 +270,18 @@ Profiling your C# code
 
 - `Mono log profiler <https://www.mono-project.com/docs/debug+profile/profile/profiler/>`_ is available via `this PR <https://github.com/godotengine/godot/pull/26513>`_
 - External Mono profiler like `JetBrains dotTrace <https://www.jetbrains.com/profiler/>`_ can be used as described `here <https://github.com/godotengine/godot/pull/34382>`_.
+
+Configure VS2019 for Debugging
+-------------------------------
+1. Install VS2019 with ```.NET desktop development``` and ```Desktop development with C++``` workloads installed.
+2.  **Ensure that you do not have ```Xamarin``` installed** (do not choose ```Mobile development with .NET``` workload.   Xamarin changes what dll's MonoDebugger uses, which breaks debugging.
+3. Install the `VSMonoDebugger extension <https://marketplace.visualstudio.com/items?itemName=GordianDotNet.VSMonoDebugger0d62>`_
+4, In VS2019 --> Extensions --> Mono --> Settings:
+  - Select ```Debug/Deploy to local Windows```
+  - Leave ```Local Deploy Path``` blank
+  - Set the ```Mono Debug Port``` to the port in Godot --> Project --> Project Settings --> Mono --> Debugger Agent
+    - Also select ```Wait for Debugger``` in the Godot Mono options.  `This Godot Addon <https://godotengine.org/asset-library/asset/435>`_ may be helpful.
+5. Run the game in Godot.  It should hang at the Godot splash screen while it waits for your debugger to attach.
+6. In VS2019, open your project and choose Extensions -->Mono --> Attach to mono Debugger.
+
+


### PR DESCRIPTION
Add docs showing how VS2019 is supported.   re: https://github.com/godotengine/godot-proposals/issues/371
