### PR TITLE
Update the Input Map tab name in the InputEvent documentation

### DIFF
--- a/tutorials/inputs/inputevent.rst
+++ b/tutorials/inputs/inputevent.rst
@@ -169,7 +169,7 @@ logic. This allows for:
    keyboard on PC, Joypad on console).
 -  Input to be reconfigured at run-time.
 
-Actions can be created from the Project Settings menu in the Input Map
+Actions can be created from the Project Settings menu in the **Input Map**
 tab.
 
 Any event has the methods :ref:`InputEvent.is_action() <class_InputEvent_method_is_action>`,

--- a/tutorials/inputs/inputevent.rst
+++ b/tutorials/inputs/inputevent.rst
@@ -169,7 +169,7 @@ logic. This allows for:
    keyboard on PC, Joypad on console).
 -  Input to be reconfigured at run-time.
 
-Actions can be created from the Project Settings menu in the Actions
+Actions can be created from the Project Settings menu in the Input Map
 tab.
 
 Any event has the methods :ref:`InputEvent.is_action() <class_InputEvent_method_is_action>`,


### PR DESCRIPTION
Hi! Noticed a small issue with the input event docs while working on my game and trying to understand the input propagation better. Specifically, the doc refers to the Project Settings dialog's "Input Map" tab as the Actions tab. While I understood what was meant, as the Input Map is where you define the Actions at, I still found it confusing at first. I mistook it to mean there may be another action feature of Godot I hadn't learned yet, but no, it's the same on I am already using. This is why I think it would maybe help to mention the tab by the actual text that is used in the UI.

![Project Settings Input Map Tab](https://user-images.githubusercontent.com/3212801/95686662-417f6000-0bcd-11eb-90f7-adcb62ba4fd5.png)

