### PR TITLE
Add proper styles for JS class reference

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -253,6 +253,27 @@ hr,
     color: var(--admonition-note-color);
 }
 
+/* JavaScript documentation directives */
+.rst-content dl:not(.docutils) tt.descclassname,
+.rst-content dl:not(.docutils) code.descclassname {
+    color: var(--highlight-type2-color)
+}
+.rst-content dl:not(.docutils) tt.descname,
+.rst-content dl:not(.docutils) code.descname {
+    color: var(--highlight-function-color)
+}
+.rst-content dl:not(.docutils) .sig-paren,
+.rst-content dl:not(.docutils) .optional {
+    color: var(--highlight-operator-color)
+}
+.rst-content dl:not(.docutils).class dt > em,
+.rst-content dl:not(.docutils).function dt > em {
+    color: var(--code-literal-color)
+}
+.rst-content dl:not(.docutils).class dt > em.property {
+    color: var(--highlight-keyword-color)
+}
+
 footer,
 #search-results .context {
     color: var(--footer-color);


### PR DESCRIPTION
"[Customizing the Web export HTML page](https://docs.godotengine.org/en/latest/tutorials/platform/customizing_html5_shell.html)" article has class reference documentation made with `js:` directives. The resulted HTML is not properly styled, which is not immediately apparent in light theme, but is unusable in dark theme:

[Light theme in master](https://user-images.githubusercontent.com/11782833/77539688-d7160500-6eb2-11ea-9e73-4c5ec440ae62.png)
[Dark theme in master](https://user-images.githubusercontent.com/11782833/77539706-dd0be600-6eb2-11ea-8b0c-1a51bb7a586e.png)

I've made some adjustments to give a better look for both themes:
[new Light theme](https://user-images.githubusercontent.com/11782833/77539829-0b89c100-6eb3-11ea-8732-a2ebcf5ab624.png)
[new Dark theme](https://user-images.githubusercontent.com/11782833/77539840-0f1d4800-6eb3-11ea-9941-d695b9f95b29.png)

While the directive is JavaScript-specific, CSS class names are generic, and at times are absent. I've tried to mitigate that, but there is a possibility, that somewhere else something may start to look different. I'm not sure, where do `js:` directives come from and if it is possible to adjust the HTML they generate.

I used the same colors that are already in use for code and syntax highlighting.