### PR TITLE
Document the lack of dynamic loops in WebGL 1.0

### DIFF
--- a/getting_started/workflow/export/exporting_for_web.rst
+++ b/getting_started/workflow/export/exporting_for_web.rst
@@ -108,6 +108,12 @@ The default HTML page does not display the boot splash while loading. However,
 the image is exported as a PNG file, so :ref:`custom HTML pages <doc_customizing_html5_shell>`
 can display it.
 
+Shader language limitations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When exporting a GLES2 project to HTML5, WebGL 1.0 will be used. WebGL 1.0
+doesn't support dynamic loops, so shaders using those won't work there.
+
 Unimplemented functionality
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tutorials/shading/shading_reference/shading_language.rst
+++ b/tutorials/shading/shading_reference/shading_language.rst
@@ -437,6 +437,11 @@ Godot Shading language supports the most common types of flow control:
 Keep in mind that, in modern GPUs, an infinite loop can exist and can freeze your application (including editor).
 Godot can't protect you from this, so be careful not to make this mistake!
 
+.. warning::
+
+    When exporting a GLES2 project to HTML5, WebGL 1.0 will be used. WebGL 1.0
+    doesn't support dynamic loops, so shaders using those won't work there.
+
 Discarding
 ----------
 


### PR DESCRIPTION
I documented it in both places where it could be relevant to ensure people don't miss it.

This closes #2980.