### PR TITLE
Search engine indexing fixes: Proper canonical and translation links

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,14 +1,12 @@
-{% extends "!layout.html" %}
-{% block linktags %}
-    <link rel="alternate" hreflang="en" href="https://docs.godotengine.org/en/" />
-    <link rel="alternate" hreflang="de" href="https://docs.godotengine.org/de/" />
-    <link rel="alternate" hreflang="es" href="https://docs.godotengine.org/es/" />
-    <link rel="alternate" hreflang="fr" href="https://docs.godotengine.org/fr/" />
-    <link rel="alternate" hreflang="ko" href="https://docs.godotengine.org/ko/" />
-    <link rel="alternate" hreflang="pl" href="https://docs.godotengine.org/pl/" />
-    <link rel="alternate" hreflang="pt-br" href="https://docs.godotengine.org/pt-br/" />
-    <link rel="alternate" hreflang="uk" href="https://docs.godotengine.org/uk/" />
-    <link rel="alternate" hreflang="zh-cn" href="https://docs.godotengine.org/zh-cn/" />
-    <link rel="alternate" hreflang="x-default" href="https://docs.godotengine.org/" />
-    {{ super() }}
-{% endblock %}
+{% extends "!layout.html" -%}
+{% block linktags -%}
+  {% if godot_inject_language_links -%}
+  {% for alternate_lang in godot_docs_supported_languages -%}
+  <link rel="alternate" hreflang="{{ alternate_lang }}" href="{{ godot_docs_basepath }}{{ alternate_lang }}/{{ godot_canonical_version }}/{{ pagename }}{{ godot_docs_suffix }}" />
+  {% endfor -%}
+  <link rel="alternate" hreflang="x-default" href="{{ godot_docs_basepath }}{{ godot_default_lang }}/{{ godot_canonical_version }}/{{ pagename }}{{ godot_docs_suffix }}" />
+  
+  <link rel="canonical" href="{{ godot_docs_basepath }}{{ lang_attr }}/{{ godot_canonical_version }}/{{ pagename }}{{ godot_docs_suffix }}" />
+  {% endif -%}
+  {{ super() }}
+{% endblock -%}

--- a/conf.py
+++ b/conf.py
@@ -49,7 +49,13 @@ if env_tags is not None:
         tags.add(tag.strip())  # noqa: F821
 
 # Language / i18n
+supported_languages = ['en', 'de', 'es', 'fr', 'fi', 'it', 'ja', 'ko', 'pl', 'pt-br', 'ru', 'uk', 'zh-cn']
 language = os.getenv("READTHEDOCS_LANGUAGE", "en")
+if not language in supported_languages:
+    print("Unknown language: " + language)
+    print("Supported languages: " + ", ".join(supported_languages))
+    print("This is an error or needs to be added to supported_languages in conf.py")
+
 is_i18n = tags.has("i18n")  # noqa: F821
 
 exclude_patterns = ["_build"]
@@ -94,6 +100,12 @@ html_context = {
     "github_repo": "godot-docs",  # Repo name
     "github_version": "master",  # Version
     "conf_py_path": "/",  # Path in the checkout to the docs root
+    "godot_inject_language_links": True,
+    "godot_docs_supported_languages": supported_languages,
+    "godot_docs_basepath": "https://docs.godotengine.org/",
+    "godot_docs_suffix": ".html",
+    "godot_default_lang": "en",
+    "godot_canonical_version": "stable",
 }
 
 html_logo = "img/docs_logo.png"

--- a/robots.txt
+++ b/robots.txt
@@ -1,7 +1,3 @@
 user-agent: *
-disallow: /*/3.2
-disallow: /*/3.1
-disallow: /*/3.0
-disallow: /*/2.1
 
 sitemap: https://docs.godotengine.org/sitemap.xml


### PR DESCRIPTION
So, I was again greeted by a finnish Godot docs page today, and as my finnish is sadly not getting better despite Google's persistent efforts, I'd thought I'd try a fix.

**In short**
This:
- makes the **STABLE** version of each page *canonical*, which means search engines should default to them over *latest* or *specific versions*
- this canonical link uses the full path to the *stable* version of the page in the currently used language
- hopefully, this again allows us to let the *specific versions* be indexed, so I'm able to find the good ol' Godot 2.1 pages that aren't there anymore (or to find docs for features in *latest* that aren't yet in *stable*) - which means I removed the *specific versions* (*2.1, 3.0, 3.1., 3.2*) from the *robots.txt* blacklist
- the translation links (`<link rel="alternate" hreflang="...">`) are fixed which means search engines should be able to recognize the translations
  - each page now has such a link pointing to itself with the full path and the correct language tag
  - each page now points to all other translated versions of that page using the correct full path with the correct language tag
  - this follows the [various](https://www.portent.com/blog/seo/implement-hreflang-canonical-tags-correctly.htm) [best practices](https://yoast.com/hreflang-ultimate-guide/) as found around the [web](https://ahrefs.com/blog/hreflang-tags/)

**Things that change for dear Remi (and anyone else adding new languages for translation)**
When you want to add a new localization, you also need to add the language to `supported_languages` in `conf.py`:
```python
supported_languages = ['en', 'de', 'es', 'fr', 'fi', 'it', 'ja', 'ko', 'pl', 'pt-br', 'ru', 'uk', 'zh-cn']
```

I built and tested this locally as good as I could and the generated HTML looks good to me, but given the nature of this change, without being Google I can only *hope* that this improves the situation, if not my finnish. More eyes are certainly welcome.

**Due to the nature of the changes, if merged, this needs to be cherrypicked for all branches/versions and languages that are published on ReadTheDocs.**

This should help with https://github.com/godotengine/godot-docs/issues/3417 and https://github.com/godotengine/godot-docs/issues/1574 and most of the issues mentioned in https://github.com/godotengine/godot-docs/issues/3262.