### PR TITLE
Improve the Contribute to the Class Reference page

### DIFF
--- a/community/contributing/updating_the_class_reference.rst
+++ b/community/contributing/updating_the_class_reference.rst
@@ -5,6 +5,8 @@ Contribute to the Class Reference
 
 .. highlight:: shell
 
+.. note:: This guide also is available as a `video tutorial on YouTube <https://www.youtube.com/watch?v=5jeHXxeX-JY>`_.
+
 Godot ships with many nodes and singletons to help you develop your games. Each is a class, documented in the :ref:`class reference <toc-class-ref>`.
 This reference is essential for anyone learning the engine: it is available both online and in the engine.
 
@@ -14,8 +16,10 @@ The developers can't write the entire reference on their own. Godot needs you, a
 **Important:** If you are planning to make larger changes or a more substantial contribution, it is usually a good idea
 to create an issue (or a comment in an existing one) to let others know so they don't start working on the same thing too.
 
-.. note:: This guide is available as a `video tutorial on YouTube <https://www.youtube.com/watch?v=5jeHXxeX-JY>`_.
+.. seealso::
 
+    Not sure where to start contributing? Take a look at the current class reference
+    completion status `here <https://godotengine.github.io/doc-status/>`__.
 
 How to contribute
 -----------------
@@ -41,7 +45,7 @@ If you're new to git and GitHub, this guide will help you get started. You'll le
 - Keep your fork up to date with other contributors
 - Create a pull request so your improvements end in the official docs
 
-.. note:: If you're new to git, the version-control system Godot uses, go through `GitHub's interactive guide <https://try.github.io/levels/1/challenges/1>`_. You'll learn some essential vocabulary and get a sense for the tool.
+.. note:: If you're new to Git, the version control system Godot uses, go through `GitHub's interactive guide <https://try.github.io/levels/1/challenges/1>`_. You'll learn some essential vocabulary and get a sense for the tool.
 
 Fork Godot
 ~~~~~~~~~~
@@ -126,7 +130,7 @@ When classes are modified in the source code, the documentation template might b
 
     ./bin/godot.linuxbsd.tools.64 --doctool .
 
-The xml files in doc/classes should then be up-to-date with current Godot Engine features. You can then check what changed using the ``git diff`` command. If there are changes to other classes than the one you are planning to document, please commit those changes first before starting to edit the template:
+The XML files in doc/classes should then be up-to-date with current Godot Engine features. You can then check what changed using the ``git diff`` command. If there are changes to other classes than the one you are planning to document, please commit those changes first before starting to edit the template:
 
 ::
 
@@ -153,7 +157,7 @@ When it's done, you can ask for a Pull Request via the GitHub UI of your Godot f
 
 .. warning::
 
-    Although you can edit files on GitHub, it's not recommended. As hundreds of contributors work on Godot, the git history must stay clean. Each commit should bundle all related improvements you make to the class reference, a new feature, bug fixes... When you edit from GitHub, it will create a new branch and a Pull Request every time you want to save it. If a few days pass before your changes get a review, you won't be able to update to the latest version of the repository cleanly. Also, it's harder to keep clean indents from GitHub. And they're very important in the docs.
+    Although you can edit files on GitHub, it's not recommended. As hundreds of contributors work on Godot, the Git history must stay clean. Each commit should bundle all related improvements you make to the class reference, a new feature, bug fixes... When you edit from GitHub, it will create a new branch and a Pull Request every time you want to save it. If a few days pass before your changes get a review, you won't be able to update to the latest version of the repository cleanly. Also, it's harder to keep clean indents from GitHub. And they're very important in the docs.
 
     TL;DR: If you don't know what you're doing exactly, do not edit files from GitHub.
 
@@ -251,6 +255,8 @@ Godot's class reference supports BBcode-like tags. They add nice formatting to t
 | [i] [/i]                  | Italic                         | Some [i]italic[/i] text.          | Some *italic* text.                               |
 +---------------------------+--------------------------------+-----------------------------------+---------------------------------------------------+
 | [code] [/code]            | Monospace                      | Some [code]monospace[/code] text. | Some ``monospace`` text.                          |
++---------------------------+--------------------------------+-----------------------------------+---------------------------------------------------+
+| [kbd] [/kbd]              | Keyboard/mouse shortcut        | Some [kbd]Ctrl + C[/kbd] key.     | Some :kbd:`Ctrl + C` key.                         |
 +---------------------------+--------------------------------+-----------------------------------+---------------------------------------------------+
 | [codeblock] [/codeblock]  | Multiline preformatted block   | *See below.*                      | *See below.*                                      |
 +---------------------------+--------------------------------+-----------------------------------+---------------------------------------------------+


### PR DESCRIPTION
- Link to the online class reference completion status page.
- Mention the `[kbd]` tag to display keyboard/mouse shortcuts.
- Improve grammar and writing style a bit.