### PR TITLE
Specify more options to `python -m http.server` to avoid errors

### DIFF
--- a/getting_started/workflow/export/exporting_for_web.rst
+++ b/getting_started/workflow/export/exporting_for_web.rst
@@ -17,7 +17,7 @@ in the user's browser.
                ``file://`` protocol. To get around this, use a local server.
 
                .. tip:: Python offers an easy method to start a local server.
-                        Use ``python -m http.server`` with Python 3 to serve the
+                        Use ``python -m http.server 8000 --bind 127.0.0.1`` with Python 3 to serve the
                         current working directory at ``http://localhost:8000``.
 
 .. attention:: `There are significant bugs when running HTML5 projects on iOS <https://github.com/godotengine/godot/issues/26554>`__


### PR DESCRIPTION
better use python -m http.server 8000 --bind 127.0.0.1 to avoid UnicodeDecodeError

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
