### PR TITLE
Add warnings on embedded pck files

### DIFF
--- a/development/compiling/optimizing_for_size.rst
+++ b/development/compiling/optimizing_for_size.rst
@@ -159,6 +159,10 @@ If you are targeting desktop platforms, the
 `UPX <https://upx.github.io/>`_ compressor can be used.
 This can reduce binary size considerably.
 
+.. warning::
+
+    You cannot use embedded PCK files with UPX compression.
+
 However, keep in mind that some antivirus programs may detect UPX-packed
 binaries as a virus. Therefore, if you are releasing a commercial game,
 make sure to sign your binaries or use a platform that will distribute them.

--- a/getting_started/workflow/export/exporting_for_pc.rst
+++ b/getting_started/workflow/export/exporting_for_pc.rst
@@ -12,3 +12,8 @@ export system. When exporting for PC (Linux, Windows, macOS), the exporter
 takes all the project files and creates a ``data.pck`` file. This file is
 bundled with a specially optimized binary that is smaller, faster and
 does not contain the editor and debugger.
+
+.. warning::
+
+    If you export for Windows with embedded PCK files, you will not be able to
+    sign the program, it will break.


### PR DESCRIPTION
Adds a warning that embedded pck files will not work with UPX compression or code signing on windows. #3930 and this PR closes #3093
