### PR TITLE
Change platform linuxbsd to x11

### DIFF
--- a/community/contributing/updating_the_class_reference.rst
+++ b/community/contributing/updating_the_class_reference.rst
@@ -128,7 +128,7 @@ When classes are modified in the source code, the documentation template might b
 
 ::
 
-    ./bin/godot.linuxbsd.tools.64 --doctool .
+    ./bin/godot.x11.tools.64 --doctool .
 
 The XML files in doc/classes should then be up-to-date with current Godot Engine features. You can then check what changed using the ``git diff`` command. If there are changes to other classes than the one you are planning to document, please commit those changes first before starting to edit the template:
 

--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -92,7 +92,7 @@ Start a terminal, go to the root dir of the engine source code and type:
 
 ::
 
-    scons -j8 platform=linuxbsd
+    scons -j8 platform=x11
 
 A good rule of thumb for the ``-j`` (*jobs*) flag, is to have at least as many
 threads compiling Godot as you have cores in your CPU, if not one or two more.
@@ -109,7 +109,7 @@ manager.
 
     ::
 
-        scons platform=linuxbsd use_llvm=yes
+        scons platform=x11 use_llvm=yes
 
     Using Clang appears to be a requirement for OpenBSD, otherwise fonts
     would not build.
@@ -159,15 +159,15 @@ following parameters:
 
 ::
 
-    scons platform=linuxbsd tools=no target=release bits=32
-    scons platform=linuxbsd tools=no target=release_debug bits=32
+    scons platform=x11 tools=no target=release bits=32
+    scons platform=x11 tools=no target=release_debug bits=32
 
 -  (64 bits)
 
 ::
 
-    scons platform=linuxbsd tools=no target=release bits=64
-    scons platform=linuxbsd tools=no target=release_debug bits=64
+    scons platform=x11 tools=no target=release bits=64
+    scons platform=x11 tools=no target=release_debug bits=64
 
 Note that cross-compiling for the opposite bits (64/32) as your host
 platform is not always straight-forward and might need a chroot environment.
@@ -210,7 +210,7 @@ the default GCC + GNU ld setup:
 To do so, install Clang and the ``lld`` package from your distribution's package manager
 then use the following SCons command::
 
-    scons platform=linuxbsd use_llvm=yes use_lld=yes
+    scons platform=x11 use_llvm=yes use_lld=yes
 
 It's still recommended to use GCC for production builds as they can be compiled using
 link-time optimization, making the resulting binaries smaller and faster.

--- a/development/compiling/compiling_with_mono.rst
+++ b/development/compiling/compiling_with_mono.rst
@@ -70,7 +70,7 @@ without having to repeat this process.
 ``<godot_binary>`` refers to the tools binary you compiled above with the Mono
 module enabled. Its exact name will differ based on your system and
 configuration, but should be of the form
-``bin/godot.<platform>.tools.<bits>.mono``, e.g. ``bin/godot.linuxbsd.tools.64.mono``
+``bin/godot.<platform>.tools.<bits>.mono``, e.g. ``bin/godot.x11.tools.64.mono``
 or ``bin/godot.windows.tools.64.mono.exe``. Be especially aware of the **.mono**
 suffix! If you've previously compiled Godot without Mono support, you might have
 similarly named binaries without this suffix. These binaries can't be used to
@@ -145,16 +145,16 @@ Example (Linux, \*BSD)
 ::
 
     # Build temporary binary
-    scons p=linuxbsd tools=yes module_mono_enabled=yes mono_glue=no
+    scons p=x11 tools=yes module_mono_enabled=yes mono_glue=no
     # Generate glue sources
-    bin/godot.linuxbsd.tools.64.mono --generate-mono-glue modules/mono/glue
+    bin/godot.x11.tools.64.mono --generate-mono-glue modules/mono/glue
 
     ### Build binaries normally
     # Editor
-    scons p=linuxbsd target=release_debug tools=yes module_mono_enabled=yes
+    scons p=x11 target=release_debug tools=yes module_mono_enabled=yes
     # Export templates
-    scons p=linuxbsd target=release_debug tools=no module_mono_enabled=yes
-    scons p=linuxbsd target=release tools=no module_mono_enabled=yes
+    scons p=x11 target=release_debug tools=no module_mono_enabled=yes
+    scons p=x11 target=release tools=no module_mono_enabled=yes
 
 .. _compiling_with_mono_data_directory:
 
@@ -173,7 +173,7 @@ Export templates
 
 The name of the data directory for an export template differs based on the
 configuration it was built with. The format is
-``data.mono.<platform>.<bits>.<target>``, e.g. ``data.mono.linuxbsd.32.release_debug`` or
+``data.mono.<platform>.<bits>.<target>``, e.g. ``data.mono.x11.32.release_debug`` or
 ``data.mono.windows.64.release``.
 
 This directory must be placed with its original name next to the Godot export

--- a/development/compiling/introduction_to_the_buildsystem.rst
+++ b/development/compiling/introduction_to_the_buildsystem.rst
@@ -68,29 +68,33 @@ To list the available target platforms, use ``scons platform=list``::
 
         android
         javascript
-        linuxbsd
+        x11
         server
         windows
 
     Please run SCons again and select a valid platform: platform=<string>
 
-To build for a platform (for example, ``linuxbsd``), run with the ``platform=``
+To build for a platform (for example, ``x11``), run with the ``platform=``
 (or ``p=`` to make it short) argument:
 
 ::
 
-    scons platform=linuxbsd
+    scons platform=x11
 
 This will start the build process, which will take a while. If you want
