### PR TITLE
Mention limit of 8 lights per mesh

### DIFF
--- a/tutorials/3d/introduction_to_3d.rst
+++ b/tutorials/3d/introduction_to_3d.rst
@@ -222,5 +222,7 @@ each viewport:
 Lights
 ------
 
-There is no limitation on the number of lights, nor of types of lights, in
-Godot. As many as desired can be added (as long as performance allows).
+Godot has a limit of up to 8 lights per mesh. Aside from that, there
+is no limitation on the number of lights, nor of types of lights, in
+Godot. As many as desired can be added, as long as performance allows,
+and no more than 8 lights shine on a single mesh.


### PR DESCRIPTION
The introduction to 3D article mentioned unlimited lights, but it did not mention the limit of 8 lights per mesh. This is a hard-coded limit in Godot. I added a mention of it to the article. This was requested by jcmonkey on Discord.