### PR TITLE
Format `gdscript.py` and `conf.py` using Black and Flake8

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -2,109 +2,109 @@
 #
 # Godot Engine documentation build configuration file
 
+import sphinx_rtd_theme
 import sys
 import os
+from gdscript import GDScriptLexer
+from sphinx.highlighting import lexers
 
 # -- General configuration ------------------------------------------------
 
-needs_sphinx = '1.3'
+needs_sphinx = "1.3"
 
 # Sphinx extension module names and templates location
-sys.path.append(os.path.abspath('extensions'))
-extensions = ['gdscript', 'sphinx_tabs.tabs', 'sphinx.ext.imgmath']
+sys.path.append(os.path.abspath("extensions"))
+extensions = ["gdscript", "sphinx_tabs.tabs", "sphinx.ext.imgmath"]
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # You can specify multiple suffix as a list of string: ['.rst', '.md']
-source_suffix = '.rst'
-source_encoding = 'utf-8-sig'
+source_suffix = ".rst"
+source_encoding = "utf-8-sig"
 
 # The master toctree document
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project
-project = 'Godot Engine'
-copyright = '2014-2020, Juan Linietsky, Ariel Manzur and the Godot community (CC-BY 3.0)'
-author = 'Juan Linietsky, Ariel Manzur and the Godot community'
+project = "Godot Engine"
+copyright = (
+    "2014-2020, Juan Linietsky, Ariel Manzur and the Godot community (CC-BY 3.0)"
+)
+author = "Juan Linietsky, Ariel Manzur and the Godot community"
 
 # Version info for the project, acts as replacement for |version| and |release|
 # The short X.Y version
-version = 'latest'
+version = "latest"
 # The full version, including alpha/beta/rc tags
-release = 'latest'
+release = "latest"
 
 # Parse Sphinx tags passed from RTD via environment
-env_tags = os.getenv('SPHINX_TAGS')
-if env_tags != None:
-   for tag in env_tags.split(','):
-       print("Adding Sphinx tag: %s" % tag.strip())
-       tags.add(tag.strip())
+env_tags = os.getenv("SPHINX_TAGS")
+if env_tags is not None:
+    for tag in env_tags.split(","):
+        print("Adding Sphinx tag: %s" % tag.strip())
+        tags.add(tag.strip())  # noqa: F821
 
 # Language / i18n
-language = os.getenv('READTHEDOCS_LANGUAGE', 'en')
-is_i18n = tags.has('i18n')
+language = os.getenv("READTHEDOCS_LANGUAGE", "en")
+is_i18n = tags.has("i18n")  # noqa: F821
 
-exclude_patterns = ['_build']
+exclude_patterns = ["_build"]
 
 # GDScript syntax highlighting
-from gdscript import GDScriptLexer
-from sphinx.highlighting import lexers
-lexers['gdscript'] = GDScriptLexer()
+lexers["gdscript"] = GDScriptLexer()
 
 # Pygments (syntax highlighting) style to use
-pygments_style = 'sphinx'
-highlight_language = 'gdscript'
+pygments_style = "sphinx"
+highlight_language = "gdscript"
 
 # -- Options for HTML output ----------------------------------------------
 
 # on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
-import sphinx_rtd_theme
-html_theme = 'sphinx_rtd_theme'
+
+html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 if on_rtd:
     using_rtd_theme = True
 
 # Theme options
 html_theme_options = {
-    # 'typekit_id': 'hiw1hhg',
-    # 'analytics_id': '',
-    # 'sticky_navigation': True  # Set to False to disable the sticky nav while scrolling.
-    'logo_only': True,  # if we have a html_logo below, this shows /only/ the logo with no title text
-    'collapse_navigation': False,  # Collapse navigation (False makes it tree-like)
-    # 'display_version': True,  # Display the docs version
-    # 'navigation_depth': 4,  # Depth of the headers shown in the navigation bar
+    # if we have a html_logo below, this shows /only/ the logo with no title text
+    "logo_only": True,
+    # Collapse navigation (False makes it tree-like)
+    "collapse_navigation": False,
 }
 
 # VCS options: https://docs.readthedocs.io/en/latest/vcs.html#github
 html_context = {
-    "display_github": not is_i18n, # Integrate GitHub
-    "github_user": "godotengine", # Username
-    "github_repo": "godot-docs", # Repo name
-    "github_version": "master", # Version
-    "conf_py_path": "/", # Path in the checkout to the docs root
+    "display_github": not is_i18n,  # Integrate GitHub
+    "github_user": "godotengine",  # Username
+    "github_repo": "godot-docs",  # Repo name
+    "github_version": "master",  # Version
+    "conf_py_path": "/",  # Path in the checkout to the docs root
 }
 
