### PR TITLE
Split gdscript intro into two pages

### DIFF
--- a/community/contributing/documentation_guidelines.rst
+++ b/community/contributing/documentation_guidelines.rst
@@ -87,7 +87,8 @@ respect the following rules (and the ones on the repo).
 Titles
 ------
 
-Always begin pages with their title and a Sphinx reference name:
+Always begin pages with their title and a Sphinx reference name. The Godot
+convention is to prefix Sphinx reference names with "_doc":
 
 ::
 

--- a/getting_started/scripting/gdscript/gdscript_basics.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics.rst
@@ -325,7 +325,7 @@ of characters for example). While you can create your own data types to
 describe your data, Godot has a set of built-in types as described 
 below for you to useful.
 
-Advanced note : Built-in types are stack-allocated. They are passed as values. 
+*Advanced note:* Built-in types are stack-allocated. They are passed as values. 
 This means a copy is created on each assignment or when passing them as 
 arguments to functions. The only exceptions are ``Arrays`` and 
 ``Dictionaries``, which are passed by reference so they are shared. (Pooled 

--- a/getting_started/scripting/gdscript/gdscript_basics.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics.rst
@@ -114,7 +114,7 @@ read this tutorial: :ref:`doc_gdscript_more_efficiently`.
 Language
 --------
 
-In the following, an overview is given to GDScript. Details, such as which
+Below is an overview of GDScript. Details such as which
 methods are available to arrays or other objects, should be looked up in
 the linked class descriptions.
 
@@ -140,63 +140,69 @@ in case you want to take a look under the hood.
 +------------+---------------------------------------------------------------------------------------------------------------+
 |  Keyword   | Description                                                                                                   |
 +============+===============================================================================================================+
-| if         | See `if/else/elif`_.                                                                                          |
+| if         | See :ref:`if/else/elif <doc_gdscript_if_else_elif>`.                                                          |
 +------------+---------------------------------------------------------------------------------------------------------------+
-| elif       | See `if/else/elif`_.                                                                                          |
+| elif       | See :ref:`if/else/elif <doc_gdscript_if_else_elif>`.                                                          |
 +------------+---------------------------------------------------------------------------------------------------------------+
-| else       | See `if/else/elif`_.                                                                                          |
+| else       | See :ref:`if/else/elif <doc_gdscript_if_else_elif>`.                                                          |
 +------------+---------------------------------------------------------------------------------------------------------------+
-| for        | See for_.                                                                                                     |
+| for        | See :ref:`for <doc_gdscript_for>`.                                                                            |
 +------------+---------------------------------------------------------------------------------------------------------------+
-| while      | See while_.                                                                                                   |
+| while      | See :ref:`while <doc_gdscript_while>`.                                                                        |
 +------------+---------------------------------------------------------------------------------------------------------------+
-| match      | See match_.                                                                                                   |
+| match      | See :ref:`match <doc_gdscript_match>`.                                                                        |
 +------------+---------------------------------------------------------------------------------------------------------------+
 | break      | Exits the execution of the current ``for`` or ``while`` loop.                                                 |
 +------------+---------------------------------------------------------------------------------------------------------------+
 | continue   | Immediately skips to the next iteration of the ``for`` or ``while`` loop.                                     |
 +------------+---------------------------------------------------------------------------------------------------------------+
 | pass       | Used where a statement is required syntactically but execution of code is undesired, e.g. in empty functions. |
+|            | See :ref:`functions <doc_gdscript_functions>`.                                                                |
 +------------+---------------------------------------------------------------------------------------------------------------+
-| return     | Returns a value from a function.                                                                              |
+| func       | Defines a function. See :ref:`functions <doc_gdscript_functions>`.                                            |
 +------------+---------------------------------------------------------------------------------------------------------------+
-| class      | Defines a class.                                                                                              |
+| return     | Returns a value from a function. See :ref:`functions <doc_gdscript_functions>`.                               |
 +------------+---------------------------------------------------------------------------------------------------------------+
-| extends    | Defines what class to extend with the current class.                                                          |
+| class      | Defines a class. A class is a template for creating objects relevant to your program. See                     |
+|            | :ref:`Classes <doc_gdscript_classes>`.                                                                        |
++------------+---------------------------------------------------------------------------------------------------------------+
+| extends    | Defines the class to extend with the current class. See :ref:`Classes <doc_gdscript_classes>`.                |
 +------------+---------------------------------------------------------------------------------------------------------------+
 | is         | Tests whether a variable extends a given class, or is of a given built-in type.                               |
 +------------+---------------------------------------------------------------------------------------------------------------+
-| as         | Cast the value to a given type if possible.                                                                   |
+| as         | Cast the value to a given type if possible. See :ref:`Casting <doc_gdscript_casting>`.                        |
 +------------+---------------------------------------------------------------------------------------------------------------+
 | self       | Refers to current class instance.                                                                             |
 +------------+---------------------------------------------------------------------------------------------------------------+
-| tool       | Executes the script in the editor.                                                                            |
+| tool       | Executes the script in the editor. See :ref:`Tool mode <doc_gdscript_tool_mode>`.                             |
 +------------+---------------------------------------------------------------------------------------------------------------+
-| signal     | Defines a signal.                                                                                             |
+| signal     | Defines a signal. See :ref:`doc_gdscript_signals`.                                                            |
 +------------+---------------------------------------------------------------------------------------------------------------+
-| func       | Defines a function.                                                                                           |
+| static     | Defines a static function. Static member variables are not allowed. See                                       |
+|            | :ref:`Static functions <doc_gdscript_static_functions>`.                                                      |
 +------------+---------------------------------------------------------------------------------------------------------------+
-| static     | Defines a static function. Static member variables are not allowed.                                           |
+| const      | Defines a constant. See :ref:`functions <doc_gdscript_constants>`.                                            |
 +------------+---------------------------------------------------------------------------------------------------------------+
-| const      | Defines a constant.                                                                                           |
+| enum       | Defines an enum. See :ref:`enums <doc_gdscript_enums>`.                                                       |
 +------------+---------------------------------------------------------------------------------------------------------------+
-| enum       | Defines an enum.                                                                                              |
-+------------+---------------------------------------------------------------------------------------------------------------+
-| var        | Defines a variable.                                                                                           |
+| var        | Defines a variable. See :ref:`variables <doc_gdscript_variables>`.                                            |
 +------------+---------------------------------------------------------------------------------------------------------------+
 | onready    | Initializes a variable once the Node the script is attached to and its children are part of the scene tree.   |
+|            | See :ref:`Onready <doc_gdscript_onready>`.                                                                    |
 +------------+---------------------------------------------------------------------------------------------------------------+
 | export     | Saves a variable along with the resource it's attached to and makes it visible and modifiable in the editor.  |
+|            | See :ref:`Exports <doc_gdscript_exports>`.                                                                    |
 +------------+---------------------------------------------------------------------------------------------------------------+
-| setget     | Defines setter and getter functions for a variable.                                                           |
+| setget     | Defines setter and getter functions for a variable. See :ref:`Setters/getters <doc_gdscript_setters_getters>`.|
 +------------+---------------------------------------------------------------------------------------------------------------+
 | breakpoint | Editor helper for debugger breakpoints.                                                                       |
 +------------+---------------------------------------------------------------------------------------------------------------+
-| preload    | Preloads a class or variable. See `Classes as resources`_.                                                    |
+| preload    | Preloads a class or variable. See :ref:`Classes as resources <doc_gdscript_classes_as_resources>`.            |
 +------------+---------------------------------------------------------------------------------------------------------------+
-| yield      | Coroutine support. See `Coroutines with yield`_.                                                              |
+| yield      | Coroutine support. See :ref:`Coroutines with yield <doc_gdscript_yield>`.                                     |
 +------------+---------------------------------------------------------------------------------------------------------------+
-| assert     | Asserts a condition, logs error on failure. Ignored in non-debug builds. See `Assert keyword`_.               |
+| assert     | Asserts a condition, logs error on failure. Ignored in non-debug builds.                                      |
+|            | See :ref:`Assert <doc_gdscript_assert>`.                                                                      |
 +------------+---------------------------------------------------------------------------------------------------------------+
 | remote     | Networking RPC annotation. See :ref:`high-level multiplayer docs <doc_high_level_multiplayer>`.               |
 +------------+---------------------------------------------------------------------------------------------------------------+
@@ -307,18 +313,23 @@ considered a comment.
 
 ::
 
-    # This is a comment.
+    # This is a comment and will be ignored.
 
 .. _doc_gdscript_builtin_types:
 
 Built-in types
 --------------
 
-Built-in types are stack-allocated. They are passed as values. This means a copy
-is created on each assignment or when passing them as arguments to functions.
-The only exceptions are ``Array``\ s and ``Dictionaries``, which are passed by
-reference so they are shared. (Pooled arrays such as ``PackedByteArray`` are still
-passed as values.)
+Data you create in Godot will be of a certain type (a whole number or a string
+of characters for example). While you can create your own data types to 
+describe your data, Godot has a set of built-in types as described 
+below for you to useful.
+
+Advanced note : Built-in types are stack-allocated. They are passed as values. 
+This means a copy is created on each assignment or when passing them as 
+arguments to functions. The only exceptions are ``Array``\ s and 
+``Dictionaries``, which are passed by reference so they are shared. (Pooled 
+arrays such as ``PackedByteArray`` are still passed as values.)
 
 Basic built-in types
 ~~~~~~~~~~~~~~~~~~~~
@@ -481,7 +492,7 @@ Negative indices count from the end.
 ::
 
     var arr = []
-    arr = [1, 2, 3]
+    arr = [1, 2, 3] # arr now contains 3 separate values - 1, 2 and 3.
     var b = arr[1] # This is 2.
     var c = arr[arr.size() - 1] # This is 3.
     var d = arr[-1] # Same as the previous line, but shorter.
@@ -560,9 +571,13 @@ assign to it::
 Data
 ----
 
+.. _doc_gdscript_variables:
+
 Variables
 ~~~~~~~~~
 
+A variable is some data that is stored with an associated label. For example
+you could store a variable "fruit" which contained the contents "apple".
 Variables can exist as class members or local to functions. They are
 created with the ``var`` keyword and may, optionally, be assigned a
 value upon initialization.
@@ -602,6 +617,8 @@ Valid types are:
 - Constant names if they contain a script resource (``MyScript`` if you declared ``const MyScript = preload("res://my_script.gd")``).
 - Other classes in the same script, respecting scope (``InnerClass.NestedClass`` if you declared ``class NestedClass`` inside the ``class InnerClass`` in the same scope).
 - Script classes declared with the ``class_name`` keyword.
+
+.. _doc_gdscript_casting:
 
 Casting
 ^^^^^^^
@@ -643,11 +660,13 @@ the scene tree::
     # Will fail if $AnimPlayer is not an AnimationPlayer, even if it has the method 'play()'.
     ($AnimPlayer as AnimationPlayer).play("walk")
 
+.. _doc_gdscript_constants:
+
 Constants
 ~~~~~~~~~
 
-Constants are similar to variables, but must be constants or constant
-expressions and must be assigned on initialization.
+Constants are similar to variables, but must be a fixed value or constant
+expression, and must be assigned on initialization.
 
 ::
 
@@ -657,11 +676,11 @@ expressions and must be assigned on initialization.
     const D = Vector2(20, 30).x # Constant expression: 20.
     const E = [1, 2, 3, 4][0] # Constant expression: 1.
     const F = sin(20) # 'sin()' can be used in constant expressions.
-    const G = x + 20 # Invalid; this is not a constant expression!
+    const G = x + 20 # Invalid; this is not a constant expression as 'x' is not defined!
     const H = A + 20 # Constant expression: 25 (`A` is a constant).
 
-Although the type of constants is inferred from the assigned value, it's also
-possible to add explicit type specification::
+Although the type of constant is inferred from the assigned value, it's also
+possible to add an explicit type specification::
 
     const A: int = 5
     const B: Vector2 = Vector2()
@@ -673,6 +692,8 @@ Assigning a value of an incompatible type will raise an error.
     Since arrays and dictionaries are passed by reference, constants are "flat".
     This means that if you declare a constant array or dictionary, it can still
     be modified afterwards. They can't be reassigned with another value though.
+
+.. _doc_gdscript_enums:
 
 Enums
 ^^^^^
@@ -701,11 +722,16 @@ dictionary of that name.
     const State = {STATE_IDLE = 0, STATE_JUMP = 5, STATE_SHOOT = 6}
     # Access values with State.STATE_IDLE, etc.
 
+.. _doc_gdscript_functions:
 
 Functions
 ~~~~~~~~~
 
-Functions always belong to a `class <Classes_>`_. The scope priority for
+A function is a block of code that performs a particular task. Separating code
+into functions makes it more readable and allows for common code to be reused
+rather than rewritten every time it is needed.
+
+Functions always belong to a `class <doc_gdscript_classes>`_. The scope priority for
 variable look-up is: local → class member → global. The ``self`` variable is
 always available and is provided as an option for accessing class members, but
 is not always required (and should *not* be sent as the function's first
@@ -753,16 +779,18 @@ return early with the ``return`` keyword, but they can't return any value.
           error because if the block is not executed, the function won't have a
           valid value to return.
 
+TALK ABOUT PASS
+
 Referencing functions
 ^^^^^^^^^^^^^^^^^^^^^
 
 Contrary to Python, functions are *not* first-class objects in GDScript. This
 means they cannot be stored in variables, passed as an argument to another
-function or be returned from other functions. This is for performance reasons.
+function, or be returned from other functions. This is for performance reasons.
 
-To reference a function by name at run-time, (e.g. to store it in a variable, or
-pass it to another function as an argument) one must use the ``call`` or
-``funcref`` helpers::
+To reference a function by name at run-time, (e.g. to store it in a variable, 
+or pass it to another function as an argument)  the ``call`` or ``funcref`` 
+helpers are required::
 
     # Call a function by name in one step.
     my_node.call("my_function", args)
@@ -772,6 +800,7 @@ pass it to another function as an argument) one must use the ``call`` or
     # Call stored function reference.
     my_func.call_func(args)
 
+.. _doc_gdscript_static_functions:
 
 Static functions
 ^^^^^^^^^^^^^^^^
@@ -790,6 +819,8 @@ Statements and control flow
 Statements are standard and can be assignments, function calls, control
 flow structures, etc (see below). ``;`` as a statement separator is
 entirely optional.
+
+.. _doc_gdscript_if_else_elif:
 
 if/else/elif
 ^^^^^^^^^^^^
@@ -821,6 +852,8 @@ boolean expression. In this case, ternary-if expressions come in handy::
     var x = [value] if [expression] else [value]
     y += 3 if y < 10 else -1
 
+.. _doc_gdscript_while:
+
 while
 ^^^^^
 
@@ -831,6 +864,8 @@ using ``break`` or continued using ``continue``:
 
     while [expression]:
         statement(s)
+
+.. _doc_gdscript_for:
 
 for
 ^^^
@@ -866,6 +901,8 @@ in the loop variable.
 
     for i in 2.2:
         statement # Similar to range(ceil(2.2))
+
+.. _doc_gdscript_match:
 
 match
 ^^^^^
@@ -1010,643 +1047,3 @@ There are 6 pattern types:
             "Sword", "Splash potion", "Fist":
                 print("Yep, you've taken damage")
 
-
-
-Classes
-~~~~~~~
-
-By default, all script files are unnamed classes. In this case, you can only
-reference them using the file's path, using either a relative or an absolute
-path. For example, if you name a script file ``character.gd``::
-
-   # Inherit from 'Character.gd'.
-
-   extends "res://path/to/character.gd"
-
-   # Load character.gd and create a new node instance from it.
-
-   var Character = load("res://path/to/character.gd")
-   var character_node = Character.new()
-
-Instead, you can give your class a name to register it as a new type in Godot's
-editor. For that, you use the ``class_name`` keyword. You can add an
-optional comma followed by a path to an image, to use it as an icon. Your class
-will then appear with its new icon in the editor::
-
-   # Item.gd
-
-   extends Node
-   class_name Item, "res://interface/icons/item.png"
-
-.. image:: img/class_name_editor_register_example.png
-
-Here's a class file example:
-
-::
-
-    # Saved as a file named 'character.gd'.
-
-    class_name Character
-
-
-    var health = 5
-
-
-    func print_health():
-        print(health)
-
-
-    func print_this_script_three_times():
-        print(get_script())
-        print(ResourceLoader.load("res://character.gd"))
-        print(Character)
-
-
-.. note:: Godot's class syntax is compact: it can only contain member variables or
-          functions. You can use static functions, but not static member variables. In the
-          same way, the engine initializes variables every time you create an instance,
-          and this includes arrays and dictionaries. This is in the spirit of thread
-          safety, since scripts can be initialized in separate threads without the user
-          knowing.
-
-Inheritance
-^^^^^^^^^^^
-
-A class (stored as a file) can inherit from:
-
-- A global class.
-- Another class file.
-- An inner class inside another class file.
-
-Multiple inheritance is not allowed.
-
-Inheritance uses the ``extends`` keyword::
-
-    # Inherit/extend a globally available class.
-    extends SomeClass
-
-    # Inherit/extend a named class file.
-    extends "somefile.gd"
-
-    # Inherit/extend an inner class in another file.
-    extends "somefile.gd".SomeInnerClass
-
-
-To check if a given instance inherits from a given class,
-the ``is`` keyword can be used::
-
-    # Cache the enemy class.
-    const Enemy = preload("enemy.gd")
-
-    # [...]
-
-    # Use 'is' to check inheritance.
-    if entity is Enemy:
-        entity.apply_damage()
-
-To call a function in a *parent class* (i.e. one ``extend``-ed in your current
-class), prepend ``.`` to the function name::
-
-    .base_func(args)
-
-This is especially useful because functions in extending classes replace
-functions with the same name in their parent classes. If you still want to
-call them, you can prefix them with ``.`` (like the ``super`` keyword
-in other languages)::
-
-    func some_func(x):
-        .some_func(x) # Calls the same function on the parent class.
-
-.. note:: Default functions like  ``_init``, and most notifications such as
-          ``_enter_tree``, ``_exit_tree``, ``_process``, ``_physics_process``,
-          etc. are called in all parent classes automatically.
-          There is no need to call them explicitly when overloading them.
-
-
-Class Constructor
-^^^^^^^^^^^^^^^^^
-
-The class constructor, called on class instantiation, is named ``_init``. As
-mentioned earlier, the constructors of parent classes are called automatically
-when inheriting a class. So, there is usually no need to call ``._init()``
-explicitly.
-
-Unlike the call of a regular function, like in the above example with
-``.some_func``, if the constructor from the inherited class takes arguments,
-they are passed like this::
-
-    func _init(args).(parent_args):
-       pass
-
-This is better explained through examples. Consider this scenario::
-
-    # State.gd (inherited class)
-    var entity = null
-    var message = null
-
-
-    func _init(e=null):
-        entity = e
-
-
-    func enter(m):
-        message = m
-
-
-    # Idle.gd (inheriting class)
-    extends "State.gd"
-
-
-    func _init(e=null, m=null).(e):
-        # Do something with 'e'.
-        message = m
-
-There are a few things to keep in mind here:
-
-1. If the inherited class (``State.gd``) defines a ``_init`` constructor that takes
-   arguments (``e`` in this case), then the inheriting class (``Idle.gd``) *must*
-   define ``_init`` as well and pass appropriate parameters to ``_init`` from ``State.gd``.
-2. ``Idle.gd`` can have a different number of arguments than the parent class ``State.gd``.
-3. In the example above, ``e`` passed to the ``State.gd`` constructor is the same ``e`` passed
-   in to ``Idle.gd``.
-4. If ``Idle.gd``'s ``_init`` constructor takes 0 arguments, it still needs to pass some value
-   to the ``State.gd`` parent class, even if it does nothing. This brings us to the fact that you
-   can pass literals in the base constructor as well, not just variables. eg.::
-
-    # Idle.gd
-
-    func _init().(5):
-        pass
-
-Inner classes
-^^^^^^^^^^^^^
-
-A class file can contain inner classes. Inner classes are defined using the
-``class`` keyword. They are instanced using the ``ClassName.new()``
-function.
-
-::
-
-    # Inside a class file.
-
-    # An inner class in this class file.
-    class SomeInnerClass:
-        var a = 5
-
-
-        func print_value_of_a():
-            print(a)
-
-
-    # This is the constructor of the class file's main class.
-    func _init():
-        var c = SomeInnerClass.new()
-        c.print_value_of_a()
-
-.. _doc_gdscript_classes_as_resources:
-
-Classes as resources
-^^^^^^^^^^^^^^^^^^^^
-
-Classes stored as files are treated as :ref:`resources <class_GDScript>`. They
-must be loaded from disk to access them in other classes. This is done using
-either the ``load`` or ``preload`` functions (see below). Instancing of a loaded
-class resource is done by calling the ``new`` function on the class object::
-
-    # Load the class resource when calling load().
-    var my_class = load("myclass.gd")
-
-    # Preload the class only once at compile time.
-    const MyClass = preload("myclass.gd")
-
-
-    func _init():
-        var a = MyClass.new()
-        a.some_function()
-
-Exports
-~~~~~~~
-
-.. note::
-
-    Documentation about exports has been moved to :ref:`doc_gdscript_exports`.
-
-Setters/getters
-~~~~~~~~~~~~~~~
-
-It is often useful to know when a class' member variable changes for
-whatever reason. It may also be desired to encapsulate its access in some way.
-
-For this, GDScript provides a *setter/getter* syntax using the ``setget`` keyword.
-It is used directly after a variable definition:
-
-::
-
-    var variable = value setget setterfunc, getterfunc
-
-Whenever the value of ``variable`` is modified by an *external* source
-(i.e. not from local usage in the class), the *setter* function (``setterfunc`` above)
-will be called. This happens *before* the value is changed. The *setter* must decide what to do
-with the new value. Vice versa, when ``variable`` is accessed, the *getter* function
-(``getterfunc`` above) must ``return`` the desired value. Below is an example::
-
-    var my_var setget my_var_set, my_var_get
-
-
-    func my_var_set(new_value):
-        my_var = new_value
-
-
-    func my_var_get():
-        return my_var # Getter must return a value.
-
-Either of the *setter* or *getter* functions can be omitted::
-
-    # Only a setter.
-    var my_var = 5 setget my_var_set
-    # Only a getter (note the comma).
-    var my_var = 5 setget ,my_var_get
-
-Setters and getters are useful when :ref:`exporting variables <doc_gdscript_exports>`
-to the editor in tool scripts or plugins, for validating input.
-
-As said, *local* access will *not* trigger the setter and getter. Here is an
-illustration of this:
-
-::
-
-    func _init():
-        # Does not trigger setter/getter.
-        my_integer = 5
-        print(my_integer)
-
-        # Does trigger setter/getter.
-        self.my_integer = 5
-        print(self.my_integer)
-
-.. _doc_gdscript_tool_mode:
-
-Tool mode
-~~~~~~~~~
-
-By default, scripts don't run inside the editor and only the exported
-properties can be changed. In some cases, it is desired that they do run
-inside the editor (as long as they don't execute game code or manually
-avoid doing so). For this, the ``tool`` keyword exists and must be
-placed at the top of the file::
-
-    tool
-    extends Button
-
-
-    func _ready():
-        print("Hello")
-
-
-See :ref:`doc_running_code_in_the_editor` for more information.
-
-.. warning:: Be cautious when freeing nodes with ``queue_free()`` or ``free()``
-             in a tool script (especially the script's owner itself). As tool
-             scripts run their code in the editor, misusing them may lead to
-             crashing the editor.
-
-Memory management
-~~~~~~~~~~~~~~~~~
-
-If a class inherits from :ref:`class_Reference`, then instances will be
-freed when no longer in use. No garbage collector exists, just
-reference counting. By default, all classes that don't define
-inheritance extend **Reference**. If this is not desired, then a class
-must inherit :ref:`class_Object` manually and must call instance.free(). To
-avoid reference cycles that can't be freed, a ``weakref`` function is
-provided for creating weak references.
-
-Alternatively, when not using references, the
-``is_instance_valid(instance)`` can be used to check if an object has been
-freed.
-
-.. _doc_gdscript_signals:
-
-Signals
-~~~~~~~
-
-Signals are a tool to emit messages from an object that other objects can react
-to. To create custom signals for a class, use the ``signal`` keyword.
-
-::
-
-   extends Node
-
-
-   # A signal named health_depleted.
-   signal health_depleted
-
-.. note::
-
-   Signals are a `Callback
-   <https://en.wikipedia.org/wiki/Callback_(computer_programming)>`_
-   mechanism. They also fill the role of Observers, a common programming
-   pattern. For more information, read the `Observer tutorial
-   <https://gameprogrammingpatterns.com/observer.html>`_ in the
-   Game Programming Patterns ebook.
-
-You can connect these signals to methods the same way you connect built-in
-signals of nodes like :ref:`class_Button` or :ref:`class_RigidBody`.
-
-In the example below, we connect the ``health_depleted`` signal from a
-``Character`` node to a ``Game`` node. When the ``Character`` node emits the
-signal, the game node's ``_on_Character_health_depleted`` is called::
-
-    # Game.gd
-
-    func _ready():
-        var character_node = get_node('Character')
-        character_node.connect("health_depleted", self, "_on_Character_health_depleted")
-
-
-    func _on_Character_health_depleted():
-        get_tree().reload_current_scene()
-
-You can emit as many arguments as you want along with a signal.
-
-Here is an example where this is useful. Let's say we want a life bar on screen
-to react to health changes with an animation, but we want to keep the user
-interface separate from the player in our scene tree.
-
-In our ``Character.gd`` script, we define a ``health_changed`` signal and emit
-it with :ref:`Object.emit_signal() <class_Object_method_emit_signal>`, and from
-a ``Game`` node higher up our scene tree, we connect it to the ``Lifebar`` using
-the :ref:`Object.connect() <class_Object_method_connect>` method::
-
-    # Character.gd
-
-    ...
-    signal health_changed
-
-
-    func take_damage(amount):
-        var old_health = health
-        health -= amount
-
-        # We emit the health_changed signal every time the
-        # character takes damage.
-        emit_signal("health_changed", old_health, health)
-    ...
-
-::
-
-    # Lifebar.gd
-
-    # Here, we define a function to use as a callback when the
-    # character's health_changed signal is emitted.
-
-    ...
-    func _on_Character_health_changed(old_value, new_value):
-        if old_value > new_value:
-            progress_bar.modulate = Color.red
-        else:
-            progress_bar.modulate = Color.green
-
-        # Imagine that `animate` is a user-defined function that animates the
-        # bar filling up or emptying itself.
-        progress_bar.animate(old_value, new_value)
-    ...
-
-.. note::
-
-    To use signals, your class has to extend the ``Object`` class or any
-    type extending it like ``Node``, ``KinematicBody``, ``Control``...
-
-In the ``Game`` node, we get both the ``Character`` and ``Lifebar`` nodes, then
-connect the character, that emits the signal, to the receiver, the ``Lifebar``
-node in this case.
-
-::
-
-    # Game.gd
-
-    func _ready():
-        var character_node = get_node('Character')
-        var lifebar_node = get_node('UserInterface/Lifebar')
-
-        character_node.connect("health_changed", lifebar_node, "_on_Character_health_changed")
-
-This allows the ``Lifebar`` to react to health changes without coupling it to
-the ``Character`` node.
-
-You can write optional argument names in parentheses after the signal's
-definition::
-
-    # Defining a signal that forwards two arguments.
-    signal health_changed(old_value, new_value)
-
-These arguments show up in the editor's node dock, and Godot can use them to
-generate callback functions for you. However, you can still emit any number of
-arguments when you emit signals; it's up to you to emit the correct values.
-
-.. image:: img/gdscript_basics_signals_node_tab_1.png
-
-GDScript can bind an array of values to connections between a signal
-and a method. When the signal is emitted, the callback method receives
-the bound values. These bound arguments are unique to each connection,
-and the values will stay the same.
-
-You can use this array of values to add extra constant information to the
-connection if the emitted signal itself doesn't give you access to all the data
-that you need.
-
-Building on the example above, let's say we want to display a log of the damage
-taken by each character on the screen, like ``Player1 took 22 damage.``. The
-``health_changed`` signal doesn't give us the name of the character that took
-damage. So when we connect the signal to the in-game console, we can add the
-character's name in the binds array argument::
-
-    # Game.gd
-
-    func _ready():
-        var character_node = get_node('Character')
-        var battle_log_node = get_node('UserInterface/BattleLog')
-
-        character_node.connect("health_changed", battle_log_node, "_on_Character_health_changed", [character_node.name])
-
-Our ``BattleLog`` node receives each element in the binds array as an extra argument::
-
-    # BattleLog.gd
-
-    func _on_Character_health_changed(old_value, new_value, character_name):
-        if not new_value <= old_value:
-            return
-
-        var damage = old_value - new_value
-        label.text += character_name + " took " + str(damage) + " damage."
-
-
-Coroutines with yield
-~~~~~~~~~~~~~~~~~~~~~
-
-GDScript offers support for `coroutines <https://en.wikipedia.org/wiki/Coroutine>`_
-via the :ref:`yield<class_@GDScript_method_yield>` built-in function. Calling ``yield()`` will
-immediately return from the current function, with the current frozen
-state of the same function as the return value. Calling ``resume()`` on
-this resulting object will continue execution and return whatever the
-function returns. Once resumed, the state object becomes invalid. Here is
-an example::
-
-    func my_func():
-        print("Hello")
-        yield()
-        print("world")
-
-
-    func _ready():
-        var y = my_func()
-        # Function state saved in 'y'.
-        print("my dear")
-        y.resume()
-        # 'y' resumed and is now an invalid state.
-
-Will print::
-
-    Hello
-    my dear
-    world
-
-It is also possible to pass values between ``yield()`` and ``resume()``,
-for example::
-
-    func my_func():
-        print("Hello")
-        print(yield())
-        return "cheers!"
-
-
-    func _ready():
-        var y = my_func()
-        # Function state saved in 'y'.
-        print(y.resume("world"))
-        # 'y' resumed and is now an invalid state.
-
-Will print::
-
-    Hello
-    world
-    cheers!
-
-Remember to save the new function state, when using multiple ``yield``\s::
-
-    func co_func():
-        for i in range(1, 5):
-            print("Turn %d" % i)
-            yield();
-
-
-    func _ready():
-        var co = co_func();
-        while co is GDScriptFunctionState && co.is_valid():
-            co = co.resume();
-
-
-Coroutines & signals
-^^^^^^^^^^^^^^^^^^^^
-
-The real strength of using ``yield`` is when combined with signals.
-``yield`` can accept two arguments, an object and a signal. When the
-signal is received, execution will recommence. Here are some examples::
-
-    # Resume execution the next frame.
-    yield(get_tree(), "idle_frame")
-
-    # Resume execution when animation is done playing.
-    yield(get_node("AnimationPlayer"), "animation_finished")
-
-    # Wait 5 seconds, then resume execution.
-    yield(get_tree().create_timer(5.0), "timeout")
-
-Coroutines themselves use the ``completed`` signal when they transition
-into an invalid state, for example::
-
-    func my_func():
-        yield(button_func(), "completed")
-        print("All buttons were pressed, hurray!")
-
-
-    func button_func():
-        yield($Button0, "pressed")
-        yield($Button1, "pressed")
-
-``my_func`` will only continue execution once both buttons have been pressed.
-
-You can also get the signal's argument once it's emitted by an object:
-
-::
-
-    # Wait for when any node is added to the scene tree.
-    var node = yield(get_tree(), "node_added")
-
-If you're unsure whether a function may yield or not, or whether it may yield
-multiple times, you can yield to the ``completed`` signal conditionally:
-
-::
-
-    func generate():
-        var result = rand_range(-1.0, 1.0)
-
-        if result < 0.0:
-            yield(get_tree(), "idle_frame")
-
-        return result
-
-
-    func make():
-        var result = generate()
-
-        if result is GDScriptFunctionState: # Still working.
-            result = yield(result, "completed")
-
-        return result
-
-This ensures that the function returns whatever it was supposed to return
-regardless of whether coroutines were used internally. Note that using
-``while`` would be redundant here as the ``completed`` signal is only emitted
-when the function didn't yield anymore.
-
-Onready keyword
-~~~~~~~~~~~~~~~
-
-When using nodes, it's common to desire to keep references to parts
-of the scene in a variable. As scenes are only warranted to be
-configured when entering the active scene tree, the sub-nodes can only
-be obtained when a call to ``Node._ready()`` is made.
-
-::
-
-    var my_label
-
-
-    func _ready():
-        my_label = get_node("MyLabel")
-
-This can get a little cumbersome, especially when nodes and external
-references pile up. For this, GDScript has the ``onready`` keyword, that
-defers initialization of a member variable until ``_ready()`` is called. It
-can replace the above code with a single line::
-
-    onready var my_label = get_node("MyLabel")
-
-Assert keyword
-~~~~~~~~~~~~~~
-
-The ``assert`` keyword can be used to check conditions in debug builds. These
-assertions are ignored in non-debug builds. This means that the expression
-passed as argument won't be evaluated in a project exported in release mode.
-Due to this, assertions must **not** contain expressions that have
-side effects. Otherwise, the behavior of the script would vary
-depending on whether the project is run in a debug build.
-
-::
-
-    # Check that 'i' is 0. If 'i' is not 0, an assertion error will occur.
-    assert(i == 0)
-
-When running a project from the editor, the project will be paused if an
-assertion error occurs.

--- a/getting_started/scripting/gdscript/gdscript_basics.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics.rst
@@ -576,8 +576,8 @@ Data
 Variables
 ~~~~~~~~~
 
-A variable is some data that is stored with an associated label. For example
-you could store a variable "fruit" which contained the contents "apple".
+A variable is some data that is stored with an associated label. For example,
+you could store a variable called ``fruit`` which contains the string ``"apple"``.
 Variables can exist as class members or local to functions. They are
 created with the ``var`` keyword and may, optionally, be assigned a
 value upon initialization.
@@ -1046,4 +1046,3 @@ There are 6 pattern types:
                 print("It's 1 - 3")
             "Sword", "Splash potion", "Fist":
                 print("Yep, you've taken damage")
-

--- a/getting_started/scripting/gdscript/gdscript_basics.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics.rst
@@ -327,7 +327,7 @@ below for you to useful.
 
 Advanced note : Built-in types are stack-allocated. They are passed as values. 
 This means a copy is created on each assignment or when passing them as 
-arguments to functions. The only exceptions are ``Array``\ s and 
+arguments to functions. The only exceptions are ``Arrays`` and 
 ``Dictionaries``, which are passed by reference so they are shared. (Pooled 
 arrays such as ``PackedByteArray`` are still passed as values.)
 
@@ -744,7 +744,24 @@ argument, unlike Python).
         print(b)
         return a + b  # Return is optional; without it 'null' is returned.
 
-A function can ``return`` at any point. The default return value is ``null``.
+
+A function can ``return`` at any point, stopping the function 
+and passing control back to the code that called the function. Functions can
+optionally return a value - the default return value is ``null``.
+In the following example, "result" will be set to whatever the function
+"my_function" returns. As the function "my_function" is passed the 
+parameters "5" and "3", and returns the sum of the two parameters, the 
+value 8 will be assigned to the variable "result".
+
+::
+
+    func my_function(a, b):
+         return a + b  
+
+    var result=my_function(5, 3)  
+
+In the event that a function is required but you do not wish it to execute any
+code, the keyword ``pass`` can be used to tell the function not to do anything.
 
 Functions can also have type specification for the arguments and for the return
 value. Types for arguments can be added in a similar way to variables::
@@ -778,8 +795,6 @@ return early with the ``return`` keyword, but they can't return any value.
           inside an ``if`` block but not after it, the editor will raise an
           error because if the block is not executed, the function won't have a
           valid value to return.
-
-TALK ABOUT PASS
 
 Referencing functions
 ^^^^^^^^^^^^^^^^^^^^^

--- a/getting_started/scripting/gdscript/gdscript_basics_part2.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics_part2.rst
@@ -1,0 +1,646 @@
+.. _doc_gdscript_basics2:
+
+GDScript basics - part 2
+========================
+
+.. _doc_gdscript_classes:
+
+Classes
+~~~~~~~
+
+By default, all script files are unnamed classes. In this case, you can only
+reference them using the file's path, using either a relative or an absolute
+path. For example, if you name a script file ``character.gd``::
+
+   # Inherit from 'Character.gd'.
+
+   extends "res://path/to/character.gd"
+
+   # Load character.gd and create a new node instance from it.
+
+   var Character = load("res://path/to/character.gd")
+   var character_node = Character.new()
+
+Instead, you can give your class a name to register it as a new type in Godot's
+editor. For that, you use the ``class_name`` keyword. You can add an
+optional comma followed by a path to an image, to use it as an icon. Your class
+will then appear with its new icon in the editor::
+
+   # Item.gd
+
+   extends Node
+   class_name Item, "res://interface/icons/item.png"
+
+.. image:: img/class_name_editor_register_example.png
+
+Here's a class file example:
+
+::
+
+    # Saved as a file named 'character.gd'.
+
+    class_name Character
+
+
+    var health = 5
+
+
+    func print_health():
+        print(health)
+
+
+    func print_this_script_three_times():
+        print(get_script())
+        print(ResourceLoader.load("res://character.gd"))
+        print(Character)
+
+
+.. note:: Godot's class syntax is compact: it can only contain member variables or
+          functions. You can use static functions, but not static member variables. In the
+          same way, the engine initializes variables every time you create an instance,
+          and this includes arrays and dictionaries. This is in the spirit of thread
+          safety, since scripts can be initialized in separate threads without the user
+          knowing.
+
+Inheritance
+^^^^^^^^^^^
+
+A class (stored as a file) can inherit from:
+
+- A global class.
+- Another class file.
+- An inner class inside another class file.
+
+Multiple inheritance is not allowed.
+
+Inheritance uses the ``extends`` keyword::
+
+    # Inherit/extend a globally available class.
+    extends SomeClass
+
+    # Inherit/extend a named class file.
+    extends "somefile.gd"
+
+    # Inherit/extend an inner class in another file.
+    extends "somefile.gd".SomeInnerClass
+
+
+To check if a given instance inherits from a given class,
+the ``is`` keyword can be used::
+
+    # Cache the enemy class.
+    const Enemy = preload("enemy.gd")
+
+    # [...]
+
+    # Use 'is' to check inheritance.
+    if entity is Enemy:
+        entity.apply_damage()
+
+To call a function in a *parent class* (i.e. one ``extend``-ed in your current
+class), prepend ``.`` to the function name::
+
+    .base_func(args)
+
+This is especially useful because functions in extending classes replace
+functions with the same name in their parent classes. If you still want to
+call them, you can prefix them with ``.`` (like the ``super`` keyword
+in other languages)::
+
+    func some_func(x):
+        .some_func(x) # Calls the same function on the parent class.
+
+.. note:: Default functions like  ``_init``, and most notifications such as
+          ``_enter_tree``, ``_exit_tree``, ``_process``, ``_physics_process``,
+          etc. are called in all parent classes automatically.
+          There is no need to call them explicitly when overloading them.
+
+
+Class Constructor
+^^^^^^^^^^^^^^^^^
+
+The class constructor, called on class instantiation, is named ``_init``. As
+mentioned earlier, the constructors of parent classes are called automatically
+when inheriting a class. So, there is usually no need to call ``._init()``
+explicitly.
+
+Unlike the call of a regular function, like in the above example with
+``.some_func``, if the constructor from the inherited class takes arguments,
+they are passed like this::
+
+    func _init(args).(parent_args):
+       pass
+
+This is better explained through examples. Consider this scenario::
+
+    # State.gd (inherited class)
+    var entity = null
+    var message = null
+
+
+    func _init(e=null):
+        entity = e
+
+
+    func enter(m):
+        message = m
+
+
+    # Idle.gd (inheriting class)
+    extends "State.gd"
+
+
+    func _init(e=null, m=null).(e):
+        # Do something with 'e'.
+        message = m
+
+There are a few things to keep in mind here:
+
+1. If the inherited class (``State.gd``) defines a ``_init`` constructor that takes
+   arguments (``e`` in this case), then the inheriting class (``Idle.gd``) *must*
+   define ``_init`` as well and pass appropriate parameters to ``_init`` from ``State.gd``.
+2. ``Idle.gd`` can have a different number of arguments than the parent class ``State.gd``.
+3. In the example above, ``e`` passed to the ``State.gd`` constructor is the same ``e`` passed
+   in to ``Idle.gd``.
+4. If ``Idle.gd``'s ``_init`` constructor takes 0 arguments, it still needs to pass some value
+   to the ``State.gd`` parent class, even if it does nothing. This brings us to the fact that you
+   can pass literals in the base constructor as well, not just variables. eg.::
+
+    # Idle.gd
+
+    func _init().(5):
+        pass
+
+Inner classes
+^^^^^^^^^^^^^
+
+A class file can contain inner classes. Inner classes are defined using the
+``class`` keyword. They are instanced using the ``ClassName.new()``
+function.
+
+::
+
+    # Inside a class file.
+
+    # An inner class in this class file.
+    class SomeInnerClass:
+        var a = 5
+
+
+        func print_value_of_a():
+            print(a)
+
+
+    # This is the constructor of the class file's main class.
+    func _init():
+        var c = SomeInnerClass.new()
+        c.print_value_of_a()
+
+.. _doc_gdscript_classes_as_resources:
+
+Classes as resources
+^^^^^^^^^^^^^^^^^^^^
+
+Classes stored as files are treated as :ref:`resources <class_GDScript>`. They
+must be loaded from disk to access them in other classes. This is done using
+either the ``load`` or ``preload`` functions (see below). Instancing of a loaded
+class resource is done by calling the ``new`` function on the class object::
+
+    # Load the class resource when calling load().
+    var my_class = load("myclass.gd")
+
+    # Preload the class only once at compile time.
+    const MyClass = preload("myclass.gd")
+
+
+    func _init():
+        var a = MyClass.new()
+        a.some_function()
+
+.. _doc_gdscript_setters_getters:
+
+Setters/getters
+~~~~~~~~~~~~~~~
+
+It is often useful to know when a class' member variable changes for
+whatever reason. It may also be desired to encapsulate its access in some way.
+
+For this, GDScript provides a *setter/getter* syntax using the ``setget`` keyword.
+It is used directly after a variable definition:
+
+::
+
+    var variable = value setget setterfunc, getterfunc
+
+Whenever the value of ``variable`` is modified by an *external* source
+(i.e. not from local usage in the class), the *setter* function (``setterfunc`` above)
+will be called. This happens *before* the value is changed. The *setter* must decide what to do
+with the new value. Vice versa, when ``variable`` is accessed, the *getter* function
+(``getterfunc`` above) must ``return`` the desired value. Below is an example::
+
+    var my_var setget my_var_set, my_var_get
+
+
+    func my_var_set(new_value):
+        my_var = new_value
+
+
+    func my_var_get():
+        return my_var # Getter must return a value.
+
+Either of the *setter* or *getter* functions can be omitted::
+
+    # Only a setter.
+    var my_var = 5 setget my_var_set
+    # Only a getter (note the comma).
+    var my_var = 5 setget ,my_var_get
+
+Setters and getters are useful when :ref:`exporting variables <doc_gdscript_exports>`
+to the editor in tool scripts or plugins, for validating input.
+
+As said, *local* access will *not* trigger the setter and getter. Here is an
+illustration of this:
+
+::
+
+    func _init():
+        # Does not trigger setter/getter.
+        my_integer = 5
+        print(my_integer)
+
+        # Does trigger setter/getter.
+        self.my_integer = 5
+        print(self.my_integer)
+
+.. _doc_gdscript_tool_mode:
+
+Tool mode
+~~~~~~~~~
+
+By default, scripts don't run inside the editor and only the exported
+properties can be changed. In some cases, it is desired that they do run
+inside the editor (as long as they don't execute game code or manually
+avoid doing so). For this, the ``tool`` keyword exists and must be
+placed at the top of the file::
+
+    tool
+    extends Button
+
+
+    func _ready():
+        print("Hello")
+
+
+See :ref:`doc_running_code_in_the_editor` for more information.
+
+.. warning:: Be cautious when freeing nodes with ``queue_free()`` or ``free()``
+             in a tool script (especially the script's owner itself). As tool
+             scripts run their code in the editor, misusing them may lead to
+             crashing the editor.
+
+Memory management
+~~~~~~~~~~~~~~~~~
+
+If a class inherits from :ref:`class_Reference`, then instances will be
+freed when no longer in use. No garbage collector exists, just
+reference counting. By default, all classes that don't define
+inheritance extend **Reference**. If this is not desired, then a class
+must inherit :ref:`class_Object` manually and must call instance.free(). To
+avoid reference cycles that can't be freed, a ``weakref`` function is
+provided for creating weak references.
+
+Alternatively, when not using references, the
+``is_instance_valid(instance)`` can be used to check if an object has been
+freed.
+
+.. _doc_gdscript_signals:
+
+Signals
+~~~~~~~
+
+Signals are a tool to emit messages from an object that other objects can react
+to. To create custom signals for a class, use the ``signal`` keyword.
+
+::
+
+   extends Node
+
+
+   # A signal named health_depleted.
+   signal health_depleted
+
+.. note::
+
+   Signals are a `Callback
+   <https://en.wikipedia.org/wiki/Callback_(computer_programming)>`_
+   mechanism. They also fill the role of Observers, a common programming
+   pattern. For more information, read the `Observer tutorial
+   <https://gameprogrammingpatterns.com/observer.html>`_ in the
+   Game Programming Patterns ebook.
+
+You can connect these signals to methods the same way you connect built-in
+signals of nodes like :ref:`class_Button` or :ref:`class_RigidBody`.
+
+In the example below, we connect the ``health_depleted`` signal from a
+``Character`` node to a ``Game`` node. When the ``Character`` node emits the
+signal, the game node's ``_on_Character_health_depleted`` is called::
+
+    # Game.gd
+
+    func _ready():
+        var character_node = get_node('Character')
+        character_node.connect("health_depleted", self, "_on_Character_health_depleted")
+
+
+    func _on_Character_health_depleted():
+        get_tree().reload_current_scene()
+
+You can emit as many arguments as you want along with a signal.
+
+Here is an example where this is useful. Let's say we want a life bar on screen
+to react to health changes with an animation, but we want to keep the user
+interface separate from the player in our scene tree.
+
+In our ``Character.gd`` script, we define a ``health_changed`` signal and emit
+it with :ref:`Object.emit_signal() <class_Object_method_emit_signal>`, and from
+a ``Game`` node higher up our scene tree, we connect it to the ``Lifebar`` using
+the :ref:`Object.connect() <class_Object_method_connect>` method::
+
+    # Character.gd
+
+    ...
+    signal health_changed
+
+
+    func take_damage(amount):
+        var old_health = health
+        health -= amount
+
+        # We emit the health_changed signal every time the
+        # character takes damage.
+        emit_signal("health_changed", old_health, health)
+    ...
+
+::
+
+    # Lifebar.gd
+
+    # Here, we define a function to use as a callback when the
+    # character's health_changed signal is emitted.
+
+    ...
+    func _on_Character_health_changed(old_value, new_value):
+        if old_value > new_value:
+            progress_bar.modulate = Color.red
+        else:
+            progress_bar.modulate = Color.green
+
+        # Imagine that `animate` is a user-defined function that animates the
+        # bar filling up or emptying itself.
+        progress_bar.animate(old_value, new_value)
+    ...
+
+.. note::
+
+    To use signals, your class has to extend the ``Object`` class or any
+    type extending it like ``Node``, ``KinematicBody``, ``Control``...
+
+In the ``Game`` node, we get both the ``Character`` and ``Lifebar`` nodes, then
+connect the character, that emits the signal, to the receiver, the ``Lifebar``
+node in this case.
+
+::
+
+    # Game.gd
+
+    func _ready():
+        var character_node = get_node('Character')
+        var lifebar_node = get_node('UserInterface/Lifebar')
+
+        character_node.connect("health_changed", lifebar_node, "_on_Character_health_changed")
+
+This allows the ``Lifebar`` to react to health changes without coupling it to
+the ``Character`` node.
+
+You can write optional argument names in parentheses after the signal's
+definition::
+
+    # Defining a signal that forwards two arguments.
+    signal health_changed(old_value, new_value)
+
+These arguments show up in the editor's node dock, and Godot can use them to
+generate callback functions for you. However, you can still emit any number of
+arguments when you emit signals; it's up to you to emit the correct values.
+
+.. image:: img/gdscript_basics_signals_node_tab_1.png
+
+GDScript can bind an array of values to connections between a signal
+and a method. When the signal is emitted, the callback method receives
+the bound values. These bound arguments are unique to each connection,
+and the values will stay the same.
+
+You can use this array of values to add extra constant information to the
+connection if the emitted signal itself doesn't give you access to all the data
+that you need.
+
+Building on the example above, let's say we want to display a log of the damage
+taken by each character on the screen, like ``Player1 took 22 damage.``. The
+``health_changed`` signal doesn't give us the name of the character that took
+damage. So when we connect the signal to the in-game console, we can add the
+character's name in the binds array argument::
+
+    # Game.gd
+
+    func _ready():
+        var character_node = get_node('Character')
+        var battle_log_node = get_node('UserInterface/BattleLog')
+
+        character_node.connect("health_changed", battle_log_node, "_on_Character_health_changed", [character_node.name])
+
+Our ``BattleLog`` node receives each element in the binds array as an extra argument::
+
+    # BattleLog.gd
+
+    func _on_Character_health_changed(old_value, new_value, character_name):
+        if not new_value <= old_value:
+            return
+
+        var damage = old_value - new_value
+        label.text += character_name + " took " + str(damage) + " damage."
+
+.. _doc_gdscript_yield:
+
+Coroutines with yield
+~~~~~~~~~~~~~~~~~~~~~
+
+GDScript offers support for `coroutines <https://en.wikipedia.org/wiki/Coroutine>`_
+via the :ref:`yield<class_@GDScript_method_yield>` built-in function. Calling ``yield()`` will
+immediately return from the current function, with the current frozen
+state of the same function as the return value. Calling ``resume()`` on
+this resulting object will continue execution and return whatever the
+function returns. Once resumed, the state object becomes invalid. Here is
+an example::
+
+    func my_func():
+        print("Hello")
+        yield()
+        print("world")
+
+
+    func _ready():
+        var y = my_func()
+        # Function state saved in 'y'.
+        print("my dear")
+        y.resume()
+        # 'y' resumed and is now an invalid state.
+
+Will print::
+
+    Hello
+    my dear
+    world
+
+It is also possible to pass values between ``yield()`` and ``resume()``,
+for example::
+
+    func my_func():
+        print("Hello")
+        print(yield())
+        return "cheers!"
+
+
+    func _ready():
+        var y = my_func()
+        # Function state saved in 'y'.
+        print(y.resume("world"))
+        # 'y' resumed and is now an invalid state.
+
+Will print::
+
+    Hello
+    world
+    cheers!
+
+Remember to save the new function state, when using multiple ``yield``\s::
+
+    func co_func():
+        for i in range(1, 5):
+            print("Turn %d" % i)
+            yield();
+
+
+    func _ready():
+        var co = co_func();
+        while co is GDScriptFunctionState && co.is_valid():
+            co = co.resume();
+
+.. _doc_gdscript_coroutines_and_signals:
+
+Coroutines & signals
+^^^^^^^^^^^^^^^^^^^^
+
+The real strength of using ``yield`` is when combined with signals.
+``yield`` can accept two arguments, an object and a signal. When the
+signal is received, execution will recommence. Here are some examples::
+
+    # Resume execution the next frame.
+    yield(get_tree(), "idle_frame")
+
+    # Resume execution when animation is done playing.
+    yield(get_node("AnimationPlayer"), "animation_finished")
+
+    # Wait 5 seconds, then resume execution.
+    yield(get_tree().create_timer(5.0), "timeout")
+
+Coroutines themselves use the ``completed`` signal when they transition
+into an invalid state, for example::
+
+    func my_func():
+        yield(button_func(), "completed")
+        print("All buttons were pressed, hurray!")
+
+
+    func button_func():
+        yield($Button0, "pressed")
+        yield($Button1, "pressed")
+
+``my_func`` will only continue execution once both buttons have been pressed.
+
+You can also get the signal's argument once it's emitted by an object:
+
+::
+
+    # Wait for when any node is added to the scene tree.
+    var node = yield(get_tree(), "node_added")
+
+If you're unsure whether a function may yield or not, or whether it may yield
+multiple times, you can yield to the ``completed`` signal conditionally:
+
+::
+
+    func generate():
+        var result = rand_range(-1.0, 1.0)
+
+        if result < 0.0:
+            yield(get_tree(), "idle_frame")
+
+        return result
+
+
+    func make():
+        var result = generate()
+
+        if result is GDScriptFunctionState: # Still working.
+            result = yield(result, "completed")
+
+        return result
+
+This ensures that the function returns whatever it was supposed to return
+regardless of whether coroutines were used internally. Note that using
+``while`` would be redundant here as the ``completed`` signal is only emitted
+when the function didn't yield anymore.
+
+.. _doc_gdscript_onready:
+
+Onready keyword
+~~~~~~~~~~~~~~~
+
+When using nodes, it's common to desire to keep references to parts
+of the scene in a variable. As scenes are only warranted to be
+configured when entering the active scene tree, the sub-nodes can only
+be obtained when a call to ``Node._ready()`` is made.
+
+::
+
+    var my_label
+
+
+    func _ready():
+        my_label = get_node("MyLabel")
+
+This can get a little cumbersome, especially when nodes and external
+references pile up. For this, GDScript has the ``onready`` keyword, that
+defers initialization of a member variable until ``_ready()`` is called. It
+can replace the above code with a single line::
+
+    onready var my_label = get_node("MyLabel")
+
+.. _doc_gdscript_assert:
+
+Assert keyword
+~~~~~~~~~~~~~~
+
+The ``assert`` keyword can be used to check conditions in debug builds. These
+assertions are ignored in non-debug builds. This means that the expression
+passed as argument won't be evaluated in a project exported in release mode.
+Due to this, assertions must **not** contain expressions that have
+side effects. Otherwise, the behavior of the script would vary
+depending on whether the project is run in a debug build.
+
+::
+
+    # Check that 'i' is 0. If 'i' is not 0, an assertion error will occur.
+    assert(i == 0)
+
+When running a project from the editor, the project will be paused if an
+assertion error occurs.

--- a/getting_started/scripting/gdscript/index.rst
+++ b/getting_started/scripting/gdscript/index.rst
@@ -6,6 +6,7 @@ GDScript
    :name: toc-learn-scripting-gdscript
 
    gdscript_basics
+   gdscript_basics_part2
    gdscript_advanced
    gdscript_exports
    gdscript_styleguide


### PR DESCRIPTION
Split of the gdscript basics page into two as discussed with @Calinou 

*Bugsquad edit: See discussion in https://github.com/godotengine/godot-docs/issues/2735.*