### PR TITLE
Include x86-64 option in adding support for Android x86 devices.

### DIFF
--- a/development/compiling/compiling_for_android.rst
+++ b/development/compiling/compiling_for_android.rst
@@ -116,15 +116,17 @@ The resulting APK will be located at ``bin/android_debug.apk``.
 Adding support for x86 devices
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you also want to include support for x86 devices, run the SCons command
-a third time with the ``android_arch=x86`` argument before building the APK
-with Gradle. For example, for the release template:
+If you also want to include support for x86 and x86-64 devices, run the SCons
+command a third and fourth time with the ``android_arch=x86``, and
+``android_arch=x86_64`` arguments before building the APK with Gradle. For
+example, for the release template:
 
 ::
 
     scons platform=android target=release android_arch=armv7
     scons platform=android target=release android_arch=arm64v8
     scons platform=android target=release android_arch=x86
+    scons platform=android target=release android_arch=x86_64
     cd platform/android/java
     # On Windows
     .\gradlew generateGodotTemplates


### PR DESCRIPTION
This patch adds the instructions for including the x86-64 architecture in the Compiling for Android, Adding Support for x86 devices [section](https://docs.godotengine.org/en/stable/development/compiling/compiling_for_android.html#adding-support-for-x86-devices).
