### PR TITLE
Fix locale names

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -2,7 +2,9 @@
 {% block linktags -%}
   {% if godot_inject_language_links -%}
   {% for alternate_lang in godot_docs_supported_languages -%}
-  <link rel="alternate" hreflang="{{ alternate_lang }}" href="{{ godot_docs_basepath }}{{ alternate_lang }}/{{ godot_canonical_version }}/{{ pagename }}{{ godot_docs_suffix }}" />
+  {# Convert to ISO 639-1 format, e.g. zh_CN -> zh-cn -#}
+  {% set alternate_lang_href = alternate_lang.lower().replace("_", "-") -%}
+  <link rel="alternate" hreflang="{{ alternate_lang_href }}" href="{{ godot_docs_basepath }}{{ alternate_lang }}/{{ godot_canonical_version }}/{{ pagename }}{{ godot_docs_suffix }}" />
   {% endfor -%}
   <link rel="alternate" hreflang="x-default" href="{{ godot_docs_basepath }}{{ godot_default_lang }}/{{ godot_canonical_version }}/{{ pagename }}{{ godot_docs_suffix }}" />
   

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -12,3 +12,7 @@
   {% endif -%}
   {{ super() }}
 {% endblock -%}
+
+{% block htmltitle -%}
+<title>{{ godot_title_prefix }}{{ title|striptags|e }}{{ titlesuffix }}</title>
+{% endblock -%}

--- a/conf.py
+++ b/conf.py
@@ -66,17 +66,6 @@ supported_languages = {
     "zh_CN": "Godot Engine (%s) 简体中文文档",
 }
 
-# Some language codes used on Weblate/RTD and in the docs URL differ,
-# so we need to remap them.
-languages_remap = {
-    "pt_BR": "pt-br",
-    "zh_CN": "zh-cn",
-}
-languages_url = sorted(
-    [l for l in supported_languages.keys() if l not in languages_remap.keys()]
-    + list(languages_remap.values())
-)
-
 language = os.getenv("READTHEDOCS_LANGUAGE", "en")
 if not language in supported_languages.keys():
     print("Unknown language: " + language)
@@ -109,7 +98,6 @@ highlight_language = "gdscript"
 # on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
 on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
-
 html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 if on_rtd:
@@ -133,7 +121,7 @@ html_context = {
     "github_version": "master",  # Version
     "conf_py_path": "/",  # Path in the checkout to the docs root
     "godot_inject_language_links": True,
-    "godot_docs_supported_languages": languages_url,
+    "godot_docs_supported_languages": list(supported_languages.keys()),
     "godot_docs_basepath": "https://docs.godotengine.org/",
     "godot_docs_suffix": ".html",
     "godot_default_lang": "en",

--- a/conf.py
+++ b/conf.py
@@ -126,6 +126,9 @@ html_context = {
     "godot_docs_suffix": ".html",
     "godot_default_lang": "en",
     "godot_canonical_version": "stable",
+    # Distinguish local development website from production website.
+    # This prevents people from looking for changes on the production website after making local changes :)
+    "godot_title_prefix": "" if on_rtd else "(DEV) ",
 }
 
 html_logo = "img/docs_logo.png"


### PR DESCRIPTION
This fixes the `hreflang` links for locale names for languages such as `zh_CN` by converting them to ISO 639-1 (`zh-cn`) where needed.

It also prepends "(DEV)" to the page title if built locally and not on ReadTheDocs, which I think @Calinou suggested.