### PR TITLE
Remove duplicated code in Sync Audio

### DIFF
--- a/tutorials/audio/sync_with_audio.rst
+++ b/tutorials/audio/sync_with_audio.rst
@@ -32,15 +32,7 @@ This delay can't be avoided but it can be estimated by calling :ref:`AudioServer
 
 The output latency (what happens after the mix) can also be estimated by calling :ref:`AudioServer.get_output_latency()<class_AudioServer_method_get_output_latency>`.
 
-Add these two and it's possible to guess almost exactly when sound or music will begin playing in the speakers:
-
-.. tabs::
- .. code-tab:: gdscript GDScript
-
-    var actual_play_time = AudioServer.get_time_to_next_mix() + AudioServer.get_output_latency()
-    $Song.play()
-
-This way, obtaining the actual playback position during *_process()* is possible:
+Add these two and it's possible to guess almost exactly when sound or music will begin playing in the speakers during *_process()*:
 
 .. tabs::
  .. code-tab:: gdscript GDScript


### PR DESCRIPTION
Not sure I got this right but it seems like duplicate code to me.

Furthermore I'm not sure what we can use this **time** for as $player.play has no timing arguments to compensate for. There is no `$player.playDelayed(time)`.

Shouldn't we use `_physics_process` for better timing?

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
