### PR TITLE
Reorder exporting articles to be more logically ordered

### DIFF
--- a/getting_started/workflow/export/index.rst
+++ b/getting_started/workflow/export/index.rst
@@ -10,11 +10,11 @@ Export
    exporting_pcks
    feature_tags
    exporting_for_pc
-   exporting_for_ios
+   changing_application_icon_for_windows
    exporting_for_uwp
+   exporting_for_ios
    exporting_for_android
+   android_custom_build
    exporting_for_web
    exporting_for_dedicated_servers
    one-click_deploy
-   android_custom_build
-   changing_application_icon_for_windows


### PR DESCRIPTION
Reorders the exporting articles to make more sense. Changing the icon for windows is now under exporting for PC. Custom builds for Android is now under exporting for Android. and exporting for UWP is under changing the icon for windows so the list now goes desktop, phones, other. I know this is a inconsequential change, I just think it looks better.

I'm not sure if One Click Deploy should be moved or not, since the HTML5 export has a similar feature.