### PR TITLE
Message label is not hidden after pressing start button

### DIFF
--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -1139,6 +1139,7 @@ functions:
 
     func _on_StartButton_pressed():
         $StartButton.hide()
+        $Message.hide()
         emit_signal("start_game")
 
     func _on_MessageTimer_timeout():


### PR DESCRIPTION
I'm following the first game guide, but isn't hiding the Text label after pressing the Start button.
Before the change:
<img width="512" alt="Screen Shot 2020-08-02 at 10 25 54 PM" src="https://user-images.githubusercontent.com/475834/89121055-b5d3be00-d50f-11ea-926c-efe115ced333.png">
After the change:
<img width="478" alt="Screen Shot 2020-08-02 at 10 26 30 PM" src="https://user-images.githubusercontent.com/475834/89121057-b8ceae80-d50f-11ea-85a0-6ddff28d2946.png">

