### PR TITLE
Improve sidebar behavior on scroll and adjust styling

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -21,6 +21,9 @@
     --navbar-level-2-color: #b8d6f0;
     --navbar-level-3-color: #a3c4e1;
     --navbar-heading-color: #ff7381;
+    --navbar-scrollbar-color: #d45a66;
+    --navbar-scrollbar-hover-color: #b14550;
+    --navbar-scrollbar-active-color: #72383e;
     --navbar-scrollbar-background: #131e2b;
 
     --link-color: #2980b9;
@@ -102,6 +105,9 @@
         --navbar-level-2-color: #ccc;
         --navbar-level-3-color: #bbb;
         --navbar-heading-color: #ee7381;
+        --navbar-scrollbar-color: #be5460;
+        --navbar-scrollbar-hover-color: #963e48;
+        --navbar-scrollbar-active-color: #5f3034;
         --navbar-scrollbar-background: #1c1e21;
 
         --link-color: #8cf;
@@ -845,7 +851,7 @@ kbd, .kbd {
 
 /* Banner panel in sidebar */
 .wy-nav-side .ethical-rtd.fixed {
-    position: fixed
+    position: fixed;
 }
 
 /* Version selector (only visible on Read the Docs) */
@@ -899,10 +905,15 @@ kbd, .kbd {
     padding: 0;
 }
 
-/* Allows the navbar's scrollbar to be shown */
+/* Allows the scrollbar to be shown in the sidebar */
 @media only screen and (min-width: 769px) {
     .wy-side-scroll {
         overflow: hidden;
+    }
+
+    .wy-nav-side .wy-side-scroll .ethical-rtd {
+        width: calc(300px - 1.25em);
+        padding: 0 0 0 1em;
     }
 }
 .wy-menu.wy-menu-vertical {
@@ -920,9 +931,9 @@ kbd, .kbd {
     }
 }
 
-/* Navbar's scrollbar styling */
+/* Scrollbar styling */
 .wy-menu.wy-menu-vertical {
-    scrollbar-color: var(--navbar-heading-color) var(--navbar-scrollbar-background);
+    scrollbar-color: var(--navbar-scrollbar-color) var(--navbar-scrollbar-background);
 }
 .wy-menu.wy-menu-vertical::-webkit-scrollbar {
     width: .75rem;
@@ -931,5 +942,12 @@ kbd, .kbd {
     background-color: var(--navbar-scrollbar-background);
 }
 .wy-menu.wy-menu-vertical::-webkit-scrollbar-thumb {
-    background-color: var(--navbar-heading-color);
+    background-color: var(--navbar-scrollbar-color);
+}
+/* Firefox does the dimming on hover automatically. We emulate it for Webkit-based browsers. */
+.wy-menu.wy-menu-vertical::-webkit-scrollbar-thumb:hover {
+    background-color: var(--navbar-scrollbar-hover-color);
+}
+.wy-menu.wy-menu-vertical::-webkit-scrollbar-thumb:active {
+    background-color: var(--navbar-scrollbar-active-color);
 }


### PR DESCRIPTION
Continuation of #3368 due to newly discovered complications. Several issues were fixed.

First of all, the banner in question is not immediately available on the page, so the way we handle it was not working. I've implemented an observer that is triggered in case some elements are added in the sidebar. This allows everything to be recalculated in case the banner appears after the code has run initially.

Secondly, the new layout for the banner was not respecting scroll height changes due to the main scroll, which resulted in this:

![image](https://user-images.githubusercontent.com/11782833/79456764-bb0c0c00-7ff7-11ea-98db-a1afdf9b689d.png)

Now, sidebar is updated on main scroll events as well.

Thirdly, there is not one, but two banner blocks added to the page. The second block is added into the footer. This was not accounted for, and the calculation was applied to both elements, causing this:

![image](https://user-images.githubusercontent.com/11782833/79456866-ebec4100-7ff7-11ea-9558-5d43d37636a3.png)

This is now resolved as well.

There was another issue specific to Firefox, so I've changed the way we extend scroll to allow the banner to be scrollable. It now works in all tested browsers as intended.

-----
Additionally, I've adjusted colors for the scrollbar itself to make them less prominent and annoying, as was suggested by @Calinou. I've gone ahead and implemented additional colors for hover and activation states. This is only applied to Webkit-based browsers, as Firefox does that automatically.

My own suggestion to make it thinner unless hovered on is not feasible at the moment. While Chrome allows arbitrary values for the width, Firefox does not. It only has `auto` and `thin` values. In theory, they could've been used, but in practice they have a different design, not just a different width.

Here is Chrome:

![2020-04-16_15-23-50](https://user-images.githubusercontent.com/11782833/79457224-8c426580-7ff8-11ea-8976-f1551de18a66.gif)
![2020-04-16_15-26-12](https://user-images.githubusercontent.com/11782833/79457229-8f3d5600-7ff8-11ea-9f06-f6fec159de95.gif)

And here is Firefox:

![2020-04-16_15-26-46](https://user-images.githubusercontent.com/11782833/79457240-919fb000-7ff8-11ea-94fc-0e29a8e380b4.gif)

-----
For testing this code can be put at the **end** of the `document.onready` function. It includes both the styling and the layout. It adds both *ethical* blocks.

```js
  // THIS IS JUST A TEST
  setTimeout(() => {
    const ethicalStyles = "div.ethical-sidebar,div.ethical-footer {display: block !important;}.ethical-sidebar,.ethical-footer {padding: 0.5em;margin: 1em 0;}.ethical-sidebar img,.ethical-footer img {width: 120px;height: 90px;display: inline-block;}.ethical-sidebar .ethical-callout,.ethical-footer .ethical-callout {padding-top: 1em;clear: both;}.ethical-sidebar .ethical-pixel,.ethical-footer .ethical-pixel,.ethical-fixedfooter .ethical-pixel {display: none !important;}.ethical-sidebar .ethical-text,.ethical-footer .ethical-text {margin-top: 1em;}.ethical-sidebar .ethical-image-link,.ethical-footer .ethical-image-link {border: 0;}.ethical-sidebar,.ethical-footer {background-color: #eee;border: 1px solid #ccc;border-radius: 5px;color: #0a0a0a;font-size: 14px;line-height: 20px;}.ethical-sidebar ul {margin: 0 !important;padding-left: 0;list-style: none;}.ethical-sidebar ul li {display: inline-block;background-color: lightskyblue;color: black;padding: 0.25em 0.4em;font-size: 75%;font-weight: 700;margin: 0.25em;border-radius: 0.25rem;text-align: center;vertical-align: baseline;white-space: nowrap;line-height: 1.41;}.ethical-sidebar ul li:not(:last-child) {margin-right: .25rem;}.ethical-sidebar a,.ethical-sidebar a:visited,.ethical-sidebar a:hover,.ethical-sidebar a:active,.ethical-footer a,.ethical-footer a:visited,.ethical-footer a:hover,.ethical-footer a:active {color: #0a0a0a;text-decoration: none !important;border-bottom: 0 !important;}.ethical-callout a {color: #707070 !important;text-decoration: none !important;}.ethical-sidebar {text-align: center;}.ethical-footer {text-align: left;font-size: 14px;line-height: 20px;}.ethical-footer img {float: right;margin-left: 25px;}.ethical-footer .ethical-callout {text-align: center;}.ethical-footer small {font-size: 10px;}.ethical-fixedfooter {box-sizing: border-box;position: fixed;bottom: 0;left: 0;z-index: 100;background-color: #eee;border-top: 1px solid #bfbfbf;font-size: 12px;line-height: 1.5;padding: 0.5em 1.5em;text-align: center;color: #404040;width: 100%;width: 100vw;}@media (min-width: 769px) {.ethical-fixedfooter {font-size: 13px;padding: 1em 1.5em;}}.ethical-fixedfooter .ethical-text:before {margin-right: 4px;padding: 2px 6px;border-radius: 3px;background-color: #4caf50;color: #fff;content: 'Sponsored';}.ethical-fixedfooter .ethical-callout {color: #999;padding-left: 6px;white-space: nowrap;}.ethical-fixedfooter a,.ethical-fixedfooter a:hover,.ethical-fixedfooter a:active,.ethical-fixedfooter a:visited {color: #404040;text-decoration: none;}.ethical-fixedfooter .ethical-close {position: absolute;top: 0;right: 5px;font-size: 20px;line-height: 20px;}.wy-nav-side .ethical-rtd {width: 300px;padding: 0 1em;}.ethical-rtd .ethical-sidebar {color: #b3b3b3;font-size: 14px;line-height: 20px;}@media (min-width: 769px) {.wy-body-for-nav .ethical-fixedfooter {padding-left: 300px;}}.ethical-alabaster a.ethical-image-link {border: 0 !important;}.ethical-alabaster hr {margin-top: 2em;}.ethical-alabaster::before {clear: both;content: '';display: table;margin-top: 3em;}.ethical-dark-theme .ethical-sidebar {background-color: #4e4b4b;border: 1px solid #a0a0a0;color: #c2c2c2 !important;}.ethical-dark-theme a,.ethical-dark-theme a:visited {color: #e6e6e6 !important;border-bottom: 0 !important;}.ethical-dark-theme .ethical-callout a {color: #b3b3b3 !important;}";
    const ethicalBlock = '<style>' + ethicalStyles + '</style><div class="ethical-dark-theme ethical-rtd"><div class="ethical-sidebar"><div class="ethical-content"><a href="https://server.ethicalads.io/proxy/click/919/NIgAcjoKrXl8Vmov/" rel="nofollow" target="_blank" class="ethical-image-link"><img src="https://ethicalads.blob.core.windows.net/media/images/2020/03/fiverr_1Yu5zab.png"></a><div class="ethical-text"><a href="https://server.ethicalads.io/proxy/click/919/NIgAcjoKrXl8Vmov/" rel="nofollow" target="_blank"><strong>Hire Fiverr Freelancers</strong> - Everything you need to grow your business</a></div></div><div class="ethical-callout"><small><em><a href="https://readthedocs.org/sustainability/advertising/">Sponsored</a><span> · </span><a href="https://docs.readthedocs.io/en/latest/ethical-advertising.html">Ads served ethically</a></em></small></div></div><img src="https://server.ethicalads.io/proxy/view/919/NIgAcjoKrXl8Vmov/" style="display: none;"></div>';
    sidebarContainer.innerHTML += ethicalBlock;

    const footerHR = document.querySelector("footer > hr");
    const footerEthicalBlock = '<div><div class="ethical-rtd"></div></div>';
    footerHR.insertAdjacentHTML('afterend', footerEthicalBlock);
  }, 2000);
```

PS. I really hope this is the last of the issues and we can roll this improvement out on other branches.