### PR TITLE
Fix syntax highlighting for various languages

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -45,6 +45,7 @@
     --search-credits-link-color: #4392c5; /* derived from --link-color */
 
     --highlight-background-color: #f5ffe1;
+    --highlight-default-color: #404040;
     --highlight-comment-color: #408090;
     --highlight-keyword-color: #007020;
     --highlight-keyword2-color: #902000;
@@ -126,6 +127,7 @@
 
         /* Colors taken from the Godot script editor with the Adaptive theme */
         --highlight-background-color: #202531;
+        --highlight-default-color: rgba(255, 255, 255, 0.85);
         --highlight-comment-color: rgba(204, 206, 211, 0.5);
         --highlight-keyword-color: #ff7085;
         --highlight-keyword2-color: #42ffc2;
@@ -495,58 +497,95 @@ code,
     background-color: var(--highlight-background-color);
 }
 
-.highlight .c1,
-.highlight .cm {
+.highlight .gh /* Generic.Heading */,
+.highlight .gu /* Generic.Subheading */,
+.highlight .go /* Generic.Output */,
+.highlight .gt /* Generic.Traceback */ {
+    color: var(--highlight-default-color);
+}
+
+.highlight .c  /* Comment */,
+.highlight .c1 /* Comment.Single */,
+.highlight .cm /* Comment.Multiline */,
+.highlight .cs /* Comment.Special */ {
     color: var(--highlight-comment-color);
 }
 
-.highlight .bp,
-.highlight .k,
-.highlight .kd,
-.highlight .kn,
-.highlight .kt,
-.highlight .ow {
+.highlight .bp /* Name.Builtin.Pseudo */,
+.highlight .k  /* Keyword */,
+.highlight .kc /* Keyword.Constant */,
+.highlight .kd /* Keyword.Declaration */,
+.highlight .kn /* Keyword.Namespace */,
+.highlight .kp /* Keyword.Pseudo */,
+.highlight .kr /* Keyword.Reserved */,
+.highlight .kt /* Keyword.Type */,
+.highlight .ow /* Operator.Word */ {
     color: var(--highlight-keyword-color);
 }
 
-.highlight .cp {
+.highlight .ch /* Comment.Hashbang */,
+.highlight .cp /* Comment.Preproc */ {
     color: var(--highlight-keyword2-color);
 }
 
-.highlight .m,
-.highlight .mf,
-.highlight .mi {
+.highlight .m  /* Literal.Number */,
+.highlight .mf /* Literal.Number.Float */,
+.highlight .mi /* Literal.Number.Integer */,
+.highlight .il /* Literal.Number.Integer.Long */,
+.highlight .mb /* Literal.Number.Bin */,
+.highlight .mh /* Literal.Number.Hex */,
+.highlight .mo /* Literal.Number.Oct */ {
     color: var(--highlight-number-color);
 }
 
-.highlight .na {
+.highlight .na /* Name.Attribute */,
+.highlight .nd /* Name.Decorator */,
+.highlight .ni /* Name.Entity */,
+.highlight .nl /* Name.Label */ {
     color: var(--highlight-decorator-color);
 }
 
-.highlight .nb {
+.highlight .nb /* Name.Builtin */,
+.highlight .ne /* Name.Exception */ {
     color: var(--highlight-type-color);
 }
 
-.highlight .nc,
-.highlight .nn,
-.highlight .nv {
+.highlight .nc /* Name.Class */,
+.highlight .nn /* Name.Namespace */,
+.highlight .no /* Name.Constant */,
+.highlight .nv /* Name.Variable */,
+.highlight .vc /* Name.Variable.Class */,
+.highlight .vg /* Name.Variable.Global */,
+.highlight .vi /* Name.Variable.Instance */,
+.highlight .vm /* Name.Variable.Magic */ {
     color: var(--highlight-type2-color);
 }
 
-.highlight .nf,
-.highlight .nt {
+.highlight .nf /* Name.Function */,
+.highlight .fm /* Name.Function.Magic */,
+.highlight .nt /* Name.Tag */ {
     color: var(--highlight-function-color);
 }
 
-.highlight .o {
+.highlight .o  /* Operator */,
+.highlight .si /* Literal.String.Interpol */,
+.highlight .sx /* Literal.String.Other */,
+.highlight .sr /* Literal.String.Regex */,
+.highlight .ss /* Literal.String.Symbol */ {
     color: var(--highlight-operator-color);
 }
 
-.highlight .cpf,
-.highlight .s,
-.highlight .s1,
-.highlight .s2,
-.highlight .se {
+.highlight .cpf/* Comment.PreprocFile */,
+.highlight .s  /* Literal.String */,
+.highlight .s1 /* Literal.String.Single */,
+.highlight .s2 /* Literal.String.Double */,
+.highlight .sc /* Literal.String.Char */,
+.highlight .se /* Literal.String.Escape */,
+.highlight .sa /* Literal.String.Affix */,
+.highlight .sb /* Literal.String.Backtick */,
+.highlight .dl /* Literal.String.Delimiter */,
+.highlight .sd /* Literal.String.Doc */,
+.highlight .sh /* Literal.String.Heredoc */ {
     color: var(--highlight-string-color);
 }
 

--- a/community/contributing/updating_the_class_reference.rst
+++ b/community/contributing/updating_the_class_reference.rst
@@ -3,6 +3,8 @@
 Contribute to the Class Reference
 =================================
 
+.. highlight:: shell
+
 Godot ships with many nodes and singletons to help you develop your games. Each is a class, documented in the :ref:`class reference <toc-class-ref>`.
 This reference is essential for anyone learning the engine: it is available both online and in the engine.
 
@@ -255,7 +257,7 @@ Godot's class reference supports BBcode-like tags. They add nice formatting to t
 
 Use ``[codeblock]`` for pre-formatted code blocks. Inside ``[codeblock]``, always use **four spaces** for indentation (the parser will delete tabs). Example:
 
-.. code-block:: xml
+.. code-block:: none
 
     [codeblock]
     func _ready():
@@ -265,7 +267,7 @@ Use ``[codeblock]`` for pre-formatted code blocks. Inside ``[codeblock]``, alway
 
 Will display as:
 
-::
+.. code-block:: gdscript
 
     func _ready():
         var sprite = get_node("Sprite")

--- a/development/compiling/getting_source.rst
+++ b/development/compiling/getting_source.rst
@@ -3,6 +3,8 @@
 Getting the source
 ==================
 
+.. highlight:: shell
+
 Downloading the Godot source code
 ---------------------------------
 

--- a/development/compiling/introduction_to_the_buildsystem.rst
+++ b/development/compiling/introduction_to_the_buildsystem.rst
@@ -3,7 +3,7 @@
 Introduction to the buildsystem
 ===============================
 
-.. highlight:: none
+.. highlight:: shell
 
 SCons
 -----
@@ -108,7 +108,9 @@ For the previous build attempt, the result would look like this::
 This means that the binary is for Linux *or* \*BSD (*not* both), is not optimized, has tools (the
 whole editor) compiled in, and is meant for 64 bits.
 
-A Windows binary with the same configuration will look like this::
+A Windows binary with the same configuration will look like this:
+
+.. code-block:: console
 
     C:\godot> dir bin/
     godot.windows.tools.64.exe
@@ -202,7 +204,7 @@ If you download the official export templates package and unzip it, you
 will notice that most files are optimized binaries or packages for each
 platform:
 
-::
+.. code-block:: none
 
     android_debug.apk
     android_release.apk

--- a/development/cpp/binding_to_external_libraries.rst
+++ b/development/cpp/binding_to_external_libraries.rst
@@ -13,7 +13,7 @@ library written in C++.
 
 To bind to an external library, set up a module directory similar to the Summator example:
 
-::
+.. code-block:: none
 
     godot/modules/tts/
 
@@ -70,7 +70,7 @@ And then you'll add the cpp file.
 Just as before, the new class needs to be registered somehow, so two more files
 need to be created:
 
-::
+.. code-block:: none
 
     register_types.h
     register_types.cpp
@@ -118,7 +118,7 @@ You'll need to install the external library on your machine to get the .a librar
 documentation for specific instructions on how to do this for your operation system.  We've included the
 installation commands for Linux below, for reference.
 
-::
+.. code-block:: shell
 
     sudo apt-get install festival festival-dev <-- Installs festival and speech_tools libraries
     apt-cache search festvox-* <-- Displays list of voice packages
@@ -135,7 +135,7 @@ files accessible to the compiler, while also keeping the module code self-contai
 festival and speech_tools libraries can be installed from the modules/tts/ directory via
 git using the following commands:
 
-::
+.. code-block:: shell
 
     git clone https://github.com/festvox/festival
     git clone https://github.com/festvox/speech_tools
@@ -143,7 +143,7 @@ git using the following commands:
 If you don't want the external repository source files committed to your repository, you
 can link to them instead by adding them as submodules (from within the modules/tts/ directory), as seen below:
 
-::
+.. code-block:: shell
 
     git submodule add https://github.com/festvox/festival
     git submodule add https://github.com/festvox/speech_tools
@@ -182,7 +182,7 @@ Example `SCsub` with custom flags:
 
 The final module should look like this:
 
-::
+.. code-block:: none
 
     godot/modules/tts/festival/
     godot/modules/tts/libpath/libestbase.a

--- a/development/cpp/configuring_an_ide.rst
+++ b/development/cpp/configuring_an_ide.rst
@@ -139,7 +139,7 @@ Now that the project has been imported, open the project configuration.
 
 Add the following includes/imports:
 
-::
+.. code-block:: none
 
     .  // a dot to indicate the root of the Godot project
     core/

--- a/development/cpp/custom_modules_in_cpp.rst
+++ b/development/cpp/custom_modules_in_cpp.rst
@@ -45,7 +45,7 @@ The example module will be called "summator", and is placed inside the
 Godot source tree (``C:\godot`` refers to wherever the Godot sources are
 located):
 
-::
+.. code-block:: console
 
     C:\godot> cd modules
     C:\godot\modules> mkdir summator
@@ -114,7 +114,7 @@ And then the cpp file.
 Then, the new class needs to be registered somehow, so two more files
 need to be created:
 
-::
+.. code-block:: none
 
     register_types.h
     register_types.cpp
@@ -211,7 +211,7 @@ this case, ``True`` means it will build for every platform).
 And that's it. Hope it was not too complex! Your module should look like
 this:
 
-::
+.. code-block:: none
 
     godot/modules/summator/config.py
     godot/modules/summator/summator.h
@@ -385,7 +385,7 @@ Once compiled, we should end up with a ``bin`` directory containing both the
 a standard directory (like ``/usr/lib``), we have to help our binary find it
 during runtime with the ``LD_LIBRARY_PATH`` environ variable:
 
-::
+.. code-block:: shell
 
     user@host:~/godot$ export LD_LIBRARY_PATH=`pwd`/bin/
     user@host:~/godot$ ./bin/godot*
@@ -431,7 +431,7 @@ and as a shared library when passing ``summator_shared=yes``.
 Finally you can even speedup build further by explicitly specifying your
 shared module as target in the scons command:
 
-::
+.. code-block:: shell
 
     user@host:~/godot$ scons summator_shared=yes platform=linuxbsd bin/libsummator.linuxbsd.tools.64.so
 
@@ -473,7 +473,7 @@ directory.
 
 3. Run command:
 
-   ::
+   .. code-block:: shell
 
       godot --doctool <path>
 

--- a/getting_started/step_by_step/exporting.rst
+++ b/getting_started/step_by_step/exporting.rst
@@ -334,7 +334,7 @@ tool that Godot uses to communicate with your device.
 Next, create a debug keystore by running the following command on your
 system's command line:
 
-::
+.. code-block:: shell
 
     keytool -keyalg RSA -genkeypair -alias androiddebugkey -keypass android -keystore debug.keystore -storepass android -dname "CN=Android Debug,O=Android,C=US" -validity 9999
 
@@ -351,7 +351,7 @@ for Android (see above). Select the Android Presets and under *Options* go to
 Click the "Export Project" button and Godot will build an APK you can download
 on your device. To do this on the command line, use the following:
 
-::
+.. code-block:: shell
 
     adb install dodge.apk
 

--- a/getting_started/step_by_step/filesystem.rst
+++ b/getting_started/step_by_step/filesystem.rst
@@ -27,7 +27,7 @@ Git, Mercurial, Perforce, etc.
 
 Example of file system contents:
 
-::
+.. code-block:: none
 
     /project.godot
     /enemy/enemy.tscn

--- a/getting_started/workflow/export/android_custom_build.rst
+++ b/getting_started/workflow/export/android_custom_build.rst
@@ -78,7 +78,7 @@ carefully:
 Create a new folder anywhere you want named ``android-sdk`` (it **must** be
 an empty directory). On Windows, the following path is usually good enough:
 
-::
+.. code-block:: none
 
   C:\users\<yourusername>\Documents\android-sdk
 
@@ -86,7 +86,7 @@ Unzip the Android SDK ZIP file you just downloaded there. The only thing in the
 directory you created in the previous step should be the ``tools`` folder with
 its contents inside, like this:
 
-::
+.. code-block:: none
 
   android-sdk/
   android-sdk/tools/
@@ -128,7 +128,7 @@ Generating the keystore
 Once the *platform tools* are installed, the last step is to generate a debug
 keystore (this is needed to build). Go up two folders by writing:
 
-::
+.. code-block:: shell
 
     cd ..\..
 
@@ -137,7 +137,7 @@ keystore (this is needed to build). Go up two folders by writing:
 And you need to input the following line (on Linux and macOS, this should work
 out of the box, for Windows there are further instructions below):
 
-::
+.. code-block:: shell
 
     keytool -keyalg RSA -genkeypair -alias androiddebugkey -keypass android -keystore debug.keystore -storepass android -dname "CN=Android Debug,O=Android,C=US" -validity 9999
 
@@ -192,7 +192,7 @@ where the *android-sdk* directory is created.
 In any case, it's better to select a different path inside your user folders.
 The recommended one is usually:
 
-::
+.. code-block:: none
 
   C:\Users\<yourusername>\Documents\android-sdk
 
@@ -218,7 +218,7 @@ The actual command line to type is the following. On Linux and macOS, it should
 work out of the box, but on Windows, it needs additional details (keep reading
 afterwards).
 
-::
+.. code-block:: shell
 
     keytool -keyalg RSA -genkeypair -alias androiddebugkey -keypass android -keystore debug.keystore -storepass android -dname "CN=Android Debug,O=Android,C=US" -validity 9999
 

--- a/getting_started/workflow/export/exporting_for_android.rst
+++ b/getting_started/workflow/export/exporting_for_android.rst
@@ -97,7 +97,7 @@ Exporting for Google Play Store
 Uploading an APK to Google's Play Store requires you to sign using a non-debug
 keystore file; such file can be generated like this:
 
-::
+.. code-block:: shell
 
     keytool -v -genkey -v -keystore mygame.keystore -alias mygame -keyalg RSA -validity 10000
 

--- a/getting_started/workflow/export/exporting_projects.rst
+++ b/getting_started/workflow/export/exporting_projects.rst
@@ -140,7 +140,7 @@ with the ``--export`` and ``--export-debug`` command line parameters.
 Exporting from the command line still requires an export preset to define
 the export parameters. A basic invocation of the command would be:
 
-::
+.. code-block:: shell
 
     godot --export "Windows Desktop" some_name
 
@@ -156,6 +156,6 @@ This takes place if the target name ends with ``.pck`` or ``.zip``.
 It is often useful to combine the ``--export`` flag with the ``--path``
 flag, and to create a dedicated export preset for automated export:
 
-::
+.. code-block:: shell
 
     godot --path path/to/project --export "pck" game_name.pck

--- a/getting_started/workflow/project_setup/project_organization.rst
+++ b/getting_started/workflow/project_setup/project_organization.rst
@@ -28,7 +28,7 @@ As an example, one can usually place into a single folder their basic assets,
 such as sprite images, 3D model meshes, materials, and music, etc.
 They can then use a separate folder to store built levels that use them.
 
-::
+.. code-block:: none
 
     /project.godot
     /docs/.gdignore  # See "Ignoring specific folders" below

--- a/tutorials/i18n/internationalizing_games.rst
+++ b/tutorials/i18n/internationalizing_games.rst
@@ -89,7 +89,7 @@ Language can be tested when running Godot from the command line.
 For example, to test a game in French, the following argument can be
 supplied:
 
-::
+.. code-block:: shell
 
    godot --language fr
 

--- a/tutorials/i18n/localization_using_gettext.rst
+++ b/tutorials/i18n/localization_using_gettext.rst
@@ -93,7 +93,7 @@ create and update the POT file from your scene files and scripts.
 
 After installing ``babel`` and ``babel-godot``, for example using pip:
 
-::
+.. code-block:: shell
 
     pip install babel babel-godot
 
@@ -101,7 +101,7 @@ Write a mapping file (for example ``babelrc``) which will indicate which files
 pybabel needs to process (note that we process GDScript as Python, which is
 generally sufficient):
 
-::
+.. code-block:: none
 
     [python: **.gd]
     encoding = utf-8
@@ -111,7 +111,7 @@ generally sufficient):
 
 You can then run pybabel like so:
 
-::
+.. code-block:: shell
 
     pybabel extract -F babelrc -k text -k LineEdit/placeholder_text -k tr -o godot-l10n.pot .
 
@@ -127,7 +127,7 @@ The ``msginit`` command is used to turn a PO template into a messages file.
 For instance, to create a French localization file, use the following command
 while in the ``locale`` directory:
 
-::
+.. code-block:: shell
 
     msginit --no-translator --input=messages.pot --locale=fr
 
@@ -157,7 +157,7 @@ that they contain new strings, while removing strings that are no longer
 present in the PO template removed in the PO template. This can be done
 automatically using the ``msgmerge`` tool:
 
-::
+.. code-block:: shell
 
     # The order matters: specify the message file *then* the PO template!
     msgmerge --update --backup=none fr.po messages.pot
@@ -171,7 +171,7 @@ Checking the validity of a PO file or template
 It is possible to check whether a gettext file's syntax is valid by running
 the command below:
 
-::
+.. code-block:: shell
 
     msgfmt fr.po --check
 

--- a/tutorials/io/background_loading.rst
+++ b/tutorials/io/background_loading.rst
@@ -28,7 +28,7 @@ Usage is generally as follows
 Obtaining a ResourceInteractiveLoader
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+.. code-block:: cpp
 
     Ref<ResourceInteractiveLoader> ResourceLoader::load_interactive(String p_path);
 
@@ -38,7 +38,7 @@ to manage the load operation.
 Polling
 ~~~~~~~
 
-::
+.. code-block:: cpp
 
     Error ResourceInteractiveLoader::poll();
 
@@ -55,7 +55,7 @@ Load progress (optional)
 
 To query the progress of the load, use the following methods:
 
-::
+.. code-block:: cpp
 
     int ResourceInteractiveLoader::get_stage_count() const;
     int ResourceInteractiveLoader::get_stage() const;
@@ -66,7 +66,7 @@ To query the progress of the load, use the following methods:
 Forcing completion (optional)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+.. code-block:: cpp
 
     Error ResourceInteractiveLoader::wait();
 
@@ -76,7 +76,7 @@ frame, without any more steps.
 Obtaining the resource
 ~~~~~~~~~~~~~~~~~~~~~~
 
-::
+.. code-block:: cpp
 
     Ref<Resource> ResourceInteractiveLoader::get_resource();
 

--- a/tutorials/networking/http_client_class.rst
+++ b/tutorials/networking/http_client_class.rst
@@ -10,7 +10,7 @@ which has a tutorial available :ref:`here <doc_http_request_class>`.
 Here's an example of using the :ref:`HTTPClient <class_HTTPClient>`
 class. It's just a script, so it can be run by executing:
 
-::
+.. code-block:: console
 
     c:\godot> godot -s http_test.gd
 

--- a/tutorials/networking/ssl_certificates.rst
+++ b/tutorials/networking/ssl_certificates.rst
@@ -61,7 +61,7 @@ and it will work.
 If you are using Linux, you can use the supplied certs file, generally
 located in:
 
-::
+.. code-block:: none
 
     /etc/ssl/certs/ca-certificates.crt
 

--- a/tutorials/platform/android_in_app_purchases.rst
+++ b/tutorials/platform/android_in_app_purchases.rst
@@ -3,8 +3,6 @@
 Android in-app purchases
 ========================
 
-.. highlight:: shell
-
 Godot engine has integrated GooglePaymentsV3 module with which we can implement in-app purchases in our game.
 
 The Godot engine demo project repository has an android-iap example project. It includes a gdscript interface for android IAP.
@@ -13,7 +11,7 @@ Check the repository here https://github.com/godotengine/godot-demo-projects
 
 Find the iap.gd script in
 
-::
+.. code-block:: none
 
     godot-demo-projects/misc/android_iap
 

--- a/tutorials/platform/services_for_ios.rst
+++ b/tutorials/platform/services_for_ios.rst
@@ -25,7 +25,7 @@ locally (no internet connection, API incorrectly configured, etc). If
 the error value is 'OK', a response event will be produced and added to
 the 'pending events' queue. Example:
 
-.. code-block:: python
+::
 
     func on_purchase_pressed():
         var result = InAppStore.purchase( { "product_id": "my_product" } )
@@ -428,7 +428,7 @@ you need inside a conditional block, you need to also define them as
 valid identifiers (local variable or class member). This is an example
 of how to work around this in a class:
 
-.. code-block:: python
+::
 
     var GameCenter = null # define it as a class member
 

--- a/tutorials/viewports/custom_postprocessing.rst
+++ b/tutorials/viewports/custom_postprocessing.rst
@@ -56,7 +56,7 @@ shader resource to it. You can access your rendered ``Viewport`` with the built-
     need to create your own uniform in the shader and pass the ``Viewport`` texture in
     manually, like so:
 
-    ::
+    .. code-block:: glsl
 
       // Inside the Shader
       uniform sampler2D ViewportTexture;
@@ -72,7 +72,7 @@ shader resource to it. You can access your rendered ``Viewport`` with the built-
 Copy the following code to your shader. The above code is a single pass edge detection filter, a
 `Sobel filter <https://en.wikipedia.org/wiki/Sobel_operator>`_.
 
-::
+.. code-block:: glsl
 
   shader_type canvas_item;
 
@@ -129,7 +129,7 @@ As an example, you could write a full screen Gaussian blur effect by attaching t
 to each of the :ref:`ViewportContainers <class_ViewportContainer>`. The order in which you apply the shaders
 does not matter:
 
-::
+.. code-block:: glsl
 
   shader_type canvas_item;
 
@@ -147,7 +147,7 @@ does not matter:
       COLOR.xyz = col;
   }
 
-::
+.. code-block:: glsl
 
   shader_type canvas_item;
 


### PR DESCRIPTION
I've noticed that we were missing some style rules defined by `Highlight.js`, which were not used by GDScript, but were used by others. For example, there is [an incorrect highlighting for JavaScript](https://docs.godotengine.org/en/latest/tutorials/platform/customizing_html5_shell.html#starting-the-project):

![image](https://user-images.githubusercontent.com/11782833/79341559-ad418280-7f34-11ea-8fed-aa2069dad2ff.png)

I've added almost every missing style rule, that was defaulting to `pygments.css`. Only omitted a couple I couldn't find any use for, and those need new, separate colors anyway. I think some of those are used in `diff`s, so if we introduce them in any guide we might need to add those rules.

I've added comments with AST entity names from `pygments.css` into our styles as well. This should help to adjust them in future without a need to go looking for classes' meanings.

Along the way I've checked whether syntax highlighting is working properly for any other code snippets that weren't GDScript and fixed several issues. There were enough of cases where highlighter was not defined or forced to a specific language, causing it to default to, in most of them, GDScript. I've tried to force proper languages wherever I've found an inconsistency. Mostly, this means that some unnecessary highlighting is no more. But there were cases where [highlighting erred and it was visible](https://docs.godotengine.org/en/latest/development/cpp/custom_modules_in_cpp.html#improving-the-build-system-for-development):

![image](https://user-images.githubusercontent.com/11782833/79341591-b7fc1780-7f34-11ea-9066-fbba29812eba.png)

Sometimes code blocks were used to display a list of files or some arbitrary output from a random source. These cannot be properly highlighted. In some cases a `console` highlighter was forced, which I'm not so sure about, but the main problem was that, once again, style rules were missing [yielding an unreadable text](https://docs.godotengine.org/en/latest/development/cpp/custom_modules_in_cpp.html#writing-custom-documentation):

![image](https://user-images.githubusercontent.com/11782833/79341618-c0545280-7f34-11ea-82c8-4a0cb80dc4a3.png)

There are a couple of cases where we do not have access to a proper highlighter. One of them is `Resource` format used by GDScript. [This documentation](https://docs.godotengine.org/en/latest/development/file_formats/tscn.html) on `.tscn` files is defaulting to GDScript and for the most part it keeps the text readable, so I left it as is. Same can be said for the article on i18n, which uses snippets of `.po` files.

-----
Couple of additional notes.

[This guide on background loading](https://docs.godotengine.org/en/latest/tutorials/io/background_loading.html) is starting with `cpp` snippets, showcasing method signatures. This is kind of strange, as the article itself seems to be about GDScript approach, and the rest of the code is actually GDScript. I didn't change anything about it, but maybe it is worth a look. There may be other articles like this, and having `cpp` in front of GDScript can be confusing for newcomers.

I'm also a bit confused by [this guide to iOS services](https://docs.godotengine.org/en/latest/tutorials/platform/services_for_ios.html), as it was using Python highlighter for GDScript (which I fixed and assumed to be just some ancient contribution, before GDScript highlighter was available), but there are also some other snippets with code signatures in another language. The problem is, it can be any C-based language from the look of it. So I don't know what highlighter to force there.