### PR TITLE
Update how to force SCons to use Python v3 on Linux.

### DIFF
--- a/development/compiling/compiling_for_x11.rst
+++ b/development/compiling/compiling_for_x11.rst
@@ -13,10 +13,11 @@ required:
 
 -  GCC 7+ or Clang 6+.
 -  Python 3.5+.
--  SCons 3.0+ build system. If your Linux distribution only provides a Python 2
-   build of SCons, install the Python 3 flavor with ``pip3 install --user scons``.
-   You may also want to uninstall the distribution ``scons`` package to ensure
-   that the pip-installed one takes precedence.
+-  SCons 3.0+ build system. If your distribution uses Python 2 by default,
+   or you are using a version of SCons prior to 3.1.2, you will need to change
+   the version of Python that SCons uses by changing the shebang (the first line)
+   of the SCons script file to ``#! /usr/bin/python3``.
+   Use the command ``which scons`` to find the location of the SCons script file.
 -  pkg-config (used to detect the dependencies below).
 -  X11, Xcursor, Xinerama, Xi and XRandR development libraries.
 -  MesaGL development libraries.


### PR DESCRIPTION
Following [#37294](https://github.com/godotengine/godot/pull/37294#) there may be a need for users to force the SCons script to use Python version 3.
