### PR TITLE
Added note to TileMap.get_used_cells_by_id()

### DIFF
--- a/classes/class_tilemap.rst
+++ b/classes/class_tilemap.rst
@@ -556,7 +556,9 @@ Returns a :ref:`Vector2<class_Vector2>` array with the positions of all cells co
 
 - :ref:`Array<class_Array>` **get_used_cells_by_id** **(** :ref:`int<class_int>` id **)** const
 
-Returns an array of all cells with the given tile ``id``.
+Returns an array of all cells with the given tile ``id``.  
+
+Note: The tile ``id`` is referred to as the tile ``index`` in other methods.
 
 ----
 


### PR DESCRIPTION
Added: Note: The tile ``id`` is referred to as the tile ``index`` in other methods. 
https://github.com/godotengine/godot-proposals/issues/814

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
