### PR TITLE
Fix broken formatting in the beginning of What is GDNative?

### DIFF
--- a/tutorials/plugins/gdnative/what_is_gdnative.rst
+++ b/tutorials/plugins/gdnative/what_is_gdnative.rst
@@ -7,10 +7,8 @@ Introduction
 ------------
 
 **GDNative** is a Godot-specific technology that lets the engine interact with
- native `shared libraries
- <https://en.wikipedia.org/wiki/Library_(computing)#Shared_libraries>`__ at
- run-time. You can use it to run native code without compiling it with the
- engine.
+native `shared libraries <https://en.wikipedia.org/wiki/Library_(computing)#Shared_libraries>`__
+at run-time. You can use it to run native code without compiling it with the engine.
 
 .. note:: GDNative is *not* a scripting language and has no relation to
           :ref:`GDScript <doc_gdscript>`.


### PR DESCRIPTION
The formatting made it appear like this:

![image](https://user-images.githubusercontent.com/180032/94920186-15216080-04b6-11eb-8045-bdbc50b52686.png)