### PR TITLE
Change incorrect MessageLabel to Message in Your first game

### DIFF
--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -1133,7 +1133,7 @@ functions:
         emit_signal("start_game")
 
     func _on_MessageTimer_timeout():
-        $MessageLabel.hide()
+        $Message.hide()
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
The Label created is called 'Message' and not 'MessageLabel'.