### PR TITLE
Spelling Fix

### DIFF
--- a/getting_started/workflow/best_practices/scenes_versus_scripts.rst
+++ b/getting_started/workflow/best_practices/scenes_versus_scripts.rst
@@ -41,7 +41,7 @@ a change in API:
         public class Game : Node
         {
             public readonly Script MyNodeScr = (Script)ResourceLoader.Load("MyNode.cs");
-            public readonly PackedScene MySceneScn = (PackedScene)ResourceLoader.load("MyScene.tscn");
+            public readonly PackedScene MySceneScn = (PackedScene)ResourceLoader.Load("MyScene.tscn");
             public Node ANode;
             public Node MyNode;
             public Node MyScene;


### PR DESCRIPTION
In: Best Practices -> Scenes versus Scripts: Capitalize `Load` in Anonymous Types C# Code Example. Does not compile otherwise. 