### PR TITLE
Mention Open JDK in step by step exporting

### DIFF
--- a/getting_started/step_by_step/exporting.rst
+++ b/getting_started/step_by_step/exporting.rst
@@ -319,7 +319,7 @@ Before you can export your project for Android, you must download the following
 software:
 
 * Android SDK: https://developer.android.com/studio/
-* Java JDK: http://www.oracle.com/technetwork/java/javase/downloads/index.html
+* Open JDK(version 8 is required, more recent versions won't work): https://adoptopenjdk.net/index.html
 
 When you run Android Studio for the first time, click on *Configure -> SDK Manager*
 and install "Android SDK Platform Tools". This installs the `adb` command-line

--- a/getting_started/workflow/export/android_custom_build.rst
+++ b/getting_started/workflow/export/android_custom_build.rst
@@ -47,9 +47,8 @@ Install a JDK
 
 The Android SDK doesn't come with Java, so it needs to be installed manually.
 You need to install a Java SDK (**not** just the runtime or JRE).
-`OpenJDK 8 <https://adoptopenjdk.net/index.html>`__ is recommended.
-Oracle JDK 8 should also work. Later versions may not work for
-Android development.
+`OpenJDK 8 <https://adoptopenjdk.net/index.html>`__ is required, newer
+versions won't work.
 
 Download the command-line tools
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Replace Oracle JDK with OpenJDK in step by step exporting. And clarifies that you must have version 8 on the android custom builds page.
