### PR TITLE
GitHub linguist: Mark .rst files as detectable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Properly detect languages on GitHub
+*.rst linguist-detectable=true


### PR DESCRIPTION
Linguist excludes documentation by default, which is not so useful on a
repo dedicated to documentation.
This attribute forces it to take .rst files into account and properly
report this report as being 99% reStructuredText.

Before:
```
$ github-linguist     
35.78%  CSS
32.78%  Python
13.05%  JavaScript
9.73%   Makefile
3.56%   GDScript
2.70%   Shell
1.40%   HTML
0.99%   Batchfile
```

After:
```
$ github-linguist        
99.21%  reStructuredText
0.28%   CSS
0.26%   Python
0.10%   JavaScript
0.08%   Makefile
0.03%   GDScript
0.02%   Shell
0.01%   HTML
0.01%   Batchfile
```

*Edit:* To clarify, GitHub linguist is what is used to generate this programming language breakdown:
![Screenshot_20200616_164944](https://user-images.githubusercontent.com/4701338/84790248-70a40d00-aff1-11ea-9819-c8c64f6fdeb5.png)
So this commit will fix it and show 99% reStructuredText.