-html_logo = 'img/docs_logo.png'
+html_logo = "img/docs_logo.png"
 
 # These folders are copied to the documentation's HTML output
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
-html_extra_path = ['robots.txt']
+html_extra_path = ["robots.txt"]
 
 # These paths are either relative to html_static_path
 # or fully qualified paths (eg. https://...)
 html_css_files = [
-    'css/custom.css',
+    "css/custom.css",
 ]
 
 html_js_files = [
-    'js/custom.js',
+    "js/custom.js",
 ]
 
 # Output file base name for HTML help builder
-htmlhelp_basename = 'GodotEnginedoc'
+htmlhelp_basename = "GodotEnginedoc"
 
 # -- Options for reStructuredText parser ----------------------------------
 
@@ -117,8 +117,13 @@ file_insertion_enabled = False
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'GodotEngine.tex', 'Godot Engine Documentation',
-   'Juan Linietsky, Ariel Manzur and the Godot community', 'manual'),
+    (
+        master_doc,
+        "GodotEngine.tex",
+        "Godot Engine Documentation",
+        "Juan Linietsky, Ariel Manzur and the Godot community",
+        "manual",
+    ),
 ]
 
 # -- Options for linkcheck builder ----------------------------------------
@@ -130,7 +135,7 @@ linkcheck_timeout = 10
 
 # -- I18n settings --------------------------------------------------------
 
-locale_dirs = ['../sphinx/po/']
+locale_dirs = ["../sphinx/po/"]
 gettext_compact = False
 
 # Couldn't find a way to retrieve variables nor do advanced string
@@ -142,10 +147,10 @@ rst_epilog = """
     :alt: Translation status
     :target: https://hosted.weblate.org/engage/godot-engine{target_locale}/?utm_source=widget
 """.format(
-    image_locale='-' if language == 'en' else language,
-    target_locale='' if language == 'en' else '/' + language
+    image_locale="-" if language == "en" else language,
+    target_locale="" if language == "en" else "/" + language,
 )
 
 # Exclude class reference when marked with tag i18n.
 if is_i18n:
-    exclude_patterns = ['classes']
+    exclude_patterns = ["classes"]

--- a/extensions/gdscript.py
+++ b/extensions/gdscript.py
@@ -13,164 +13,335 @@
 
 import re
 
-from pygments.lexer import Lexer, RegexLexer, include, bygroups, using, \
-    default, words, combined, do_insertions
-from pygments.util import get_bool_opt, shebang_matches
-from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
-    Number, Punctuation, Generic, Other, Error
-from pygments import unistring as uni
+from pygments.lexer import (
+    RegexLexer,
+    include,
+    bygroups,
+    default,
+    words,
+    combined,
+)
+from pygments.token import (
+    Text,
+    Comment,
+    Operator,
+    Keyword,
+    Name,
+    String,
+    Number,
+    Punctuation,
+)
 
-__all__ = ['GDScriptLexer']
+__all__ = ["GDScriptLexer"]
 
-line_re = re.compile('.*?\n')
+line_re = re.compile(".*?\n")
 
 
 class GDScriptLexer(RegexLexer):
     """
-    For `Godot source code <https://www.godotengine.org>`_ source code.
+    For `GDScript source code <https://www.godotengine.org>`_.
     """
 
