### PR TITLE
Make note about atlases 3.2

### DIFF
--- a/tutorials/3d/reflection_probes.rst
+++ b/tutorials/3d/reflection_probes.rst
@@ -107,6 +107,6 @@ In the current renderer implementation, all probes are the same size and
 are fit into a Reflection Atlas. The size and amount of probes can be
 customized in Project Settings -> Quality -> Reflections
 
-The default settings of Atlas Size: 2048 and Atlas Subdiv: 8 will allow up to 16 reflection probes in a scene. These values need to be increased if you need more.
+The default setting of Atlas Subdiv: 8 will allow up to 16 reflection probes in a scene. This value needs to be increased if you need more reflection probes.
 
 .. image:: img/refprobe_atlas.png

--- a/tutorials/3d/reflection_probes.rst
+++ b/tutorials/3d/reflection_probes.rst
@@ -107,4 +107,6 @@ In the current renderer implementation, all probes are the same size and
 are fit into a Reflection Atlas. The size and amount of probes can be
 customized in Project Settings -> Quality -> Reflections
 
+The default settings of Atlas Size: 2048 and Atlas Subdiv: 8 will allow up to 16 reflection probes in a scene. These values need to be increased if you need more.
+
 .. image:: img/refprobe_atlas.png


### PR DESCRIPTION
Make note that default atlas setting only allows 16 probes. may not apply to godot 4.0

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
