### PR TITLE
Adjust code sample to use new offset syntax

### DIFF
--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -815,7 +815,7 @@ Note that a new instance must be added to the scene using
 
     func _on_MobTimer_timeout():
         # Choose a random location on Path2D.
-        $MobPath/MobSpawnLocation.set_offset(randi())
+        $MobPath/MobSpawnLocation.offset = randi()
         # Create a Mob instance and add it to the scene.
         var mob = Mob.instance()
         add_child(mob)


### PR DESCRIPTION
The existing tutorial code uses `set_offset(randi())` - change this to `offset = randi()` to match the 3.2 syntax change.