### PR TITLE
Fix TextureButton texture number in Design interfaces with the Control nodes

### DIFF
--- a/getting_started/step_by_step/ui_introduction_to_the_ui_system.rst
+++ b/getting_started/step_by_step/ui_introduction_to_the_ui_system.rst
@@ -97,7 +97,7 @@ the ``Modulate`` property and use the color picker.
 TextureButton
 ~~~~~~~~~~~~~
 
-**TextureButton** is like TextureRect, except it has 5 texture slots:
+**TextureButton** is like TextureRect, except it has 6 texture slots:
 one for each of the button's states. Most of the time, you'll use the
 Normal, Pressed, and Hover textures. Focused is useful if your interface
 listens to the keyboard's input. The sixth image slot, the Click Mask,


### PR DESCRIPTION
The TextureButton node has 6 texture slots, not 5. Closes #3927 