### PR TITLE
Add a FAQ item about "When is the next release of Godot out?"

### DIFF
--- a/about/faq.rst
+++ b/about/faq.rst
@@ -243,6 +243,12 @@ as well as the `unofficial Python support <https://github.com/touilleMan/godot-p
 This would be a good starting point to see how another third-party library
 integrates with Godot.
 
+When is the next release of Godot out?
+--------------------------------------
+
+When it's ready! See :ref:`doc_release_policy_when_is_next_release_out` for more
+information.
+
 I would like to contribute! How can I get started?
 --------------------------------------------------
 

--- a/about/release_policy.rst
+++ b/about/release_policy.rst
@@ -65,6 +65,8 @@ for each Godot version:
 Pre-release Godot versions aren't intended to be used in production and are
 provided on a best-effort basis.
 
+.. _doc_release_policy_when_is_next_release_out:
+
 When is the next release out?
 -----------------------------
 


### PR DESCRIPTION
People still ask me this occasionally, as the [Godot release policy](https://docs.godotengine.org/en/latest/about/release_policy.html) page is usually not read by newcomers.