### PR TITLE
Fix spelling in C# code sample in the Input examples tutorial

### DIFF
--- a/tutorials/inputs/input_examples.rst
+++ b/tutorials/inputs/input_examples.rst
@@ -194,7 +194,7 @@ the :kbd:`T`:
     {
         if (inputEvent is InputEventKey keyEvent && keyEvent.Pressed)
         {
-            if ((Keylist)keyEvent.Scancode == KeyList.T)
+            if ((KeyList)keyEvent.Scancode == KeyList.T)
             {
                 GD.Print("T was pressed");
             }


### PR DESCRIPTION
`(Keylist)keyEvent.Scancode` -> `(KeyList)...`

Project does not compile otherwise. 