### PR TITLE
Travis CI: Check for possible typos using codespell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 dist: bionic
 language: python
 
@@ -21,6 +22,10 @@ matrix:
 
 script:
   - bash ./format.sh
+
+  # Check for possible typos
+  - pip install codespell
+  - codespell -I codespell-ignore.txt {about,community,development,getting_started,tutorials}/**/*.rst
 
   - pip install -r requirements.txt
   # TODO: Add `-W` to turn warnings into errors.

--- a/codespell-ignore.txt
+++ b/codespell-ignore.txt
@@ -1,0 +1,6 @@
+doubleclick
+dof
+lod
+que
+raison
+uint


### PR DESCRIPTION
This should hopefully not result in too many false positives due to how codespell works (it only checks for misspellings from its own dictionary). On the other hand, false negatives may slip in.