### PR TITLE
Update links to source code files in `core/`

### DIFF
--- a/development/cpp/common_engine_methods_and_macros.rst
+++ b/development/cpp/common_engine_methods_and_macros.rst
@@ -237,10 +237,10 @@ Godot features many error macros to make error reporting more convenient.
 
 .. seealso::
 
-    See `core/error_macros.h <https://github.com/godotengine/godot/blob/master/core/error_macros.h>`__
+    See `core/error/error_macros.h <https://github.com/godotengine/godot/blob/master/core/error/error_macros.h>`__
     in Godot's codebase for more information about each error macro.
 
     Some functions return an error code (materialized by a return type of
     ``Error``). This value can be returned directly from an error macro.
     See the list of available error codes in
-    `core/error_list.h <https://github.com/godotengine/godot/blob/master/core/error_list.h>`__.
+    `core/error/error_list.h <https://github.com/godotengine/godot/blob/master/core/error/error_list.h>`__.

--- a/development/cpp/core_types.rst
+++ b/development/cpp/core_types.rst
@@ -165,10 +165,10 @@ The Vector<> class also has a few nice features:
 References:
 ~~~~~~~~~~~
 
--  `core/vector.h <https://github.com/godotengine/godot/blob/master/core/vector.h>`__
--  `core/list.h <https://github.com/godotengine/godot/blob/master/core/list.h>`__
--  `core/set.h <https://github.com/godotengine/godot/blob/master/core/set.h>`__
--  `core/map.h <https://github.com/godotengine/godot/blob/master/core/map.h>`__
+-  `core/templates/vector.h <https://github.com/godotengine/godot/blob/master/core/templates/vector.h>`__
+-  `core/templates/list.h <https://github.com/godotengine/godot/blob/master/core/templates/list.h>`__
+-  `core/templates/set.h <https://github.com/godotengine/godot/blob/master/core/templates/set.h>`__
+-  `core/templates/map.h <https://github.com/godotengine/godot/blob/master/core/templates/map.h>`__
 
 String
 ------
@@ -181,7 +181,7 @@ conversion and visualization.
 References:
 ~~~~~~~~~~~
 
--  `core/ustring.h <https://github.com/godotengine/godot/blob/master/core/ustring.h>`__
+-  `core/string/ustring.h <https://github.com/godotengine/godot/blob/master/core/string/ustring.h>`__
 
 StringName
 ----------
@@ -197,7 +197,7 @@ is fast.
 References:
 ~~~~~~~~~~~
 
--  `core/string_name.h <https://github.com/godotengine/godot/blob/master/core/string_name.h>`__
+-  `core/string/string_name.h <https://github.com/godotengine/godot/blob/master/core/string/string_name.h>`__
 
 Math types
 ----------
@@ -219,7 +219,7 @@ referencing them fast.
 References:
 ~~~~~~~~~~~
 
--  `core/node_path.h <https://github.com/godotengine/godot/blob/master/core/node_path.h>`__
+-  `core/string/node_path.h <https://github.com/godotengine/godot/blob/master/core/string/node_path.h>`__
 
 RID
 ---
@@ -232,4 +232,4 @@ referenced data.
 References:
 ~~~~~~~~~~~
 
--  `core/rid.h <https://github.com/godotengine/godot/blob/master/core/rid.h>`__
+-  `core/templates/rid.h <https://github.com/godotengine/godot/blob/master/core/templates/rid.h>`__

--- a/development/cpp/custom_godot_servers.rst
+++ b/development/cpp/custom_godot_servers.rst
@@ -76,7 +76,7 @@ an initialization state and a cleanup procedure.
 	private:
 		uint64_t counter;
 		RID_Owner<InfiniteBus> bus_owner;
-		// https://github.com/godotengine/godot/blob/master/core/rid.h#L196
+		// https://github.com/godotengine/godot/blob/master/core/templates/rid.h
 		Set<RID> buses;
 		void _emit_occupy_room(uint64_t room, RID rid);
 
@@ -204,7 +204,7 @@ an initialization state and a cleanup procedure.
 		return ret;
 	}
 
