### PR TITLE
Add `FOG`/`RADIANCE`/`IRRADIANCE` built-ins in Spatial shaders

### DIFF
--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -273,11 +273,11 @@ these properties, and if you don't write to them, Godot will optimize away the c
 +-----------------------------------+--------------------------------------------------------------------------------------------------+
 | in vec2 **POINT_COORD**           | Point Coordinate for drawing points with POINT_SIZE.                                             |
 +-----------------------------------+--------------------------------------------------------------------------------------------------+
-| out vec4 **FOG**                  | If written to, blends final pixel color with FOG.rgb based on FOG.a                              |
+| out vec4 **FOG**                  | If written to, blends final pixel color with FOG.rgb based on FOG.a.                             |
 +-----------------------------------+--------------------------------------------------------------------------------------------------+
-| out vec4 **RADIANCE**             | If written to, blends environment map radiance with RADIANCE.rgb based on RADIANCE.a             |
+| out vec4 **RADIANCE**             | If written to, blends environment map radiance with RADIANCE.rgb based on RADIANCE.a.            |
 +-----------------------------------+--------------------------------------------------------------------------------------------------+
-| out vec4 **IRRADIANCE**           | If written to, blends environment map IRRADIANCE with IRRADIANCE.rgb based on IRRADIANCE.a       |
+| out vec4 **IRRADIANCE**           | If written to, blends environment map IRRADIANCE with IRRADIANCE.rgb based on IRRADIANCE.a.      |
 +-----------------------------------+--------------------------------------------------------------------------------------------------+
 Light built-ins
 ^^^^^^^^^^^^^^^

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -273,7 +273,12 @@ these properties, and if you don't write to them, Godot will optimize away the c
 +-----------------------------------+--------------------------------------------------------------------------------------------------+
 | in vec2 **POINT_COORD**           | Point Coordinate for drawing points with POINT_SIZE.                                             |
 +-----------------------------------+--------------------------------------------------------------------------------------------------+
-
+| out vec4 **FOG**                  | If written to, blends final pixel color with FOG.rgb based on FOG.a                              |
++-----------------------------------+--------------------------------------------------------------------------------------------------+
+| out vec4 **RADIANCE**             | If written to, blends environment map radiance with RADIANCE.rgb based on RADIANCE.a             |
++-----------------------------------+--------------------------------------------------------------------------------------------------+
+| out vec4 **IRRADIANCE**           | If written to, blends environment map IRRADIANCE with IRRADIANCE.rgb based on IRRADIANCE.a       |
++-----------------------------------+--------------------------------------------------------------------------------------------------+
 Light built-ins
 ^^^^^^^^^^^^^^^
 

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -279,6 +279,7 @@ these properties, and if you don't write to them, Godot will optimize away the c
 +-----------------------------------+--------------------------------------------------------------------------------------------------+
 | out vec4 **IRRADIANCE**           | If written to, blends environment map IRRADIANCE with IRRADIANCE.rgb based on IRRADIANCE.a.      |
 +-----------------------------------+--------------------------------------------------------------------------------------------------+
+
 Light built-ins
 ^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
added entries for Fog, Radiance and Irradiance as per #4290 

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
