### PR TITLE
Improved documentation of TileMap.cell_y_sort

### DIFF
--- a/classes/class_tilemap.rst
+++ b/classes/class_tilemap.rst
@@ -303,7 +303,7 @@ Position for tile origin. See :ref:`TileOrigin<enum_TileMap_TileOrigin>` for pos
 | *Getter*  | is_y_sort_mode_enabled() |
 +-----------+--------------------------+
 
-If ``true``, the TileMap's children will be drawn in order of their Y coordinate.
+If ``true``, the TileMap's direct children will be drawn in order of their Y coordinate.
 
 ----
 


### PR DESCRIPTION
Clarifying that not all but only the _direct_ children are sorted.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
