### PR TITLE
Fix typo in Enemy Scene section

### DIFF
--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -534,7 +534,7 @@ Now it's time to make the enemies our player will have to dodge. Their
 behavior will not be very complex: mobs will spawn randomly at the edges
 of the screen, choose a random direction, and move in a straight line.
 
-We'll create a ``Mob`` scene, which we can then *instance* to create any
+We'll create a ``Mob`` scene, which we can then *instantiate* to create any
 number of independent mobs in the game.
 
 .. note:: See :ref:`doc_instancing` to learn more about instancing.


### PR DESCRIPTION
Replace the word *instance* for *instantiate* as it is used as a verb in the Enemy Scene section

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
