### PR TITLE
Remove references to Python 2.7 in build requirements.

### DIFF
--- a/development/compiling/compiling_for_android.rst
+++ b/development/compiling/compiling_for_android.rst
@@ -21,7 +21,7 @@ Requirements
 
 For compiling under Windows, Linux or macOS, the following is required:
 
--  `Python 2.7+ or Python 3.5+ <https://www.python.org/downloads/>`_
+-  `Python 3.5+ <https://www.python.org/downloads/>`_
 -  `SCons <https://scons.org/pages/download.html>`_ build system
 -  `Android SDK <https://developer.android.com/studio/#command-tools>`_ (command-line tools are sufficient)
 

--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -10,7 +10,7 @@ Requirements
 
 For compiling under macOS, the following is required:
 
-- Python 3.5+ (recommended) or Python 2.7+.
+- `Python 3.5+ <https://www.python.org>`_
 - `SCons <https://www.scons.org>`_ build system.
 - `Xcode <https://apps.apple.com/us/app/xcode/id497799835>`_
   (or the more lightweight Command Line Tools for Xcode).

--- a/development/compiling/compiling_for_web.rst
+++ b/development/compiling/compiling_for_web.rst
@@ -13,7 +13,7 @@ To compile export templates for the Web, the following is required:
 -  `Emscripten 1.38.27+ <http://kripken.github.io/emscripten-site>`__: If the version available
    per package manager is not recent enough, the best alternative is to install
    using the `Emscripten SDK <http://kripken.github.io/emscripten-site/docs/getting_started/downloads.html>`__
--  `Python 2.7+ or Python 3.5+ <https://www.python.org/>`__
+-  `Python 3.5+ <https://www.python.org/>`__
 -  `SCons <https://www.scons.org>`__ build system
 
 .. seealso:: For a general overview of SCons usage for Godot, see

--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -16,7 +16,7 @@ For compiling under Windows, the following is required:
   will have to run/download the installer again.**
 - MinGW-w64 with GCC can be used as an alternative to Visual Studio.
   Be sure to install/configure it to use the ``posix`` thread model.
-- `Python 3.5+ (recommended) or Python 2.7+. <https://www.python.org/downloads/windows/>`_
+- `Python 3.5+ <https://www.python.org/downloads/windows/>`_
 - `SCons <https://www.scons.org>`_ build system. If using Visual Studio 2019,
   you *must* have SCons 3.1.1 or later.
 - *Optional* - `yasm <https://yasm.tortall.net/>`_ (for WebM SIMD optimizations)

--- a/development/compiling/compiling_for_x11.rst
+++ b/development/compiling/compiling_for_x11.rst
@@ -12,7 +12,7 @@ For compiling under Linux or other Unix variants, the following is
 required:
 
 -  GCC or Clang
--  Python 3 or 2.7+
+-  Python 3.5+
 -  SCons build system (3.0 or later for Python 3)
 -  pkg-config (used to detect the dependencies below)
 -  X11, Xcursor, Xinerama, Xi and XRandR development libraries


### PR DESCRIPTION
Further to @akien-mga's [comment](https://github.com/godotengine/godot-docs/pull/3216#issuecomment-598684766), this patch removes references to Python 2.7 in the compiling documents.