### PR TITLE
Improve Docs writing guidelines

### DIFF
--- a/community/contributing/docs_writing_guidelines.rst
+++ b/community/contributing/docs_writing_guidelines.rst
@@ -298,7 +298,7 @@ The exception is topics that explain static typing concepts to users.
     var body_sprite := $Sprite as Sprite
 
 
-**Do** write constants variables with dynamic typing:
+**Do** write constants and variables with dynamic typing:
 
 ::
 
@@ -312,7 +312,7 @@ The exception is topics that explain static typing concepts to users.
 
 ::
 
-    func choose(arguments: Array):
+    func choose(arguments: PackedStringArray) -> String:
         # Chooses one of the arguments from array with equal chances
         randomize()
         var size := arguments.size()
@@ -392,7 +392,7 @@ functionality, in up to 200 characters.
 ::
 
     **Node2D**
-    2D game object, parent of all 2D related nodes. Has a position, rotation, scale and z-index.
+    A 2D game object, inherited by all 2D-related nodes. Has a position, rotation, scale, and Z index.
 
 Use the node's full description to provide more information, and a code
 example, if possible.
@@ -518,10 +518,14 @@ Screenshot sizes should not exceed 1920×1080 to ensure fast loading on slower
 connections.
 
 When you need to highlight an area of the editor to show something, like a
-button or option, use a 2 pixel thick outline without a bevel.
+button or option, use a 2 pixel-thick yellow outline without a bevel. If the
+outline is on a dark background, the outline should be yellow (*not* red) so it
+can be easily seen by colorblind people.
 
 Before you add or replace any images in the documentation, they should be run
-through a PNG compressor to save size. The built in lossless compressor in
-programs like Krita or Photoshop should be enough. For heavier images, also look
-into using a lossy compressor, such as `pngquant <https://pngquant.org/>`_ where
-almost no image quality is lost during compression.
+through a PNG compressor to save size. You can use the lossless OxiPNG
+compressor included in `Squoosh <https://squoosh.app/>`__ for this purpose.
+For heavier images, also look into using a lossy compressor, such as
+`pngquant <https://pngquant.org/>`_ where almost no image quality is lost
+during compression. (This compressor must be installed locally as it's
+not available in Squoosh.)


### PR DESCRIPTION
- Add a return type to the "don't add return type hints" example.
- Update the Node2D brief description to match the current documentation.
- Recommend a colorblind-friendly color for outlines in screenshots.
- Reference Squoosh and OxiPNG in the image compression guidelines.