### PR TITLE
[iOS] Update required Xcode/SDK version

### DIFF
--- a/development/compiling/compiling_for_ios.rst
+++ b/development/compiling/compiling_for_ios.rst
@@ -10,7 +10,7 @@ Requirements
 
 -  SCons 3.0+ (you can install it via Homebrew or Macports, you should be able
    to run ``scons`` in a terminal when installed).
--  Xcode 10.0 (or later) with the iOS (10.0) SDK and the command line tools.
+-  Xcode 11.0 (or later) with the iOS (13.0) SDK and the command line tools.
 
 If you are building the ``master`` branch:
 


### PR DESCRIPTION
Related issue: https://github.com/godotengine/godot/issues/42584

Increases required Xcode and SDK version to compile iOS builds.