### PR TITLE
Fix the display of very long class names in the navigation bar

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -547,6 +547,12 @@ code,
 
 /* Second (and higher) levels of navigation items */
 
+.wy-menu-vertical li.current a {
+    /* Make long words always display on a single line, keep wrapping for multiple words */
+    /* This fixes the class reference titles' display with very long class names */
+    display: flex;
+}
+
 .wy-menu-vertical li.current a,
 .wy-menu-vertical li.toctree-l2.current > a,
 .wy-menu-vertical li.toctree-l2.current li.toctree-l3 > a,


### PR DESCRIPTION
Thanks to @KieranCarden for providing a fix :slightly_smiling_face:

This closes #3092.