### PR TITLE
Viewport Usage enumeration

### DIFF
--- a/classes/class_viewport.rst
+++ b/classes/class_viewport.rst
@@ -337,7 +337,7 @@ enum **MSAA**:
 
 enum **Usage**:
 
-- **USAGE_2D** = **0** --- Allocates all buffers needed for drawing 2D scenes. This takes less VRAM than the 3D usage modes.
+- **USAGE_2D** = **0** --- Allocates all buffers needed for drawing 2D scenes. This takes less VRAM than the 3D usage modes. Note that 3D rendering effects such as glow, HDR, SSAO, etc. are not available. 
 
 - **USAGE_2D_NO_SAMPLING** = **1** --- Allocates buffers needed for 2D scenes without allocating a buffer for screen copy. Accordingly, you cannot read from the screen. Of the :ref:`Usage<enum_Viewport_Usage>` types, this requires the least VRAM.
 


### PR DESCRIPTION
Mention that 3D effects are not available when using USAGE_2D

Fixes https://github.com/godotengine/godot/issues/41151

Targeting stable since the Usage enumeration seems to no longer be available in the latest version of the documentation.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
