### PR TITLE
Fix in the C# code example

### DIFF
--- a/getting_started/workflow/best_practices/godot_interfaces.rst
+++ b/getting_started/workflow/best_practices/godot_interfaces.rst
@@ -70,7 +70,7 @@ access.
 
     // Tool script added for the sake of the "const [Export]" example.
     [Tool]
-    public MyType : extends Object
+    public MyType
     {
         // Property initializations load during Script instancing, i.e. .new().
         // No "preload" loads during scene load exists in C#.
@@ -472,7 +472,7 @@ accesses:
   .. code-tab:: csharp
 
     // Child.cs
-    public class Child extends Node
+    public class Child : Node
     {
         public FuncRef FN = null;
 
@@ -484,7 +484,7 @@ accesses:
     }
 
     // Parent.cs
-    public class Parent extends Node
+    public class Parent : Node
     {
         public Node Child;
 


### PR DESCRIPTION
The keyword `extends` is used in Java to extend/inherit from another class, but in C# the correct syntax is just the colon mark `:`
Also rectified one part of the code where the example is extending from Object, although it would not cause any trouble, all classes in C# already derive from `Object`  by default.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
