### PR TITLE
Fix gcc compilation flags for GDNative with C example

### DIFF
--- a/tutorials/plugins/gdnative/gdnative-c-example.rst
+++ b/tutorials/plugins/gdnative/gdnative-c-example.rst
@@ -361,8 +361,8 @@ On Linux:
 
 .. code-block:: none
 
-    gcc -std=c11 -fPIC -c -I../../godot_headers simple.c -o simple.os
-    gcc -shared simple.os -o ../bin/libsimple.so
+    gcc -std=c11 -fPIC -c -I../../godot_headers simple.c -o simple.o
+    gcc -rdynamic -shared simple.o -o ../bin/libsimple.so
 
 On macOS:
 


### PR DESCRIPTION
`-rdynamic` flag is needed to properly export the symbols (otherwise Godot may not find them).

Also changed to use the more common `.o` extension for objects on Linux.