### PR TITLE
Update gdscript_exports.rst

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_exports.rst
+++ b/getting_started/scripting/gdscript/gdscript_exports.rst
@@ -165,11 +165,7 @@ If in doubt, use boolean variables instead.
 Exporting arrays
 ----------------
 
-Exporting arrays works, but with an important caveat: while regular
-arrays are created local to every class instance, exported arrays are *shared*
-between all instances. This means that editing them in one instance will
-cause them to change in all other instances. Exported arrays can have
-initializers, but they must be constant expressions.
+Exported arrays can have initializers, but they must be constant expressions.
 
 If the exported array specifies a type which inherits from Resource, the array
 values can be set in the inspector by dragging and dropping multiple files
@@ -177,7 +173,6 @@ from the FileSystem dock at once.
 
 ::
 
-    # Exported array, shared between all instances.
     # Default value must be a constant expression.
 
     export var a = [1, 2, 3]
@@ -204,7 +199,6 @@ from the FileSystem dock at once.
     export var vector3s = PackedVector3Array()
     export var strings = PackedStringArray()
 
-    # Regular array, created local for every instance.
     # Default value can include run-time values, but can't
     # be exported.
 


### PR DESCRIPTION
Testing on 3.2.2 reveals that Array sharing does not work as described. And I distinctly remember this not being a feature, but a bug. If the bug is still present in certain scenarios, it should not be advertised as a feature.

The only scenario in which an Array is _incorrectly_ shared. Is this:

`export var test = []`

and this:

`export(Array<, type>) var right: Array = []`

If an Array is exported as such. Empty and with no contents. And is then not assigned a value in the editor. Only then is the reference shared across instances. And only modifications of the array through code will reveal this. (This is a bug similar to how var a: Array, without = [] would create a broken "shared" array in  the past.)

Since the Docs policy is _not to document bugs_, I feel that a complete removal of any mention of shared arrays is in order.

I'm a bit angry right now because there is still so much misinformation spread about this.
