### PR TITLE
Replace outdated identifier in example code

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_basics.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics.rst
@@ -1507,7 +1507,7 @@ Remember to save the new function state, when using multiple ``yield``\s::
 
     func _ready():
         var co = co_func();
-        while co is GDScriptFunction && co.is_valid():
+        while co is GDScriptFunctionState && co.is_valid():
             co = co.resume();
 
 


### PR DESCRIPTION
Replaces outdated identifier `GDScriptFunction` with `GDScriptFunctionState ` in example code of the GDScript basics documentation page.

Fixes #3527
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
