### PR TITLE
Remove duplicate from GDScript Style Guide in Indentation

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_styleguide.rst
+++ b/getting_started/scripting/gdscript/gdscript_styleguide.rst
@@ -118,9 +118,6 @@ Each indent level should be one greater than the block containing it.
 ::
 
     for i in range(10):
-      print("hello")
-
-    for i in range(10):
             print("hello")
 
 Use 2 indent levels to distinguish continuation lines from


### PR DESCRIPTION
I noticed in GDScript style guide at "Indentation", the **Bad** showed an example of **Good**, then **Bad**