### PR TITLE
Update android_custom_build.rst

### DIFF
--- a/getting_started/workflow/export/android_custom_build.rst
+++ b/getting_started/workflow/export/android_custom_build.rst
@@ -84,17 +84,15 @@ an empty directory). On Windows, the following path is usually good enough:
     If you already have an android-sdk folder, normally located in ``%LOCALAPPDATA%\Android\Sdk``, 
     then use this folder instead of creating an empty ``android-sdk`` folder. 
 
-Unzip the Android SDK ZIP file into the ``android-sdk`` folder. This folder should 
-now contain the unzipped folder called ``tools``. Rename ``tools`` to ``latest``. 
-Finally, create an empty folder named ``cmdline-tools`` and place ``latest`` into it. 
+Unzip the Android SDK ZIP file into ``andriod-sdk`` folder. This folder should
+now contain the unzipped folder called ``tools``.
 Your final directory structure should look like this :
 
 .. code-block:: none
 
   android-sdk/
-  android-sdk/cmdline-tools/
-  android-sdk/cmdline-tools/latest
-  android-sdk/cmdline-tools/latest/allTheOtherFiles
+  android-sdk/tools/
+  android-sdk/tools/allTheOtherFiles
   
 We need to setup the directory structure this way for the sdkmanager (inside the bin folder) to work.
 


### PR DESCRIPTION
changed folder name into tools because tools has to be in folder "android-sdk/tools" for Godot to recognize the custom build path in the editor settings or else it gives error "-Invalid Android SDK path for custom build in Editor Setting" ...

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
