### PR TITLE
Fix incorrect Node label in "Your first game"

### DIFF
--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -1145,7 +1145,7 @@ functions:
 
     public void OnMessageTimerTimeout()
     {
-        GetNode<Label>("MessageLabel").Hide();
+        GetNode<Label>("Message").Hide();
     }
 
 Connecting HUD to Main


### PR DESCRIPTION
In the HUD section, one of the new nodes created is named "Message". The OnMessageTimerTimeout() description in the docs incorrectly refers to this as "MesageLabel". This would cause a runtime error and also does not match the actual code repository linked in the docs.