### PR TITLE
Add information on how get_slide_count counts collisions

### DIFF
--- a/tutorials/physics/using_kinematic_body_2d.rst
+++ b/tutorials/physics/using_kinematic_body_2d.rst
@@ -130,6 +130,8 @@ and ``get_slide_collision()``:
         var collision = get_slide_collision(i)
         print("I collided with ", collision.collider.name)
 
+.. note:: `get_slide_count()` only counts times the body has collided and changed direction.      
+
 See :ref:`KinematicCollision2D <class_KinematicCollision2D>` for details on what
 collision data is returned.
 


### PR DESCRIPTION
Someone opened an issue that the Using KinematicBody2D page doesn't explain how the get_slide_count counts collisions. It does not count collisions that don't change the KinematicBody direction. The docs do say under the code example to go to the class reference for more information , but I'm not sure if that would be considered enough. If you guys think that's already enough then close this PR and that issue, if not merge this. Closes #3889
