### PR TITLE
qt_creator.rst: Add .glsl to the file extensions step

### DIFF
--- a/development/cpp/configuring_an_ide/qt_creator.rst
+++ b/development/cpp/configuring_an_ide/qt_creator.rst
@@ -22,8 +22,8 @@ Importing the project
 
 - Next, you can choose which folders and files will be visible to the project.
   While C/C++ files are added automatically, other extensions can be potentially useful:
-  ``*.py`` for buildsystem files, ``*.java`` for Android platform development,
-  ``*.mm`` for macOS platform development.
+  ``*.glsl`` for shader files, ``*.py`` for buildsystem files,
+  ``*.java`` for Android platform development, ``*.mm`` for macOS platform development.
 
 .. figure:: img/qtcreator-apply-import-filter.png
    :figclass: figure-w480


### PR DESCRIPTION
Story behind this PR:
I was recently working on an issue which involved tinkering with shaders, but shader files weren't picked up by the IDE and it took me quite a while to figure out what was happening :) 

I've added the .glsl extension first in the list as I thought shader files are like core .cpp files and the tutorial reader should definetly be notified that they are not visible to the IDE by default.  