### PR TITLE
Add clamp to custom light function example

### DIFF
--- a/tutorials/shading/shading_reference/spatial_shader.rst
+++ b/tutorials/shading/shading_reference/spatial_shader.rst
@@ -293,7 +293,7 @@ Below is an example of a custom light function using a Lambertian lighting model
 .. code-block:: glsl
 
     void light() {
-        DIFFUSE_LIGHT += clamp(dot(NORMAL, LIGHT), 0, 1) * ATTENUATION * ALBEDO;
+        DIFFUSE_LIGHT += clamp(dot(NORMAL, LIGHT), 0.0, 1.0) * ATTENUATION * ALBEDO;
     }
 
 If you want the lights to add together, add the light contribution to ``DIFFUSE_LIGHT`` using ``+=``, rather than overwriting it.

--- a/tutorials/shading/shading_reference/spatial_shader.rst
+++ b/tutorials/shading/shading_reference/spatial_shader.rst
@@ -293,7 +293,7 @@ Below is an example of a custom light function using a Lambertian lighting model
 .. code-block:: glsl
 
     void light() {
-        DIFFUSE_LIGHT += dot(NORMAL, LIGHT) * ATTENUATION * ALBEDO;
+        DIFFUSE_LIGHT += clamp(dot(NORMAL, LIGHT), 0, 1) * ATTENUATION * ALBEDO;
     }
 
 If you want the lights to add together, add the light contribution to ``DIFFUSE_LIGHT`` using ``+=``, rather than overwriting it.


### PR DESCRIPTION
Without this clamp, negative lighting will be applied to the back side of the object.
