### PR TITLE
Removed GD namespace from RandRange

### DIFF
--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -898,11 +898,11 @@ Note that a new instance must be added to the scene using ``add_child()``.
         mobInstance.Position = mobSpawnLocation.Position;
 
         // Add some randomness to the direction.
-        direction += GD.RandRange(-Mathf.Pi / 4, Mathf.Pi / 4);
+        direction += RandRange(-Mathf.Pi / 4, Mathf.Pi / 4);
         mobInstance.Rotation = direction;
 
         // Choose the velocity.
-        mobInstance.LinearVelocity = new Vector2(GD.RandRange(150f, 250f), 0).Rotated(direction);
+        mobInstance.LinearVelocity = new Vector2(RandRange(150f, 250f), 0).Rotated(direction);
     }
 
 .. important:: Why ``PI``? In functions requiring angles, GDScript uses *radians*,


### PR DESCRIPTION
`GD.RandRange` was returning a double where a float was expected causing a type error. Using the `RandRange` function as described in the tutorial fixes the error.

*Bugsquad edit:* Fixes #4047.