### PR TITLE
Add a warning about `latest` documentation compatibility

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -230,6 +230,21 @@ def godot_get_image_filename_for_language(filename, env):
 
 sphinx.util.i18n.get_image_filename_for_language = godot_get_image_filename_for_language
 
+# Read the Docs adds a note at the top of the page when reading documentation
+# for an old stable version, but not when reading the latest unstable version.
+# We want to add a warning note as the `latest` documentation may not always
+# apply to Godot 3.2.x.
+rst_prolog = """
+.. attention::
+    You are reading the ``latest`` (unstable) version of this documentation,
+    which may document features not available or compatible with Godot 3.2.x.
+
+    See `this page <https://docs.godotengine.org/{locale}/stable/>`__
+    for the stable version of this documentation.
+""".format(
+    locale=language,
+)
+
 # Couldn't find a way to retrieve variables nor do advanced string
 # concat from reST, so had to hardcode this in the "epilog" added to
 # all pages. This is used in index.rst to display the Weblate badge.


### PR DESCRIPTION
Not everything in the `latest` branch applies to Godot 3.2.x. Read the Docs adds a warning notice for old versions automatically, but it doesn't offer an option to do so for the `latest`/unstable branch so we have to add it ourselves.

**Note:** Right now, clicking the link redirects you to the homepage. Is there a way to get the current page URL/ID so we can
redirect to the same page, but with a different version?