### PR TITLE
Make PerlinNoise3D accept scalars directly

### DIFF
--- a/tutorials/plugins/editor/visual_shader_plugins.rst
+++ b/tutorials/plugins/editor/visual_shader_plugins.rst
@@ -50,6 +50,10 @@ all you need to initialize your plugin.
         return "Classic Perlin-Noise-3D function (by Curly-Brace)"
 
 
+    func _init():
+        set_input_port_default_value(2, 0.0)
+
+
     func _get_return_icon_type():
         return VisualShaderNode.PORT_TYPE_SCALAR
 


### PR DESCRIPTION
The current code requires creating and plugging a Scalar node just to enter the value "10" (see current screenshot); with this change, the node, like existing Godot nodes, can take the scalar value directly within the PerlinNoise3D Node.