### PR TITLE
Capitalize all instances of Git in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ They are meant to be parsed with the [Sphinx](https://www.sphinx-doc.org/) docum
 
 **Pull Requests should use the `master` branch by default. Only make Pull Requests against other branches (e.g. `2.1` or `3.0`) if your changes only apply to that specific version of Godot.**
 
-Though arguably less convenient to edit than a wiki, this git repository is meant to receive pull requests to always improve the documentation, add new pages, etc. Having direct access to the source files in a revision control system is a big plus to ensure the quality of our documentation.
+Though arguably less convenient to edit than a wiki, this Git repository is meant to receive pull requests to always improve the documentation, add new pages, etc. Having direct access to the source files in a revision control system is a big plus to ensure the quality of our documentation.
 
 ### Editing existing pages
 

--- a/community/contributing/bug_triage_guidelines.rst
+++ b/community/contributing/bug_triage_guidelines.rst
@@ -62,7 +62,7 @@ The following labels are currently defined in the Godot repository:
 -  *Junior job*: the issue is *assumed* to be an easy one to fix, which makes
    it a great fit for junior contributors who need to become familiar with
    the code base.
--  *Needs rebase*: the issue need a git rebase to be merged.
+-  *Needs rebase*: the issue need a Git rebase to be merged.
 -  *Needs testing*: the issue/pull request could not be completely tested
    and thus need further testing. This can mean that it needs to be tested
    on different hardware/software configurations or even that the steps to

--- a/community/contributing/pr_workflow.rst
+++ b/community/contributing/pr_workflow.rst
@@ -255,7 +255,7 @@ You would then do your changes to our example's
 (text editor, IDE, etc.).
 
 By default, those changes are *unstaged*. The staging area is a layer between
-your working directory (where you make your modifications) and the local git
+your working directory (where you make your modifications) and the local Git
 repository (the commits and all the metadata in the ``.git`` folder). To
 bring changes from the working directory to the Git repository, you need to
 *stage* them with the ``git add`` command, and then to commit them with the

--- a/community/contributing/updating_the_class_reference.rst
+++ b/community/contributing/updating_the_class_reference.rst
@@ -39,7 +39,7 @@ There are 5 steps to update the class reference (full guide below):
 Get started with GitHub
 -----------------------
 
-If you're new to git and GitHub, this guide will help you get started. You'll learn to:
+If you're new to Git and GitHub, this guide will help you get started. You'll learn to:
 
 - Fork and clone Godot's repository
 - Keep your fork up to date with other contributors
@@ -83,7 +83,7 @@ You can check the list of all remote servers with:
 
     git remote -v
 
-You should have two: ``origin``, your fork on GitHub, that git adds by default, and ``upstream``, that you just added:
+You should have two: ``origin``, your fork on GitHub that Git adds by default, and ``upstream``, that you just added:
 
 
 ::
@@ -119,7 +119,7 @@ Another option is to delete the branch you're working on, synchronize the master
     git pull --rebase upstream master
     git checkout -b your-new-branch-name
 
-If you're feeling lost by now, come to our `IRC channels <http://webchat.freenode.net/?channels=#godotengine>`_ and ask for help. Experienced git users will give you a hand.
+If you're feeling lost by now, come to our `IRC channels <https://webchat.freenode.net/?channels=#godotengine>`_ and ask for help. Experienced Git users will give you a hand.
 
 Updating the documentation template
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/community/contributing/ways_to_contribute.rst
+++ b/community/contributing/ways_to_contribute.rst
@@ -63,7 +63,7 @@ As such, everyone is entitled to modify
 modifications back to the upstream project in the form of a patch (a text file
 describing the changes in a ready-to-apply manner) or - in the modern workflow
 that we use - via a so-called "pull request" (PR), i.e. a proposal to directly
-merge one or more git commits (patches) into the main development branch.
+merge one or more Git commits (patches) into the main development branch.
 
 Contributing code changes upstream has two big advantages:
 
@@ -82,7 +82,7 @@ Contributing code changes upstream has two big advantages:
 
 To ensure good collaboration and overall quality, the Godot developers
 enforce some rules for code contributions, for example regarding the style to
-use in the C++ code (indentation, brackets, etc.) or the git and PR workflow.
+use in the C++ code (indentation, brackets, etc.) or the Git and PR workflow.
 
 A good place to start is by searching for issues tagged as `junior jobs <https://github.com/godotengine/godot/issues?q=is%3Aissue+is%3Aopen+label%3A%22junior+job%22>`_ (or `Hacktoberfest <https://github.com/godotengine/godot/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3AHacktoberfest+>`_ during October) on GitHub.
 
@@ -181,7 +181,7 @@ There are two separate resources referred to as "documentation" in Godot:
    consulted offline, directly in Godot's code editor, or online at
    :ref:`Godot API <toc-class-ref>`.
    To contribute to the class reference, you have to edit the
-   `doc/base/classes.xml` in Godot's git repository, and make a pull request.
+   `doc/base/classes.xml` in Godot's Git repository, and make a pull request.
    See :ref:`doc_updating_the_class_reference` for more details.
 
 -  **The tutorials and engine documentation and its translations.** This is the part you are reading

--- a/development/cpp/custom_modules_in_cpp.rst
+++ b/development/cpp/custom_modules_in_cpp.rst
@@ -474,7 +474,7 @@ main ``doc/classes`` directory.
 
 .. tip::
 
-    You can use git to check if you have missed some of your classes by checking the 
+    You can use Git to check if you have missed some of your classes by checking the
     untracked files with ``git status``. For example::
 
         user@host:~/godot$ git status


### PR DESCRIPTION
This is the official casing we use elsewhere in the documentation.