### PR TITLE
Update exporting_for_android.rst

### DIFF
--- a/getting_started/workflow/export/exporting_for_android.rst
+++ b/getting_started/workflow/export/exporting_for_android.rst
@@ -31,7 +31,7 @@ macOS, you can find it in the ``~/.android`` directory).
 If you can't find it or need to generate one, the keytool command from
 the JDK can be used for this purpose::
 
-    keytool -keyalg RSA -genkeypair -alias androiddebugkey -keypass android -keystore debug.keystore -storepass android -dname "CN=Android Debug,O=Android,C=US" -validity 9999
+    keytool -keyalg RSA -genkeypair -alias androiddebugkey -keypass android -keystore debug.keystore -storepass android -dname "CN=Android Debug,O=Android,C=US" -validity 9999 -deststoretype pkcs12
 
 This will create a ``debug.keystore`` file in your current directory. You should move it to a memorable location such as ``%USERPROFILE%\.android\``, because you will need its location in a later step. For more information on ``keytool`` usage, see `this Q&A article <https://godotengine.org/qa/21349/jdk-android-file-missing>`__.
 


### PR DESCRIPTION
I ran the original command and keytool printed:                                                                                                                                                         ```Warning: 
The JKS keystore uses a proprietary format. It is recommended to migrate to PKCS12 which is an industry standard format using "keytool -importkeystore -srckeystore debug.keystore -destkeystore debug.keystore -deststoretype pkcs12". ```

So I added the `-deststoretype pkcs12` to the command used for the generation. Maybe we should also add a note for old projects to migrate using that command printed by keytool. 

Also, there is a default directory Android/keystores when you install the SDK (tested only on Windows 10 but I think it is the same on Mac & Linux), so maybe we should propose that as the default location for the debug.keystore

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
