### PR TITLE
Add options per compile method for .app bundle creation on Mac OSX

### DIFF
--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -59,11 +59,26 @@ manager.
 
 To create an ``.app`` bundle like in the official builds, you need to use the
 template located in ``misc/dist/osx_tools.app``. Typically, for an optimized
-editor binary built with ``target=release_debug``::
+editor binary built with ``target=release_debug``, you may do this::
 
+Start first with::
     cp -r misc/dist/osx_tools.app ./Godot.app
     mkdir -p Godot.app/Contents/MacOS
-    cp bin/godot.osx.opt.tools.universal Godot.app/Contents/MacOS/Godot
+
+Then, if you compiled solely for Intel (x86-64) powered Macs::
+
+    cp bin/godot.osx.tools.x86_64 Godot.app/Contents/MacOS/Godot
+
+Or if you compiled solely for Apple Silicon (ARM64) powered Macs::
+
+    cp bin/godot.osx.tools.arm64 Godot.app/Contents/MacOS/Godot
+
+Or if you bundled both into a single "Universal 2" binary::
+
+    cp bin/godot.osx.tools.universal Godot.app/Contents/MacOS/Godot
+
+Finally, set execute permissions through this command::
+
     chmod +x Godot.app/Contents/MacOS/Godot
 
 If you are building the ``master`` branch, additionally copy the Vulkan library::

--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -59,26 +59,11 @@ manager.
 
 To create an ``.app`` bundle like in the official builds, you need to use the
 template located in ``misc/dist/osx_tools.app``. Typically, for an optimized
-editor binary built with ``target=release_debug``, you may do this::
+editor binary built with ``target=release_debug``::
 
-Start first with::
     cp -r misc/dist/osx_tools.app ./Godot.app
     mkdir -p Godot.app/Contents/MacOS
-
-Then, if you compiled solely for Intel (x86-64) powered Macs::
-
-    cp bin/godot.osx.tools.x86_64 Godot.app/Contents/MacOS/Godot
-
-Or if you compiled solely for Apple Silicon (ARM64) powered Macs::
-
-    cp bin/godot.osx.tools.arm64 Godot.app/Contents/MacOS/Godot
-
-Or if you bundled both into a single "Universal 2" binary::
-
-    cp bin/godot.osx.tools.universal Godot.app/Contents/MacOS/Godot
-
-Finally, set execute permissions through this command::
-
+    cp bin/godot.osx.opt.tools.universal Godot.app/Contents/MacOS/Godot
     chmod +x Godot.app/Contents/MacOS/Godot
 
 If you are building the ``master`` branch, additionally copy the Vulkan library::

--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -63,7 +63,21 @@ editor binary built with ``target=release_debug``::
 
     cp -r misc/dist/osx_tools.app ./Godot.app
     mkdir -p Godot.app/Contents/MacOS
-    cp bin/godot.osx.opt.tools.universal Godot.app/Contents/MacOS/Godot
+
+Then, if you compiled solely for Intel (x86-64) powered Macs::
+
+    cp bin/godot.osx.tools.x86_64 Godot.app/Contents/MacOS/Godot
+
+Or if you compiled solely for Apple Silicon (ARM64) powered Macs::
+
+    cp bin/godot.osx.tools.arm64 Godot.app/Contents/MacOS/Godot
+
+Or if you bundled both into a single "Universal 2" binary::
+
+    cp bin/godot.osx.tools.universal Godot.app/Contents/MacOS/Godot
+
+Finally, set execute permissions through this command::
+
     chmod +x Godot.app/Contents/MacOS/Godot
 
 If you are building the ``master`` branch, additionally copy the Vulkan library::


### PR DESCRIPTION
In the Compiling for MacOS section, the terminal commands (the directories particularly) listed for creating an .app bundle were only for Universal 2 binaries. I added the commands for the Intel and the ARM64 compile options as well, for smoother compiling.