### PR TITLE
Fix missing semicolon in C# code sample in Exporting tutorial

### DIFF
--- a/getting_started/step_by_step/exporting.rst
+++ b/getting_started/step_by_step/exporting.rst
@@ -170,7 +170,7 @@ changed:
             // Move towards the target and stop when close.
             if (Position.DistanceTo(_target) > 10)
             {
-                velocity = _target - Position
+                velocity = _target - Position;
             }
 
             // Remove keyboard controls.


### PR DESCRIPTION
Player.cs code (c#) won't compile because of a missing simicolon.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
