### PR TITLE
Add C# examples to running_code_in_the_editor.rst

### DIFF
--- a/tutorials/misc/running_code_in_the_editor.rst
+++ b/tutorials/misc/running_code_in_the_editor.rst
@@ -39,6 +39,13 @@ For example, if you want to execute some code only in the editor, use:
     if Engine.editor_hint:
         # Code to execute when in editor.
 
+ .. code-tab:: csharp
+
+    if (Engine.EditorHint)
+    {
+        // Code to execute when in editor.
+    }
+
 On the other hand, if you want to execute code only in game, simply negate the same statement:
 
 .. tabs::
@@ -46,6 +53,13 @@ On the other hand, if you want to execute code only in game, simply negate the s
 
     if not Engine.editor_hint:
         # Code to execute when in game.
+
+ .. code-tab:: csharp
+
+    if (!Engine.EditorHint)
+    {
+        // Code to execute when in game.
+    }
 
 Pieces of code do not have either of the 2 conditions above will run both in-editor and in-game.
 
@@ -63,6 +77,23 @@ Here is how a ``_process()`` function might look for you:
 
         # Code to execute both in editor and in game.
 
+ .. code-tab:: csharp
+
+    public override void _Process(float delta)
+    {
+        if (Engine.EditorHint)
+        {
+            // Code to execute in editor.
+        }
+
+        if (!Engine.EditorHint)
+        {
+            // Code to execute in game.
+        }
+
+        // Code to execute both in editor and in game.
+    }
+
 .. note:: Modifications in editor are permanent. For example, in the following case, when we remove the script, the node will keep its rotation. Be careful to avoid making unwanted modifications.
 
 Try it out
@@ -78,6 +109,20 @@ Add a ``Sprite`` node to your scene and set the texture to Godot icon. Attach an
 
     func _process(delta):
         rotation_degrees += 180 * delta
+
+ .. code-tab:: csharp
+
+    using Godot;
+    using System;
+
+    [Tool]
+    public class MySprite : Sprite
+    {
+        public override void _Process(float delta)
+        {
+            RotationDegrees += 180 * delta;
+        }
+    }
 
 Save the script and return to the editor. You should now see your object rotate. If you run the game, it will also rotate.
 
@@ -95,6 +140,20 @@ Now let's choose which code runs when. Modify your ``_process()`` function to lo
             rotation_degrees += 180 * delta
         else:
             rotation_degrees -= 180 * delta
+
+ .. code-tab:: csharp
+
+    public override void _Process(float delta)
+    {
+        if (Engine.EditorHint)
+        {
+            RotationDegrees += 180 * delta;
+        }
+        else
+        {
+            RotationDegrees -= 180 * delta;
+        }
+    }
 
 Save the script. Now the object will spin clockwise in the editor, but if you run the game, it will spin counter-clockwise.
 
@@ -122,6 +181,35 @@ Modify  ``_process()`` to include the rotation speed.
     func _process(delta):
     	rotation_degrees += 180 * delta * speed
 
+ .. code-tab:: csharp
+
+    using Godot;
+    using System;
+
+    [Tool]
+    public class MySprite : Sprite
+    {
+        private float speed = 1;
+
+        [Export]
+        public float Speed {
+            get => speed;
+            set => SetSpeed(value);
+        }
+
+        // Update speed and reset the rotation.
+        private void SetSpeed(float newSpeed)
+        {
+            speed = newSpeed;
+            RotationDegrees = 0;
+        }
+
+        public override void _Process(float delta)
+        {
+            RotationDegrees += 180 * delta * speed;
+        }
+    }
+
 .. note:: Code from other nodes doesn't run in the editor. Your access to other nodes is limited. You can access the tree and nodes, and their default properties, but you can't access user variables. If you want to do so, other nodes have to run in the editor too. AutoLoad nodes cannot be accessed in the editor at all.
 
 Instancing scenes
@@ -139,6 +227,15 @@ If you are using ``tool``:
         add_child(node) # Parent could be any node in the scene
         node.set_owner(get_tree().edited_scene_root)
 
+ .. code-tab:: csharp
+
+    public override void _Ready()
+    {
+        var node = new Spatial();
+        AddChild(node); // Parent could be any node in the scene
+        node.Owner = GetTree().EditedSceneRoot;
+    }
+
 If you are using :ref:`EditorScript<class_EditorScript>`:
 
 .. tabs::
@@ -149,5 +246,15 @@ If you are using :ref:`EditorScript<class_EditorScript>`:
         var node = Spatial.new()
         parent.add_child(node)
         node.set_owner(get_scene())
+
+ .. code-tab:: csharp
+
+    public override void _Run()
+    {
+        var parent = GetScene().FindNode("Parent"); // Parent could be any node in the scene
+        var node = new Spatial();
+        parent.AddChild(node);
+        node.Owner = GetScene();
+    }
 
 .. warning:: Using ``tool`` improperly can yield many errors. It is advised to first write the code how you want it, and only then add the ``tool`` keyword to the top. Also, make sure to separate code that runs in-editor from code that runs in-game. This way, you can find bugs more easily.


### PR DESCRIPTION
This page did not have C# examples so I added them.