### PR TITLE
Use new full-page search UI from upstream RTD

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 # Code tabs for GDScript/C#
 sphinx-tabs
+
+# Full-page search UI for RTD: https://readthedocs-sphinx-search.readthedocs.io
+git+https://github.com/readthedocs/readthedocs-sphinx-search@master


### PR DESCRIPTION
From https://readthedocs-sphinx-search.readthedocs.io,
can also be tested on https://docs.readthedocs.io.

![Screenshot_20200316_134641](https://user-images.githubusercontent.com/4701338/76759747-97516e00-678c-11ea-9ebd-9657add22526.png)

It only works on RTD so I haven't confirmed yet that it's working, the build resulting from merging this PR will be the test in production.