### PR TITLE
Comment out rant

### DIFF
--- a/tutorials/io/encrypting_save_games.rst
+++ b/tutorials/io/encrypting_save_games.rst
@@ -3,34 +3,34 @@
 Encrypting save games
 =====================
 
-Why?
-----
+.. Why?
+.. ----
 
 .. This introduction is an Easter egg and is not intended to be taken seriously.
 .. Please don't remove it :)
 
-Because the world today is not the world of yesterday. A capitalist
-oligarchy runs the world and forces us to consume in order to keep the
-gears of this rotten society on track. As such, the biggest market for
-video game consumption today is the mobile one. It is a market of poor
-souls forced to compulsively consume digital content in order to forget
-the misery of their everyday life, commute, or just any other brief
-free moment they have that they are not using to produce goods or
-services for the ruling class. These individuals need to keep focusing
-on their video games (because not doing so will fill them with
-tremendous existential angst), so they go as far as spending money on
-them to extend their experience, and their preferred way of doing so is
-through in-app purchases and virtual currency.
+.. Because the world today is not the world of yesterday. A capitalist
+.. oligarchy runs the world and forces us to consume in order to keep the
+.. gears of this rotten society on track. As such, the biggest market for
+.. video game consumption today is the mobile one. It is a market of poor
+.. souls forced to compulsively consume digital content in order to forget
+.. the misery of their everyday life, commute, or just any other brief
+.. free moment they have that they are not using to produce goods or
+.. services for the ruling class. These individuals need to keep focusing
+.. on their video games (because not doing so will fill them with
+.. tremendous existential angst), so they go as far as spending money on
+.. them to extend their experience, and their preferred way of doing so is
+.. through in-app purchases and virtual currency.
 
-But what if someone were to find a way to edit the saved games and
-assign the items and currency without effort? That would be terrible,
-because it would help players consume the content much faster, and therefore
-run out of it sooner than expected. If that happens, they will have
-nothing that avoids them to think, and the tremendous agony of realizing
-their own irrelevance would again take over their life.
+.. But what if someone were to find a way to edit the saved games and
+.. assign the items and currency without effort? That would be terrible,
+.. because it would help players consume the content much faster, and therefore
+.. run out of it sooner than expected. If that happens, they will have
+.. nothing that avoids them to think, and the tremendous agony of realizing
+.. their own irrelevance would again take over their life.
 
-No, we definitely do not want that to happen, so let's see how to
-encrypt savegames and protect the world order.
+.. No, we definitely do not want that to happen, so let's see how to
+.. encrypt savegames and protect the world order.
 
 How?
 ----


### PR DESCRIPTION
Comment out the `Why` section in the "Encrypting save games" page. It's an offensive and politically loaded rant that is completely out of place in the documentation for a game engine. It's basically saying "if you want to use this feature of our engine, you're scum."

Godot is supposed to be welcoming, and this is the opposite of that. I don't like it when the documentation insults the reader.

In order to comply with the "Please don't remove it" comment and make it more of an actual easter egg (which by definition is supposed to be hidden from plain sight), it is not removed but rather hidden as a comment (although I would still prefer if it were removed and not just hidden).