-    name = 'GDScript'
-    aliases = ['gdscript', 'gd']
-    filenames = ['*.gd']
-    mimetypes = ['text/x-gdscript', 'application/x-gdscript']
+    name = "GDScript"
+    aliases = ["gdscript", "gd"]
+    filenames = ["*.gd"]
+    mimetypes = ["text/x-gdscript", "application/x-gdscript"]
 
     def innerstring_rules(ttype):
         return [
             # the old style '%s' % (...) string formatting
-            (r'%(\(\w+\))?[-#0 +]*([0-9]+|[*])?(\.([0-9]+|[*]))?'
-             '[hlL]?[E-GXc-giorsux%]', String.Interpol),
+            (
+                r"%(\(\w+\))?[-#0 +]*([0-9]+|[*])?(\.([0-9]+|[*]))?"
+                "[hlL]?[E-GXc-giorsux%]",
+                String.Interpol,
+            ),
             # backslashes, quotes and formatting signs must be parsed one at a time
             (r'[^\\\'"%\n]+', ttype),
             (r'[\'"\\]', ttype),
             # unhandled string formatting sign
-            (r'%', ttype),
+            (r"%", ttype),
             # newlines are an error (use "nl" state)
         ]
 
     tokens = {
-        'root': [
-            (r'\n', Text),
-            (r'^(\s*)([rRuUbB]{,2})("""(?:.|\n)*?""")',
-             bygroups(Text, String.Affix, String.Doc)),
-            (r"^(\s*)([rRuUbB]{,2})('''(?:.|\n)*?''')",
-             bygroups(Text, String.Affix, String.Doc)),
-            (r'[^\S\n]+', Text),
-            (r'#.*$', Comment.Single),
-            (r'[]{}:(),;[]', Punctuation),
-            (r'\\\n', Text),
-            (r'\\', Text),
-            (r'(in|and|or|not)\b', Operator.Word),
-            (r'!=|==|<<|>>|&&|\+=|-=|\*=|/=|%=|&=|\|=|\|\||[-~+/*%=<>&^.!|$]', Operator),
-            include('keywords'),
-            (r'(func)((?:\s|\\\s)+)', bygroups(Keyword, Text), 'funcname'),
-            (r'(class)((?:\s|\\\s)+)', bygroups(Keyword, Text), 'classname'),
-            include('builtins'),
-            ('([rR]|[uUbB][rR]|[rR][uUbB])(""")',
-             bygroups(String.Affix, String.Double), 'tdqs'),
-            ("([rR]|[uUbB][rR]|[rR][uUbB])(''')",
-             bygroups(String.Affix, String.Single), 'tsqs'),
-            ('([rR]|[uUbB][rR]|[rR][uUbB])(")',
-             bygroups(String.Affix, String.Double), 'dqs'),
-            ("([rR]|[uUbB][rR]|[rR][uUbB])(')",
-             bygroups(String.Affix, String.Single), 'sqs'),
-            ('([uUbB]?)(""")', bygroups(String.Affix, String.Double),
-             combined('stringescape', 'tdqs')),
-            ("([uUbB]?)(''')", bygroups(String.Affix, String.Single),
-             combined('stringescape', 'tsqs')),
-            ('([uUbB]?)(")', bygroups(String.Affix, String.Double),
-             combined('stringescape', 'dqs')),
-            ("([uUbB]?)(')", bygroups(String.Affix, String.Single),
-             combined('stringescape', 'sqs')),
-            include('name'),
-            include('numbers'),
+        "root": [
+            (r"\n", Text),
+            (
+                r'^(\s*)([rRuUbB]{,2})("""(?:.|\n)*?""")',
+                bygroups(Text, String.Affix, String.Doc),
+            ),
+            (
+                r"^(\s*)([rRuUbB]{,2})('''(?:.|\n)*?''')",
+                bygroups(Text, String.Affix, String.Doc),
+            ),
+            (r"[^\S\n]+", Text),
+            (r"#.*$", Comment.Single),
+            (r"[]{}:(),;[]", Punctuation),
+            (r"\\\n", Text),
+            (r"\\", Text),
+            (r"(in|and|or|not)\b", Operator.Word),
+            (
+                r"!=|==|<<|>>|&&|\+=|-=|\*=|/=|%=|&=|\|=|\|\||[-~+/*%=<>&^.!|$]",
+                Operator,
+            ),
+            include("keywords"),
+            (r"(func)((?:\s|\\\s)+)", bygroups(Keyword, Text), "funcname"),
+            (r"(class)((?:\s|\\\s)+)", bygroups(Keyword, Text), "classname"),
+            include("builtins"),
+            (
+                '([rR]|[uUbB][rR]|[rR][uUbB])(""")',
+                bygroups(String.Affix, String.Double),
+                "tdqs",
+            ),
+            (
+                "([rR]|[uUbB][rR]|[rR][uUbB])(''')",
+                bygroups(String.Affix, String.Single),
+                "tsqs",
+            ),
+            (
+                '([rR]|[uUbB][rR]|[rR][uUbB])(")',
+                bygroups(String.Affix, String.Double),
+                "dqs",
+            ),
+            (
+                "([rR]|[uUbB][rR]|[rR][uUbB])(')",
+                bygroups(String.Affix, String.Single),
+                "sqs",
+            ),
+            (
+                '([uUbB]?)(""")',
+                bygroups(String.Affix, String.Double),
+                combined("stringescape", "tdqs"),
+            ),
+            (
+                "([uUbB]?)(''')",
+                bygroups(String.Affix, String.Single),
+                combined("stringescape", "tsqs"),
+            ),
+            (
+                '([uUbB]?)(")',
+                bygroups(String.Affix, String.Double),
+                combined("stringescape", "dqs"),
+            ),
+            (
+                "([uUbB]?)(')",
+                bygroups(String.Affix, String.Single),
+                combined("stringescape", "sqs"),
+            ),
+            include("name"),
+            include("numbers"),
         ],
-        'keywords': [
-            (words((
-                'and', 'in', 'not', 'or', 'as', 'breakpoint', 'class', 'class_name',
-                'extends', 'is', 'func', 'setget', 'signal', 'tool', 'const',
-                'enum', 'export', 'onready', 'static', 'var', 'break', 'continue',
-                'if', 'elif', 'else', 'for', 'pass', 'return', 'match', 'while',
-                'remote', 'master', 'puppet', 'remotesync', 'mastersync',
-                'puppetsync'), suffix=r'\b'),
-             Keyword),
+        "keywords": [
+            (
+                words(
+                    (
+                        "and",
+                        "in",
+                        "not",
+                        "or",
+                        "as",
+                        "breakpoint",
+                        "class",
+                        "class_name",
+                        "extends",
+                        "is",
+                        "func",
+                        "setget",
+                        "signal",
+                        "tool",
+                        "const",
+                        "enum",
+                        "export",
+                        "onready",
+                        "static",
+                        "var",
+                        "break",
+                        "continue",
+                        "if",
+                        "elif",
+                        "else",
+                        "for",
+                        "pass",
+                        "return",
+                        "match",
+                        "while",
+                        "remote",
+                        "master",
+                        "puppet",
+                        "remotesync",
+                        "mastersync",
+                        "puppetsync",
+                    ),
+                    suffix=r"\b",
+                ),
+                Keyword,
+            ),
         ],
-        'builtins': [
-            (words((
-                'Color8', 'ColorN', 'abs', 'acos', 'asin', 'assert', 'atan', 'atan2',
-                'bytes2var', 'ceil', 'char', 'clamp', 'convert', 'cos', 'cosh',
-                'db2linear', 'decimals', 'dectime', 'deg2rad', 'dict2inst',
-                'ease', 'exp', 'floor', 'fmod', 'fposmod', 'funcref', 'hash',
-                'inst2dict', 'instance_from_id', 'is_inf', 'is_nan', 'lerp',
-                'linear2db', 'load', 'log', 'max', 'min', 'nearest_po2', 'pow',
-                'preload', 'print', 'print_stack', 'printerr', 'printraw',
-                'prints', 'printt', 'rad2deg', 'rand_range', 'rand_seed',
-                'randf', 'randi', 'randomize', 'range', 'round', 'seed', 'sign',
-                'sin', 'sinh', 'sqrt', 'stepify', 'str', 'str2var', 'tan',
-                'tan', 'tanh', 'type_exist', 'typeof', 'var2bytes', 'var2str',
-                'weakref', 'yield'),
-                prefix=r'(?<!\.)', suffix=r'\b'),
-             Name.Builtin),
-            (r'((?<!\.)(self|false|true)|(PI|TAU|NAN|INF)'
-             r')\b', Name.Builtin.Pseudo),
-            (words((
-                'bool', 'int', 'float', 'String', 'NodePath'
-                'Vector2', 'Rect2', 'Transform2D',
-                'Vector3', 'Rect3', 'Plane', 'Quat', 'Basis', 'Transform',
-                'Color', "RID", 'Object', 'NodePath', 'Dictionary',
-                'Array', 'PoolByteArray', 'PoolIntArray', 'PoolRealArray',
-                'PoolStringArray', 'PoolVector2Array', 'PoolVector3Array', 'PoolColorArray',
-                'null',
-            ), prefix=r'(?<!\.)', suffix=r'\b'), Name.Builtin.Type),
+        "builtins": [
+            (
+                words(
+                    (
+                        "Color8",
+                        "ColorN",
+                        "abs",
+                        "acos",
+                        "asin",
+                        "assert",
+                        "atan",
+                        "atan2",
+                        "bytes2var",
+                        "ceil",
+                        "char",
+                        "clamp",
+                        "convert",
+                        "cos",
+                        "cosh",
+                        "db2linear",
+                        "decimals",
+                        "dectime",
+                        "deg2rad",
+                        "dict2inst",
+                        "ease",
+                        "exp",
+                        "floor",
+                        "fmod",
+                        "fposmod",
+                        "funcref",
+                        "hash",
+                        "inst2dict",
+                        "instance_from_id",
+                        "is_inf",
+                        "is_nan",
+                        "lerp",
+                        "linear2db",
+                        "load",
+                        "log",
+                        "max",
+                        "min",
+                        "nearest_po2",
+                        "pow",
+                        "preload",
+                        "print",
+                        "print_stack",
+                        "printerr",
+                        "printraw",
+                        "prints",
+                        "printt",
+                        "rad2deg",
+                        "rand_range",
+                        "rand_seed",
+                        "randf",
+                        "randi",
+                        "randomize",
+                        "range",
+                        "round",
+                        "seed",
+                        "sign",
+                        "sin",
+                        "sinh",
+                        "sqrt",
+                        "stepify",
+                        "str",
+                        "str2var",
+                        "tan",
+                        "tan",
+                        "tanh",
+                        "type_exist",
+                        "typeof",
+                        "var2bytes",
+                        "var2str",
+                        "weakref",
+                        "yield",
+                    ),
+                    prefix=r"(?<!\.)",
+                    suffix=r"\b",
+                ),
+                Name.Builtin,
+            ),
+            (r"((?<!\.)(self|false|true)|(PI|TAU|NAN|INF)" r")\b", Name.Builtin.Pseudo),
+            (
+                words(
+                    (
+                        "bool",
+                        "int",
+                        "float",
+                        "String",
+                        "NodePath",
+                        "Vector2",
+                        "Rect2",
+                        "Transform2D",
+                        "Vector3",
+                        "Rect3",
+                        "Plane",
+                        "Quat",
+                        "Basis",
+                        "Transform",
+                        "Color",
+                        "RID",
+                        "Object",
+                        "NodePath",
+                        "Dictionary",
+                        "Array",
+                        "PoolByteArray",
+                        "PoolIntArray",
+                        "PoolRealArray",
+                        "PoolStringArray",
+                        "PoolVector2Array",
+                        "PoolVector3Array",
+                        "PoolColorArray",
+                        "null",
+                    ),
+                    prefix=r"(?<!\.)",
+                    suffix=r"\b",
+                ),
+                Name.Builtin.Type,
+            ),
         ],
-        'numbers': [
-            (r'(\d+\.\d*|\d*\.\d+)([eE][+-]?[0-9]+)?j?', Number.Float),
-            (r'\d+[eE][+-]?[0-9]+j?', Number.Float),
-            (r'0[xX][a-fA-F0-9]+', Number.Hex),
-            (r'\d+j?', Number.Integer)
+        "numbers": [
+            (r"(\d+\.\d*|\d*\.\d+)([eE][+-]?[0-9]+)?j?", Number.Float),
+            (r"\d+[eE][+-]?[0-9]+j?", Number.Float),
+            (r"0[xX][a-fA-F0-9]+", Number.Hex),
+            (r"\d+j?", Number.Integer),
         ],
-        'name': [
-            ('[a-zA-Z_]\w*', Name),
+        "name": [(r"[a-zA-Z_]\w*", Name)],
+        "funcname": [(r"[a-zA-Z_]\w*", Name.Function, "#pop"), default("#pop")],
+        "classname": [(r"[a-zA-Z_]\w*", Name.Class, "#pop")],
+        "stringescape": [
+            (
+                r'\\([\\abfnrtv"\']|\n|N\{.*?\}|u[a-fA-F0-9]{4}|'
+                r"U[a-fA-F0-9]{8}|x[a-fA-F0-9]{2}|[0-7]{1,3})",
+                String.Escape,
+            )
         ],
-        'funcname': [
-            ('[a-zA-Z_]\w*', Name.Function, '#pop'),
-            default('#pop'),
-        ],
-        'classname': [
-            ('[a-zA-Z_]\w*', Name.Class, '#pop')
-        ],
-        'stringescape': [
-            (r'\\([\\abfnrtv"\']|\n|N\{.*?\}|u[a-fA-F0-9]{4}|'
-             r'U[a-fA-F0-9]{8}|x[a-fA-F0-9]{2}|[0-7]{1,3})', String.Escape)
-        ],
-        'strings-single': innerstring_rules(String.Single),
-        'strings-double': innerstring_rules(String.Double),
-        'dqs': [
-            (r'"', String.Double, '#pop'),
+        "strings-single": innerstring_rules(String.Single),
+        "strings-double": innerstring_rules(String.Double),
+        "dqs": [
+            (r'"', String.Double, "#pop"),
             (r'\\\\|\\"|\\\n', String.Escape),  # included here for raw strings
-            include('strings-double')
+            include("strings-double"),
         ],
-        'sqs': [
-            (r"'", String.Single, '#pop'),
+        "sqs": [
+            (r"'", String.Single, "#pop"),
             (r"\\\\|\\'|\\\n", String.Escape),  # included here for raw strings
-            include('strings-single')
+            include("strings-single"),
         ],
-        'tdqs': [
-            (r'"""', String.Double, '#pop'),
-            include('strings-double'),
-            (r'\n', String.Double)
+        "tdqs": [
+            (r'"""', String.Double, "#pop"),
+            include("strings-double"),
+            (r"\n", String.Double),
         ],
-        'tsqs': [
-            (r"'''", String.Single, '#pop'),
-            include('strings-single'),
-            (r'\n', String.Single)
+        "tsqs": [
+            (r"'''", String.Single, "#pop"),
+            include("strings-single"),
+            (r"\n", String.Single),
         ],
     }
 
+
 def setup(sphinx):
-    sphinx.add_lexer('gdscript', GDScriptLexer())
+    sphinx.add_lexer("gdscript", GDScriptLexer())
 
     return {
-        'parallel_read_safe': True,
-        'parallel_write_safe': True,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
     }


### PR DESCRIPTION
This also adds a missing comma in the middle of the list of built-in types. The `name`, `funcname` and `classname` were also missing a `r` qualifier, so it was added.

Commands used for formatting and linting:

    black conf.py extensions/gdscript.py
    flake8 --ignore E501 conf.py extensions/gdscript.py