### PR TITLE
Fix `vformat()` example in Common engine methods and macros

### DIFF
--- a/development/cpp/common_engine_methods_and_macros.rst
+++ b/development/cpp/common_engine_methods_and_macros.rst
@@ -89,7 +89,8 @@ To insert placeholders in localizable strings, wrap the localization macro in a
 
 .. code-block:: cpp
 
-    vformat(TTR("Couldn't open \"%s\" for reading."));
+    String file_path = "example.txt";
+    vformat(TTR("Couldn't open \"%s\" for reading."), file_path);
 
 .. note::
 


### PR DESCRIPTION
Thanks to Noshyaar on Twitter for reporting it :slightly_smiling_face: 