### PR TITLE
Use consistant case for Tween

### DIFF
--- a/getting_started/step_by_step/ui_code_a_life_bar.rst
+++ b/getting_started/step_by_step/ui_code_a_life_bar.rst
@@ -440,7 +440,7 @@ duration in seconds.
 
 ::
 
-    ...  0.6, tween.TRANS_LINEAR, Tween.EASE_IN)
+    ...  0.6, Tween.TRANS_LINEAR, Tween.EASE_IN)
 
 The last two arguments are constants from the ``Tween`` class.
 ``TRANS_LINEAR`` means the animation should be linear. ``EASE_IN``


### PR DESCRIPTION
Change the first lowercase `tween` to a capitalised `Tween` to match previous code.

The capitalised Tween is a class name and the lowercase tween is a variable name.

While this works, the initial presentation of the call uses the class name for both interpolation options.

This is being picky but is accurate.
