### PR TITLE
Split the GDScript warning system documentation into its own page

### DIFF
--- a/getting_started/scripting/gdscript/index.rst
+++ b/getting_started/scripting/gdscript/index.rst
@@ -10,4 +10,5 @@ GDScript
    gdscript_exports
    gdscript_styleguide
    static_typing
+   warning_system
    gdscript_format_string

--- a/getting_started/scripting/gdscript/static_typing.rst
+++ b/getting_started/scripting/gdscript/static_typing.rst
@@ -240,7 +240,7 @@ You can also use your own nodes as return types:
         var item: Item = find_item(reference)
         if not item:
             item = ItemDatabase.get_instance(reference)
-            
+
         item.amount += amount
         return item
 
@@ -318,51 +318,10 @@ it's anything else, like an ``Area2D``, or any node that doesn't extend
 Warning system
 --------------
 
-The warning system complements typed GDScript. It's here to help you
-avoid mistakes that are hard to spot during development, and that may
-lead to runtime errors.
+.. note::
 
-You can configure warnings in the Project Settings under a new section
-called ``GDScript``:
-
-.. figure:: ./img/typed_gdscript_warning_system_settings.png
-   :alt: warning system project settings
-
-   warning system project settings
-
-You can find a list of warnings for the active GDScript file in the
-script editor's status bar. The example below has 3 warnings:
-
-.. figure:: ./img/typed_gdscript_warning_example.png
-   :alt: warning system example
-
-   warning system example
-
-To ignore specific warnings in one file, insert a special comment of the
-form ``# warning-ignore:warning-id``, or click on the ignore link to the
-right of the warning's description. Godot will add a comment above the
-corresponding line and the code won't trigger the corresponding warning
-anymore:
-
-.. figure:: ./img/typed_gdscript_warning_system_ignore.png
-   :alt: warning system ignore example
-
-   warning system ignore example
-
-You can also choose to ignore not just one but all warnings of a certain
-type in this file with ``# warning-ignore-all:warning-id``. To ignore all
-warnings of all types in a file add the comment ``# warnings-disable`` to it.
-
-Warnings won't prevent the game from running, but you can turn them into
-errors if you'd like. This way your game won't compile unless you fix
-all warnings. Head to the ``GDScript`` section of the Project Settings to
-turn on this option. Here's the same file as the previous example with
-warnings as errors turned on:
-
-.. figure:: ./img/typed_gdscript_warning_system_errors.png
-   :alt: warnings as errors
-
-   warnings as errors
+    Documentation about the GDScript warning system has been moved to
+    :ref:`doc_gdscript_warning_system`.
 
 Cases where you can't specify types
 -----------------------------------

--- a/getting_started/scripting/gdscript/warning_system.rst
+++ b/getting_started/scripting/gdscript/warning_system.rst
@@ -1,0 +1,51 @@
+.. _doc_gdscript_warning_system:
+
+GDScript warning system
+=======================
+
+The GDScript warning system complements :ref:`static typing <doc_gdscript_static_typing>`
+(but it can work without static typing too). It's here to help you avoid
+mistakes that are hard to spot during development, and that may lead
+to runtime errors.
+
+You can configure warnings in the Project Settings under the section
+called **Gdscript**:
+
+.. figure:: ./img/typed_gdscript_warning_system_settings.png
+   :alt: Warning system project settings
+
+   Warning system project settings
+
+You can find a list of warnings for the active GDScript file in the
+script editor's status bar. The example below has 3 warnings:
+
+.. figure:: ./img/typed_gdscript_warning_example.png
+   :alt: Warning system example
+
+   Warning system example
+
+To ignore specific warnings in one file, insert a special comment of the
+form ``# warning-ignore:warning-id``, or click on the ignore link to the
+right of the warning's description. Godot will add a comment above the
+corresponding line and the code won't trigger the corresponding warning
+anymore:
+
+.. figure:: ./img/typed_gdscript_warning_system_ignore.png
+   :alt: Warning system ignore example
+
+   Warning system ignore example
+
+You can also choose to ignore not just one but all warnings of a certain
+type in this file with ``# warning-ignore-all:warning-id``. To ignore all
+warnings of all types in a file add the comment ``# warnings-disable`` to it.
+
+Warnings won't prevent the game from running, but you can turn them into
+errors if you'd like. This way your game won't compile unless you fix
+all warnings. Head to the ``GDScript`` section of the Project Settings to
+turn on this option. Here's the same file as the previous example with
+warnings as errors turned on:
+
+.. figure:: ./img/typed_gdscript_warning_system_errors.png
+   :alt: Warnings as errors
+
+   Warnings as errors


### PR DESCRIPTION
It's not strictly related to static typing, as it can work without it (e.g. to signal unreachable code).

This should also make it a bit easier to find.