### PR TITLE
Typo in C# example change velocity to _velocity

### DIFF
--- a/tutorials/physics/using_kinematic_body_2d.rst
+++ b/tutorials/physics/using_kinematic_body_2d.rst
@@ -263,7 +263,7 @@ Attach a script to the KinematicBody2D and add the following code:
         public override void _PhysicsProcess(float delta)
         {
             GetInput();
-            MoveAndCollide(velocity * delta);
+            MoveAndCollide(_velocity * delta);
         }
     }
 


### PR DESCRIPTION
There's a typo in the C# example code:

MoveAndCollide(velocity * delta);

should be 

MoveAndCollide(_velocity * delta);

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
