### PR TITLE
Suggest `is_null` over `!is_valid` for examples in error macros

### DIFF
--- a/development/cpp/common_engine_methods_and_macros.rst
+++ b/development/cpp/common_engine_methods_and_macros.rst
@@ -200,7 +200,7 @@ Godot features many error macros to make error reporting more convenient.
 
     // Conditionally prints an error message and returns from the function.
     // Use this in methods which don't return a value.
-    ERR_FAIL_COND_MSG(!mesh.is_valid(), vformat("Couldn't load mesh at: %s", path));
+    ERR_FAIL_COND_MSG(mesh.is_null(), vformat("Couldn't load mesh at: %s", path));
 
     // Conditionally prints an error message and returns `0` from the function.
     // Use this in methods which must return a value.


### PR DESCRIPTION
I see inconsistent usage of those methods for error checking throughout the engine, using `is_null` is much better for interpreting the error condition, both for engine programmers and the way errors are reported in Godot projects, so this should give a good example for new contributors and existing devs. 🙂