### PR TITLE
Improve CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 os: linux
 dist: bionic
-language: python
+language: python - "3.8"
 
-python:
-  - "3.8"
-
-stages:
-  - build
+env:
+  global:
+    - SPHINX_NO_GDSCRIPT=1
+    - SPHINX_NO_SEARCH=1
+    - SPHINX_NO_DESCRIPTIONS=1
 
 matrix:
   include:
@@ -18,16 +18,17 @@ matrix:
           packages:
             - dos2unix
             - recode
-            - texlive-full
+
+install:
+  - pip install -r requirements.txt
+  - pip install codespell
 
 script:
   - bash ./format.sh
 
   # Check for possible typos
-  - pip install codespell
   - codespell -I codespell-ignore.txt {about,community,development,getting_started,tutorials}/**/*.rst
 
-  - pip install -r requirements.txt
   # TODO: Add `-W` to turn warnings into errors.
   # This can only be done once all warnings have been fixed.
-  - sphinx-build --color -b html -d _build/doctrees . _build/html
+  - sphinx-build --color -b dummy -d _build/doctrees . _build/html

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ help:
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 	@echo "  coverage   to run coverage check of the documentation (if enabled)"
+	@echo "  dummy      to run only the parse steps without generating output"
 
 clean:
 	rm -rf $(BUILDDIR)/*
@@ -195,3 +196,8 @@ pseudoxml:
 	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
 	@echo
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
+
+dummy:
+	$(SPHINXBUILD) -b dummy $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. No output."

--- a/conf.py
+++ b/conf.py
@@ -13,12 +13,23 @@ needs_sphinx = "1.3"
 # Sphinx extension module names and templates location
 sys.path.append(os.path.abspath("_extensions"))
 extensions = [
-    "gdscript",
-    "godot_descriptions",
-    "sphinx_search.extension",
     "sphinx_tabs.tabs",
     "sphinx.ext.imgmath",
 ]
+
+# Warning when the Sphinx Tabs extension is used with unknown
+# builders (like the dummy builder) - as it doesn't cause errors,
+# we can ignore this so we still can treat other warnings as errors.
+sphinx_tabs_nowarn = True
+
+if not os.getenv("SPHINX_NO_GDSCRIPT"):
+    extensions.append("gdscript")
+
+if not os.getenv("SPHINX_NO_SEARCH"):
+    extensions.append("sphinx_search.extension")
+
+if not os.getenv("SPHINX_NO_DESCRIPTIONS"):
+    extensions.append("godot_descriptions")
 
 templates_path = ["_templates"]
 


### PR DESCRIPTION
Improve CI build times by using a dummy builder for (empty) output, dropping LaTeX, and disabling some Sphinx extensions when building for CI (GDScript lexing, creating a search index, and generating HTML description tags).

In my tests, this improves Travis CI build times: from up to 30 minutes down to 3 minutes.

**Before**
![before](https://user-images.githubusercontent.com/1654763/83653661-56fbd200-a5bc-11ea-9b5e-36b1150edcd3.PNG)

**After**
![after](https://user-images.githubusercontent.com/1654763/83653679-5a8f5900-a5bc-11ea-99d0-d07d3cde57cb.PNG)

**Things that didn't work**

Travis CI caching didn't seem to improve build times.
I tried both enabling the Python PIP cache as well as creating a per-branch cache for the Sphinx doctrees.

**Things that did work**
- Switching to a dummy output writer instead of building HTML files and throwing them away. Build times improved by roughly ~40%.
- Disabling extensions that aren't needed for CI. Build times improved by roughly ~20%.
- Disabling LaTeX. Build times improved by roughly ~20%.

**Caveats**

We're now not really building the HTML anymore, just parsing, then stopping the Sphinx build.
From testing, this still works fine: invalid formatting, spelling errors, and invalid links and references still lead all to warnings.

Some things may or may not be caught anymore however that would previously be detected (in theory), because some extensions/internal Sphinx behaviour may depend on the HTML builder.
Don't ask me for examples; in my testing, this worked fine :) Still, something to be aware of in case we notice anything in the future.

**Things still to investigate, will do after this**

- Moving from Travis to GitHub Actions for more concurrent builds
- Removing the `imgmath` Sphinx extension, it's only used on [this](https://docs.godotengine.org/en/stable/tutorials/math/vector_math.html) page anyway and doesn't work with the dark theme
- Completely removing LaTeX, not only for CI as this does; we don't seem to offer PDF downloads anymore
- Currently, most time is spent reading the `classses/class_*.rst` files. Maybe we can optimize this somehow, they don't really change that often (only when synced with the main repo)
- Theoretically, we could abort the build early on first errors (Sphinx warnings, spelling errors and such) - this would improve CI times at the cost of making CI output less useful, potentially requiring multiple fix-submit-CI cycles from contributors. IMO not worth it.