### PR TITLE
Recommend vertex shading for particles in GPU optimization

### DIFF
--- a/tutorials/performance/gpu_optimization.rst
+++ b/tutorials/performance/gpu_optimization.rst
@@ -173,6 +173,8 @@ You can increase performance in a fill rate-limited project by reducing the
 amount of work the GPU has to do. You can do this by simplifying the shader
 (perhaps turn off expensive options if you are using a :ref:`StandardMaterial3D
 <class_StandardMaterial3D>`), or reducing the number and size of textures used.
+Also, when using non-unshaded particles, consider forcing vertex shading in
+their material to decrease the shading cost.
 
 **When targeting mobile devices, consider using the simplest possible shaders
 you can reasonably afford to use.**


### PR DESCRIPTION
Vertex shading is a common way to speed up particle rendering, since shading a quad is much faster on a per-vertex approach compared to a per-pixel approach. (It makes sense for many kinds of "3D" particles too.)