### PR TITLE
C# Correct how to type cast Dictionaries returned from JSONParseResult

### DIFF
--- a/tutorials/io/saving_games.rst
+++ b/tutorials/io/saving_games.rst
@@ -267,7 +267,7 @@ load function:
         while (saveGame.GetPosition() < save_game.GetLen())
         {
             // Get the saved dictionary from the next line in the save file
-            var nodeData = (Godot.Collections.Dictionary<string, object>)JSON.Parse(saveGame.GetLine()).Result;
+            var nodeData = new Godot.Collections.Dictionary<string, object>((Godot.Collections.Dictionary)JSON.Parse(saveGame.GetLine()).Result);
 
             // Firstly, we need to create the object and add it to the tree and set its position.
             var newObjectScene = (PackedScene)ResourceLoader.Load(nodeData["Filename"].ToString());


### PR DESCRIPTION
Casting with either `(Godot.Collections.Dictionary<string,
object>)parsedResult` or `parsedResult as
Godot.Collections.Dictionary<string, object>` fails with an
InvalidCastException (or silently returning null with the `as` keyword).
Instead, a typed constructor using `new` should be used.

[JsonParseExample.zip](https://github.com/godotengine/godot-docs/files/4786685/JsonParseExample.zip) shows all 3 ways

