### PR TITLE
Use MinGW-w64 package available in Arch Linux's official repository

### DIFF
--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -179,7 +179,9 @@ and 64-bit variants. The package names may differ based on your distribution,
 here are some known ones:
 
 +----------------+--------------------------------------------------------------+
-| **Arch Linux** | Install `mingw-w64-gcc from the AUR`_.                       |
+| **Arch Linux** | ::                                                           |
+|                |                                                              |
+|                |     pacman -Sy mingw-w64                                     |
 +----------------+--------------------------------------------------------------+
 | **Debian** /   | ::                                                           |
 | **Ubuntu**     |                                                              |
@@ -199,8 +201,6 @@ here are some known ones:
 |                |     urpmi mingw64-gcc-c++ mingw64-winpthreads-static \       |
 |                |           mingw32-gcc-c++ mingw32-winpthreads-static         |
 +----------------+--------------------------------------------------------------+
-
-.. _mingw-w64-gcc from the AUR: https://aur.archlinux.org/packages/mingw-w64-gcc/
 
 Before attempting the compilation, SCons will check for
 the following binaries in your ``PATH`` environment variable::


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->

Mingw-w64 package is officially available in the arch linux repository and people can install mingw-w64 directly from official repository.
