### PR TITLE
Add missing code formatting to function name in GDScript basics

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_basics.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics.rst
@@ -1317,7 +1317,7 @@ If a class inherits from :ref:`class_Reference`, then instances will be
 freed when no longer in use. No garbage collector exists, just
 reference counting. By default, all classes that don't define
 inheritance extend **Reference**. If this is not desired, then a class
-must inherit :ref:`class_Object` manually and must call instance.free(). To
+must inherit :ref:`class_Object` manually and must call ``instance.free()``. To
 avoid reference cycles that can't be freed, a ``weakref`` function is
 provided for creating weak references.
 


### PR DESCRIPTION
Hi, this is a tiny MR adding missing formatting to function name.