### PR TITLE
C# bullet documentation

### DIFF
--- a/tutorials/physics/using_kinematic_body_2d.rst
+++ b/tutorials/physics/using_kinematic_body_2d.rst
@@ -397,13 +397,13 @@ And the code for the Bullet:
 
         public override void _PhysicsProcess(float delta)
         {
-            var collsion = MoveAndCollide(_velocity * delta);
-            if (collsion != null)
+            var collision = MoveAndCollide(_velocity * delta);
+            if (collision != null)
             {
-                _velocity = _velocity.Bounce(collsion.Normal);
-                if (collsion.Collider.HasMethod("Hit"))
+                _velocity = _velocity.Bounce(collision.Normal);
+                if (collision.Collider.HasMethod("Hit"))
                 {
-                    collsion.Collider.Hit();
+                    collision.Collider.Call("Hit");
                 }
             }
         }


### PR DESCRIPTION
Unless I am mistaken, you cannot directly call the hit method, and must use .Call(). Seems to not even be capable of compiling, not sure how much these C# sections are tested?
I also presume there's not much reason to shorten collision to collsion, so I threw that change in as well.