### PR TITLE
Ubuntu Jarsigner location hint

### DIFF
--- a/getting_started/workflow/export/exporting_for_android.rst
+++ b/getting_started/workflow/export/exporting_for_android.rst
@@ -62,7 +62,7 @@ In that screen, the path to 3 files needs to be set:
   - It can usually be found at ``%LOCALAPPDATA%\Android\Sdk\platform-tools\adb.exe``.
 
 - The ``jarsigner`` executable (from JDK 6 or 8)
-  - On Windows, OpenJDK installs to a dir like ``%PROGRAMFILES%\ojdkbuild\java-1.8.0-openjdk-1.8.0.232-2\bin``. On Ubuntu, it installs to a dir like ``/urs/bin/jarsigner``. The exact path may vary depending on the OpenJDK update you've installed and your machine's Operating System.
+  - On Windows, OpenJDK installs to a dir like ``%PROGRAMFILES%\ojdkbuild\java-1.8.0-openjdk-1.8.0.232-2\bin``. On Linux, it typically installs to a dir like ``/usr/bin/jarsigner``. The exact path may vary depending on the OpenJDK update you've installed and your machine's operating system.
 
 - The debug ``.keystore`` file
   - It can be found in the folder where you put the ``debug.keystore`` file you created above.

--- a/getting_started/workflow/export/exporting_for_android.rst
+++ b/getting_started/workflow/export/exporting_for_android.rst
@@ -62,7 +62,7 @@ In that screen, the path to 3 files needs to be set:
   - It can usually be found at ``%LOCALAPPDATA%\Android\Sdk\platform-tools\adb.exe``.
 
 - The ``jarsigner`` executable (from JDK 6 or 8)
-  - On Windows, OpenJDK installs to a dir like ``%PROGRAMFILES%\ojdkbuild\java-1.8.0-openjdk-1.8.0.232-2\bin``. The exact path may vary depending on the OpenJDK update you've installed.
+  - On Windows, OpenJDK installs to a dir like ``%PROGRAMFILES%\ojdkbuild\java-1.8.0-openjdk-1.8.0.232-2\bin``. On Ubuntu, it installs to a dir like ``/urs/bin/jarsigner``. The exact path may vary depending on the OpenJDK update you've installed and your machine's Operating System.
 
 - The debug ``.keystore`` file
   - It can be found in the folder where you put the ``debug.keystore`` file you created above.


### PR DESCRIPTION
This change is aimed to make the jarsigner location easier to find in Ubuntu (and maybe other Linux distros). The Windows hint is really good, and I found myself lost without one for Ubuntu. Luckily I found it after messing in the terminal a bit, but it would be helpful to provide this info.