### PR TITLE
Mention self-contained mode in the editor compilation guides

### DIFF
--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -123,6 +123,11 @@ manager.
           As link-time optimization is a memory-intensive process,
           this will require about 3 GB of available RAM while compiling.
 
+.. note:: If you want to use separate editor settings for your own Godot builds
+          and official releases, you can enable
+          :ref:`doc_data_paths_self_contained_mode` by creating a file called
+          ``._sc_`` or ``_sc_`` in the ``bin/`` folder.
+
 Building export templates
 -------------------------
 

--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -39,9 +39,14 @@ If all goes well, the resulting binary executable will be placed in the
 runs without any dependencies. Executing it will bring up the project
 manager.
 
-To create an .app like in the official builds, you need to use the template
-located in ``misc/dist/osx_tools.app``. Typically, for an optimized editor
-binary built with ``scons p=osx target=release_debug``::
+.. note:: If you want to use separate editor settings for your own Godot builds
+          and official releases, you can enable
+          :ref:`doc_data_paths_self_contained_mode` by creating a file called
+          ``._sc_`` or ``_sc_`` in the ``bin/`` folder.
+
+To create an ``.app`` bundle like in the official builds, you need to use the
+template located in ``misc/dist/osx_tools.app``. Typically, for an optimized
+editor binary built with ``scons p=osx target=release_debug``::
 
     user@host:~/godot$ cp -r misc/dist/osx_tools.app ./Godot.app
     user@host:~/godot$ mkdir -p Godot.app/Contents/MacOS

--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -109,19 +109,18 @@ You can specify a number of CPU threads to use to speed up the build::
 
     C:\godot> scons -j6 platform=windows
 
-In general, it is OK to have at least as many threads compiling Godot as
-you have cores in your CPU, if not one or two more. Feel free to add the
--j option to any SCons command you see below.
+In general, it is OK to have at least as many threads compiling Godot as you
+have cores in your CPU, if not one or two more. Feel free to add the ``-j``
+option to any SCons command you see below.
 
 .. note:: When compiling with multiple CPU threads, SCons may warn about
           pywin32 being missing. You can safely ignore this warning.
 
 If all goes well, the resulting binary executable will be placed in
 ``C:\godot\bin\`` with the name ``godot.windows.tools.32.exe`` or
-``godot.windows.tools.64.exe``.
-
-.. note:: By default, SCons will build a binary matching your CPU architecture,
-          but this can be overridden using ``bits=64`` or ``bits=32``.
+``godot.windows.tools.64.exe``. By default, SCons will build a binary matching
+your CPU architecture, but this can be overridden using ``bits=64`` or
+``bits=32``.
 
 This executable file contains the whole engine and runs without any
 dependencies. Running it will bring up the Project Manager.
@@ -134,6 +133,11 @@ dependencies. Running it will bring up the Project Manager.
           even smaller and faster by adding the SCons option ``use_lto=yes``.
           As link-time optimization is a memory-intensive process,
           this will require about 3 GB of available RAM while compiling.
+
+.. note:: If you want to use separate editor settings for your own Godot builds
+          and official releases, you can enable
+          :ref:`doc_data_paths_self_contained_mode` by creating a file called
+          ``._sc_`` or ``_sc_`` in the ``bin/`` folder.
 
 Development in Visual Studio or other IDEs
 ------------------------------------------

--- a/tutorials/io/data_paths.rst
+++ b/tutorials/io/data_paths.rst
@@ -79,6 +79,8 @@ the specification to change the editor (and project) data paths.
           the editor data paths will be located in subfolders in
           ``~/.var/app/org.godotengine.Godot/``.
 
+.. _doc_data_paths_self_contained_mode:
+
 Self-contained mode
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
When working on the editor itself, using separate configuration is sometimes desired to avoid conflicts or accidentally losing settings.

This closes https://github.com/godotengine/godot/issues/21567.