### PR TITLE
Always use parentheses when calling `assert()` in GDScript

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_styleguide.rst
+++ b/getting_started/scripting/gdscript/gdscript_styleguide.rst
@@ -64,7 +64,7 @@ Here is a complete class example based on these guidelines:
             return
 
         var target_state = get_node(target_state_path)
-        assert target_state.is_composite == false
+        assert(target_state.is_composite == false)
 
         _state.exit()
         self._state = target_state
@@ -635,7 +635,7 @@ in that order.
             return
 
         var target_state = get_node(target_state_path)
-        assert target_state.is_composite == false
+        assert(target_state.is_composite == false)
 
         _state.exit()
         self._state = target_state

--- a/getting_started/workflow/best_practices/godot_interfaces.rst
+++ b/getting_started/workflow/best_practices/godot_interfaces.rst
@@ -167,8 +167,8 @@ Nodes likewise have an alternative access point: the SceneTree.
             return
 
         # Fail and terminate.
-        # Compiled scripts in final binary do not include assert statements
-        assert prop.
+        # Note: Scripts run from a release export template don't run `assert` statements.
+        assert(prop, "'prop' wasn't initialized")
 
     # Use an autoload.
     # Dangerous for typical nodes, but useful for true singleton nodes
@@ -342,9 +342,9 @@ accesses:
       # If one does not wish to fail these checks without notifying users, one
       # can use an assert instead. These will trigger runtime errors
       # immediately if not true.
-      assert child.has("set_visible")
-      assert child.is_in_group("offer")
-      assert child is CanvasItem
+      assert(child.has("set_visible"))
+      assert(child.is_in_group("offer"))
+      assert(child is CanvasItem)
 
       # Can also use object labels to imply an interface, i.e. assume it implements certain methods.
       # There are two types, both of which only exist for Nodes: Names and Groups


### PR DESCRIPTION
This is now required since Godot 3.2.

This also adds an assert message to the Godot interfaces page to match its C# counterpart.