### PR TITLE
Update the Blender collision empties tip for Blender 2.80+

### DIFF
--- a/getting_started/workflow/assets/importing_scenes.rst
+++ b/getting_started/workflow/assets/importing_scenes.rst
@@ -432,7 +432,7 @@ reliability.
 .. note::
 
     For better visibility on Blender's editor, you can set the "X-Ray" option
-    on collision empties and set some distinct color for them by going on
+    on collision empties and set some distinct color for them by changing```
     **Edit > Preferences > Themes > 3D Viewport > Empty**.
     
     If using Blender 2.79 or older, follow these steps instead:

--- a/getting_started/workflow/assets/importing_scenes.rst
+++ b/getting_started/workflow/assets/importing_scenes.rst
@@ -435,7 +435,7 @@ reliability.
     on collision empties and set some distinct color for them by going on
     **Edit > Preferences > Themes > 3D Viewport > Empty**.
     
-    Obs.: if you are using a Blender's version below 2.8, maybe the steps are
+    If using Blender 2.79 or older, change the following setting instead:
     **User Preferences > Themes > 3D View > Empty**.
 
 .. seealso::

--- a/getting_started/workflow/assets/importing_scenes.rst
+++ b/getting_started/workflow/assets/importing_scenes.rst
@@ -435,7 +435,7 @@ reliability.
     on collision empties and set some distinct color for them by going on
     **Edit > Preferences > Themes > 3D Viewport > Empty**.
     
-    If using Blender 2.79 or older, change the following setting instead:
+    If using Blender 2.79 or older, follow these steps instead:
     **User Preferences > Themes > 3D View > Empty**.
 
 .. seealso::

--- a/getting_started/workflow/assets/importing_scenes.rst
+++ b/getting_started/workflow/assets/importing_scenes.rst
@@ -432,7 +432,7 @@ reliability.
 .. note::
 
     For better visibility on Blender's editor, you can set the "X-Ray" option
-    on collision empties and set some distinct color for them by changing```
+    on collision empties and set some distinct color for them by changing
     **Edit > Preferences > Themes > 3D Viewport > Empty**.
     
     If using Blender 2.79 or older, follow these steps instead:

--- a/getting_started/workflow/assets/importing_scenes.rst
+++ b/getting_started/workflow/assets/importing_scenes.rst
@@ -431,8 +431,11 @@ reliability.
 
 .. note::
 
-    For better visibility in Blender's editor, you can set the "X-Ray" option
-    on collision empties and set some distinct color for them in Blender's
+    For better visibility on Blender's editor, you can set the "X-Ray" option
+    on collision empties and set some distinct color for them by going on
+    **Edit > Preferences > Themes > 3D Viewport > Empty**.
+    
+    Obs.: if you are using a Blender's version below 2.8, maybe the steps are
     **User Preferences > Themes > 3D View > Empty**.
 
 .. seealso::


### PR DESCRIPTION
My purpose is to update the steps guide on "Note" (from line 432 and forward) to matches the current Blender's version plus an observation for users who still on Blender's old versions.

Obs.: this is my first pull request. Did I made it right?