### PR TITLE
Update grid snap info in your_first_game.rst

### DIFF
--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -674,10 +674,9 @@ you will see some new buttons at the top of the editor:
 .. image:: img/path2d_buttons.png
 
 Select the middle one ("Add Point") and draw the path by clicking to add
-the points at the corners shown. To have the points snap to the grid, make sure "Snap to
-Grid" is checked. This option can be found under the "Snapping options"
-button to the left of the "Lock" button, appearing as a series of three
-vertical dots.
+the points at the corners shown. To have the points snap to the grid, make
+sure "Use Grid Snap" is selected. This option can be found to the left of
+the "Lock" button, appearing as a magnet next to some intersecting lines.
 
 .. image:: img/draw_path2d.gif
 


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->

Godot 3.2 has a button for Grid Snap:

![gridsnap](https://user-images.githubusercontent.com/7436252/73406585-c25b2d80-42c4-11ea-8128-6e23cf1badcf.PNG)

I got a bit confused when I looked in the specified snapping options (three vertical dots) and this setting was not in there.