### PR TITLE
Clarify license requirement in Asset Library submitting instructions

### DIFF
--- a/tutorials/assetlib/uploading_to_assetlib.rst
+++ b/tutorials/assetlib/uploading_to_assetlib.rst
@@ -38,7 +38,10 @@ are a few requirements your asset needs to meet to be approved.
   asset needs the contents of the submodule, your asset won't work.
 
 * The license needs to be correct. The license listed on the asset
-  library must match the license in the repository.
+  library must match the license in the repository. The repo MUST
+  have a license file, called either "LICENSE" or "LICENSE.md".
+  This file must contain the license text itself and a copyright
+  statement that includes the year(s) and copyright holder.
 
 * Use proper English for the name and description of your asset.
   This includes using correct capitalization, and using full


### PR DESCRIPTION
One user submitted an asset with an incorrect license, and I had to explain what was wrong so that they could fix it. I think the information of what qualifies as a correct license should be in the documentation, so I added it.

```
* The license needs to be correct. The license listed on the asset
  library must match the license in the repository. The repo MUST
  have a license file, called either "LICENSE" or "LICENSE.md".
  This file must contain the license text itself and a copyright
  statement that includes the year(s) and copyright holder.
```