### PR TITLE
Fix shader `TIME` description to match how it actually works (3.2)

### DIFF
--- a/tutorials/shading/shading_reference/canvas_item_shader.rst
+++ b/tutorials/shading/shading_reference/canvas_item_shader.rst
@@ -51,7 +51,7 @@ Global built-ins are available everywhere, including custom functions.
 +-------------------+-----------------------------------------------------------------------------+
 | Built-in          | Description                                                                 |
 +===================+=============================================================================+
-| in float **TIME** | Global time since the shader was compiled, in seconds (always positive).    |
+| in float **TIME** | Global time since the engine has started, in seconds (always positive).     |
 |                   | It's subject to the rollover setting (which is 3,600 seconds by default).   |
 |                   | It's not affected by :ref:`time_scale<class_Engine_property_time_scale>`    |
 |                   | or pausing, but you can override the ``TIME`` variable's time scale by      |


### PR DESCRIPTION
Follow-up to #4283.