### PR TITLE
Update "Download the command-line tools" section 

### DIFF
--- a/getting_started/workflow/export/android_custom_build.rst
+++ b/getting_started/workflow/export/android_custom_build.rst
@@ -65,8 +65,6 @@ To save disk space, you don't want the full IDE, so don't download it.
 Look on that page for the *Command line tools only* section. Currently, they are listed under
 *Download Options*. Scroll down a bit until you see them.
 
-.. image:: img/custom_build_command_line.png
-
 Download the ZIP file for your platform, there will be a single ``tools``
 folder inside:
 
@@ -81,17 +79,25 @@ an empty directory). On Windows, the following path is usually good enough:
 ::
 
   C:\users\<yourusername>\Documents\android-sdk
+  
+.. note::
 
-Unzip the Android SDK ZIP file you just downloaded there. The only thing in the
-directory you created in the previous step should be the ``tools`` folder with
-its contents inside, like this:
+    If you already have an android-sdk folder, normally located in ``%LOCALAPPDATA%\Android\Sdk``, 
+    then use this folder instead of creating an empty ``android-sdk`` folder. 
+
+Unzip the Android SDK ZIP file into the ``android-sdk`` folder. This folder should 
+now contain the unzipped folder called ``tools``. Rename ``tools`` to ``latest``. 
+Finally, create an empty folder named ``cmdline-tools`` and place ``latest`` into it. 
+Your final directory structure should look like this :
 
 ::
 
   android-sdk/
-  android-sdk/tools/
-  android-sdk/tools/allthefiles
-
+  android-sdk/cmdline-tools/
+  android-sdk/cmdline-tools/latest
+  android-sdk/cmdline-tools/latest/allTheOtherFiles
+  
+We need to setup the directory structure this way for the sdkmanager (inside the bin folder) to work.
 
 Accepting the licenses
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Remove the unrelevant image under "Download the command-line tools" section.

Update the information under this section too as I believe it is outdated. 
I couldn't execute the sdkmanager following the outlined directory structure.
I followed the solutions in the following links.
https://stackoverflow.com/questions/60440509/android-command-line-tools-sdkmanager-always-shows-warning-could-not-create-se
https://stackoverflow.com/questions/47150410/failed-to-run-sdkmanager-list-with-java-9?noredirect=1&lq=1

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
