### PR TITLE
Fix build error in input_examples.rst

### DIFF
--- a/tutorials/inputs/input_examples.rst
+++ b/tutorials/inputs/input_examples.rst
@@ -141,7 +141,7 @@ avoid this, make sure to test the event type first:
     {
         if (inputEvent is InputEventMouseButton mouseEvent)
         {
-            GD.Print($"mouse button event at {mouseEvent.Position}");
+            GD.Print("Mouse button event at {0}", mouseEvent.Position);
         }
     }
 
@@ -282,12 +282,12 @@ also counts as a button - two buttons, to be precise, with both
 
     public override void _Input(InputEvent inputEvent)
     {
-        if (inputEvent as InputEventMouseButton mouseEvent && mouseEvent.Pressed)
+        if (inputEvent is InputEventMouseButton mouseEvent && mouseEvent.Pressed)
         {
             switch ((ButtonList)mouseEvent.ButtonIndex)
             {
                 case ButtonList.Left:
-                    GD.Print($"Left button was clicked at {mouseEvent.Position}");
+                    GD.Print("Left button was clicked at {0}", mouseEvent.Position);
                     break;
                 case ButtonList.WheelUp:
                     GD.Print("Wheel up");


### PR DESCRIPTION
There's a sphinx build error that prevents the page from building. The C# string interpolation code is correct but it seems the parser or linter can't parse it. I replaced it with string formatting

This also replaces an `as` which people pointed out should be `is`.

Co-authored-by: pycbouh