### PR TITLE
Removed unneeded code from resource_queue.gd

### DIFF
--- a/tutorials/io/files/resource_queue.gd
+++ b/tutorials/io/files/resource_queue.gd
@@ -81,8 +81,6 @@ func is_ready(path):
 func _wait_for_resource(res, path):
 	_unlock("wait_for_resource")
 	while true:
-		VisualServer.sync()
-		OS.delay_usec(16000) # Wait approximately 1 frame.
 		_lock("wait_for_resource")
 		if queue.size() == 0 || queue[0] != res:
 			return pending[path]


### PR DESCRIPTION
`VisualServer.sync()` is unimplemented in 3.2 at least according to the docs.

I'm not sure why we need the `OS.delay_usec` either.