### PR TITLE
GDNative C Example folder structure consistency with demo repository

### DIFF
--- a/tutorials/plugins/gdnative/gdnative-c-example.rst
+++ b/tutorials/plugins/gdnative/gdnative-c-example.rst
@@ -375,7 +375,7 @@ On Windows:
 .. code-block:: none
 
     cl /Fosimple.obj /c simple.c /nologo -EHsc -DNDEBUG /MD /I. /I..\godot_headers
-    link /nologo /dll /out:..\bin\libsimple.dll /implib:..\simple\bin\libsimple.lib simple.obj
+    link /nologo /dll /out:..\simple\bin\libsimple.dll /implib:..\simple\bin\libsimple.lib simple.obj
 
 .. note::
 

--- a/tutorials/plugins/gdnative/gdnative-c-example.rst
+++ b/tutorials/plugins/gdnative/gdnative-c-example.rst
@@ -118,16 +118,15 @@ structure that looks along those lines:
           - libsimple.dll/so/dylib
           - libsimple.gdnlib
           - simple.gdns
-        + src
-          - .gdignore
-          - simple.c
         main.tscn
         project.godot
+      + src
+        - simple.c
 
 Open up Godot and create a new project called "simple" alongside your
 ``godot_headers`` Git clone. This will create the ``simple`` folder and
-``project.godot`` file. Then manually create ``bin`` and ``src`` subfolders in
-this folder.
+``project.godot`` file. Then manually create a ``src`` folder alongside the
+``simple`` folder, and a ``bin`` subfolder in the ``simple`` folder.
 
 We're going to start by having a look at what our ``simple.c`` file contains.
 Now, for our example here we're making a single C source file without a header
@@ -361,22 +360,22 @@ On Linux:
 
 .. code-block:: none
 
-    gcc -std=c11 -fPIC -c -I../../godot_headers simple.c -o simple.o
-    gcc -rdynamic -shared simple.o -o ../bin/libsimple.so
+    gcc -std=c11 -fPIC -c -I../godot_headers simple.c -o simple.o
+    gcc -rdynamic -shared simple.o -o ../simple/bin/libsimple.so
 
 On macOS:
 
 .. code-block:: none
 
-    clang -std=c11 -fPIC -c -I../../godot_headers simple.c -o simple.os
-    clang -dynamiclib simple.os -o ../bin/libsimple.dylib
+    clang -std=c11 -fPIC -c -I../godot_headers simple.c -o simple.os
+    clang -dynamiclib simple.os -o ../simple/bin/libsimple.dylib
 
 On Windows:
 
 .. code-block:: none
 
-    cl /Fosimple.obj /c simple.c /nologo -EHsc -DNDEBUG /MD /I. /I..\..\godot_headers
-    link /nologo /dll /out:..\bin\libsimple.dll /implib:..\bin\libsimple.lib simple.obj
+    cl /Fosimple.obj /c simple.c /nologo -EHsc -DNDEBUG /MD /I. /I..\godot_headers
+    link /nologo /dll /out:..\bin\libsimple.dll /implib:..\simple\bin\libsimple.lib simple.obj
 
 .. note::
 
@@ -384,13 +383,6 @@ On Windows:
     is a library that you can compile into a project to provide access to the
     DLL. We get it as a byproduct and we do not need it :)
     When exporting your game for release this file will be ignored.
-
-.. tip::
-
-    If you add a blank ``.gdignore`` file to the ``src`` folder, Godot will not
-    try to import the compiler-generated files. This is necessary on Windows
-    were compiled objects have the ``.obj`` extension, which is also a 3D model
-    format supported by the engine.
 
 Creating the GDNativeLibrary (``.gdnlib``) file
 -----------------------------------------------


### PR DESCRIPTION
Hello!

I was following the said page in the documentation when I noticed that the folder structure described on the page differed from the folder structure in the linked [demo git repo](https://github.com/GodotNativeTools/GDNative-demos/tree/master/c/SimpleDemo), specifically, the `src` folder was in the `simple` Godot project folder on the page, but it was alongside the `simple` folder in the git repo.

I have changed the page such that it describes the `src` folder as being alongside the `simple` project folder, and have changed the compiling commands accordingly. I also removed the tip about adding the `.gdignore` file in the `src` folder, as it was no longer necessary.