### PR TITLE
Update class_color.rst - "contrasted()" desc.

### DIFF
--- a/classes/class_color.rst
+++ b/classes/class_color.rst
@@ -875,7 +875,7 @@ Returns a new color resulting from blending this color over another. If the colo
 
 - :ref:`Color<class_Color>` **contrasted** **(** **)**
 
-Returns the most contrasting color.
+Returns the color's complimentary color.
 
 ::
 


### PR DESCRIPTION
Original: "Returns the most contrasting color."
New: "Returns the color's complimentary color."

This change was made because `contrasted()` does not always return the most contrasting color due to its simple code. For example, the most contrasting color to black (0, 0, 0) is white (1, 1, 1), but `Color(0, 0, 0, 1).contrasted() = Color(0.5, 0.5, 0.5, 1)` (light gray).

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
