### PR TITLE
Replaced deprecated "get" cs func in fps tutorial

### DIFF
--- a/tutorials/3d/fps_tutorial/part_one.rst
+++ b/tutorials/3d/fps_tutorial/part_one.rst
@@ -290,7 +290,7 @@ Add the following code to ``Player.gd``:
             //  -------------------------------------------------------------------
             //  Walking
             _dir = new Vector3();
-            Transform camXform = _camera.GetGlobalTransform();
+            Transform camXform = _camera.GlobalTransform;
 
             Vector2 inputMovementVector = new Vector2();
 


### PR DESCRIPTION
In the 3D fps tutorial, changed the camera global transform
function to use direct property setting instead of getter
since the getter is deprecated in 3.2.1.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
