### PR TITLE
Add paragraph to specify that IK chains are editor-only

### DIFF
--- a/tutorials/animation/cutout_animation.rst
+++ b/tutorials/animation/cutout_animation.rst
@@ -236,9 +236,12 @@ position of hands, feet and other extremities of rigs like the one we've made.
 Imagine you want to pose a character's foot in a specific position on the ground.
 Without IK chains, each motion of the foot would require rotating and positioning
 several other bones (the shin and the thigh at least). This would be quite
-complex and lead to imprecise results.
+complex and lead to imprecise results. IK allows us to move the foot directly 
+while the shin and thigh self-adjust.
 
-IK allows us to move directly the foot while the shin and thigh self-adjust.
+It should be noted that IK chains in Godot currently work in the editor only, not
+at runtime. They are intended to ease the process of setting keyframes, and are
+not currently useful for techniques like procedural animation. 
 
 To create an IK chain, select a chain of bones from endpoint to
 the base for the chain. For example, to create an IK chain for the right
@@ -254,8 +257,8 @@ As a result, the base of the chain will turn *Yellow*.
 
 .. image:: img/tuto_cutout19.png
 
-Once the IK chain is set-up grab any child or grand-child of the base of the
-chain (e.g. a foot) and move it. You'll see the rest of the chain adjust as you
+Once the IK chain is set up, grab any child or grand-child of the base of the
+chain (e.g. a foot), and move it. You'll see the rest of the chain adjust as you
 adjust its position.
 
 .. image:: img/tutovec_torso5.gif

--- a/tutorials/animation/cutout_animation.rst
+++ b/tutorials/animation/cutout_animation.rst
@@ -239,9 +239,11 @@ several other bones (the shin and the thigh at least). This would be quite
 complex and lead to imprecise results. IK allows us to move the foot directly 
 while the shin and thigh self-adjust.
 
-It should be noted that IK chains in Godot currently work in the editor only, not
-at runtime. They are intended to ease the process of setting keyframes, and are
-not currently useful for techniques like procedural animation. 
+.. note::
+
+    **IK chains in Godot currently work in the editor only**, not
+    at runtime. They are intended to ease the process of setting keyframes, and are
+    not currently useful for techniques like procedural animation. 
 
 To create an IK chain, select a chain of bones from endpoint to
 the base for the chain. For example, to create an IK chain for the right


### PR DESCRIPTION
Much needed clarification here that IK chains are not responsive at runtime, as I assumed they would be. I would not have wasted a day trying to make them work if I'd known better. I see lots of questions on forums/Discord about IK solvers that indicate a similar misunderstanding, and I thought it'd be good to save others the trouble. I also added some small proofreading changes.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
