### PR TITLE
Add an 'unsupported on android' warning to 2d skeleton documentation

### DIFF
--- a/tutorials/animation/2d_skeletons.rst
+++ b/tutorials/animation/2d_skeletons.rst
@@ -5,8 +5,8 @@
 
 .. warning::
 
-   Please note that 2D skeletons are currently not supported on Android (see `this issue
-   <https://github.com/godotengine/godot/issues/35772>`_ for more information).
+    There are known issues with 2D skeletons on mobile and web platforms with the GLES2 renderer. We
+    recommend using the GLES3 renderer if your project relies on Skeleton2D for now.
 
 Introduction
 ------------

--- a/tutorials/animation/2d_skeletons.rst
+++ b/tutorials/animation/2d_skeletons.rst
@@ -3,6 +3,11 @@
 2D skeletons
 ============
 
+.. warning::
+
+   Please note that 2D skeletons are currently not supported on Android (see `this issue
+   <https://github.com/godotengine/godot/issues/35772>`_ for more information).
+
 Introduction
 ------------
 


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
