### PR TITLE
Update GDScript examples - Step By Step: Scripting

### DIFF
--- a/getting_started/step_by_step/scripting.rst
+++ b/getting_started/step_by_step/scripting.rst
@@ -259,7 +259,7 @@ using :ref:`Object.connect() <class_Object_method_connect>`.
  .. code-tab:: gdscript GDScript
 
     func _ready():
-        get_node("Button").connect("pressed", self, "_on_Button_pressed")
+        get_node("Button").connect("pressed", self._on_Button_pressed)
 
  .. code-tab:: csharp
 
@@ -276,7 +276,7 @@ The final script should look like this:
     extends Panel
 
     func _ready():
-        get_node("Button").connect("pressed", self, "_on_Button_pressed")
+        get_node("Button").connect("pressed", self._on_Button_pressed)
 
     func _on_Button_pressed():
         get_node("Label").text = "HELLO!"


### PR DESCRIPTION
Howdy all,

This is my first contribution to the Godot community; excited to learn more about the project over time. This is a relatively small change, but I wanted to ask a few questions:

* Does it make sense to only update the GDScript version of these code snippets? The concern would be that it becomes harder to track that the C# version needs to be updated.
* Tied with the above; if we're happy to include this change without updating the C# version, should I add some form of TODO or FIXME? Not sure what the current protocols/tracking mechanisms we use are.
* Before opening this PR, I looked for issues related to updating documentation around the new `Callable` class, but didn't find one. I'm not sure if these little piecemeal diffs are how the maintainers like to operate, or if there are plans for a larger unified effort.

"Regular" PR message follows. Thanks!

---

In Godot 4.0, the connect() function no longer takes an object and a string name of a function, but rather the new Callable type. Following the current instructions leads to error messages.

This updates this page to make the GDScript options.

Unfortunately, I don't have C# development set up on my machine, so I have not updated the C# examples as I'm currently unable to validate that they work as intended.