### PR TITLE
Update vector math doc

### DIFF
--- a/tutorials/math/vector_math.rst
+++ b/tutorials/math/vector_math.rst
@@ -203,8 +203,10 @@ by its magnitude. Because this is such a common operation,
 
 .. warning:: Because normalization involves dividing by the vector's length,
              you cannot normalize a vector of length ``0``. Attempting to
-             do so will result in an undefined value. Though while programming,
-             if using the normalized() function, it will return ``Vector3(0, 0, 0)``
+              do so would normally result in an error. In GDScript though,
+              trying to call the ``normalized()`` method on a ``Vector2`` or
+              ``Vector3`` of length 0 leaves the value untouched and avoids the
+              error for you.
 
 Reflection
 ----------

--- a/tutorials/math/vector_math.rst
+++ b/tutorials/math/vector_math.rst
@@ -203,7 +203,8 @@ by its magnitude. Because this is such a common operation,
 
 .. warning:: Because normalization involves dividing by the vector's length,
              you cannot normalize a vector of length ``0``. Attempting to
-             do so will result in an error.
+             do so will result in an undefined value. Though while programming,
+             if using the normalized() function, it will return ``Vector3(0, 0, 0)``
 
 Reflection
 ----------


### PR DESCRIPTION
In the section explaining about normalizing a vector. In the warning, it says we cannot normalize a vector with a length of 0. And doing so will result in an error.

But after testing out normalizing a vector ( via normalized() function ), no errors are reported. Also printing out to the console shows (0, 0, 0) as the output. Similarly, normalizing manually by dividing it by the length shows strange result if printed out, but still no error.

I think GDScript ( not tested with other languages ) handles normalization of vector in such a way that we don't have to worry about normalizing a vector of length 0 ( only when done through normalized() function ).

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
