### PR TITLE
Qt Creator tutorial: Specify C++ code style settings location

### DIFF
--- a/development/cpp/configuring_an_ide/qt_creator.rst
+++ b/development/cpp/configuring_an_ide/qt_creator.rst
@@ -93,7 +93,7 @@ Code style configuration
 Developers must follow the project's :ref:`code style <doc_code_style_guidelines>`
 and the IDE should help them follow it. By default, Qt Creator uses spaces
 for indentation which doesn't match the Godot code style guidelines. You can
-change this behavior by changing the **Code Style** in **Options > C++**.
+change this behavior by changing the **Code Style** in **Tools > Options > C++**.
 
 .. figure:: img/qtcreator-options-cpp.png
    :figclass: figure-w480


### PR DESCRIPTION
Hello, I have recently set up QtCreator to work with Godot's source code. 

Towards the end of the tutorial there's a section about how to configure the coding style and it says to go to Options > C++.
Since Options isn't immediately visible when looking at the IDE, I thought it might be a good idea to be a bit more explicit about the location. 

Here's a gif about what I mean: 

![Tools_Options](https://user-images.githubusercontent.com/43905913/92404446-479c9f80-f13c-11ea-9abf-19fbacb49a5f.gif)

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