-	// https://github.com/godotengine/godot/blob/master/core/rid.h#L187
+	// https://github.com/godotengine/godot/blob/master/core/templates/rid.h
 	bool HilbertHotel::delete_bus(RID id) {
 		if (bus_owner.owns(id)) {
 			lock();
@@ -316,7 +316,7 @@ References
 ~~~~~~~~~~~
 
 - :ref:`RID<class_rid>`
-- `core/rid.h <https://github.com/godotengine/godot/blob/master/core/rid.h>`__
+- `core/templates/rid.h <https://github.com/godotengine/godot/blob/master/core/templates/rid.h>`__
 
 Registering the class in GDScript
 ---------------------------------
@@ -474,7 +474,7 @@ to execute the desired behavior. The queue will be flushed whenever either
 References:
 ~~~~~~~~~~~
 
-- `core/message_queue.cpp <https://github.com/godotengine/godot/blob/master/core/message_queue.cpp>`__
+- `core/object/message_queue.cpp <https://github.com/godotengine/godot/blob/master/core/object/message_queue.cpp>`__
 
 Summing it up
 -------------

--- a/development/cpp/custom_resource_format_loaders.rst
+++ b/development/cpp/custom_resource_format_loaders.rst
@@ -12,7 +12,7 @@ path again, the previous loaded Resource will be referenced. Naturally,
 loaded resources must be stateless.
 
 This guide assumes the reader knows how to create C++ modules and Godot
-data types. If not, refer to this guide :ref:`doc_custom_modules_in_c++`.
+data types. If not, refer to this guide: :ref:`doc_custom_modules_in_c++`
 
 References
 ~~~~~~~~~~
@@ -304,7 +304,7 @@ References
 
 - `istream <http://www.cplusplus.com/reference/istream/istream/>`_
 - `streambuf <http://www.cplusplus.com/reference/streambuf/streambuf/?kw=streambuf>`_
-- `core/io/fileaccess.h <https://github.com/godotengine/godot/blob/master/core/os/file_access.h>`_
+- `core/io/file_access.h <https://github.com/godotengine/godot/blob/master/core/os/file_access.h>`_
 
 Registering the new file format
 -------------------------------

--- a/development/cpp/object_class.rst
+++ b/development/cpp/object_class.rst
@@ -35,7 +35,7 @@ This makes Objects gain a lot of functionality, like for example
 References:
 ~~~~~~~~~~~
 
--  `core/object.h <https://github.com/godotengine/godot/blob/master/core/object.h>`__
+-  `core/object/object.h <https://github.com/godotengine/godot/blob/master/core/object/object.h>`__
 
 Registering an Object
 ---------------------
@@ -93,7 +93,7 @@ string passing the name can be passed for brevity.
 References:
 ~~~~~~~~~~~
 
--  `core/class_db.h <https://github.com/godotengine/godot/blob/master/core/class_db.h>`__
+-  `core/object/class_db.h <https://github.com/godotengine/godot/blob/master/core/object/class_db.h>`__
 
 Constants
 ---------
@@ -258,7 +258,7 @@ templates point to it.
 References:
 ~~~~~~~~~~~
 
--  `core/reference.h <https://github.com/godotengine/godot/blob/master/core/reference.h>`__
+-  `core/object/reference.h <https://github.com/godotengine/godot/blob/master/core/object/reference.h>`__
 
 Resources:
 ----------
@@ -274,7 +274,7 @@ Resources without a path are fine too.
 References:
 ~~~~~~~~~~~
 
--  `core/resource.h <https://github.com/godotengine/godot/blob/master/core/resource.h>`__
+-  `core/io/resource.h <https://github.com/godotengine/godot/blob/master/core/io/resource.h>`__
 
 Resource loading
 ----------------

--- a/development/cpp/variant_class.rst
+++ b/development/cpp/variant_class.rst
@@ -37,7 +37,7 @@ of C++ with little effort. Become a friend of Variant today.
 References:
 ~~~~~~~~~~~
 
--  `core/variant.h <https://github.com/godotengine/godot/blob/master/core/variant.h>`__
+-  `core/variant/variant.h <https://github.com/godotengine/godot/blob/master/core/variant/variant.h>`__
 
 Containers: Dictionary and Array
 --------------------------------
@@ -56,5 +56,5 @@ Copy-on-write (COW) mode support for containers was dropped with Godot 3.0.
 References:
 ~~~~~~~~~~~
 
--  `core/dictionary.h <https://github.com/godotengine/godot/blob/master/core/dictionary.h>`__
--  `core/array.h <https://github.com/godotengine/godot/blob/master/core/array.h>`__
+-  `core/variant/dictionary.h <https://github.com/godotengine/godot/blob/master/core/variant/dictionary.h>`__
+-  `core/variant/array.h <https://github.com/godotengine/godot/blob/master/core/variant/array.h>`__


### PR DESCRIPTION
`core/` was reorganized in the `master` branch by https://github.com/godotengine/godot/commit/127458ed175c5aeac8dee7f09d23fae4c8928eb7.

See https://github.com/godotengine/godot/issues/42719#issuecomment-726824113.