### PR TITLE
Update instructions to make subresources unique in inspector

### DIFF
--- a/getting_started/step_by_step/instancing.rst
+++ b/getting_started/step_by_step/instancing.rst
@@ -102,7 +102,7 @@ changes to that scene will affect all instances.
 You can also adjust individual instances. Set the bounce value back to ``0``
 and then in the ``Main`` scene, select one of the instanced balls. Resources
 like ``PhysicsMaterial`` are shared between instances by default, so we need
-to make it unique. Click on the down arrow and select "Make Unique". Set its
+to make it unique. Click on the tools button in the top-right of the Inspector dock (its hover-text says "Object properties.") and select "Make Sub-Resources Unique". Set its
 ``Bounce`` to ``1`` and press "Play".
 
 .. image:: img/instancing_property.png

--- a/getting_started/step_by_step/instancing.rst
+++ b/getting_started/step_by_step/instancing.rst
@@ -102,8 +102,9 @@ changes to that scene will affect all instances.
 You can also adjust individual instances. Set the bounce value back to ``0``
 and then in the ``Main`` scene, select one of the instanced balls. Resources
 like ``PhysicsMaterial`` are shared between instances by default, so we need
-to make it unique. Click on the tools button in the top-right of the Inspector dock (its hover-text says "Object properties.") and select "Make Sub-Resources Unique". Set its
-``Bounce`` to ``1`` and press "Play".
+to make it unique. Click on the tools button in the top-right of the Inspector
+dock and select "Make Sub-Resources Unique". Set its ``Bounce`` to ``1`` and
+press "Play".
 
 .. image:: img/instancing_property.png
 


### PR DESCRIPTION
As of 3.2.2 the icon for Object Properties is no longer a down arrow, it is now a tools emoji. It's also not clear from the sentence the tutorial is expecting the user to look for the Object Properties button, just 'the down arrow', so I added clarity there as well.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
