### PR TITLE
Add a symbol next to class reference page links

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -31,6 +31,7 @@
     --link-color-active: #105078;
     --link-color-visited: #9b59b6;
     --external-reference-icon: url("data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjEyIiB3aWR0aD0iMTIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGcgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMjk4MGI5Ij48cGF0aCBkPSJtNy41IDcuMXYzLjRoLTZ2LTZoMy40Ii8+PHBhdGggZD0ibTUuNzY1IDFoNS4yMzV2NS4zOWwtMS41NzMgMS41NDctMS4zMS0xLjMxLTIuNzI0IDIuNzIzLTIuNjktMi42ODggMi44MS0yLjgwOC0xLjMxMy0xLjMxeiIvPjwvZz48L3N2Zz4K");
+    --classref-badge-text-color: hsl(0, 0%, 45%);
 
     --hr-color: #e1e4e5;
     --table-row-odd-background-color: #f3f6f6;
@@ -117,6 +118,7 @@
         --link-color-active: #6ad;
         --link-color-visited: #cb99f6;
         --external-reference-icon: url("data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjEyIiB3aWR0aD0iMTIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGcgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjOGNmIj48cGF0aCBkPSJtNy41IDcuMXYzLjRoLTZ2LTZoMy40Ii8+PHBhdGggZD0ibTUuNzY1IDFoNS4yMzV2NS4zOWwtMS41NzMgMS41NDctMS4zMS0xLjMxLTIuNzI0IDIuNzIzLTIuNjktMi42ODggMi44MS0yLjgwOC0xLjMxMy0xLjMxeiIvPjwvZz48L3N2Zz4K");
+        --classref-badge-text-color: hsl(0, 0%, 70%);
 
         --hr-color: #555;
         --table-row-odd-background-color: #3b3e41;
@@ -275,6 +277,18 @@ a.btn:hover {
     background-repeat: no-repeat;
     background-image: var(--external-reference-icon);
     padding-right: 13px;
+}
+
+/* Distinguish class reference page links from "user manual" page links with a "ref" badge. */
+a[href*="classes/"]::before {
+    content: "ref";
+    color: var(--classref-badge-text-color);
+    background-color: hsla(0, 0%, 50%, 0.3);
+    font-weight: 700;
+    font-size: 80%;
+    border-radius: 9999px;
+    padding: 0.125rem 0.375rem;
+    margin-right: 0.25rem;
 }
 
 hr,


### PR DESCRIPTION
This makes them easier to distinguish from "user manual" page links, especially in search results. The "C" is for "class" :slightly_smiling_face: 

It's not perfect, but it should be a decent interim solution until we add a way to filter between user manual and class reference results in search.

## Preview

![image](https://user-images.githubusercontent.com/180032/97116376-e7b68400-16fc-11eb-9191-2766d21a5063.png)

![image](https://user-images.githubusercontent.com/180032/97116371-e08f7600-16fc-11eb-993a-0b09297eab9b.png)

<details>
<summary>Old version</summary>

### Page (light theme)

![image](https://user-images.githubusercontent.com/180032/97083669-ed836b00-1611-11eb-87eb-4193c3f74976.png)

### Search results (dark theme)

![image](https://user-images.githubusercontent.com/180032/97083652-ce84d900-1611-11eb-8e3f-13ee16de9d10.png)
</details>