### PR TITLE
replace 'Linux or other Unix Variants' with macOS

### DIFF
--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -8,8 +8,7 @@ Compiling for macOS
 Requirements
 ------------
 
-For compiling under Linux or other Unix variants, the following is
-required:
+For compiling under macOS, the following is required:
 
 -  Python 2.7+ or Python 3.5+
 -  SCons build system


### PR DESCRIPTION
The page about building for macOS refers to "Linux and other Unix variants". Change this to macOS.

Two questions :-

The docs use macOS while the build system refers to it as osx and the relevant filenames use osx. Is there any interest in changing the docs to use osx?

Python 2.7 has reached end of life. Is there interest in removing references to py27 from the docs? Use Python 3.5+?
