### PR TITLE
Add notice for signing issues when exporting to iOS with same name

### DIFF
--- a/getting_started/workflow/export/exporting_for_ios.rst
+++ b/getting_started/workflow/export/exporting_for_ios.rst
@@ -63,6 +63,9 @@ In the following example:
   * **exported_xcode_project_name** is the name of the exported iOS application (as above).
   * **godot_project_to_export** is the name of the Godot project.
 
+.. note:: **godot_project_to_export** must not be the same as **exported_xcode_project_name**
+          to prevent signing issues in Xcode.
+
 Steps to link a Godot project folder to Xcode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Add notice to signing issues when exporting with active development considerations.
When using the same project name for Xcode as the Godot project folder Xcode fails to sign the project.

Fixes #3809 
