### PR TITLE
Update enum usage in "Import plugins"

### DIFF
--- a/tutorials/plugins/editor/import_plugins.rst
+++ b/tutorials/plugins/editor/import_plugins.rst
@@ -178,7 +178,7 @@ good practice to use an enum so you can refer to them using names.
     tool
     extends EditorImportPlugin
 
-    enum Presets { PRESET_DEFAULT }
+    enum Presets { DEFAULT }
 
     ...
 
@@ -199,7 +199,7 @@ now, but we can make this method future-proof by returning the size of our
 
     func get_preset_name(preset):
         match preset:
-            PRESET_DEFAULT:
+            Presets.DEFAULT:
                 return "Default"
             _:
                 return "Unknown"
@@ -222,7 +222,7 @@ you do this you have to be careful when you add more presets.
 
     func get_import_options(preset):
         match preset:
-            PRESET_DEFAULT:
+            Presets.DEFAULT:
                 return [{
                            "name": "use_red_anyway",
                            "default_value": false


### PR DESCRIPTION
The examples using the `Presets` enum don't work as-is. The enum key must be referenced with the enum name prefixed. According to [GDScript basics](https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/gdscript_basics.html) this was changed in 3.1.