### PR TITLE
Document differences between Bullet and GodotPhysics

### DIFF
--- a/tutorials/physics/bullet_and_godotphysics_differences.rst
+++ b/tutorials/physics/bullet_and_godotphysics_differences.rst
@@ -1,0 +1,22 @@
+.. _doc_bullet_and_godotphysics_differences:
+
+Bullet and GodotPhysics Differences
+===================================
+
+Godot includes two different physics engines for 3D physics, Bullet, which
+is the default, and GodotPhysics. There are several important differences
+in how the physics engines function. They will **not** always produce
+identical or even similar results.
+
+RigidBody3D
+-----------
+
+In Bullet physics, the center of mass for RigidBody3D nodes is the center
+of the node. In GodotPhysics, the center of mass is the average of the
+collision shape centers.
+
+Linear and angular damping behave very differently in Bullet compared to
+GodotPhysics. Values over 1 do not make a difference in Bullet, but do make
+a difference in GodoyPhysics. Additionally, in Bullet the effect at 1 is
+significantly stronger compared to GodotPhysics. Conversely, a value of -1
+is significantly less strong in Bullet compared to GodotPhysics.

--- a/tutorials/physics/index.rst
+++ b/tutorials/physics/index.rst
@@ -13,3 +13,4 @@ Physics
    ragdoll_system
    kinematic_character_2d
    soft_body
+   bullet_and_godotphysics_differences


### PR DESCRIPTION
Adds a page to the physics section going over the known differences between Bullet and GodotPhysics. Closes #2161. These are not all the differences, only the ones that have been brought up in issues.