### PR TITLE
Fix the "Caution" admonition colors when using the dark theme

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -372,12 +372,14 @@ code,
 }
 
 .rst-content .admonition.attention,
+.rst-content .admonition.caution,
 .rst-content .admonition.warning {
     background-color: var(--admonition-attention-background-color);
     color: var(--admonition-attention-color);
 }
 
 .rst-content .admonition.attention .admonition-title,
+.rst-content .admonition.caution .admonition-title,
 .rst-content .admonition.warning .admonition-title {
     background-color: var(--admonition-attention-title-background-color);
     color: var(--admonition-attention-title-color);


### PR DESCRIPTION
This can be seen by browsing [Exporting for Android](https://docs.godotengine.org/en/latest/getting_started/workflow/export/exporting_for_android.html) with the dark theme enabled (via the OS settings).