### PR TITLE
Small grammatical error fix for readability

### DIFF
--- a/getting_started/workflow/best_practices/data_preferences.rst
+++ b/getting_started/workflow/best_practices/data_preferences.rst
@@ -128,7 +128,7 @@ the expense of memory and some minor operational efficiency.
       minimize hash collisions and maintain the speed of the accesses.
 
 As one might be able to tell, Dictionaries specialize in tasks that Arrays
-aren't. An overview of their operational details is as follows:
+do not. An overview of their operational details is as follows:
 
 - **Iterate:** Fast.
 


### PR DESCRIPTION
"As one might be able to tell, Dictionaries specialize in tasks that Arrays
aren't." changed to "As one might be able to tell, Dictionaries specialize in tasks that Arrays
do not."

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
