### PR TITLE
Fix missing indentation in State design pattern

### DIFF
--- a/tutorials/misc/state_design_pattern.rst
+++ b/tutorials/misc/state_design_pattern.rst
@@ -207,10 +207,10 @@ will not change it makes sense to call this new script ``persistent_state.gd``.
 
         # Input code was placed here for tutorial purposes.
         func _process(_delta):
-        if Input.is_action_pressed("ui_left"):
-            move_left()
-        elif Input.is_action_pressed("ui_right"):
-            move_right()
+            if Input.is_action_pressed("ui_left"):
+                move_left()
+            elif Input.is_action_pressed("ui_right"):
+                move_right()
 
         func move_left():
             state.move_left()


### PR DESCRIPTION
Added missing indent for Input Code in persistance_state.gd

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
