### PR TITLE
Remove error that Dictionary starts with 1000 records.

### DIFF
--- a/getting_started/workflow/best_practices/data_preferences.rst
+++ b/getting_started/workflow/best_practices/data_preferences.rst
@@ -103,11 +103,12 @@ Contiguous memory stores imply the following operation performance:
       ordered-aware search algorithm.
 
 Godot implements Dictionary as an ``OrderedHashMap<Variant, Variant>``. The engine
-stores a giant array (initialized to 1000 records) of key-value pairs. When
+stores a small array (initialized to 2^3 or 8 records) of key-value pairs. When
 one attempts to access a value, they provide it a key. It then *hashes* the
-key, i.e. converts it into a number. The "hash" becomes the index into the
-array, giving the OHM a quick lookup for the value within the conceptual
-"table" of keys mapped to values.
+key, i.e. converts it into a number. The "hash" is used to calculate the index
+into the array. As an array, the OHM then has a quick lookup within the "table"
+of keys mapped to values. When the HashMap becomes too full, it increases to
+the next power of 2 (so, 16 records, then 32, etc.) and rebuilds the structure.
 
 Hashes are to reduce the chance of a key collision. If one occurs, the table
 must recalculate another index for the value that takes the previous position
@@ -121,11 +122,12 @@ the expense of memory and some minor operational efficiency.
       too dependent on the density of the table, things will stay fast.
       Which leads to...
 
-2. Maintaining a huge size for the table.
+2. Maintaining an ever-growing size for the table.
 
-    - The reason it starts with 1000 records, and the reason it forces
-      large gaps of unused memory interspersed in the table is to
-      minimize hash collisions and maintain the speed of the accesses.
+    - HashMaps maintain gaps of unused memory interspersed in the table
+      on purpose to reduce hash collisions and maintain the speed of
+      accesses. This is why it constantly increases in size quadratically by
+      powers of 2.
 
 As one might be able to tell, Dictionaries specialize in tasks that Arrays
 do not. An overview of their operational details is as follows:


### PR DESCRIPTION
When initially writing this, I misread the source code, interpreting a bitwise operation to be applied in base 10 rather than base 2...cause I'm an idiot. Therefore, many people have been likely misinformed, believing Dictionary to be horribly inefficient as you create new instances of them. This is a gross mistake that should never have made it into the "best practices" documentation.
