### PR TITLE
[Docs] Clarify type of Main Node in tutorial.

### DIFF
--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -669,7 +669,7 @@ Main scene
 ----------
 
 Now it's time to bring it all together. Create a new scene and add a
-:ref:`Node <class_Node>` named ``Main``. Click the "Instance" button and select your
+:ref:`Node <class_Node>` named ``Main``. This should be a basic Node, NOT a Node2D. Click the "Instance" button and select your
 saved ``Player.tscn``.
 
 .. image:: img/instance_scene.png

--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -669,7 +669,8 @@ Main scene
 ----------
 
 Now it's time to bring it all together. Create a new scene and add a
-:ref:`Node <class_Node>` named ``Main``. This should be a basic Node, NOT a Node2D. Click the "Instance" button and select your
+:ref:`Node <class_Node>` named ``Main``. Ensure you create a Node, **not** a
+Node2D. Click the "Instance" button and select your
 saved ``Player.tscn``.
 
 .. image:: img/instance_scene.png


### PR DESCRIPTION
If a user follows the tutorial, and accidentally [creates the Main scene][1] using a Node2D instead of a basic Node, they will be unable to [add a background][2] with Layout -> Full Rect as instructed later in the tutorial.

This expected (although possibly confusing) behaviour for Node2D is described in [#18166][3].

I encountered this personally while working through the tutorial. Because I am not familiar with the node types available in Godot, and because the node search function scrolls to Node2D when searching for 'Node', I completed the tutorial using a Node2D as my Main node, then encountered the issue where I couldn't use Layout -> Full Rect to set the size of the background colour.

[1]: https://docs.godotengine.org/en/stable/getting_started/step_by_step/your_first_game.html#main-scene
[2]: https://docs.godotengine.org/en/stable/getting_started/step_by_step/your_first_game.html#background
[3]: https://github.com/godotengine/godot/issues/18166

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
