### PR TITLE
Remove UPX recommendation in Optimizing for size

### DIFF
--- a/development/compiling/optimizing_for_size.rst
+++ b/development/compiling/optimizing_for_size.rst
@@ -151,18 +151,3 @@ If you build from source, remember to strip debug symbols from binaries:
 ::
 
     strip godot.64
-
-Using UPX to compress binaries
-------------------------------
-
-If you are targeting desktop platforms, the
-`UPX <https://upx.github.io/>`_ compressor can be used.
-This can reduce binary size considerably.
-
-.. warning::
-
-    You cannot use embedded PCK files with UPX compression.
-
-However, keep in mind that some antivirus programs may detect UPX-packed
-binaries as a virus. Therefore, if you are releasing a commercial game,
-make sure to sign your binaries or use a platform that will distribute them.


### PR DESCRIPTION
The downsides (such as false positives in antivirus programs) are usually not worth the upsides.

Moreover, when distributing a game using a platform like Steam, SteamPipe will compress the data that will be sent to the player downloading the game, even if the original game data is uncompressed.


<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->