### PR TITLE
Update VS Code debugging setup instructions

### DIFF
--- a/getting_started/scripting/c_sharp/c_sharp_basics.rst
+++ b/getting_started/scripting/c_sharp/c_sharp_basics.rst
@@ -293,15 +293,7 @@ Configuring VS 2019 for debugging
 Configuring Visual Studio Code for debugging
 --------------------------------------------
 
-To configure Visual Studio Code for debugging open up a project in Godot. Click on Project
-and open the project settings. Scroll down and click on Debugger Agent under the Mono
-category. Then turn on the setting "wait for debugger." Next, copy the port number
-and open up Visual Studio Code.
-
-You need to download the Mono Debug extension from Microsoft. Then open the Godot
-project folder. Go to the run tab and click on create a launch.json file. Select C#
-Mono from the dropdown menu. When the launch.json file is automatically opened,
-change the port number to the number you copied previously and save the file. On the
-run tab, switch the run setting from launch to attach. Whenever you want to debug,
-make sure Wait for Debugger is turned on in Godot, run the project, and run the
-debugger in Visual Studio Code.
+To configure debugging, open Visual Studio Code and download the Mono Debug extension from
+Microsoft and the Godot extension by Ignacio. Then open the Godot project folder in VS Code.
+Go to the Run tab and click on **create a launch.json file**. Select **C# Godot** from the dropdown
+menu. Now, when you start the debugger in VS Code your Godot project will run.


### PR DESCRIPTION
Updates the instructions for setting up C# debugging with VSCode. The instructions go over using the new C# extension by Ignacio instead of just the Mono extension.

Copying the port number is no longer needed with the new extension. And it's assuming people will be debugging with the "Play in Editor" setting instead of attach so there's less to do for setup.