### PR TITLE
Fixes typo in tutorials/plugins/editor/making_plugins.rst

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -57,7 +57,7 @@ You should end up with a directory structure like this:
 .. image:: img/making_plugins-my_custom_mode_folder.png
 
 ``plugin.cfg`` is a simple INI file with metadata about your plugin.
-The name and description help people undersatnd what it does.
+The name and description help people understand what it does.
 Your name helps you get properly credited for your work.
 The version number helps others know if they have an outdated version;
 if you are unsure on how to come up with the version number, check out `Semantic Versioning <https://semver.org/>`_.


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
Corrects the spelling of "understand" on line 60. Previously, it was spelled "undersatnd".