### PR TITLE
Add Collapse Support in Code Tabs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@
 sphinx==1.8.5  # pyup: <2.0.0
 sphinx_rtd_theme==0.4.3
 
-# Code tabs extension for GDScript/C#
-sphinx-tabs==1.1.13
+# Code tabs extension for GDScript/C# with collapse support
+https://github.com/HaSa1002/sphinx-tabs/releases/download/v1.1.13-collapse/sphinx-tabs-1.1.13-collapse.tar.gz
 
 # Full-page search UI for RTD: https://readthedocs-sphinx-search.readthedocs.io
 git+https://github.com/readthedocs/readthedocs-sphinx-search@faa85a9dabb71e53bb01832edc9a3be07d22bd5a


### PR DESCRIPTION
This adds support to collapse the code tabs.
![lightsOn](https://user-images.githubusercontent.com/14185889/88224795-ca8b9880-cc69-11ea-8574-76b80f426f48.gif)


For this PR I just updated the requirements.txt to my fork of the sphinx tabs plugin.
See https://github.com/hasa1002/sphinx-tabs/compare/v1.1.13...master#diff-18ebda7f97c7080dce090794fc519128 for changes.
I don't know if it would be better to include the plugin directly in the repository and make the changes there.

I am not sure if it would be better if just the the clicked item should collapse.