### PR TITLE
Install tools required by `format.sh` on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
 
       - name: Lint and build documentation
         run: |
+          # Install tools used by `_tools/format.sh`.
+          sudo apt-get update -qq
+          sudo apt-get install -qq dos2unix recode
           # Append the `PATH` so we can run `codespell`.
           export PATH="$HOME/.local/bin:$PATH"
           pip3 install -r requirements.txt


### PR DESCRIPTION
The script would silently fail otherwise. Thanks to @aaronfranke for catching it :slightly_smiling_face: