### PR TITLE
Replace x11 with linux in GDNative C++ example

### DIFF
--- a/tutorials/plugins/gdnative/gdnative-cpp-example.rst
+++ b/tutorials/plugins/gdnative/gdnative-cpp-example.rst
@@ -129,7 +129,7 @@ Place the resulting ``api.json`` file in the project folder and add
 below.
 
 To generate and compile the bindings, use this command (replacing ``<platform>``
-with ``windows``, ``x11`` or ``osx`` depending on your OS):
+with ``windows``, ``linux`` or ``osx`` depending on your OS):
 
 .. code-block:: none
 


### PR DESCRIPTION
"x11" it's not the correct platform. It works with "linux".

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
