### PR TITLE
Tweak the theme font stack to follow Bootstrap 5.0.0-alpha1

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -190,7 +190,7 @@ legend,
 .rst-content .toctree-wrapper p.caption,
 .rst-versions {
     /* Use a system font stack for better performance (no Web fonts required) */
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
 h1,


### PR DESCRIPTION
This most notably removes Oxgyen which was reported to have a poor "œ" character appearance under certain font weights.