### PR TITLE
Rephrase dock descriptions to be location-agnostic

### DIFF
--- a/getting_started/step_by_step/intro_to_the_editor_interface.rst
+++ b/getting_started/step_by_step/intro_to_the_editor_interface.rst
@@ -79,21 +79,21 @@ When the folder path is correct, you'll see a green checkmark.
 Your first look at Godot’s editor
 ---------------------------------
 
-Welcome to Godot! With your project open, you should see the editor’s
-interface with empty docks on the right side.
+Welcome to Godot! With your project open, you should see the editor’s interface
+with menus along the top of the interface and docks along the far extremes of
+the interface on either side of the viewport.
 
 .. image:: img/editor_ui_intro_editor_interface_overview.png
 
 At the top, from left to right, you can see the **main menus**, the
 **workspaces**, and the **playtest buttons**.
 
-On the bottom left side, you have the **FileSystem dock**, where you’ll
-manage your project files and assets.
+The **FileSystem dock** is where you’ll manage your project files and assets.
 
 .. image:: img/editor_ui_intro_dock_filesystem.png
 
-On the right side, you’ll find the **Scene dock**, which lists the active
-scene’s content and the **Inspector** in the bottom right corner.
+The **Scene dock** lists the active scene’s content and the **Inspector**
+allows for the management of the properties of a scene's content.
 
 .. image:: img/editor_ui_intro_dock_inspector.png
 

--- a/getting_started/step_by_step/scenes_and_nodes.rst
+++ b/getting_started/step_by_step/scenes_and_nodes.rst
@@ -130,8 +130,8 @@ And finally, create the Label! A lot happens when Create is pressed:
 First of all, the scene changes to the 2D editor (because Label is a 2D Node
 type), and the Label appears, selected, at the top left corner of the viewport.
 
-The node appears in the scene tree editor ("Scene" tab in the top-left panel),
-and the label properties appear in the Inspector (tab in the right-hand panel).
+The node appears in the scene tree editor in the Scene dock, and the label
+properties appear in the Inspector dock.
 
 The next step will be to change the "Text" Property of the label. Let's
 change it to "Hello World":


### PR DESCRIPTION
On my setup the Scene dock was not on the right side but rather on the
left side and when changes are made to the UI, it will be challenging to
keep track of all references in the documentation that may need
updating.

Keeping the documentation loosely coupled to the actual location of
elements in the UI should avoid confusion for new users and minimize
work for maintainers.