### PR TITLE
Define the Weblate badge size to avoid reflows during page loading

### DIFF
--- a/community/contributing/documentation_guidelines.rst
+++ b/community/contributing/documentation_guidelines.rst
@@ -121,9 +121,11 @@ You can help to translate the official Godot documentation on our `Hosted Weblat
     :alt: Translation state
     :align: center
     :target: https://hosted.weblate.org/engage/godot-engine/?utm_source=widget
+    :width: 287
+    :height: 66
 
 There also is the official
-`Godot i18N repository <https://github.com/godotengine/godot-docs-l10n>`_
+`Godot i18n repository <https://github.com/godotengine/godot-docs-l10n>`_
 where you can see when the data was last synchronized.
 
 License

--- a/conf.py
+++ b/conf.py
@@ -168,6 +168,8 @@ rst_epilog = """
 .. |weblate_widget| image:: https://hosted.weblate.org/widgets/godot-engine/{image_locale}/godot-docs/287x66-white.png
     :alt: Translation status
     :target: https://hosted.weblate.org/engage/godot-engine{target_locale}/?utm_source=widget
+    :width: 287
+    :height: 66
 """.format(
     image_locale="-" if language == "en" else language,
     target_locale="" if language == "en" else "/" + language,


### PR DESCRIPTION
This improves perceived performance slightly.

There are still other sources of reflows during loading (namely the logo and "+" buttons in the navigation bar). I'll try to look at those in the future.