### PR TITLE
Improved CSS media queries to remove conflicts

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -256,7 +256,7 @@ footer,
     background-color: var(--content-wrap-background-color);
 }
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 769px) {
     .wy-body-for-nav {
         /* Center the page on wide displays for better readability */
         max-width: 1100px;
@@ -469,7 +469,7 @@ kbd, .kbd {
     position: fixed;
 }
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 769px) {
     /* Simulate a drop shadow that only affects the bottom edge */
     /* This is used to indicate the search bar is fixed */
     .wy-side-nav-search.fixed::after {
@@ -520,7 +520,7 @@ kbd, .kbd {
     background-color: var(--navbar-background-color);
 }
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 769px) {
     .wy-nav-side {
         /* Required to center the page on wide displays */
         left: inherit;
@@ -629,7 +629,7 @@ kbd, .kbd {
     background-color: var(--navbar-current-background-color);
 }
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 769px) {
     .rst-versions {
         /* Required to center the page on wide displays */
         left: inherit;

--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -42,7 +42,7 @@ function registerOnScrollEvent(mediaQuery) {
 }
 
 $(document).ready(() => {
-  const mediaQuery = window.matchMedia('only screen and (min-width: 768px)');
+  const mediaQuery = window.matchMedia('only screen and (min-width: 769px)');
   registerOnScrollEvent(mediaQuery);
   mediaQuery.addListener(registerOnScrollEvent);
 });


### PR DESCRIPTION
Fixes #3186.

File `theme.css` uses media queries with `max-width: 768px` to define "mobile" styles. Which makes default styles to apply to every screen and viewport as wide as 769px or wider.

Our `custom.css` implements rules in reverse. Default styles are applied to smaller screens, while media queries override them for wider screens. The query used is `min-width: 768px`. This makes the two files to have conflicting rules at exactly 768px wide mark.

This PR changes queries in `custom.css` and `custom.js` to only start applying from 769px.