### PR TITLE
Replace register_method with bind_method

### DIFF
--- a/development/cpp/object_class.rst
+++ b/development/cpp/object_class.rst
@@ -66,13 +66,13 @@ Registering functions is one:
 
 .. code-block:: cpp
 
-    ClassDB::register_method(D_METHOD("methodname", "arg1name", "arg2name"), &MyCustomMethod);
+    ClassDB::bind_method(D_METHOD("methodname", "arg1name", "arg2name"), &MyCustomMethod);
 
 Default values for arguments can be passed in reverse order:
 
 .. code-block:: cpp
 
-    ClassDB::register_method(D_METHOD("methodname", "arg1name", "arg2name"), &MyCustomType::method, DEFVAL(-1)); // default value for arg2name
+    ClassDB::bind_method(D_METHOD("methodname", "arg1name", "arg2name"), &MyCustomType::method, DEFVAL(-1)); // default value for arg2name
 
 ``D_METHOD`` is a macro that converts "methodname" to a StringName for more
 efficiency. Argument names are used for introspection, but when
@@ -223,7 +223,7 @@ languages). Connecting to them is rather easy:
     obj->connect("enter_tree", this, "_node_entered_tree")
 
 The method ``_node_entered_tree`` must be registered to the class using
-``ClassDB::register_method`` (explained before).
+``ClassDB::bind_method`` (explained before).
 
 Adding signals to a class is done in ``_bind_methods``, using the
 ``ADD_SIGNAL`` macro, for example:


### PR DESCRIPTION
ClassDB exposes `bind_method` in order to register functions, and not
`register_method` anymore. Updated the Engine Development section to
mention the correct function.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
