### PR TITLE
Add AUTHORS.md with list of main contributors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,27 @@
+Andreas Haas <liu.gam3@gmail.com>
+Andrew Conrad <aconrad103@gmail.com>
+Andrii Doroshenko <xrayez@gmail.com>
+puchik <puchik@users.noreply.github.com> <48544263+puchik@users.noreply.github.com>
+Chris Bradfield <chris@kidscancode.org> <cb@scribe.net>
+clayjohn <claynjohn@gmail.com>
+clayjohn <claynjohn@gmail.com> <clayjohn@shaw.ca>
+corrigentia <coryan25@gmail.com> <20541985+corrigentia@users.noreply.github.com>
+Frido <f.schermutzki@gmail.com>
+Hugo Locurcio <hugo.locurcio@hugo.pro> <calinou@opmbx.org>
+Hugo Locurcio <hugo.locurcio@hugo.pro> <hugo.l@openmailbox.org>
+Ignacio Etcheverry <ignalfonsore@gmail.com> <neikeq@users.noreply.github.com>
+Julian Murgia <the.straton@gmail.com>
+Kelly Thomas <kelly.thomas@hotmail.com.au>
+Leon Krause <lk@leonkrause.com>
+Leon Krause <lk@leonkrause.com> <eska@eska.me>
+Max Hilbrunner <m.hilbrunner@gmail.com>
+Max Hilbrunner <m.hilbrunner@gmail.com> <mhilbrunner@users.noreply.github.com>pn
+Michael Alexsander <michaelalexsander@protonmail.com>
+Nathan Lovato <nathan@gdquest.com>
+Paul Joannon <hello@pauljoannon.com> <437025+paulloz@users.noreply.github.com>
+Rémi Verschelde <rverschelde@gmail.com> <remi@verschelde.fr>
+skyace65 <trekie96@hotmail.com>
+Will Nations <willnationsdev@gmail.com>
+Yuri Roubinsky <chaosus89@gmail.com>
+Yuri Sizov <pycbouh@users.noreply.github.com> <yuris@humnom.net>
+ZX-WT <ZX-WT@ymail.com> <ZX_WT@ymail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -7,6 +7,7 @@ clayjohn <claynjohn@gmail.com>
 clayjohn <claynjohn@gmail.com> <clayjohn@shaw.ca>
 corrigentia <coryan25@gmail.com> <20541985+corrigentia@users.noreply.github.com>
 Frido <f.schermutzki@gmail.com>
+Frido <f.schermutzki@gmail.com> <43795127+mega-bit@users.noreply.github.com>
 Hugo Locurcio <hugo.locurcio@hugo.pro> <calinou@opmbx.org>
 Hugo Locurcio <hugo.locurcio@hugo.pro> <hugo.l@openmailbox.org>
 Ignacio Etcheverry <ignalfonsore@gmail.com> <neikeq@users.noreply.github.com>
@@ -15,12 +16,14 @@ Kelly Thomas <kelly.thomas@hotmail.com.au>
 Leon Krause <lk@leonkrause.com>
 Leon Krause <lk@leonkrause.com> <eska@eska.me>
 Max Hilbrunner <m.hilbrunner@gmail.com>
-Max Hilbrunner <m.hilbrunner@gmail.com> <mhilbrunner@users.noreply.github.com>pn
+Max Hilbrunner <m.hilbrunner@gmail.com> <mhilbrunner@users.noreply.github.com>
 Michael Alexsander <michaelalexsander@protonmail.com>
 Nathan Lovato <nathan@gdquest.com>
 Paul Joannon <hello@pauljoannon.com> <437025+paulloz@users.noreply.github.com>
 Rémi Verschelde <rverschelde@gmail.com> <remi@verschelde.fr>
 skyace65 <trekie96@hotmail.com>
+skyace65 <trekie96@hotmail.com> <trekie96@Hotmail.com>
+TwistedTwigleg <beard.noah@gmail.com> <Beard.noah@gmail.com>
 Will Nations <willnationsdev@gmail.com>
 Yuri Roubinsky <chaosus89@gmail.com>
 Yuri Sizov <pycbouh@users.noreply.github.com> <yuris@humnom.net>

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,53 @@
+# Godot Engine documentation authors
+
+Godot Engine is developed by a community of voluntary contributors who
+contribute on all areas, including writing and maintaining the documentation.
+
+It is impossible to list them all; nevertheless, this file aims at listing
+the writers who contributed significant patches to this CC-BY licensed
+documentation on the `godot-docs` repository.
+
+GitHub usernames are indicated in parentheses, or as sole entry when no other
+name is available.
+
+## Main contributors
+
+(in alphabetical order, with over 10 commits excluding merges)
+
+Aaron Franke (aaronfranke)
+Andrew Conrad (her001)
+Andrii Doroshenko (Xrayez)
+Arman (puchik)
+Bastiaan Olij (BastiaanOlij)
+bitbutter
+Camille Mohr-Daurat (pouleyKetchoupp)
+Chris Bradfield (cbscribe)
+Clay John (clayjohn)
+corrigentia
+Fabio Alessandrelli (Faless)
+FeralBytes
+Frido (mega-bit)
+George Marques (vnen)
+Gerrit Großkopf (Grosskopf)
+Griatch
+Haoyu Qiu (timothyqiu)
+Hugo Locurcio (Calinou)
+Ignacio Roldán Etcheverry (neikeq)
+Jérôme Gully (Nutriz)
+Juan Linietsky (reduz)
+Julian Murgia (StraToN)
+Kelly Thomas (KellyThomas)
+Leon Krause (leonkrause)
+Matthew (skyace65)
+Max Hilbrunner (mhilbrunner)
+Michael Alexsander (YeldhamDev)
+Nathan Lovato (NathanLovato)
+Paul Joannon (paulloz)
+Poommetee Ketson (Naryosha)
+Rémi Verschelde (akien-mga)
+Tomasz Chabora (KoBeWi)
+TwistedTwigleg
+Will Nations (willnationsdev)
+Yuri Roubinsky (Chaosus)
+Yuri Sizov (pycbouh)
+ZX-WT


### PR DESCRIPTION
Fixes #1489.

----

I went with the "easy" approach used on the main engine repo, where we include all contributors with 10+ commits in `AUTHORS.md`.

I list them with `git shortlog -s -n -e --no-merges`, and then use the public info on their GitHub profile to decide whether to put full (public) name or only the GitHub handle.

I also included contributors who had over 10 commits on the engine repo's `doc/classes` and `modules/*/doc_classes` folders, so that class reference writers can also be credited here even if their contribution was initially on a different repository.