### PR TITLE
Remove references for the now removed "Constants" section in the shad…

### DIFF
--- a/tutorials/shading/migrating_to_godot_shader_language.rst
+++ b/tutorials/shading/migrating_to_godot_shader_language.rst
@@ -127,7 +127,7 @@ Types
 ^^^^^
 
 Shadertoy uses the webgl spec, so it runs a slightly different version of GLSL. However, it still
-has the regular types, including `Constants`_ and macros.
+has the regular types, including constants and macros.
 
 mainImage
 ^^^^^^^^^
@@ -194,7 +194,7 @@ Types
 ^^^^^
 
 The Book of Shaders uses the webgl spec, so it runs a slightly different version of GLSL. However, it still
-has the regular types, including `Constants`_ and macros.
+has the regular types, including constants and macros.
 
 Main
 ^^^^


### PR DESCRIPTION
The "Constants" section was removed in #3747, but the references to it weren't.