### PR TITLE
Typo macos compiling

### DIFF
--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -63,7 +63,7 @@ editor binary built with ``target=release_debug``::
 
     cp -r misc/dist/osx_tools.app ./Godot.app
     mkdir -p Godot.app/Contents/MacOS
-    cp bin/godot.osx.tools.universal Godot.app/Contents/MacOS/Godot
+    cp bin/godot.osx.opt.tools.universal Godot.app/Contents/MacOS/Godot
     chmod +x Godot.app/Contents/MacOS/Godot
 
 If you are building the ``master`` branch, additionally copy the Vulkan library::


### PR DESCRIPTION
Not sure about the line 66 edit but since at line 48 the output is godot.osx.tools.universal I suppose we should also use it (at least in my case I needed to)