### PR TITLE
Adjust styling of new instant search popup

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -35,6 +35,14 @@
     --input-background-color: #fcfcfc;
     --input-focus-border-color: #5f8cff;
 
+    --search-input-background-color: #e6eef3; /* derived from --input-background-color */
+    --search-match-color: #2c6b96; /* derived from --link-color */
+    --search-match-background-color: #e3f2fd; /* derived from --link-color */
+    --search-active-color: #efefef;
+    --search-credits-background-color: #333f67; /* derived from --navbar-background-color */
+    --search-credits-color: #b3b3b3; /* derived from --footer-color */
+    --search-credits-link-color: #4392c5; /* derived from --link-color */
+
     --highlight-background-color: #f5ffe1;
     --highlight-comment-color: #408090;
     --highlight-keyword-color: #007020;
@@ -105,6 +113,14 @@
         --code-literal-color: #faa;
         --input-background-color: #333537;
         --input-focus-border-color: #5f8cff;
+
+        --search-input-background-color: #43464a; /* derived from --input-background-color */
+        --search-match-color: #52b4ff; /* derived from --link-color */
+        --search-match-background-color: #414c56; /* derived from --link-color */
+        --search-active-color: #202326;
+        --search-credits-background-color: #202123; /* derived from --navbar-background-color */
+        --search-credits-color: #6b6b6b; /* derived from --footer-color */
+        --search-credits-link-color: #628fb1; /* derived from --link-color */
 
         /* Colors taken from the Godot script editor with the Adaptive theme */
         --highlight-background-color: #202531;
@@ -240,6 +256,99 @@ hr,
 footer,
 #search-results .context {
     color: var(--footer-color);
+}
+
+/* Sphinx Search extension */
+/* .wy-body-for-nav is used for higher rule specificity */
+
+/* search popup body */
+.wy-body-for-nav .search__outer {
+    background-color: var(--content-background-color);
+    border: 2px solid var(--content-background-color);
+}
+.wy-body-for-nav .search__cross svg {
+    fill: var(--body-color);
+}
+
+.wy-body-for-nav .search__outer::-webkit-scrollbar-track {
+    border-radius: 10px;
+    background-color: var(--content-background-color);
+}
+.wy-body-for-nav .search__outer::-webkit-scrollbar {
+    width: 7px;
+    height: 7px;
+    background-color: var(--content-background-color);
+}
+.wy-body-for-nav .search__outer::-webkit-scrollbar-thumb {
+    border-radius: 10px;
+    background-color: var(--hr-color);
+}
+
+/* search input */
+.wy-body-for-nav .search__outer__input {
+    background-color: var(--search-input-background-color);
+    background-image: none;
+    border-radius: 50px;
+    border: 2px solid transparent;
+    color: var(--body-color);
+    height: 36px;
+    padding: 6px 12px;
+}
+.wy-body-for-nav .search__outer__input:focus {
+    border-color: var(--input-focus-border-color);
+}
+.wy-body-for-nav .search__outer .bar:after,
+.wy-body-for-nav .search__outer .bar:before {
+    display: none;
+}
+
+/* search item */
+.wy-body-for-nav .search__result__single {
+    border-bottom-color: var(--hr-color);
+}
+/* search item title */
+.wy-body-for-nav .search__result__title {
+    color: var(--link-color);
+    border-bottom: none;
+    font-size: 120%;
+    font-weight: 400;
+}
+
+/* search item section */
+.wy-body-for-nav .outer_div_page_results:hover,
+.wy-body-for-nav .search__result__box .active {
+    background-color: var(--search-active-color);
+}
+.wy-body-for-nav .search__result__subheading{
+    color: var(--body-color);
+    font-size: 100%;
+    font-weight: 400;
+}
+.wy-body-for-nav .search__result__content {
+    color: var(--footer-color);
+}
+
+/* search item matching substring */
+.wy-body-for-nav .search__outer .search__result__title span,
+.wy-body-for-nav .search__outer .search__result__content span {
+    color: var(--search-match-color);
+    border-bottom: 1px solid var(--search-match-color);
+    background-color: var(--search-match-background-color);
+    padding: 0 2px;
+}
+.wy-body-for-nav .search__result__subheading span {
+    border-bottom-color: var(--body-color);
+}
+
+/* search credits */
+.wy-body-for-nav .rtd__search__credits {
+    background-color: var(--search-credits-background-color);
+    border-color: var(--search-credits-background-color);
+    color: var(--search-credits-color);
+    padding: 4px 8px;
+}
+.wy-body-for-nav .rtd__search__credits a {
+    color: var(--search-credits-link-color);
 }
 
 /* Main sections */


### PR DESCRIPTION
Adjusted light and added dark theme for new instant search popup added in #3277. Changed some default styling to match current static search page better.

Light theme:
https://giant.gfycat.com/JoyousGlisteningBoubou.mp4

Dark theme:
https://giant.gfycat.com/GenuineSaneAiredale.mp4

Edit: I've tested it by manually applying styles to the production page, as this extension does not run on local server due to a built-in limitation:
```
[INFO] Docs are not being served on Read the Docs, readthedocs-sphinx-search will not work.
```

**Technical note:** While extension's styles are added later than `custom.css` it is possible to override them using higher specificity rules, which is what I did.