### PR TITLE
Clarify that "them" refers to script classes.

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -138,7 +138,7 @@ custom behavior.
   Nodes added via an EditorPlugin are "CustomType" nodes. While they work
   with any scripting language, they have fewer features than
   :ref:`the Script Class system <doc_scripting_continued_class_name>`. If you
-  are writing GDScript or NativeScript, we recommend using them instead.
+  are writing GDScript or NativeScript, we recommend using Script Classes instead.
 
 To create a new node type, you can use the function
 :ref:`add_custom_type() <class_EditorPlugin_method_add_custom_type>` from the


### PR DESCRIPTION
I _think_ this block is recommending using script classes instead of Custom Types, but I had to read it a few times to determine whether "these" meant "Script Classes" or "Custom Tyes".

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
