### PR TITLE
Prevent the `3.2` branch from being indexed by search engines

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,5 @@
 user-agent: *
+disallow: /*/3.2
 disallow: /*/3.1
 disallow: /*/3.0
 disallow: /*/2.0


### PR DESCRIPTION
See #3002 for rationale.

PS: It seems the `robots.txt` file isn't actually working per [this Reddit thread](https://www.reddit.com/r/godot/comments/ey9wz3/when_31_docs_still_have_better_search_engine/), even though it's deployed to production on both the `3.1` and `master` branches. Any ideas why?

cc @NathanLovato