### PR TITLE
Fix C# link in List of features

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -282,7 +282,7 @@ Scripting
 - :ref:`Use threads <doc_using_multiple_threads>` to perform asynchronous actions
   or make use of multiple processor cores.
 
-:ref:`C#: <toc-learn-scripting-gdscript>`
+:ref:`C#: <toc-learn-scripting-C#>`
 
 - Packaged in a separate binary to keep file sizes and dependencies down.
 - Uses Mono 6.x.


### PR DESCRIPTION
Fixes a typo from #3775. This should also be cherry-picked to the `3.2` branch.