### PR TITLE
Document that `light()` functions aren't run if vertex shading is forced

### DIFF
--- a/tutorials/shading/shading_reference/spatial_shader.rst
+++ b/tutorials/shading/shading_reference/spatial_shader.rst
@@ -298,6 +298,13 @@ Below is an example of a custom light function using a Lambertian lighting model
 
 If you want the lights to add together, add the light contribution to ``DIFFUSE_LIGHT`` using ``+=``, rather than overwriting it.
 
+.. warning::
+
+    The ``light()`` function won't be run if the ``vertex_lighting`` render mode
+    is enabled, or if
+    **Rendering > Quality > Shading > Force Vertex Shading** is enabled in the
+    Project Settings. (It's enabled by default on mobile platforms.)
+
 +-----------------------------------+-----------------------------------------------------+
 | Built-in                          | Description                                         |
 +===================================+=====================================================+

--- a/tutorials/shading/your_first_shader/what_are_shaders.rst
+++ b/tutorials/shading/your_first_shader/what_are_shaders.rst
@@ -90,7 +90,14 @@ between the vertices to provide the values for the ``fragment()`` function.
 The ``light()`` function runs for every pixel and for every light. It takes variables from the
 ``fragment()`` function and from previous runs of itself.
 
-For more information about how shaders operate specifically in Godot see the :ref:`Shaders <doc_shaders>` doc.
+For more information about how shaders operate specifically in Godot, see the :ref:`Shaders <doc_shaders>` doc.
+
+.. warning::
+
+    The ``light()`` function won't be run if the ``vertex_lighting`` render mode
+    is enabled, or if
+    **Rendering > Quality > Shading > Force Vertex Shading** is enabled in the
+    Project Settings. (It's enabled by default on mobile platforms.)
 
 Technical overview
 ------------------


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/39513.