### PR TITLE
Improve explanations around shader language's `TIME` variable

### DIFF
--- a/tutorials/shaders/shader_reference/canvas_item_shader.rst
+++ b/tutorials/shaders/shader_reference/canvas_item_shader.rst
@@ -51,8 +51,11 @@ Global built-ins are available everywhere, including custom functions.
 +-------------------+-----------------------------------------------------------------------------+
 | Built-in          | Description                                                                 |
 +===================+=============================================================================+
-| in float **TIME** | Global time, in seconds.                                                    |
-|                   | It's subject to the rollover setting (which is 3,600 -1 hour- by default).  |
+| in float **TIME** | Global time since the shader was compiled, in seconds (always positive).    |
+|                   | It's subject to the rollover setting (which is 3,600 seconds by default).   |
+|                   | It's not affected by :ref:`time_scale<class_Engine_property_time_scale>`    |
+|                   | or pausing, but you can define a global shader uniform to add a "scaled"    |
+|                   | ``TIME`` variable if desired.                                               |
 +-------------------+-----------------------------------------------------------------------------+
 
 Vertex built-ins


### PR DESCRIPTION
`master` version of #4283.