### PR TITLE
Add warning about script syncing incompatibility with external editors

### DIFF
--- a/getting_started/editor/external_editor.rst
+++ b/getting_started/editor/external_editor.rst
@@ -5,8 +5,7 @@ Using an external text editor
 
 .. warning::
 
-    External editors are currently incompatible with Godot's "Sync Script Changes" feature.
-    https://github.com/godotengine/godot/issues/10946
+    `External editors are currently incompatible with Godot's "Sync Script Changes" feature. <https://github.com/godotengine/godot/issues/10946>`__
 
 Godot can be used with an external text editor, such as Sublime Text or Visual Studio Code.
 To enable an external text editor, browse to the relevant editor settings via:

--- a/getting_started/editor/external_editor.rst
+++ b/getting_started/editor/external_editor.rst
@@ -3,6 +3,11 @@
 Using an external text editor
 ==============================
 
+.. warning::
+
+    External editors are currently incompatible with Godot's "Sync Script Changes" feature.
+    https://github.com/godotengine/godot/issues/10946
+
 Godot can be used with an external text editor, such as Sublime Text or Visual Studio Code.
 To enable an external text editor, browse to the relevant editor settings via:
 ``Editor -> Editor Settings -> Text Editor -> External``


### PR DESCRIPTION
Add warning about script syncing incompatibility with external editors

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
