### PR TITLE
Autowrap text inside tables by default

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -463,6 +463,18 @@ footer,
     background-color: var(--table-row-odd-background-color);
 }
 
+/* Override table no-wrap */
+/* The first column cells are not verbose, no need to wrap them */
+.wy-table-responsive table td:not(:nth-child(1)), 
+.wy-table-responsive table th:not(:nth-child(1)) {
+    white-space: normal;
+}
+
+/* Make sure not to wrap keyboard shortcuts */
+.wy-table-responsive table td kbd {
+    white-space: nowrap;
+}
+
 /* Code display tweaks */
 
 code,


### PR DESCRIPTION
### Before
![no-wrap](https://user-images.githubusercontent.com/17108460/80305987-104ed700-87c9-11ea-9c2d-d5a79998e63a.png)


### After
![wrap](https://user-images.githubusercontent.com/17108460/80305992-1349c780-87c9-11ea-9374-ee72c3044f58.png)

---

The CSS is basically taken from this [SO answer](https://stackoverflow.com/a/41596044/2564620), so take this with a grain of salt. But to me this doesn't seem to break anything visually. UPDATE: https://github.com/godotengine/godot-docs/pull/3448#issuecomment-619548077.

To note, it seems like it's possible to manually setup column width on case-to-case basis with:

```rst
.. table::
    :widths: 20 30 50
```

But I guess it's better to enable autowrap by default for most cases, and configure the width when necessary manually, WDYT?

Some code snippets written inside tables may also wrap, but those kind of snippets are not inside `::` code block specifier in the first place which would prevent them to be wrapped, so those cases may need to be fixed if proven critical.
