### PR TITLE
Fix typo in c# script of bouncing/reflecting part

### DIFF
--- a/tutorials/physics/using_kinematic_body_2d.rst
+++ b/tutorials/physics/using_kinematic_body_2d.rst
@@ -304,11 +304,11 @@ uses the mouse pointer. Here is the code for the Player, using ``move_and_slide(
             _velocity = new Vector2();
             if (Input.IsActionPressed("backward"))
             {
-                _velocity = new Vector2(-speed/3, 0).Rotated(Rotation);
+                _velocity = new Vector2(-Speed/3, 0).Rotated(Rotation);
             }
             if (Input.IsActionPressed("forward"))
             {
-                _velocity = new Vector2(speed, 0).Rotated(Rotation);
+                _velocity = new Vector2(Speed, 0).Rotated(Rotation);
             }
             if (Input.IsActionPressed("mouse_click"))
             {


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->

Speed variable was with uppercase in declaration but lowercase in the rest of the class. Now it is Uppercase.
