### PR TITLE
Link to the Object class reference on the Object class page

### DIFF
--- a/development/cpp/object_class.rst
+++ b/development/cpp/object_class.rst
@@ -3,6 +3,11 @@
 Object class
 ============
 
+.. seealso::
+
+    This page describes the C++ implementation of objects in Godot.
+    Looking for the Object class reference? :ref:`Have a look here. <class_Object>`
+
 General definition
 ------------------
 


### PR DESCRIPTION
People who end up on this page from a search engine might be confusedas to where they can find the Object class reference.

See https://github.com/godotengine/godot-docs/issues/3772.