### PR TITLE
Add information on compiling targets

### DIFF
--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -92,11 +92,22 @@ Start a terminal, go to the root dir of the engine source code and type:
 
 ::
 
-    scons -j8 platform=linuxbsd
+    scons -j8 platform=linuxbsd target=release_debug
 
 A good rule of thumb for the ``-j`` (*jobs*) flag, is to have at least as many
 threads compiling Godot as you have cores in your CPU, if not one or two more.
 Feel free to add the ``-j`` option to any SCons command you see below.
+
+You have 3 target options when compiling.
+
+- ``debug``, Performance will be worse and the executable will be larger.
+  However you can debug Godot and it compiles the fastest.
+- ``release_debug``. Godot will have normal performance and file size, and you
+  can debug it.
+- ``release``. Godot will have normal performance and file size, but Godot
+  cannot be debugged.
+
+If you do not specify a target ``debug`` will be used.
 
 .. note::
 
@@ -119,12 +130,8 @@ manager.
 
     Using Clang appears to be a requirement for OpenBSD, otherwise fonts
     would not build.
-
-.. note:: If you are compiling Godot for production use, then you can
-          make the final executable smaller and faster by adding the
-          SCons option ``target=release_debug``.
-
-          If you are compiling Godot with GCC, you can make the binary
+ 
+.. note:: If you are compiling Godot with GCC, you can make the binary
           even smaller and faster by adding the SCons option ``use_lto=yes``.
           As link-time optimization is a memory-intensive process,
           this will require about 3 GB of available RAM while compiling.

--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -35,13 +35,24 @@ Compiling
 
 Start a terminal, go to the root directory of the engine source code.
 
+You have 3 target options when compiling.
+
+- ``debug``, Performance will be worse and the executable will be larger.
+  However you can debug Godot and it compiles the fastest.
+- ``release_debug``. Godot will have normal performance and file size, and you
+  can debug it.
+- ``release``. Godot will have normal performance and file size, but Godot
+  cannot be debugged.
+
+If you do not specify a target ``debug`` will be used.
+
 To compile for Intel (x86-64) powered Macs, use::
 
-    scons platform=osx arch=x86_64 --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=osx arch=x86_64 target=release_debug --jobs=$(sysctl -n hw.logicalcpu)
 
 To compile for Apple Silicon (ARM64) powered Macs, use::
 
-    scons platform=osx arch=arm64 --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=osx arch=arm64 target=release_debug --jobs=$(sysctl -n hw.logicalcpu)
 
 To support both architectures in a single "Universal 2" binary, run the above two commands and then use ``lipo`` to bundle them together::
 

--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -126,6 +126,20 @@ option to any SCons command you see below.
 .. note:: When compiling with multiple CPU threads, SCons may warn about
           pywin32 being missing. You can safely ignore this warning.
 
+Finally you have 3 target options when compiling.
+
+- ``debug``, Performance will be worse and the executable will be larger.
+  However you can debug Godot and it compiles the fastest.
+- ``release_debug``. Godot will have normal performance and file size, and you
+  can debug it.
+- ``release``. Godot will have normal performance and file size, but Godot
+  cannot be debugged.
+
+If you do not specify a target ``debug`` will be used. The target can be
+specified like this::
+
+    C:\godot> scons -j4 platform=windows target=release_debug
+
 If all goes well, the resulting binary executable will be placed in
 ``C:\godot\bin\`` with the name ``godot.windows.tools.32.exe`` or
 ``godot.windows.tools.64.exe``. By default, SCons will build a binary matching
@@ -135,11 +149,7 @@ your CPU architecture, but this can be overridden using ``bits=64`` or
 This executable file contains the whole engine and runs without any
 dependencies. Running it will bring up the Project Manager.
 
-.. note:: If you are compiling Godot for production use, then you can
-          make the final executable smaller and faster by adding the
-          SCons option ``target=release_debug``.
-
-          If you are compiling Godot with MinGW, you can make the binary
+.. note:: If you are compiling Godot with MinGW, you can make the binary
           even smaller and faster by adding the SCons option ``use_lto=yes``.
           As link-time optimization is a memory-intensive process,
           this will require about 3 GB of available RAM while compiling.


### PR DESCRIPTION
Adds information to the Windows, Mac and X11 compiling pages on compiling targets. You cannot miss this information now so this should close #2813