### PR TITLE
Clarify misleading sentence

### DIFF
--- a/getting_started/step_by_step/scripting.rst
+++ b/getting_started/step_by_step/scripting.rst
@@ -97,9 +97,9 @@ demonstrate:
 - Hooking up UI elements via signals.
 - Writing a script that can access other nodes in the scene.
 
-Before continuing, please make sure to read the :ref:`GDScript<doc_gdscript>` reference.
-It's a language designed to be simple, and the reference is short, so it will not take more
-than a few minutes to get an overview of the concepts.
+Before continuing, make sure to skim and bookmark the :ref:`GDScript<doc_gdscript>` reference.
+It's a language designed to be simple, and the reference is structured into sections to make it
+easier to get an overview of the concepts.
 
 Scene setup
 ~~~~~~~~~~~


### PR DESCRIPTION
[Scripting](https://docs.godotengine.org/en/stable/getting_started/step_by_step/scripting.html) is a page for beginners, and until this point, the writing has been easy and accessible, but the GDScript Reference is over 6.2k words long and difficult to grok in a few minutes by a beginner.

I think we shouldn't be promising it **will** take the reader no more than a couple minutes if it's possible it's not true for most beginners.

This MR changes this sentence to instead suggest skimming and bookmarking the page for later, because I think this was the original intent.