### PR TITLE
Remove needless note about signals and classes.

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_basics.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics.rst
@@ -1424,11 +1424,6 @@ the :ref:`Object.connect() <class_Object_method_connect>` method::
         progress_bar.animate(old_value, new_value)
     ...
 
-.. note::
-
-    To use signals, your class has to extend the ``Object`` class or any
-    type extending it like ``Node``, ``KinematicBody``, ``Control``...
-
 In the ``Game`` node, we get both the ``Character`` and ``Lifebar`` nodes, then
 connect the character, that emits the signal, to the receiver, the ``Lifebar``
 node in this case.


### PR DESCRIPTION
As far as I know, any user-defined class must extend Object or a
subclass thereof, meaning it would be impossible to define a class that
couldn't use signals. This warning is therefore unnecessary.

Please let me know if I misinterpreted this.
It seemed as easy to open a PR as an issue asking.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->