### PR TITLE
Change C# page titles to describe the pages' contents

### DIFF
--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -1,7 +1,10 @@
 .. _doc_c_sharp:
 
+C# basics
+=========
+
 Introduction
-============
+------------
 
 .. warning:: C# support is a new feature available since Godot 3.0.
              As such, you may still run into some issues, or find spots

--- a/getting_started/scripting/c_sharp/c_sharp_differences.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_differences.rst
@@ -1,7 +1,7 @@
 .. _doc_c_sharp_differences:
 
-API differences to GDScript
-===========================
+C# API differences to GDScript
+==============================
 
 This is a (incomplete) list of API differences between C# and GDScript.
 

--- a/getting_started/scripting/c_sharp/c_sharp_features.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_features.rst
@@ -1,7 +1,7 @@
 .. _doc_c_sharp_features:
 
-Features
-========
+C# features
+===========
 
 This page provides an overview of the commonly used features of both C# and Godot
 and how they are used together.


### PR DESCRIPTION
The page title will be used in the tab name, which can impact search engine results as well as general usability. Using just "Introduction" or "Features" doesn't make it very meaningful.