### PR TITLE
Update intro_to_the_editor_interface.rst

### DIFF
--- a/getting_started/step_by_step/intro_to_the_editor_interface.rst
+++ b/getting_started/step_by_step/intro_to_the_editor_interface.rst
@@ -146,7 +146,7 @@ Modify the interface
 
 Godot’s interface lives in a single window. You cannot split it across
 multiple screens although you can work with an external code editor like
-Atom or Visual Studio for instance.
+Atom or Visual Studio Code for instance.
 
 Move and resize docks
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Visual Studio is usually defined as an IDE, whereas Visual Studio Code is meant to be a code editor.

Even though Visual Studio can work as an external code editor for Godot (especially for Godot Mono), I suppose that Visual Studio Code was intended to be written instead.
