### PR TITLE
Center the main pane on wide displays

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -173,6 +173,11 @@
     }
 }
 
+html {
+    /* Hack to prevent taking the scroll bar into account when centering the main pane */
+    padding-left: calc(100vw - 100%);
+}
+
 body,
 h1,
 h2,
@@ -440,8 +445,9 @@ footer,
 
 @media only screen and (min-width: 769px) {
     .wy-body-for-nav {
-        /* Center the page on wide displays for better readability */
-        max-width: 1100px;
+        /* Center the page's main pane on wide displays for better readability */
+        /* `max-width` is (navbar width + main pane width) */
+        max-width: 1400px;
         margin: 0 auto;
     }
 }


### PR DESCRIPTION
Thanks to @ericrybick for the suggestion.

PS: I didn't understand what this part does:

> also add `padding-left: calc(100vw - 100%);` to `:root` to avoid scroll-bar repositioning.

I couldn't notice any difference in Firefox after applying it.

## Preview

### Before (both panes are centered as a group)

![Godot docs homepage](https://user-images.githubusercontent.com/180032/82131978-3ae5eb80-97db-11ea-97f9-d4f8887b456b.png)

### After (main pane is centered)

![Godot docs homepage](https://user-images.githubusercontent.com/180032/82131985-420cf980-97db-11ea-9e9b-0d3839b90275.png)

This closes #3139.