### PR TITLE
Enable visible whitespace characters with emphasized lines

### DIFF
--- a/_extensions/gdscript.py
+++ b/_extensions/gdscript.py
@@ -31,6 +31,9 @@ from pygments.token import (
     Number,
     Punctuation,
 )
+from pygments.filters import (
+    VisibleWhitespaceFilter,
+)
 
 __all__ = ["GDScriptLexer"]
 
@@ -341,7 +344,15 @@ class GDScriptLexer(RegexLexer):
 
 
 def setup(sphinx):
-    sphinx.add_lexer("gdscript", GDScriptLexer())
+    """
+    We force the whitespaces filter here because Sphinx takes control away from us
+    further down the line. This hack requires add_lexer to accept an instance of the lexer.
+    This type of argument is not supported starting with Sphinx 3.x.
+    See https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_lexer
+    """
+    l = GDScriptLexer()
+    l.add_filter(VisibleWhitespaceFilter(spaces=" ",wstokentype=True))
+    sphinx.add_lexer("gdscript", l)
 
     return {
         "parallel_read_safe": True,

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -48,6 +48,7 @@
     --search-credits-link-color: #4392c5; /* derived from --link-color */
 
     --highlight-background-color: #f5ffe1;
+    --highlight-background-emph-color: #dbe6c3;
     --highlight-default-color: #404040;
     --highlight-comment-color: #408090;
     --highlight-keyword-color: #007020;
@@ -59,6 +60,7 @@
     --highlight-function-color: #06287e;
     --highlight-operator-color: #666666;
     --highlight-string-color: #4070a0;
+    --highlight-whitespace-color: #abb793;
 
     --admonition-note-background-color: #e7f2fa;
     --admonition-note-color: #404040;
@@ -133,6 +135,7 @@
 
         /* Colors taken from the Godot script editor with the Adaptive theme */
         --highlight-background-color: #202531;
+        --highlight-background-emph-color: #2d3444;
         --highlight-default-color: rgba(255, 255, 255, 0.85);
         --highlight-comment-color: rgba(204, 206, 211, 0.5);
         --highlight-keyword-color: #ff7085;
@@ -144,6 +147,7 @@
         --highlight-function-color: #57b3ff;
         --highlight-operator-color: #abc8ff;
         --highlight-string-color: #ffeca1;
+        --highlight-whitespace-color: #636875;
 
         --admonition-note-background-color: #303d4f;
         --admonition-note-color: #bfeeff;
@@ -501,6 +505,30 @@ code,
 
 .highlight {
     background-color: var(--highlight-background-color);
+}
+
+/* Emphasized lines */
+.highlight .hll {
+    background-color: var(--highlight-background-emph-color);
+}
+
+.highlight .w /* Text.Whitespace */ {
+    position: relative;
+    tab-size: 4; /* Defaults to 8, which is too big. */
+    -moz-tab-size: 4;
+}
+/* Whitespace characters only visible on emphasized lines. */
+.highlight .hll .w:before {
+    /* This is a blunt way to add just enough characters to cover most of reasonable indentations. */
+    content: "→   →   →   →   →   →   →   →   →   →   ";
+    color: var(--highlight-whitespace-color);
+    position: absolute;
+    left: 0;
+    width: 100%;
+    overflow: hidden;
+    /* Disable text selection and mouse events, as these elements are display-only. */
+    user-select: none;
+    pointer-events: none;
 }
 
 .highlight .gh /* Generic.Heading */,

--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -201,4 +201,12 @@ $(document).ready(() => {
   registerSidebarObserver(() => {
     registerOnScrollEvent(mediaQuery);
   });
+
+  // GDScript, as per the official style guide, uses tabs for indentation.
+  // Sphinx, however, replaces everything with spaces; additionally, most docs use spaces outright.
+  // This forces any 4-space combination in GDScript code samples to be converted into a tab,
+  // thus ensuring that code snippets are properly formatted and are ready to be copied.
+  document.querySelectorAll(".highlight-gdscript .highlight span.w").forEach((item) => {
+     item.innerText = item.innerText.replace(/[ ]{4}/g, "\t")
+  });
 });

--- a/getting_started/scripting/gdscript/gdscript_styleguide.rst
+++ b/getting_started/scripting/gdscript/gdscript_styleguide.rst
@@ -108,18 +108,22 @@ Each indent level should be one greater than the block containing it.
 
 **Good**:
 
-::
+.. code-block::
+    :emphasize-lines: 2
 
     for i in range(10):
         print("hello")
 
 **Bad**:
 
-::
+.. code-block::
+    :emphasize-lines: 3,7
 
+    # This example uses 2 spaces for the indentation instead of a full tab.
     for i in range(10):
       print("hello")
 
+    # This example uses 2 indent levels (or 2 tabs) for the indentation instead of just one.
     for i in range(10):
             print("hello")
 


### PR DESCRIPTION
Fixes #3426.

This adds special markup for whitespace characters in GDScript highlighter. While markup is always added, only emphasized lines display actual symbols. The "→" symbol is used, as GDScript must be indented with tabs, and not spaces.

This also automatically replaces 4 spaces with a tab in every GDScript code snippet. This should make it easier to copy code snippets throughout the docs. Note, that it's Sphinx that strips all tabs in `code-block`s.

So far only this particular example highlights tabs, as it has confusing "bad" examples. This also adds two explanatory comments for those examples, so that the distinction is even clearer.

![image](https://user-images.githubusercontent.com/11782833/80213958-b1f7ec00-8642-11ea-85e6-544f44aafa71.png)

![image](https://user-images.githubusercontent.com/11782833/80213965-b6bca000-8642-11ea-975c-1fed371d9b25.png)

This also fixes incorrect colors for emphasized lines in the dark theme, which are only found in [this C# basics doc](https://docs.godotengine.org/en/stable/getting_started/scripting/c_sharp/c_sharp_basics.html#project-setup-and-workflow) currently.