### PR TITLE
Set the recommended distribution for "portable" builds to Ubuntu 18.04

### DIFF
--- a/development/compiling/compiling_for_x11.rst
+++ b/development/compiling/compiling_for_x11.rst
@@ -120,7 +120,7 @@ Building export templates
 .. warning:: Linux binaries usually won't run on distributions that are
              older than the distribution they were built on. If you wish to
              distribute binaries that work on most distributions,
-             you should build them on an old distribution such as Ubuntu 16.04.
+             you should build them on an old distribution such as Ubuntu 18.04.
              You can use a virtual machine or a container to set up a suitable
              build environment.
 


### PR DESCRIPTION
Godot 4.0 requires a C++17-compliant compiler, which is only available in Ubuntu 18.04 and later.

While it's possible to build it on Ubuntu 16.04 with third-party repositories, Ubuntu 18.04 has everything required in the official repositories, making it easier to set up.

This was suggested by Mistery Man on Discord.