### PR TITLE
Fix the "ref" badge appearing twice in instant search results

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -291,6 +291,20 @@ a[href*="classes/"]::before {
     margin-right: 0.25rem;
 }
 
+/* Prevent the "ref" badge from appearing twice in the instant search results (not testable locally). */
+.wy-body-for-nav .search__result__single a[href*="classes/"]::before {
+    display: none;
+}
+
+.wy-body-for-nav .search__result__single a[href*="classes/"]:first-child::before {
+    display: inline;
+}
+
+/* Prevent the "ref" badge from appearing several times per item in the dedicated search results page. */
+#search-results .context a[href*="classes/"]::before {
+    display: none;
+}
+
 hr,
 #search-results .search li:first-child,
 #search-results .search li {


### PR DESCRIPTION
Tested using the Firefox developer tools on the live website.

Thanks @pycbouh for finding this fix :slightly_smiling_face: 

This closes #4338.