### PR TITLE
Grammar fix for Optimization using Servers page

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -1,5 +1,5 @@
-Godot Docs – *master* branch
-============================
+Godot Docs – *3.2* branch
+=========================
 
 .. only:: not i18n
 
@@ -7,9 +7,11 @@ Godot Docs – *master* branch
             Expand the "Read the Docs" panel at the bottom of the sidebar to see
             the list.
 
-  .. attention:: This is the documentation for the development (master) branch.
-                 Looking for the documentation of the current **stable** branch?
-                 `Have a look here <https://docs.godotengine.org/en/stable>`_.
+  .. tip:: This is the documentation for the stable 3.2 branch.
+           Looking for the documentation of the current **development** branch?
+           `Have a look here <https://docs.godotengine.org/en/latest>`_.
+           You can also browse the documentation for the previous stable
+           `3.1 <https://docs.godotengine.org/en/3.1>`_ branch.
 
 .. only:: i18n
 

--- a/tutorials/optimization/using_servers.rst
+++ b/tutorials/optimization/using_servers.rst
@@ -38,7 +38,7 @@ The most common servers are:
 * :ref:`Physics2DServer <class_Physics2DServer>`: handles everything related to 2D physics.
 * :ref:`AudioServer <class_AudioServer>`: handles everything related to audio.
 
-Just explore their APIs and you will realize that the all functions provided are low-level
+Just explore their APIs and you will realize that all the functions provided are low-level
 implementations of everything Godot allows you to do.
 
 RIDs


### PR DESCRIPTION
I noticed a small grammatical error on the Optimization using Servers page of the 3.2 docs