### PR TITLE
Update CSV translation tutorial

### DIFF
--- a/getting_started/workflow/assets/importing_translations.rst
+++ b/getting_started/workflow/assets/importing_translations.rst
@@ -3,106 +3,6 @@
 Importing translations
 ======================
 
-Games and internationalization
-------------------------------
-
-The world is full of different markets and cultures and, to maximize
-profits™, nowadays games are released in several languages. To solve
-this, internationalized text must be supported in any modern game
-engine.
-
-In regular desktop or mobile applications, internationalized text is
-usually located in resource files (or .po files for GNU stuff). Games,
-however, can use several orders of magnitude more text than
-applications, so they must support efficient methods for dealing with
-loads of multilingual text.
-
-There are two approaches to generate multilingual language games and
-applications. Both are based on a key:value system. The first is to use
-one of the languages as the key (usually English), the second is to use a
-specific identifier. The first approach is probably easier for
-development if a game is released first in English, later in other
-languages, but a complete nightmare if working with many languages at
-the same time.
-
-In general, games use the second approach and a unique ID is used for
-each string. This allows you to revise the text while it is being
-translated to other languages. The unique ID can be a number, a string,
-or a string with a number (it's just a unique string anyway).
-
-.. note:: If you need a more powerful file format, Godot also supports
-          loading translations written in the gettext ``.po`` format. See
-          :ref:`doc_localization_using_gettext` for details.
-
-Translation format
-------------------
-
-To complete the picture and allow efficient support for translations,
-Godot has a special importer that can read CSV files. Most spreadsheet
-editors can export to this format, so the only requirement is that the files
-have a special arrangement. The CSV files **must** be saved with UTF-8 encoding
-without a `byte order mark <https://en.wikipedia.org/wiki/Byte_order_mark>`__.
-
-.. warning::
-
-    By default, Microsoft Excel will always save CSV files with ANSI encoding
-    rather than UTF-8. There is no built-in way to do this, but there are
-    workarounds as described
-    `here <https://stackoverflow.com/questions/4221176/excel-to-csv-with-utf8-encoding>`__.
-
-    We recommend using `LibreOffice <https://www.libreoffice.org/>`__ or Google Sheets instead.
-
-CSV files must be formatted as follows:
-
-+--------+----------+----------+----------+
-| keys   | <lang1>  | <lang2>  | <langN>  |
-+========+==========+==========+==========+
-| KEY1   | string   | string   | string   |
-+--------+----------+----------+----------+
-| KEY2   | string   | string   | string   |
-+--------+----------+----------+----------+
-| KEYN   | string   | string   | string   |
-+--------+----------+----------+----------+
-
-The "lang" tags must represent a language, which must be one of the :ref:`valid
-locales <doc_locales>` supported by the engine. The "KEY" tags must be
-unique and represent a string universally (they are usually in
-uppercase, to differentiate from other strings). These keys will be replaced at
-runtime by the matching translated string. Note that the case is important,
-"KEY1" and "Key1" will be different keys.
-The top-left cell is ignored and can be left empty or having any content.
-Here's an example:
-
-+-------+-----------------------+------------------------+------------------------------+
-| keys  | en                    | es                     | ja                           |
-+=======+=======================+========================+==============================+
-| GREET | Hello, friend!        | Hola, amigo!           | こんにちは                   |
-+-------+-----------------------+------------------------+------------------------------+
-| ASK   | How are you?          | Cómo está?             | 元気ですか                   |
-+-------+-----------------------+------------------------+------------------------------+
-| BYE   | Goodbye               | Adiós                  | さようなら                   |
-+-------+-----------------------+------------------------+------------------------------+
-| QUOTE | "Hello" said the man. | "Hola" dijo el hombre. | 「こんにちは」男は言いました |
-+-------+-----------------------+------------------------+------------------------------+
-
-The same example is shown below as a comma-separated plain text file,
-which should be the result of editing the above in a spreadsheet.
-When editing the plain text version, be sure to enclose with double
-quotes any message that contains commas, line breaks or double quotes,
-so that commas are not parsed as delimiters, line breaks don't create new
-entries and double quotes are not parsed as enclosing characters. Be sure
-to escape any double quotes a message may contain by preceding them with
-another double quote. Alternatively, you can select another delimiter than
-comma in the import options.
-
-.. code-block:: none
-
-    keys,en,es,ja
-    GREET,"Hello, friend!","Hola, amigo!",こんにちは
-    ASK,How are you?,Cómo está?,元気ですか
-    BYE,Goodbye,Adiós,さようなら
-    QUOTE,"""Hello"" said the man.","""Hola"" dijo el hombre.",「こんにちは」男は言いました
-
 CSV importer
 ------------
 
@@ -118,6 +18,19 @@ Select the ``.csv`` file and access the **Import** dock to define import
 options. You can toggle the compression of the imported translations, and
 select the delimiter to use when parsing the CSV file.
 
+.. note:: For translation tutorial using CSV files, see 
+          :ref:`doc_localization_using_csv` for details.
+
 .. image:: img/import_csv.png
 
 Be sure to click **Reimport** after any change to these options.
+
+PO files
+--------
+
+The other translation file format which Godot accepts is the ``.po`` file
+format. To import these files, just drag and drop them into your Godot project 
+folder.
+
+.. note:: For translation tutorial using PO files, see 
+          :ref:`doc_localization_using_gettext` for details.

--- a/tutorials/i18n/index.rst
+++ b/tutorials/i18n/index.rst
@@ -6,5 +6,6 @@ Internationalization
    :name: toc-learn-features-i18n
 
    internationalizing_games
+   localization_using_csv
    localization_using_gettext
    locales

--- a/tutorials/i18n/internationalizing_games.rst
+++ b/tutorials/i18n/internationalizing_games.rst
@@ -14,27 +14,41 @@ often require localization. Godot offers many tools to make this process
 more straightforward, so this tutorial is more like a collection of
 tips and tricks.
 
-Localization is usually done by specific studios hired for the job and,
-despite the huge amount of software and file formats available for this,
-the most common way to do localization to this day is still with
-spreadsheets. The process of creating the spreadsheets and importing
-them is already covered in the :ref:`doc_importing_translations` tutorial,
-so this one could be seen more like a follow-up to that one.
-
-
 .. note:: We will be using the official demo as an example; you can
           `download it from the Asset Library <https://godotengine.org/asset-library/asset/134>`_.
 
-Configuring the imported translation
-------------------------------------
+Localizing texts
+----------------
 
-Translations can get updated and re-imported when they change, but
-they still have to be added to the project. This is done in
-**Project → Project Settings → Localization**:
+The most common topic in localization is text translation. 
 
-.. image:: img/localization_dialog.png
+Godot offers two ways to localize text, by using CSV files or gettext 
+PO files. These files contain the translation data needed to translate 
+the texts in a game. Both formats have their own advantage and disadvantage, 
+which you can learn in detail in the tutorials :ref:`doc_localization_using_csv` 
+and :ref:`doc_localization_using_gettext`. In this section, we'll provide a quick 
+overview of text translation.
 
-The above dialog is used to add or remove translations project-wide.
+Some controls, such as :ref:`Button <class_Button>` and :ref:`Label <class_Label>`,
+will automatically fetch a translation if their text matches a key. 
+The keys are imported from a CSV file or gettext PO files.
+For example, if a label's text is "MAIN_SCREEN_GREETING1" and that key exists, 
+then the text will automatically be translated.
+
+In ``GDScript``, the :ref:`Object.tr() <class_Object_method_tr>` and 
+:ref:`Object.tr_n() <class_Object_method_tr_n>` functions are used with keys to provide
+translation. These two functions will look up the key in the imported translations 
+and convert it into the translated text if found:
+
+::
+
+    # Text localization using keys (CSV method).
+    level.set_text(tr("LEVEL_5_NAME"))
+    status.set_text(tr("GAME_STATUS_" + str(status_index)))
+    
+    # Text localization using source strings as keys (gettext PO method).
+    level.set_text(tr("Level 5: The Infinite Void"))
+    status.set_text(tr("Game status: " + str(status_index)))
 
 Localizing resources
 --------------------
@@ -47,23 +61,6 @@ can be used for this:
 
 Select the resource to be remapped, then add some alternatives for each
 locale.
-
-Converting keys to text
------------------------
-
-Some controls, such as :ref:`Button <class_Button>` and :ref:`Label <class_Label>`,
-will automatically fetch a translation if their text matches a translation key.
-For example, if a label's text is "MAIN_SCREEN_GREETING1" and that key exists
-in the current translation, then the text will automatically be translated.
-
-In code, the :ref:`Object.tr() <class_Object_method_tr>`
-function can be used. This will just look up the text in the
-translations and convert it if found:
-
-::
-
-    level.set_text(tr("LEVEL_5_NAME"))
-    status.set_text(tr("GAME_STATUS_" + str(status_index)))
 
 Making controls resizable
 --------------------------

--- a/tutorials/i18n/localization_using_csv.rst
+++ b/tutorials/i18n/localization_using_csv.rst
@@ -1,0 +1,183 @@
+.. _doc_localization_using_csv:
+
+Localization using CSV
+======================
+
+Introduction
+------------
+
+There are two approaches to translate multilingual language games and
+applications. Both are based on a key:value system. The first is to use
+one of the languages as the key (usually English), the second is to use a
+specific identifier (which can be a number, a string, or a combination of both). 
+The first approach is the :ref:`gettext PO approach <doc_localization_using_gettext>`, 
+while the second approach is the CSV approach, which is what we'll discuss here.
+
+.. note:: There is a `translation demo <https://godotengine.org/asset-library/asset/134>`_ 
+          which can be downloaded in the Asset Library where we display how to use CSV 
+          translation and resource remapping.
+
+Translation format
+------------------
+
+There are two requirements that the CSV translation file must follow:
+
+- It must follow the format shown in table just below.
+- It must be saved with UTF-8 encoding without a `byte order mark <https://en.wikipedia.org/wiki/Byte_order_mark>`__.
+
++--------+----------+----------+----------+
+| keys   | <lang1>  | <lang2>  | <langN>  |
++========+==========+==========+==========+
+| KEY1   | string   | string   | string   |
++--------+----------+----------+----------+
+| KEY2   | string   | string   | string   |
++--------+----------+----------+----------+
+| KEYN   | string   | string   | string   |
++--------+----------+----------+----------+
+
+.. warning::
+
+    By default, Microsoft Excel will always save CSV files with ANSI encoding
+    rather than UTF-8. There is no built-in way to do this, but there are
+    workarounds as described
+    `here <https://stackoverflow.com/questions/4221176/excel-to-csv-with-utf8-encoding>`__.
+
+    We recommend using `LibreOffice <https://www.libreoffice.org/>`__ or Google Sheets instead.
+
+The "lang" tags must represent a language, which must be one of the :ref:`valid
+locales <doc_locales>` supported by the engine. The "KEY" tags must be
+unique and represent a string universally (they are usually in
+uppercase, to differentiate from other strings). These keys will be replaced at
+runtime by the matching translated string. Note that the case is important,
+"KEY1" and "Key1" will be different keys.
+The top-left cell is ignored and can be left empty or having any content.
+Here's an example:
+
++-------+-----------------------+------------------------+------------------------------+
+| keys  | en                    | es                     | ja                           |
++=======+=======================+========================+==============================+
+| GREET | Hello, friend!        | Hola, amigo!           | こんにちは                   |
++-------+-----------------------+------------------------+------------------------------+
+| ASK   | How are you?          | Cómo está?             | 元気ですか                   |
++-------+-----------------------+------------------------+------------------------------+
+| BYE   | Goodbye               | Adiós                  | さようなら                   |
++-------+-----------------------+------------------------+------------------------------+
+| QUOTE | "Hello" said the man. | "Hola" dijo el hombre. | 「こんにちは」男は言いました |
++-------+-----------------------+------------------------+------------------------------+
+
+The same example is shown below as a comma-separated plain text file,
+which should be the result of editing the above in a spreadsheet.
+When editing the plain text version, be sure to enclose with double
+quotes any message that contains commas, line breaks or double quotes,
+so that commas are not parsed as delimiters, line breaks don't create new
+entries and double quotes are not parsed as enclosing characters. Be sure
+to escape any double quotes a message may contain by preceding them with
+another double quote. Alternatively, you can select another delimiter than
+comma in the import options.
+
+.. code-block:: none
+
+    keys,en,es,ja
+    GREET,"Hello, friend!","Hola, amigo!",こんにちは
+    ASK,How are you?,Cómo está?,元気ですか
+    BYE,Goodbye,Adiós,さようなら
+    QUOTE,"""Hello"" said the man.","""Hola"" dijo el hombre.",「こんにちは」男は言いました
+
+Importing the CSV file
+----------------------
+
+Godot has its own CSV importer. When you drop a CSV file into your Godot project folder,
+a list of translation resources will be generated for all the locales in the CSV. 
+There's also an option to compress the translation resources. For a more 
+throughout explanation, see :ref:`doc_importing_translations`.
+
+Once you have imported the CSV file, you will need to add the translation resources to be
+used in the game. This is done in **Project → Project Settings → Localization**:
+
+.. image:: img/localization_dialog.png
+
+Using the translations in game
+------------------------------
+
+Once you have added the translations into your project, you're ready to translate your game.
+
+The first step is to ask ``TranslationServer`` to use the language that you want.
+To do this, call the :ref:`TranslationServer.set_locale() <class_TranslationServer_method_set_locale>` function.
+
+To fetch a translation from a key, use the translation API :ref:`tr() <class_Object_method_tr>`. As an example, see 
+the ``GDScript`` below. For scene nodes containing user-facing texts, assign key for the text properties 
+that you want to be translated. Some of these translated properties are ``Text``, ``Hint_Tooltip`` and ``Placeholder_Text``.
+
+.. note:: All of these is covered in the `translation demo project <https://godotengine.org/asset-library/asset/134>`_.
+          
+::
+
+    # translation_example.gd
+    
+    extends Node2D
+
+    func _ready():
+        TranslationServer.set_locale("ja")      
+    
+        print(tr("GREET"))
+        
+        TranslationServer.set_locale("es")
+        
+        print(tr("BYE"))
+
+Plural translation
+------------------
+
+Plural translation can be tricky and is a common problem in text localization.
+
+In Godot, it is possible to provide plural translation with CSV files. To do this, 
+append the subscript ``[0]``, ``[1]``, ``[2]`` and so on for the keys dealing with plural translations.
+How far the index of the subscript goes depends on the required number of indices to satisfy the number of 
+plural forms of all locales. For example, Arabic has six plural forms. So if Arabic is one of 
+the supported locale in the CSV, the plural keys will have up to index ``[5]`` subscript.
+
++-------------+-----------------------+------------------------+------------------------------+
+| keys        | en                    | ja                     | ru                           |
++=============+=======================+========================+==============================+
+| KEY_HELLO   | Hello!                | こんにちは!            | Привет!                      |
++-------------+-----------------------+------------------------+------------------------------+
+| KEY_DAYS[0] | One day ago           | %d日前                 | %d день назад                |
++-------------+-----------------------+------------------------+------------------------------+
+| KEY_DAYS[1] | %d days ago           |                        | %d дня назад                 |
++-------------+-----------------------+------------------------+------------------------------+
+| KEY_DAYS[2] |                       |                        | %d дней назад                |
++-------------+-----------------------+------------------------+------------------------------+
+
+In ``GDScript``, use the :ref:`tr_n() <class_Object_method_tr_n>` function for plural translation. You don't need 
+to precise the subscript when using the key. Godot engine will concatenate the appropriate subscript for you 
+based on the current locale of ``TranslationServer`` and the argument ``n`` passed into the ``tr_n()`` function.
+For example (based on the above table):
+
+::
+
+    # translation_example.gd
+    
+    extends Node2D
+
+    func _ready():
+        TranslationServer.set_locale("en")      
+    
+        print(tr_n(1, "KEY_DAYS")) # Will print "One day ago".
+        print(tr_n(6, "KEY_DAYS")) # Will print "%d days ago".
+        print(tr_n(6, "KEY_DAYS") % 6) # Will print "6 days ago".
+		
+        TranslationServer.set_locale("ja")
+        
+        print(tr_n(1, "KEY_DAYS")) # Will print "%d日前".
+        print(tr_n(6, "KEY_DAYS")) # Will print "%d日前".
+        print(tr_n(6, "KEY_DAYS") % 6) # Will print "6日前".	
+
+Workflow
+--------
+
+One question that often arises is what is the process of adding keys in the CSV and using keys in the game.
+Which one comes first?
+
+One recommended workflow is to have a spreadsheet open, then record the key along with the base language source string
+in the spreadsheet as soon as a key is needed in the game during development. After the game is finished, the spreadsheet will be 
+sent to a translation company or team to be translated. The translated spreadsheet will then be imported into the project.


### PR DESCRIPTION
Made a tutorial dedicated to CSV translation by regrouping bits and pieces of information regarding CSV translation from [Importing translations](https://docs.godotengine.org/en/3.2/getting_started/workflow/assets/importing_translations.html) and [Internationalizing games](https://docs.godotengine.org/en/latest/tutorials/i18n/internationalizing_games.html).

Also to incorporate changes from godotengine/godot#41519.

