### PR TITLE
Updated android IAP documentation to 3.2

### DIFF
--- a/tutorials/platform/android_in_app_purchases.rst
+++ b/tutorials/platform/android_in_app_purchases.rst
@@ -18,6 +18,9 @@ Find the ``iap.gd`` script in:
 Copy it to your project, then open the Project Settings, add it to the AutoLoad
 list and name it as IAP so that we can reference it anywhere in the game.
 
+Since the introduction of the android module system, you now also need to add ``org/godotengine/godot/GodotPaymentV3`` to your list of selected android modules.
+This list is found under the Android section of the Project Settings. It is called Modules, and is a comma-separated list of modules that will be built into your android apk.
+
 Getting the product details
 ---------------------------
 


### PR DESCRIPTION
This code no longer works in Godot >=3.2 without the addition of the "org/godotengine/godot/GodotPaymentV3" module in the Modules section of the Project Settings. This setting is present in the demo project, but not in the documentation.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
