### PR TITLE
Set up continuous integration using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 dist: bionic
+language: python
+
+python:
+  - "3.8"
 
 stages:
   - build
 
 matrix:
   include:
-    - name: Static checks (format.sh)
+    - name: Static checks (format.sh) + Sphinx build
       stage: build
       os: linux
       addons:
@@ -13,6 +17,12 @@ matrix:
           packages:
             - dos2unix
             - recode
+            - texlive-full
 
 script:
   - bash ./format.sh
+
+  - pip install -r requirements.txt
+  # TODO: Add `-W` to turn warnings into errors.
+  # This can only be done once all warnings have been fixed.
+  - sphinx-build --color -b html -d _build/doctrees . _build/html


### PR DESCRIPTION
This is used to catch build warnings early on.

[Example job output](https://travis-ci.org/github/Calinou/godot-docs/builds/673323009)