### PR TITLE
Fix reference to a node in FPS tutorial part 2

### DIFF
--- a/tutorials/3d/fps_tutorial/part_two.rst
+++ b/tutorials/3d/fps_tutorial/part_two.rst
@@ -694,9 +694,9 @@ If the currently loaded/open scene is ``Testing_Area.tscn``, we'd be adding our 
 .. warning:: As mentioned later below in the section on adding sounds, this method makes an assumption. This will be explained later
              in the section on adding sounds in :ref:`doc_fps_tutorial_part_three`
 
-Next we set the global transform of the clone to the ``Pistol_Aim_Point``'s global transform. The reason we do this is so the bullet is spawned at the end of the pistol.
+Next we set the global transform of the clone to the ``Pistol_Point``'s global transform. The reason we do this is so the bullet is spawned at the end of the pistol.
 
-You can see that ``Pistol_Aim_Point`` is positioned right at the end of the pistol by clicking the :ref:`AnimationPlayer <class_AnimationPlayer>` and
+You can see that ``Pistol_Point`` is positioned right at the end of the pistol by clicking the :ref:`AnimationPlayer <class_AnimationPlayer>` and
 scrolling through ``Pistol_fire``. You'll find the position is more or less at the end of the pistol when it fires.
 
 Next we scale it up by a factor of ``4`` because the bullet scene is a little too small by default.


### PR DESCRIPTION
The element self from which we are grabbing the global transform is Pistol_Point. The Aim Point is further away
Resolves https://github.com/godotengine/godot-docs/issues/3411

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
