### PR TITLE
MoltenVK SDK for iOS

### DIFF
--- a/development/compiling/compiling_for_ios.rst
+++ b/development/compiling/compiling_for_ios.rst
@@ -12,6 +12,11 @@ Requirements
    to run ``scons`` in a terminal when installed).
 -  Xcode 10.0 (or later) with the iOS (10.0) SDK and the command line tools.
 
+If you are building the ``master`` branch:
+
+-  Download and follow README instructions to build a static ``.a`` library
+   from the `MoltenVK SDK <https://github.com/KhronosGroup/MoltenVK#fetching-moltenvk-source-code>`__.
+
 .. seealso:: For a general overview of SCons usage for Godot, see
              :ref:`doc_introduction_to_the_buildsystem`.
 


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
Updated iOS instructions to mention **MoltenVK**, that's required for exported iOS project to be compiled and run.

depends on: https://github.com/godotengine/godot/pull/40434

