### PR TITLE
Fix highlighting of XML tags when using a dark theme

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -349,7 +349,8 @@ code,
     color: var(--highlight-type2-color);
 }
 
-.highlight .nf {
+.highlight .nf,
+.highlight .nt {
     color: var(--highlight-function-color);
 }
 


### PR DESCRIPTION
This sets the color of XML tags on pages like [Contribute to the Class Reference](https://docs.godotengine.org/en/3.2/community/contributing/updating_the_class_reference.html).