### PR TITLE
Escape double quotes for meta descriptions in HTML

### DIFF
--- a/_extensions/godot_descriptions.py
+++ b/_extensions/godot_descriptions.py
@@ -78,6 +78,9 @@ class DescriptionGenerator:
         # Replace multiple spaces with single spaces
         desc = re.sub("\\s+", " ", desc)
 
+        # Escape double quotes for HTML
+        desc = re.sub('"', "&quot;", desc)
+
         return desc
 
     def create_description(self, cutoff_suffix="..."):


### PR DESCRIPTION
If this not done, some descriptions will be closed earlier than intended.