### PR TITLE
Mention hosts that support on-the-fly compression in Exporting for the Web

### DIFF
--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -167,6 +167,11 @@ the ``.pck`` and ``.wasm`` files, which are usually large in size.
 The WebAssembly module compresses particularly well, down to around a quarter
 of its original size with gzip compression.
 
+**Hosts that provide on-the-fly compression:** GitHub Pages (gzip)
+
+**Hosts that don't provide on-the-fly compression:** itch.io, GitLab Pages
+(`supports manual gzip precompression <https://webd97.de/post/gitlab-pages-compression/>`__
+
 Export options
 --------------
 


### PR DESCRIPTION
This can help the user make more informed hosting decisions.

Note that [GitHub Pages doesn't support precompressed Brotli files yet](https://github.community/t/support-for-pre-compressed-assets-and-brotli-compression/10605).