### PR TITLE
Rename file for Submitting to the Asset Library

### DIFF
--- a/community/asset_library/index.rst
+++ b/community/asset_library/index.rst
@@ -7,4 +7,4 @@ Asset Library
 
    what_is_assetlib
    using_assetlib
-   uploading_to_assetlib
+   submitting_to_assetlib

--- a/community/asset_library/submitting_to_assetlib.rst
+++ b/community/asset_library/submitting_to_assetlib.rst
@@ -1,4 +1,4 @@
-.. _doc_uploading_to_assetlib:
+.. _doc_submitting_to_assetlib:
 
 Submitting to the Asset Library
 ===============================

--- a/community/asset_library/using_assetlib.rst
+++ b/community/asset_library/using_assetlib.rst
@@ -99,7 +99,7 @@ new functions:
 |image6|
 
 You can learn how to submit assets to the Library, and what the asset submission
-guidelines are, in the next part of this tutorial, :ref:`doc_uploading_to_assetlib`.
+guidelines are, in the next part of this tutorial, :ref:`doc_submitting_to_assetlib`.
 
 In the editor
 -------------


### PR DESCRIPTION
Rename the file to match the article's title (the file is now `submitting_to_assetlib.rst`). #4227 moved these files, so we may as well take the opportunity to fix the file name while we're at it.