### PR TITLE
disable smartquotes

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -101,6 +101,8 @@ from sphinx.highlighting import lexers
 lexers["gdscript"] = GDScriptLexer()
 # fmt: on
 
+smartquotes = False
+
 # Pygments (syntax highlighting) style to use
 pygments_style = "sphinx"
 highlight_language = "gdscript"


### PR DESCRIPTION
Smartquotes will convert `"..."` to `“...”`, will cause unexpected result when we reference a string without using code block.

also in some languages (zh_TW for example), it will be converted to `「...」`, usually not a desired result.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
