### PR TITLE
Document the GDScript debugger not supporting threads yet

### DIFF
--- a/tutorials/debug/debugger_panel.rst
+++ b/tutorials/debug/debugger_panel.rst
@@ -32,6 +32,12 @@ You can use the buttons in the top-right corner to:
 - **Break**. This button pauses the game's execution.
 - **Continue**. This button resumes the game after a breakpoint or pause.
 
+.. warning::
+
+    Breakpoints won't break on code if it's
+    :ref:`running in a thread <doc_using_multiple_threads>`.
+    This is a current limitation of the GDScript debugger.
+
 Errors
 ++++++
 

--- a/tutorials/debug/overview_of_debugging_tools.rst
+++ b/tutorials/debug/overview_of_debugging_tools.rst
@@ -90,6 +90,12 @@ The **Keep Debugger Open** option keeps the debugger open after a scene
 has been closed. And the **Debug with External Editor** option lets you
 debug your game with an external editor.
 
+.. warning::
+
+    Breakpoints won't break on code if it's
+    :ref:`running in a thread <doc_using_multiple_threads>`.
+    This is a current limitation of the GDScript debugger.
+
 Debug project settings
 ----------------------
 


### PR DESCRIPTION
The notice is duplicated to make it harder to miss.

See https://github.com/godotengine/godot/issues/2446.