### PR TITLE
Add note about register_types file locations

### DIFF
--- a/development/cpp/binding_to_external_libraries.rst
+++ b/development/cpp/binding_to_external_libraries.rst
@@ -75,7 +75,12 @@ need to be created:
     register_types.h
     register_types.cpp
 
-With the following contents:
+.. note::
+    **Important:** These files must be in the top level folder of your module
+    (next to your ``SCsub`` and ``config.py`` files) in order for the module
+    to be registered properly.
+
+These files should contain the following:
 
 .. code-block:: cpp
 

--- a/development/cpp/binding_to_external_libraries.rst
+++ b/development/cpp/binding_to_external_libraries.rst
@@ -75,10 +75,9 @@ need to be created:
     register_types.h
     register_types.cpp
 
-.. note::
-    **Important:** These files must be in the top level folder of your module
-    (next to your ``SCsub`` and ``config.py`` files) in order for the module
-    to be registered properly.
+.. important::
+    These files must be in the top-level folder of your module (next to your
+    ``SCsub`` and ``config.py`` files) for the module to be registered properly.
 
 These files should contain the following:
 
@@ -129,8 +128,8 @@ installation commands for Linux below, for reference.
     apt-cache search festvox-* <-- Displays list of voice packages
     sudo apt-get install festvox-don festvox-rablpc16k festvox-kallpc16k festvox-kdlpc16k <-- Installs voices
 
-.. note::
-    **Important:** The voices that Festival uses (and any other potential external/3rd-party
+.. important::
+    The voices that Festival uses (and any other potential external/3rd-party
     resource) all have varying licenses and terms of use; some (if not most) of them may be
     be problematic with Godot, even if the Festival Library itself is MIT License compatible.
     Please be sure to check the licenses and terms of use.
@@ -153,8 +152,8 @@ can link to them instead by adding them as submodules (from within the modules/t
     git submodule add https://github.com/festvox/festival
     git submodule add https://github.com/festvox/speech_tools
 
-.. note::
-    **Important:** Please note that Git submodules are not used in the Godot repository.  If
+.. important::
+    Please note that Git submodules are not used in the Godot repository.  If
     you are developing a module to be merged into the main Godot repository, you should not
     use submodules.  If your module doesn't get merged in, you can always try to implement
     the external library as a GDNative C++ plugin.

--- a/development/cpp/custom_modules_in_cpp.rst
+++ b/development/cpp/custom_modules_in_cpp.rst
@@ -427,7 +427,7 @@ library that will be dynamically loaded when starting our game's binary.
     # next to the Godot binary.
     shared_lib = module_env.SharedLibrary(target='#bin/summator', source=sources)
 
-    # Finally, notify the main env it has our shared lirary as a new dependency.
+    # Finally, notify the main env it has our shared library as a new dependency.
     # To do so, SCons wants the name of the lib with it custom suffixes
     # (e.g. ".linuxbsd.tools.64") but without the final ".so".
     # We pass this along with the directory of our library to the main env.

--- a/development/cpp/custom_modules_in_cpp.rst
+++ b/development/cpp/custom_modules_in_cpp.rst
@@ -119,7 +119,12 @@ need to be created:
     register_types.h
     register_types.cpp
 
-With the following contents:
+.. note::
+    **Important:** These files must be in the top level folder of your module
+    (next to your ``SCsub`` and ``config.py`` files) in order for the module
+    to be registered properly.
+
+These files should contain the following:
 
 .. code-block:: cpp
 

--- a/development/cpp/custom_modules_in_cpp.rst
+++ b/development/cpp/custom_modules_in_cpp.rst
@@ -119,10 +119,9 @@ need to be created:
     register_types.h
     register_types.cpp
 
-.. note::
-    **Important:** These files must be in the top level folder of your module
-    (next to your ``SCsub`` and ``config.py`` files) in order for the module
-    to be registered properly.
+.. important::
+    These files must be in the top-level folder of your module (next to your
+    ``SCsub`` and ``config.py`` files) for the module to be registered properly.
 
 These files should contain the following:
 
@@ -446,8 +445,9 @@ during runtime with the ``LD_LIBRARY_PATH`` environment variable:
     export LD_LIBRARY_PATH="$PWD/bin/"
     ./bin/godot*
 
-**note**: Pay attention you have to ``export`` the environ variable otherwise
-you won't be able to play your project from within the editor.
+.. note::
+  You have to ``export`` the environment variable otherwise
+  you won't be able to play your project from within the editor.
 
 On top of that, it would be nice to be able to select whether to compile our
 module as shared library (for development) or as a part of the Godot binary


### PR DESCRIPTION
I organize my projects with 'include' and 'src' directories. When I put the
register_types.[h,cpp] in them, the module would "compile fine" (no errors),
but it wouldn't work.

This took a long time to figure out, so this PR adds a note to ensure that
these files are in the right place to be picked up by the build.
