### PR TITLE
Pin ReadTheDocs sphinx search to specific commit instead of master tip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ sphinx_rtd_theme==0.4.3
 sphinx-tabs==1.1.13
 
 # Full-page search UI for RTD: https://readthedocs-sphinx-search.readthedocs.io
-git+https://github.com/readthedocs/readthedocs-sphinx-search@master
+git+https://github.com/readthedocs/readthedocs-sphinx-search@faa85a9dabb71e53bb01832edc9a3be07d22bd5a


### PR DESCRIPTION
Should hopefully help prevent things like https://github.com/godotengine/godot-docs/issues/3565 in the future

Using the last `master` commit for now:
https://github.com/readthedocs/readthedocs-sphinx-search/commits/master

https://github.com/readthedocs/readthedocs-sphinx-search/commit/faa85a9dabb71e53bb01832edc9a3be07d22bd5a