### PR TITLE
Update link to GDNative simple demo project

### DIFF
--- a/tutorials/scripting/gdnative/gdnative_c_example.rst
+++ b/tutorials/scripting/gdnative/gdnative_c_example.rst
@@ -13,7 +13,7 @@ that is to come after this.
 
 Before we begin, you can download the source code to the example object we
 describe below in the `GDNative-demos repository
-<https://github.com/GodotNativeTools/GDNative-demos/tree/master/c/SimpleDemo>`_.
+<https://github.com/GodotNativeTools/GDNative-demos/tree/master/c/simple>`_.
 
 This example project also contains a SConstruct file that makes compiling a
 little easier, but in this tutorial we'll be doing things by hand to


### PR DESCRIPTION
The folder was renamed from `SimpleDemo` to `simple`
See: https://github.com/godotengine/gdnative-demos/pull/38

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
