### PR TITLE
Fix "intaller" typo in Configuring Visual Studio IDE

### DIFF
--- a/development/cpp/configuring_an_ide/visual_studio.rst
+++ b/development/cpp/configuring_an_ide/visual_studio.rst
@@ -21,7 +21,7 @@ with the solution file, it can be generated using SCons.
 - Use the **Build** top menu to build the project.
 
 .. warning:: Visual Studio must be configured with the C++ package. It can be selected
-             in the intaller:
+             in the installer:
 
              .. figure:: img/vs_1_install_cpp_package.png
                 :align: center


### PR DESCRIPTION
-Changed a typo: 
Intaller -> Installer

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
