### PR TITLE
Update GDScript FAQ text to not reference history in link

### DIFF
--- a/about/faq.rst
+++ b/about/faq.rst
@@ -96,8 +96,8 @@ GDScript is Godot's integrated scripting language. It was built from the ground
 up to maximize Godot's potential in the least amount of code, affording both novice
 and expert developers alike to capitalize on Godot's strengths as fast as possible.
 If you've ever written anything in a language like Python before then you'll feel
-right at home. For examples, history, and a complete overview of the power GDScript
-offers you, check out the :ref:`GDScript scripting guide <doc_gdscript>`.
+right at home. For examples and a complete overview of the power GDScript offers
+you, check out the :ref:`GDScript scripting guide <doc_gdscript>`.
 
 There are several reasons to use GDScript--especially when you are prototyping, in
 alpha/beta stages of your project, or are not creating the next AAA title--but the


### PR DESCRIPTION
Since GDScript history was moved from scripting guide to FAQ, we want to remove the link back to guide mentioning "history".

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
