### PR TITLE
Update the Editor icons optimization guide to follow current usage

### DIFF
--- a/development/editor/creating_icons.rst
+++ b/development/editor/creating_icons.rst
@@ -50,16 +50,28 @@ Because the editor renders SVGs once at load time, they need to be small
 in size so they can be efficiently parsed. Editor icons must be first
 optimized before being added to the engine, to do so:
 
-1. Add them to the ``engine/icons/svg`` folder.
+1. Install `svgcleaner <https://github.com/RazrFalcon/svgcleaner>`__
+   by downloading a binary from its
+   `Releases tab <https://github.com/RazrFalcon/svgcleaner/releases/latest>`__
+   and placing it into a location in your ``PATH`` environment variable.
 
-2. Run the ``optimize.py`` script. You must have the ``scour`` package installed:
+2. Run the command below, replacing ``svg_source.svg`` with the path to your
+   SVG file (which can be a relative or absolute path):
 
    .. code-block:: bash
 
-       pip install scour
-       cd godot-design/engine/icons && ./optimize.py
+       svgcleaner --multipass svg_source.svg svg_optimized.svg
 
-The optimized icons will be generated in the ``engine/icons/optimized`` folder.
+The ``--multipass`` switch improves compression, so make sure to include it.
+The optimized icon will be saved to ``svg_optimized.svg``. You can also change
+the destination parameter to any relative or absolute path you'd like.
+
+.. note::
+
+    While this optimization step won't impact the icon's quality noticeably, it
+    will still remove editor-only information such as guides. Therefore, it's
+    recommended to keep the source SVG around if you need to make further
+    changes.
 
 Integrating and sharing the icons
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
We have transitioned from scour to svgcleaner lately due to its better performance and ease of installation.