### PR TITLE
Mention Git for Windows CRLF/LF line ending issues

### DIFF
--- a/getting_started/workflow/project_setup/version_control_systems.rst
+++ b/getting_started/workflow/project_setup/version_control_systems.rst
@@ -43,4 +43,4 @@ Most Git for Windows clients are configured with the ``core.autocrlf`` set to ``
 This can lead to files unnecessarily being marked as modified by Git due to their line endings being converted automatically.
 It is better to set this option as::
 
-    git config core.autocrlf input
+    git config --global core.autocrlf input

--- a/getting_started/workflow/project_setup/version_control_systems.rst
+++ b/getting_started/workflow/project_setup/version_control_systems.rst
@@ -39,7 +39,7 @@ There are some folders Godot creates you should have your VCS ignore:
 Working with Git on Windows
 ---------------------------
 
-Most Git for Windows clients are configured with the `core.autocrlf` set to `true`.
+Most Git for Windows clients are configured with the ``core.autocrlf`` set to ``true``.
 This can lead to files unnecessarily being marked as modified by Git due to their line endings being converted automatically.
 It is better to set this option as::
 

--- a/getting_started/workflow/project_setup/version_control_systems.rst
+++ b/getting_started/workflow/project_setup/version_control_systems.rst
@@ -40,8 +40,8 @@ Working with Git on Windows
 ---------------------------
 
 Most Git for Windows clients are configured with the `core.autocrlf` set to `true`.
-This can lead to weird git status and warnings in the diff output. It is better to set this
-option as:
-::
+This can lead to files unnecessarily being marked as modified by Git due to their line endings being converted automatically.
+It is better to set this option as::
+
 
   git config core.autocrlf input

--- a/getting_started/workflow/project_setup/version_control_systems.rst
+++ b/getting_started/workflow/project_setup/version_control_systems.rst
@@ -43,5 +43,4 @@ Most Git for Windows clients are configured with the ``core.autocrlf`` set to ``
 This can lead to files unnecessarily being marked as modified by Git due to their line endings being converted automatically.
 It is better to set this option as::
 
-
-  git config core.autocrlf input
+    git config core.autocrlf input

--- a/getting_started/workflow/project_setup/version_control_systems.rst
+++ b/getting_started/workflow/project_setup/version_control_systems.rst
@@ -35,3 +35,13 @@ There are some folders Godot creates you should have your VCS ignore:
   project, including sensitive information such as Android keystore credentials.
 - ``.mono/``: This folder stores automatically-generated Mono files. It only exists
   in projects that use the Mono version of Godot.
+
+Working with Git on Windows
+---------------------------
+
+Most Git for Windows clients are configured with the `core.autocrlf` set to `true`.
+This can lead to weird git status and warnings in the diff output. It is better to set this
+option as:
+::
+
+  git config core.autocrlf input


### PR DESCRIPTION
Got bitten by this `core.autocrlf` when working with Godot, I think it is good information to have in the documentation.
