### PR TITLE
Safe line vs Unsafe line unclear label

### DIFF
--- a/getting_started/scripting/gdscript/static_typing.rst
+++ b/getting_started/scripting/gdscript/static_typing.rst
@@ -201,9 +201,9 @@ Godot will ensure the type works and if so, the line number will turn
 green at the left of the script editor.
 
 .. figure:: ./img/typed_gdscript_safe_unsafe_line.png
-   :alt: Safe vs Unsafe Line
+   :alt: Unsafe vs Safe Line
 
-   Safe vs Unsafe Line
+   Unsafe line (line 7) vs Safe Lines (line 6 and 8)
 
 .. note::
 


### PR DESCRIPTION
Although line 6 is safe, line 7, that actually is what the paragraph talking about, is unsafe and line 8 is safe.
The way it was before, it was in reverse order, making it confusing which is safe and which is not. So I changed the order to be as the picture.
To further assure it is clear, I added the line numbers in parentheses.
The parentheses could be excessive verbosity, but the order importance stands. I believe it was confusing before.
Alternatively, the picture could be changed, having the safe line first. Then it's clearer as the unsafe line it's the only one different and the order would be also correct; 2 safe lines, one unsafe for last. Specifying the lines would not be needed then.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
