### PR TITLE
Clarification on "Identifier" term in docs

### DIFF
--- a/getting_started/workflow/export/exporting_for_ios.rst
+++ b/getting_started/workflow/export/exporting_for_ios.rst
@@ -23,7 +23,7 @@ The following export options are required. Leaving any blank will cause the
 exporter to throw an error:
 
   * In the **Application** category
-    * **App Store Team ID**
+    * **App Store Team ID** and (Bundle) **Identifier**
   * Everything in the **Required Icons** category
   * Everything in the **Landscape Launch Screens** category
   * Everything in the **Portrait Launch Screens** category


### PR DESCRIPTION
When filling iOS export forms, I got a red error that I'm missing an "Identifier". As an iOS developer and I find the term "Identifier" confusing and it should be explicitly told that it's a Bundle Identifier. When I'm looking at the form itself I thought this doesn't need to be filled as there was already a placeholder with reverse dns notation and I thought it was a default value.

It's my first contact with Godot engine and this also should be renamed within the export window itself.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
