### PR TITLE
Improve Windows compiling instructions

### DIFF
--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -20,7 +20,7 @@ For compiling under Windows, the following is required:
   MinGW does not officially release GCC 9 yet, you can get an alternate installer from 
   `here <https://jmeubank.github.io/tdm-gcc/articles/2020-03/9.2.0-release>`_.
 - `Python 3.5+ <https://www.python.org/downloads/windows/>`_.
-- `SCons 3.0 <https://www.scons.org>`_ build system. If using Visual Studio 2019,
+- `SCons 3.0 <https://www.scons.org/>`_ build system. If using Visual Studio 2019,
   you need at least SCons 3.1.1.
 - *Optional* - `yasm <https://yasm.tortall.net/>`_ (for WebM SIMD optimizations)
 
@@ -43,12 +43,19 @@ For compiling under Windows, the following is required:
 .. seealso:: For a general overview of SCons usage for Godot, see
              :ref:`doc_introduction_to_the_buildsystem`.
 
+Setting up Python
+-----------------
+
+First you need to install Python 3.5 or newer. Make sure to enable the option
+to add Python to the ``PATH`` in the Python installer. The SCons installer
+should then detect and use the existing Python installation.
+
 Setting up SCons
 ----------------
 
-First, make sure to enable the option to add Python to the ``PATH`` in
-the Python installer. The SCons installer should then detect and use
-the existing Python installation.
+To install SCons open the command prompt and run the following command.
+
+``python -m pip install scons``
 
 To check whether you have installed Python and SCons correctly, you can
 type ``python --version`` and ``scons --version`` into a command prompt


### PR DESCRIPTION
This fixes some issues I ran into when compiling the engine for the first time.

-The information about installing Python is now its own small section
-Added instructions for installing SCons. As someone who hasn't had to install Python stuff before this section gave me issues, I just assumed you needed to double click the install.py file and it would automatically install.
