### PR TITLE
Add yield with multiple arguments example to GDSCript Basics

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_basics.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics.rst
@@ -1591,19 +1591,19 @@ You can also get the signal's argument once it's emitted by an object:
     # Wait for when any node is added to the scene tree.
     var node = yield(get_tree(), "node_added")
 
-If there are more than one argument ``yield`` returns an array containing
-the arguments:
-
-::
+If there is more than one argument, ``yield`` returns an array containing
+the arguments::
 
     signal done(input, processed)
+    
     func process_input(input):
         print("Processing initialized")
         yield(get_tree(), "idle_frame")
         print("Waiting")
         yield(get_tree(), "idle_frame")
         emit_signal(input, "Processed " + input)
-    
+
+
     func _ready():
         process_input("Test") # Prints: Processing initialized
         var data = yield(self, "done") # Prints: waiting

--- a/getting_started/scripting/gdscript/gdscript_basics.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics.rst
@@ -1591,6 +1591,24 @@ You can also get the signal's argument once it's emitted by an object:
     # Wait for when any node is added to the scene tree.
     var node = yield(get_tree(), "node_added")
 
+If there are more than one argument ``yield`` returns an array containing
+the arguments:
+
+::
+
+    signal done(input, processed)
+    func process_input(input):
+        print("Processing initialized")
+        yield(get_tree(), "idle_frame")
+        print("Waiting")
+        yield(get_tree(), "idle_frame")
+        emit_signal(input, "Processed " + input)
+    
+    func _ready():
+        process_input("Test") # Prints: Processing initialized
+        var data = yield(self, "done") # Prints: waiting
+        print(data[1]) # Prints: Processed Test
+
 If you're unsure whether a function may yield or not, or whether it may yield
 multiple times, you can yield to the ``completed`` signal conditionally:
 


### PR DESCRIPTION
I think this is a really powerful feature, that should be taught somewhere.

However my example is not the best. I thought about using the `HTTPRequest` class and it's `_request_completed` signal, but it requires knowledge about the node and would be a little longer. On the other hand, it would be a real world example.