### PR TITLE
Possible typo

### DIFF
--- a/tutorials/plugins/editor/inspector_plugins.rst
+++ b/tutorials/plugins/editor/inspector_plugins.rst
@@ -39,7 +39,7 @@ editor that we'll later define.
         # We will handle properties of type integer.
         if type == TYPE_INT:
             # Register *an instance* of the custom property editor that we'll define next.
-            add_custom_property_editor(path, MyIntEditor.new())
+            add_property_editor(path, MyIntEditor.new())
             # We return `true` to notify the inspector that we'll be handling
             # this integer property, so it doesn't need to parse other plugins
             # (including built-in ones) for an appropriate editor.


### PR DESCRIPTION
Tutorial for 3.2 suggests calling 'add_custom_property_editor' which is not a member of EditorInspectorPlugin; however 'add_property_editor' does exist.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
