### PR TITLE
conf: Add language name in page title and translate it

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -49,12 +49,27 @@ if env_tags is not None:
         tags.add(tag.strip())  # noqa: F821
 
 # Language / i18n
-supported_languages = ['en', 'de', 'es', 'fr', 'fi', 'it', 'ja', 'ko', 'pl', 'pt-br', 'ru', 'uk', 'zh-cn']
+supported_languages = {
+    "en": "Godot Engine (%s) documentation in English",
+    "de": "Godot Engine (%s) Dokumentation auf Deutsch",
+    "es": "Documentación de Godot Engine (%s) en español",
+    "fr": "Documentation de Godot Engine (%s) en français",
+    "fi": "Godot Engine (%s) dokumentaatio suomeksi",
+    "it": "Godot Engine (%s) documentazione in italiano",
+    "ja": "日本語のGodot Engine (%s)ドキュメント",
+    "ko": "한국어로 된 Godot Engine (%s) 문서",
+    "pl": "Dokumentacja Godot Engine (%s) w języku polskim",
+    "pt-br": "Documentação do Godot Engine (%s) em português do Brasil",
+    "ru": "Godot Engine (%s) документация на русском языке",
+    "uk": "Документація Godot Engine (3.2) російською мовою",
+    "zh-cn": "Godot Engine（%s）文档为俄语",
+}
 language = os.getenv("READTHEDOCS_LANGUAGE", "en")
-if not language in supported_languages:
+if not language in supported_languages.keys():
     print("Unknown language: " + language)
-    print("Supported languages: " + ", ".join(supported_languages))
-    print("This is an error or needs to be added to supported_languages in conf.py")
+    print("Supported languages: " + ", ".join(supported_languages.keys()))
+    print("The configured language is either wrong, or it should be added to supported_languages in conf.py. Falling back to 'en'.")
+    language = en
 
 is_i18n = tags.has("i18n")  # noqa: F821
 
@@ -93,6 +108,8 @@ html_theme_options = {
     "collapse_navigation": False,
 }
 
+html_title = supported_languages[language] % version
+
 # VCS options: https://docs.readthedocs.io/en/latest/vcs.html#github
 html_context = {
     "display_github": not is_i18n,  # Integrate GitHub
@@ -101,7 +118,7 @@ html_context = {
     "github_version": "master",  # Version
     "conf_py_path": "/",  # Path in the checkout to the docs root
     "godot_inject_language_links": True,
-    "godot_docs_supported_languages": supported_languages,
+    "godot_docs_supported_languages": list(supported_languages.keys()),
     "godot_docs_basepath": "https://docs.godotengine.org/",
     "godot_docs_suffix": ".html",
     "godot_default_lang": "en",


### PR DESCRIPTION
I couldn't find how to make the `html_title` value translatable using
sphinx-gettext (tried `sphinx.locale._()` but it wouldn't extract it),
so I'm hardcoding translations for now.

---

Thanks @mhilbrunner for the suggestion.

Reviews needed for the non-latin languages, I used machine translation as placeholders.

It looks like this (French):
![Screenshot_20200426_221020](https://user-images.githubusercontent.com/4701338/80318562-54fb6200-880b-11ea-950e-ad6c7d3669a3.png)