### PR TITLE
Update Discord server link in Community channels

### DIFF
--- a/community/channels.rst
+++ b/community/channels.rst
@@ -17,18 +17,18 @@ Q&A
 IRC on Freenode
 ---------------
 
-- `General: #godotengine <http://webchat.freenode.net/?channels=#godotengine>`_
-- `Engine development: #godotengine-devel <http://webchat.freenode.net/?channels=#godotengine-devel>`_
-- `Documentation: #godotengine-doc <http://webchat.freenode.net/?channels=#godotengine-doc>`_
-- `Pull request meetings: #godotengine-meeting <http://webchat.freenode.net/?channels=#godotengine-meeting>`_
-- `GDNative: #godotengine-gdnative <http://webchat.freenode.net/?channels=#godotengine-gdnative>`_
-- `Website and public relations: #godotengine-atelier <http://webchat.freenode.net/?channels=#godotengine-atelier>`_
+- `General: #godotengine <https://webchat.freenode.net/?channels=#godotengine>`_
+- `Engine development: #godotengine-devel <https://webchat.freenode.net/?channels=#godotengine-devel>`_
+- `Documentation: #godotengine-doc <https://webchat.freenode.net/?channels=#godotengine-doc>`_
+- `Pull request meetings: #godotengine-meeting <https://webchat.freenode.net/?channels=#godotengine-meeting>`_
+- `GDNative: #godotengine-gdnative <https://webchat.freenode.net/?channels=#godotengine-gdnative>`_
+- `Website and public relations: #godotengine-atelier <https://webchat.freenode.net/?channels=#godotengine-atelier>`_
 - `IRC logs <https://godot.eska.me/irc-logs/>`_
 
 Other chats
 -----------
 
-- `Discord Server <https://discordapp.com/invite/zH7NUgz>`_
+- `Discord <https://discord.gg/4JBkykG>`_
 - `Matrix (IRC compatible) <https://matrix.to/#/#godotengine:matrix.org>`_
 
 Language-based communities
@@ -45,7 +45,8 @@ Social networks
 
 - `GitHub <https://github.com/godotengine/>`_
 - `Facebook group <https://www.facebook.com/groups/godotengine/>`_
-- `Twitter (also, #godotengine) <https://twitter.com/godotengine>`_
+- `Twitter <https://twitter.com/godotengine>`_
+  (see also the `#GodotEngine <https://twitter.com/hashtag/GodotEngine>`_ hashtag)
 - `Reddit <https://www.reddit.com/r/godot>`_
 - `YouTube <https://www.youtube.com/c/GodotEngineOfficial>`_
 - `Steam <https://steamcommunity.com/app/404790>`_
@@ -53,4 +54,4 @@ Social networks
 Forum
 -----
 
-- `Forum (godotforums.org) <https://godotforums.org/>`_
+- `Godot Forums <https://godotforums.org/>`_


### PR DESCRIPTION
The Discord server link was taken from https://godotengine.org/community.

This also makes URLs use HTTPS when possible.