-SCons to build faster, use the ``-j <cores>`` parameter to specify how many
-cores will be used for the build. Or leave it using one core, so you
+SCons to build faster, use the ``-j <processes>`` parameter to specify how many
+processes that will be used for the build. Or leave it using one process, so you
 can use your computer for something else :)
 
-Example for using 4 cores:
+The number of parallel processes are usually set to the number of cores that
+your system has, or one or two more. For instance, on a quadcore system, four 
+to six parallel processes usually makes sense.
+
+Example for using 4 parallel processes:
 
 ::
 
-    scons platform=linuxbsd -j 4
+    scons platform=x11 -j 4
 
 Resulting binary
 ----------------
@@ -103,7 +107,7 @@ generally with this naming convention::
 For the previous build attempt, the result would look like this::
 
     ls bin
-    bin/godot.linuxbsd.tools.64
+    bin/godot.x11.tools.64
 
 This means that the binary is for Linux *or* \*BSD (*not* both), is not optimized, has tools (the
 whole editor) compiled in, and is meant for 64 bits.

--- a/development/cpp/configuring_an_ide/kdevelop.rst
+++ b/development/cpp/configuring_an_ide/kdevelop.rst
@@ -77,7 +77,7 @@ Debugging the project
 - Click **Add** to create a new launch configuration.
 - Select **Executable** option and specify the path to your executable located in 
   the ``<Godot root directory>/bin`` folder. The name depends on your build configuration,
-  e.g. ``godot.linuxbsd.tools.64`` for 64-bit LinuxBSD platform with ``tools`` enabled.
+  e.g. ``godot.x11.tools.64`` for 64-bit LinuxBSD platform with ``tools`` enabled.
 
 .. figure:: img/kdevelop_configlaunches2.png
    :figclass: figure-w480

--- a/development/cpp/configuring_an_ide/qt_creator.rst
+++ b/development/cpp/configuring_an_ide/qt_creator.rst
@@ -75,8 +75,8 @@ Debugging the project
 - From the left-side menu select **Projects** and open the **Run** tab.
 - Under **Executable** specify the path to your executable located in 
   the ``<Godot root directory>/bin`` folder. The name depends on your build configuration,
-  e.g. ``godot.linuxbsd.tools.64`` for 64-bit LinuxBSD platform with ``tools`` enabled.
-  You can use ``%{buildDir}`` to reference the project root, e.g: ``%{buildDir}/bin/godot.linuxbsd.opt.tools.64``.
+  e.g. ``godot.x11.tools.64`` for 64-bit LinuxBSD platform with ``tools`` enabled.
+  You can use ``%{buildDir}`` to reference the project root, e.g: ``%{buildDir}/bin/godot.x11.opt.tools.64``.
 - If you want to run a specific project, specify its root folder under **Working directory**.
 - If you want to run the editor, add ``-e`` to the **Command line arguments** field.
 

--- a/development/cpp/configuring_an_ide/visual_studio_code.rst
+++ b/development/cpp/configuring_an_ide/visual_studio_code.rst
@@ -38,7 +38,7 @@ Importing the project
     "command": "scons",
     "group": "build",
     "args": [
-      "platform=linuxbsd", // Change to your current platform
+      "platform=x11", // Change to your current platform
       "target=debug",
       "-j4"
     ],
@@ -76,7 +76,7 @@ To run and debug the project you need to create a new configuration in the ``lau
     "type": "cppdbg",
     "request": "launch",
     // Change the path below to match your current platform.
-    "program": "${workspaceFolder}/bin/godot.linuxbsd.tools.64",
+    "program": "${workspaceFolder}/bin/godot.x11.tools.64",
     // Change the arguments below for the project you want to test with.
     // To run the project instead of editing it, remove the "--editor" argument.
     "args": [ "--editor", "--path", "path-to-your-godot-project-folder" ],
@@ -102,7 +102,7 @@ To run and debug the project you need to create a new configuration in the ``lau
    An example of a filled out ``launch.json``.
 
 The name under ``program`` depends on your build configuration,
-e.g. ``godot.linuxbsd.tools.64`` for 64-bit LinuxBSD platform with ``tools`` enabled.
+e.g. ``godot.x11.tools.64`` for 64-bit LinuxBSD platform with ``tools`` enabled.
 
 If you run into any issues, ask for help in one of
 `Godot's community channels <https://godotengine.org/community>`__.

--- a/development/cpp/custom_modules_in_cpp.rst
+++ b/development/cpp/custom_modules_in_cpp.rst
@@ -439,7 +439,7 @@ library that will be dynamically loaded when starting our game's binary.
     env.Append(LIBPATH=['#bin'])
 
     # SCons wants the name of the library with it custom suffixes
-    # (e.g. ".linuxbsd.tools.64") but without the final ".so".
+    # (e.g. ".x11.tools.64") but without the final ".so".
     shared_lib_shim = shared_lib[0].name.rsplit('.', 1)[0]
     env.Append(LIBS=[shared_lib_shim])
 
@@ -497,7 +497,7 @@ shared module as target in the SCons command:
 
 .. code-block:: shell
 
-    scons summator_shared=yes platform=linuxbsd bin/libsummator.linuxbsd.tools.64.so
+    scons summator_shared=yes platform=x11 bin/libsummator.x11.tools.64.so
 
 Writing custom documentation
 ----------------------------


### PR DESCRIPTION
As the scons platforms (at least since 3.2.2-stable) has renamed linuxbsd to x11,
all references to the linuxbsd platform have been updated to x11. The platform
is still called LinuxBSD when mentioned as a name in the text, but all scons and
binary references have been changed.

Notice that I did *not* update the tutorials/plugins/gdnative files.