### PR TITLE
Corrected TextEdit reference in Optimizing a build for size

### DIFF
--- a/development/compiling/optimizing_for_size.rst
+++ b/development/compiling/optimizing_for_size.rst
@@ -41,7 +41,7 @@ Disabling advanced GUI nodes
 ----------------------------
 
 Most small games don't require complex GUI controls such as Tree, ItemList,
-TextEditor or GraphEdit. They can be disabled using a build flag:
+TextEdit or GraphEdit. They can be disabled using a build flag:
 
 ::
 


### PR DESCRIPTION
Optimizing Builds For Size referenced a node type called TextEditor when talking about advanced GUI nodes when it most likely means the TextEdit node instead.
