### PR TITLE
Fix commands not appearing in "Bisecting regressions" page

### DIFF
--- a/community/contributing/bisecting_regressions.rst
+++ b/community/contributing/bisecting_regressions.rst
@@ -93,19 +93,19 @@ instead of a commit hash.
 is done, in the terminal window, use ``cd`` to reach the Godot repository
 folder and enter the following command:
 
-.. code-block::
+.. code-block:: shell
 
     # <good> is the commit hash of the build that works as expected.
     # <bad> is the commit hash of the build exhibiting the bug.
-    git bisect start <good> <bad>
+    $ git bisect start <good> <bad>
 
 Compile Godot. This assumes you've set up a build environment:
 
-.. code-block::
+.. code-block:: shell
 
     # <platform> is the platform you're targeting for regression testing,
     # like "windows", "x11" or "osx".
-    scons platform=<platform> -j4
+    $ scons platform=<platform> -j4
 
 Since building Godot takes a while, you want to dedicate as many CPU threads as
 possible to the task. This is what the ``-j`` parameter does. Here, the command
@@ -115,15 +115,15 @@ Run the binary located in the ``bin/`` folder and try to reproduce the bug.
 
 If the build **still** exhibits the bug, run the following command:
 
-.. code-block::
+.. code-block:: shell
 
-    git bisect bad
+    $ git bisect bad
 
 If the build **does not** exhibit the bug, run the following command:
 
-.. code-block::
+.. code-block:: shell
 
-    git bisect good
+    $ git bisect good
 
 After entering one of the commands above, Git will switch to a different commit.
 You should now build Godot again, try to reproduce the bug, then enter ``git

--- a/community/contributing/bug_triage_guidelines.rst
+++ b/community/contributing/bug_triage_guidelines.rst
@@ -123,7 +123,7 @@ be filed under the corresponding milestone; if they don't correspond to
 any current roadmap, they should be left without milestone. As a rule of
 thumb, an issue corresponds to a given milestone if it concerns a feature
 that is new in the milestone, or a critical bug that can't be accepted in any
-future stable release, or anything that Juan wants to work on right now
+future stable release, or anything that Juan wants to work on right now.
 :)
 
 Contributors are free to pick issues regardless of their assigned milestone;


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
