### PR TITLE
styleguide: clarify "static typing" syntax

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_styleguide.rst
+++ b/getting_started/scripting/gdscript/gdscript_styleguide.rst
@@ -688,19 +688,37 @@ Static typing
 
 Since Godot 3.1, GDScript supports :ref:`optional static typing<doc_gdscript_static_typing>`.
 
-Type hints
-~~~~~~~~~~
+Declared Types
+~~~~~~~~~~~~~~
 
-Place the colon right after the variable's name, without a space, and let the
-GDScript compiler infer the variable's type when possible.
+To declare a variable's type, use ``<variable>: <type>``:
+
+::
+
+   var health: int = 0
+
+To declare the return type of a function, use ``-> <type>``: 
+
+::
+
+   func heal(amount: int) -> void:
+
+Inferred Types
+~~~~~~~~~~~~~~
+
+In some cases you can let the compiler infer the type, using ``:=``:
+
+::
+   var health := 0  # The compiler will use the int type.
+
+However, in other cases the compiler is not able to infer the exact type, 
+so you should set it explicitly.
 
 **Good**:
 
 ::
 
    onready var health_bar: ProgressBar = get_node("UI/LifeBar")
-
-   var health := 0 # The compiler will use the int type.
 
 **Bad**:
 
@@ -709,15 +727,3 @@ GDScript compiler infer the variable's type when possible.
    # The compiler can't infer the exact type and will use Node
    # instead of ProgressBar.
    onready var health_bar := get_node("UI/LifeBar")
-
-When you let the compiler infer the type hint, write the colon and equal signs together: ``:=``.
-
-::
-
-   var health := 0 # The compiler will use the int type.
-
-Add a space on either sides of the return type arrow when defining functions.
-
-::
-
-   func heal(amount: int) -> void:

--- a/getting_started/scripting/gdscript/gdscript_styleguide.rst
+++ b/getting_started/scripting/gdscript/gdscript_styleguide.rst
@@ -697,7 +697,7 @@ To declare a variable's type, use ``<variable>: <type>``:
 
    var health: int = 0
 
-To declare the return type of a function, use ``-> <type>``: 
+To declare the return type of a function, use ``-> <type>``:
 
 ::
 
@@ -706,13 +706,15 @@ To declare the return type of a function, use ``-> <type>``:
 Inferred Types
 ~~~~~~~~~~~~~~
 
-In some cases you can let the compiler infer the type, using ``:=``:
+In most cases you can let the compiler infer the type, using ``:=``:
 
 ::
    var health := 0  # The compiler will use the int type.
 
-However, in other cases the compiler is not able to infer the exact type, 
-so you should set it explicitly.
+However, in a few cases when context is missing, the compiler falls back to
+the function's return type. For example, ``get_node()`` cannot infer a type
+unless the scene or file of the node is loaded in memory. In this case, you
+should set the type explicitly.
 
 **Good**:
 


### PR DESCRIPTION
This change is an edit to: https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/gdscript_styleguide.html#static-typing

I first explored making an update here because I felt the current docs were confusing:

1. I could not tell if everything below "bad" was actually bad... It seemed like some of it was "good".
2. The examples involving ` var health := 0  # The compiler will use the int type` seemed redundant, and re: (1) it was confusing to see one in "good" and one in "bad".
3. I also wasn't able to understand "Place the colon right after the variable's name, without a space, and let the GDScript compiler infer the variable's type when possible".

First off: do you agree whether a change is useful or did I misunderstand the docs as written?

---

While writing this proposed update, I realize that the write-up is a mixture of style and explaining how types work. Is that what we expect in the style guide, or should it only focus on syntax and code clarity? If the latter, perhaps we should keep this minimal and treat the linked static typing guide as the source of truth: https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/static_typing.html#doc-gdscript-static-typing.

Thanks for the awesome game engine!
