### PR TITLE
Improve explanation about WAV and Ogg looping metadata

### DIFF
--- a/tutorials/audio/audio_streams.rst
+++ b/tutorials/audio/audio_streams.rst
@@ -29,8 +29,8 @@ your use case best:
   This format works well for music, long sound effect sequences, and voice
   at relatively low bitrates.
 
-Keep in mind that WAV files may contain looping information in its metadata, 
-while Ogg Vorbis files do not. If looping an Ogg Vorbis file is desired, 
+Keep in mind that while WAV files may contain looping information in its metadata, 
+Ogg Vorbis files do not. If looping an Ogg Vorbis file is desired, 
 it must be set up using the import options:
 
 .. image:: img/audio_stream_import.png

--- a/tutorials/audio/audio_streams.rst
+++ b/tutorials/audio/audio_streams.rst
@@ -29,7 +29,7 @@ your use case best:
   This format works well for music, long sound effect sequences, and voice
   at relatively low bitrates.
 
-Keep in mind that while WAV files may contain looping information in its metadata, 
+Keep in mind that while WAV files may contain looping information in their metadata,
 Ogg Vorbis files do not. If looping an Ogg Vorbis file is desired, 
 it must be set up using the import options:
 

--- a/tutorials/audio/audio_streams.rst
+++ b/tutorials/audio/audio_streams.rst
@@ -29,8 +29,9 @@ your use case best:
   This format works well for music, long sound effect sequences, and voice
   at relatively low bitrates.
 
-Keep in mind Ogg Vorbis files don't contain looping information. If looping an
-Ogg Vorbis file is desired, it must be set up using the import options:
+Keep in mind that WAV files may contain looping information in its metadata, 
+while Ogg Vorbis files do not. If looping an Ogg Vorbis file is desired, 
+it must be set up using the import options:
 
 .. image:: img/audio_stream_import.png
 


### PR DESCRIPTION
I had quite some headache with this, since the information that WAV may contain looping metadata isn't easily available on the internet. @akien-mga then informed me about this, resolving the issue. With this, may no other newbie download an audio sample from the internet and spend 2 hours struggling to understand why the hell it is looping, when they think it shouldn't.