### PR TITLE
Fix GUI Skinning typo in code

### DIFF
--- a/tutorials/gui/gui_skinning.rst
+++ b/tutorials/gui/gui_skinning.rst
@@ -79,7 +79,7 @@ An example usage:
  .. code-tab:: gdscript GDScript
 
     var theme = Theme.new()
-    ttheme.set_color("font_color", "Label", Color.red)
+    theme.set_color("font_color", "Label", Color.red)
 
     var label = Label.new()
     label.theme = theme


### PR DESCRIPTION
Fixes `ttheme` to `theme`
introduced in #3825
I oversaw it while doing the changes...