### PR TITLE
Updated custom webexport to be more clear

### DIFF
--- a/getting_started/workflow/export/exporting_for_web.rst
+++ b/getting_started/workflow/export/exporting_for_web.rst
@@ -166,31 +166,6 @@ the ``.pck`` and ``.wasm`` files, which are usually large in size.
 The WebAssembly module compresses particularly well, down to around a quarter
 of its original size with gzip compression.
 
-Trying to access files which aren't compiled with the project but are used by the
-application needs to be loaded with a custom HTML page. The reason for that is 
-that the WebAssembly does not have the permission to access files that aren't
-compiled.
-
-Here is an example of the part of the HTML page that needs to be modified.
-Use the default HTML page `/misc/dist/html/full-size.html <https://github.com/godotengine/godot/blob/master/misc/dist/html/full-size.html>`__. as a refrence 
-and replace the lines 250 to 255 with.
-
-::
-		Engine.load(MAIN_PACK)
-		engine.preloadFile('$GODOT_BASENAME.js')
-		engine.preloadFile('$GODOT_BASENAME.pck')
-		engine.preloadFile('$GODOT_BASENAME.png')
-		engine.preloadFile('$GODOT_BASENAME.wasm')
-		engine.preloadFile('my_text.txt')
-		engine.init()
-		setStatusMode('indeterminate');
-		engine.setCanvas(canvas);
-		engine.start().then(() => {
-			setStatusMode('hidden');
-			initializing = true;
-		}, displayFailureNotice);
-
-
 Export options
 --------------
 

--- a/getting_started/workflow/export/exporting_for_web.rst
+++ b/getting_started/workflow/export/exporting_for_web.rst
@@ -166,6 +166,31 @@ the ``.pck`` and ``.wasm`` files, which are usually large in size.
 The WebAssembly module compresses particularly well, down to around a quarter
 of its original size with gzip compression.
 
+Trying to access files which aren't compiled with the project but are used by the
+application needs to be loaded with a custom HTML page. The reason for that is 
+that the WebAssembly does not have the permission to access files that aren't
+compiled.
+
+Here is an example of the part of the HTML page that needs to be modified.
+Use the default HTML page `/misc/dist/html/full-size.html <https://github.com/godotengine/godot/blob/master/misc/dist/html/full-size.html>`__. as a refrence 
+and replace the lines 250 to 255 with.
+
+::
+		Engine.load(MAIN_PACK)
+		engine.preloadFile('$GODOT_BASENAME.js')
+		engine.preloadFile('$GODOT_BASENAME.pck')
+		engine.preloadFile('$GODOT_BASENAME.png')
+		engine.preloadFile('$GODOT_BASENAME.wasm')
+		engine.preloadFile('my_text.txt')
+		engine.init()
+		setStatusMode('indeterminate');
+		engine.setCanvas(canvas);
+		engine.start().then(() => {
+			setStatusMode('hidden');
+			initializing = true;
+		}, displayFailureNotice);
+
+
 Export options
 --------------
 

--- a/tutorials/platform/customizing_html5_shell.rst
+++ b/tutorials/platform/customizing_html5_shell.rst
@@ -133,6 +133,23 @@ them by calling the :js:meth:`engine.preloadFile` method with a path to a file o
 with an ``ArrayBuffer`` object. In case of the ``ArrayBuffer``, or one of its views, a second argument
 must be specified to define an internal path for the loaded resource.
 
+Here is a short example for loading additionals files. In this case the file "my_text.txt" is loaded in
+when while the engine starts up.
+::
+		Engine.load(MAIN_PACK)
+		engine.preloadFile('$GODOT_BASENAME.js')
+		engine.preloadFile('$GODOT_BASENAME.pck')
+		engine.preloadFile('$GODOT_BASENAME.png')
+		engine.preloadFile('$GODOT_BASENAME.wasm')
+		engine.preloadFile('my_text.txt')
+		engine.init()
+		setStatusMode('indeterminate');
+		engine.setCanvas(canvas);
+		engine.start().then(() => {
+			setStatusMode('hidden');
+			initializing = true;
+		}, displayFailureNotice);
+
 Customizing the presentation
 ----------------------------
 Several methods can be used to further customize the look and behavior of the game on your page.

--- a/tutorials/platform/customizing_html5_shell.rst
+++ b/tutorials/platform/customizing_html5_shell.rst
@@ -136,19 +136,19 @@ must be specified to define an internal path for the loaded resource.
 Here is a short example for loading additionals files. In this case the file "my_text.txt" is loaded in
 when while the engine starts up.
 ::
-		Engine.load(MAIN_PACK)
-		engine.preloadFile('$GODOT_BASENAME.js')
-		engine.preloadFile('$GODOT_BASENAME.pck')
-		engine.preloadFile('$GODOT_BASENAME.png')
-		engine.preloadFile('$GODOT_BASENAME.wasm')
-		engine.preloadFile('my_text.txt')
-		engine.init()
-		setStatusMode('indeterminate');
-		engine.setCanvas(canvas);
-		engine.start().then(() => {
-			setStatusMode('hidden');
-			initializing = true;
-		}, displayFailureNotice);
+    Engine.load(MAIN_PACK)
+    engine.preloadFile('$GODOT_BASENAME.js')
+    engine.preloadFile('$GODOT_BASENAME.pck')
+    engine.preloadFile('$GODOT_BASENAME.png')
+    engine.preloadFile('$GODOT_BASENAME.wasm')
+    engine.preloadFile('my_text.txt')
+    engine.init()
+    setStatusMode('indeterminate');
+    engine.setCanvas(canvas);
+    engine.start().then(() => {
+    	setStatusMode('hidden');
+    	initializing = true;
+    }, displayFailureNotice);
 
 Customizing the presentation
 ----------------------------


### PR DESCRIPTION
Added a description of how to use external files after HTML export as well as a simple example of how to do this.

Correlates with this pull request :
https://github.com/godotengine/godot-docs/pull/2510
