### PR TITLE
Fix RichTextEffects not loading correctly in BBCode in RichTextLabel

### DIFF
--- a/tutorials/gui/bbcode_in_richtextlabel.rst
+++ b/tutorials/gui/bbcode_in_richtextlabel.rst
@@ -232,6 +232,7 @@ Ghost
 
     tool
     extends RichTextEffect
+    class_name RichTextGhost
 
     # Syntax: [ghost freq=5.0 span=10.0][/ghost]
 
@@ -254,6 +255,7 @@ Pulse
 
     tool
     extends RichTextEffect
+    class_name RichTextPulse
 
     # Syntax: [pulse color=#00FFAA height=0.0 freq=2.0][/pulse]
 
@@ -280,6 +282,7 @@ Matrix
 
     tool
     extends RichTextEffect
+    class_name RichTextMatrix
 
     # Syntax: [matrix clean=2.0 dirty=1.0 span=50][/matrix]
 


### PR DESCRIPTION
Added class names to all three of the custom RichText examples, as without these the effects did not load correctly in the "Custom Effect Array" property of the RichTextLabel. (Godot v3.2.2.stable)

