### PR TITLE
make example asteroids spaceship fly up/forward

### DIFF
--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -261,7 +261,7 @@ For example, here is the code for an "Asteroids" style spaceship:
 
     extends RigidBody2D
 
-    var thrust = Vector2(0, 250)
+    var thrust = Vector2(0, -250)
     var torque = 20000
 
     func _integrate_forces(state):
@@ -280,7 +280,7 @@ For example, here is the code for an "Asteroids" style spaceship:
 
     class Spaceship : RigidBody2D
     {
-        private Vector2 _thrust = new Vector2(0, 250);
+        private Vector2 _thrust = new Vector2(0, -250);
         private float _torque = 20000;
 
         public override void _IntegrateForces(Physics2DDirectBodyState state)


### PR DESCRIPTION
I noticed that in the physics `RigidBody2D` example game the "asteroids" like spaceship would accelerate downwards when pressing the UP key.

This changes the thrust to the "upwards Vector2" of `Vector2(0, -250)`.

[Source: NASA](https://www.grc.nasa.gov/WWW/K-12/rocket/rktth1.html)