### PR TITLE
Fix first snippet in Change scenes manually

### DIFF
--- a/tutorials/misc/change_scenes_manually.rst
+++ b/tutorials/misc/change_scenes_manually.rst
@@ -12,7 +12,7 @@ scenes which one instances and adds to the tree at runtime:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    var simultaneous_scene = preload("res://levels/level2.tscn")
+    var simultaneous_scene = preload("res://levels/level2.tscn").instance()
 
     func _add_a_scene_manually():
         # This is like autoloading the scene, only
@@ -25,7 +25,7 @@ scenes which one instances and adds to the tree at runtime:
 
     public MyClass()
     {
-        simultaneousScene = (PackedScene)ResourceLoader.Load("res://levels/level2.tscn");
+        simultaneousScene = (PackedScene)ResourceLoader.Load("res://levels/level2.tscn").instance();
     }
 
     public void _AddASceneManually()


### PR DESCRIPTION
In the first snippet, a PackedScene is loaded but never instanced, which would throw this error:
`Invalid type in function 'add_child' in base 'Node'. The Object-derived class of argument 1 (PackedScene) is not a subclass of the expected argument class.`

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
