### PR TITLE
Add singular "Signal" meta keyword to signal tutorials

### DIFF
--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -1,3 +1,6 @@
+.. meta::
+    :keywords: Signal
+
 .. _doc_signals:
 
 Signals
@@ -208,7 +211,7 @@ To emit a signal via code, use the ``emit_signal`` function:
             EmitSignal(nameof(MySignal));
         }
     }
-    
+
 A signal can also optionally declare one or more arguments. Specify the
 argument names between parentheses:
 

--- a/tutorials/misc/instancing_with_signals.rst
+++ b/tutorials/misc/instancing_with_signals.rst
@@ -1,3 +1,6 @@
+.. meta::
+    :keywords: Signal
+
 .. _doc_instancing_with_signals:
 
 Instancing with signals


### PR DESCRIPTION
This makes possible to find them when searching for "signal", instead of just "signals".

This closes #2629.

PS: This appears to work only when using the old-style search, not the new "instant" search. This is probably an issue with the search plugin (try searching for `faq` on the current site).