### PR TITLE
compiling on osx needs to be forced to python3

### DIFF
--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -32,7 +32,7 @@ Compiling
 
 Start a terminal, go to the root directory of the engine source code and type::
 
-    scons platform=osx --jobs=$(sysctl -n hw.logicalcpu)
+    python3 $(which scons platform=osx --jobs=$(sysctl -n hw.logicalcpu))
 
 If all goes well, the resulting binary executable will be placed in the
 ``bin/`` subdirectory. This executable file contains the whole engine and


### PR DESCRIPTION
Since python2 is deprecated, compiling for MacOS needs to be forced to python3.
MacOS has python2 as `python` for it's default env. Changing your python env on OSX is not advised as the system uses it for sereval MacOS features. This simple python3 forcing seems to be the cleanest way to get it working on any MacOS.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
