### PR TITLE
Update WebAssembly export templates' ZIP archive names

### DIFF
--- a/development/compiling/introduction_to_the_buildsystem.rst
+++ b/development/compiling/introduction_to_the_buildsystem.rst
@@ -307,8 +307,8 @@ platform:
 
     android_debug.apk
     android_release.apk
-    javascript_debug.zip
-    javascript_release.zip
+    webassembly_debug.zip
+    webassembly_release.zip
     linux_server_32
     linux_server_64
     linux_x11_32_debug


### PR DESCRIPTION
There is currently contradicting information between the following two pages:
- https://docs.godotengine.org/en/latest/development/compiling/compiling_for_web.html
- https://docs.godotengine.org/en/latest/development/compiling/introduction_to_the_buildsystem.html