### PR TITLE
Fix "compiling_for_windows.rst:4: WARNING: Duplicate explicit target name: "mingw-w64".

### DIFF
--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -160,7 +160,7 @@ Cross-compiling for Windows from other operating systems
 --------------------------------------------------------
 
 If you are a Linux or macOS user, you need to install
-`MinGW-w64 <https://mingw-w64.org/doku.php>`_, which typically comes in 32-bit
+`MinGW-w64 <https://mingw-w64.org/doku.php>`__, which typically comes in 32-bit
 and 64-bit variants. The package names may differ based on your distribution,
 here are some known ones:
 


### PR DESCRIPTION
Sphinx is throwing a duplicate explicit target name warning:
> /home/travis/build/godotengine/godot-docs/development/compiling/compiling_for_windows.rst:4: WARNING: Duplicate explicit target name: "mingw-w64".

This patch removes the warning by converting the second link to an anonymous reference.
