### PR TITLE
Remove a "simple" words 

### DIFF
--- a/classes/class_@gdscript.rst
+++ b/classes/class_@gdscript.rst
@@ -1517,7 +1517,7 @@ Usable for creating loop-alike behavior or infinite surfaces.
 
 **Note:** If you just want to wrap between 0.0 and ``n`` (where ``n`` is a positive floating-point value), it is better for performance to use the :ref:`fmod<class_@GDScript_method_fmod>` method like ``fmod(number, n)``.
 
-``wrapf`` is more flexible than using the :ref:`fmod<class_@GDScript_method_fmod>` approach by giving the user a simple control over the minimum value. It also fully supports negative numbers, e.g.
+``wrapf`` is more flexible than using the :ref:`fmod<class_@GDScript_method_fmod>` approach by giving the user a control over the minimum value. It also fully supports negative numbers, e.g.
 
 ::
 
@@ -1551,7 +1551,7 @@ Usable for creating loop-alike behavior or infinite surfaces.
 
 **Note:** If you just want to wrap between 0 and ``n`` (where ``n`` is a positive integer value), it is better for performance to use the modulo operator like ``number % n``.
 
-``wrapi`` is more flexible than using the modulo approach by giving the user a simple control over the minimum value. It also fully supports negative numbers, e.g.
+``wrapi`` is more flexible than using the modulo approach by giving the user a control over the minimum value. It also fully supports negative numbers, e.g.
 
 ::
 

--- a/classes/class_animationnodetransition.rst
+++ b/classes/class_animationnodetransition.rst
@@ -16,7 +16,7 @@ A generic animation transition node for :ref:`AnimationTree<class_AnimationTree>
 Description
 -----------
 
-Simple state machine for cases which don't require a more advanced :ref:`AnimationNodeStateMachine<class_AnimationNodeStateMachine>`. Animations can be connected to the inputs and transition times can be specified.
+State machine for cases which don't require a more advanced :ref:`AnimationNodeStateMachine<class_AnimationNodeStateMachine>`. Animations can be connected to the inputs and transition times can be specified.
 
 Tutorials
 ---------

--- a/classes/class_camera2d.rst
+++ b/classes/class_camera2d.rst
@@ -18,7 +18,7 @@ Description
 
 Camera node for 2D scenes. It forces the screen (current layer) to scroll following this node. This makes it easier (and faster) to program scrollable scenes than manually changing the position of :ref:`CanvasItem<class_CanvasItem>`-based nodes.
 
-This node is intended to be a simple helper to get things going quickly and it may happen that more functionality is desired to change how the camera works. To make your own custom camera node, simply inherit from :ref:`Node2D<class_Node2D>` and change the transform of the canvas by calling get_viewport().set_canvas_transform(m) in :ref:`Viewport<class_Viewport>`.
+This node is intended to be a helper to get things going quickly and it may happen that more functionality is desired to change how the camera works. To make your own custom camera node, simply inherit from :ref:`Node2D<class_Node2D>` and change the transform of the canvas by calling get_viewport().set_canvas_transform(m) in :ref:`Viewport<class_Viewport>`.
 
 Properties
 ----------

--- a/classes/class_editorplugin.rst
+++ b/classes/class_editorplugin.rst
@@ -315,7 +315,7 @@ When given node or resource is selected, the base type will be instanced (e.g. "
 
 You can use the virtual method :ref:`handles<class_EditorPlugin_method_handles>` to check if your custom object is being edited by checking the script or using the ``is`` keyword.
 
-During run-time, this will be a simple object with a script so this function does not need to be called then.
+During run-time, this will be an object with a script so this function does not need to be called then.
 
 ----
 

--- a/classes/class_httpclient.rst
+++ b/classes/class_httpclient.rst
@@ -520,7 +520,7 @@ Returns the response headers.
 
 - :ref:`Dictionary<class_Dictionary>` **get_response_headers_as_dictionary** **(** **)**
 
-Returns all response headers as a Dictionary of structure ``{ "key": "value1; value2" }`` where the case-sensitivity of the keys and values is kept like the server delivers it. A value is a simple String, this string can have more than one value where "; " is used as separator.
+Returns all response headers as a Dictionary of structure ``{ "key": "value1; value2" }`` where the case-sensitivity of the keys and values is kept like the server delivers it. A value is a String, this string can have more than one value where "; " is used as separator.
 
 **Example:**
 

--- a/classes/class_immediategeometry.rst
+++ b/classes/class_immediategeometry.rst
@@ -11,12 +11,12 @@ ImmediateGeometry
 
 **Inherits:** :ref:`GeometryInstance<class_GeometryInstance>` **<** :ref:`VisualInstance<class_VisualInstance>` **<** :ref:`Spatial<class_Spatial>` **<** :ref:`Node<class_Node>` **<** :ref:`Object<class_Object>`
 
-Draws simple geometry from code.
+Draws a geometry from code.
 
 Description
 -----------
 
-Draws simple geometry from code. Uses a drawing mode similar to OpenGL 1.x.
+Draws a geometry from code. Uses a drawing mode similar to OpenGL 1.x.
 
 Methods
 -------
@@ -50,7 +50,7 @@ Method Descriptions
 
 - void **add_sphere** **(** :ref:`int<class_int>` lats, :ref:`int<class_int>` lons, :ref:`float<class_float>` radius, :ref:`bool<class_bool>` add_uv=true **)**
 
-Simple helper to draw an UV sphere with given latitude, longitude and radius.
+Helper to draw an UV sphere with given latitude, longitude and radius.
 
 ----
 

--- a/classes/class_linkbutton.rst
+++ b/classes/class_linkbutton.rst
@@ -11,7 +11,7 @@ LinkButton
 
 **Inherits:** :ref:`BaseButton<class_BaseButton>` **<** :ref:`Control<class_Control>` **<** :ref:`CanvasItem<class_CanvasItem>` **<** :ref:`Node<class_Node>` **<** :ref:`Object<class_Object>`
 
-Simple button used to represent a link to some resource.
+Button used to represent a link to some resource.
 
 Description
 -----------

--- a/classes/class_mainloop.rst
+++ b/classes/class_mainloop.rst
@@ -22,7 +22,7 @@ Description
 
 Upon the application start, a ``MainLoop`` implementation must be provided to the OS; otherwise, the application will exit. This happens automatically (and a :ref:`SceneTree<class_SceneTree>` is created) unless a main :ref:`Script<class_Script>` is provided from the command line (with e.g. ``godot -s my_loop.gd``, which should then be a ``MainLoop`` implementation.
 
-Here is an example script implementing a simple ``MainLoop``:
+Here is an example script implementing a ``MainLoop``:
 
 ::
 

--- a/classes/class_margincontainer.rst
+++ b/classes/class_margincontainer.rst
@@ -11,7 +11,7 @@ MarginContainer
 
 **Inherits:** :ref:`Container<class_Container>` **<** :ref:`Control<class_Control>` **<** :ref:`CanvasItem<class_CanvasItem>` **<** :ref:`Node<class_Node>` **<** :ref:`Object<class_Object>`
 
-Simple margin container.
+Margin container.
 
 Description
 -----------

--- a/classes/class_meshtexture.rst
+++ b/classes/class_meshtexture.rst
@@ -11,12 +11,12 @@ MeshTexture
 
 **Inherits:** :ref:`Texture2D<class_Texture2D>` **<** :ref:`Texture<class_Texture>` **<** :ref:`Resource<class_Resource>` **<** :ref:`Reference<class_Reference>` **<** :ref:`Object<class_Object>`
 
-Simple texture that uses a mesh to draw itself.
+Texture that uses a mesh to draw itself.
 
 Description
 -----------
 
-Simple texture that uses a mesh to draw itself. It's limited because flags can't be changed and region drawing is not supported.
+Texture that uses a mesh to draw itself. It's limited because flags can't be changed and region drawing is not supported.
 
 Properties
 ----------

--- a/classes/class_object.rst
+++ b/classes/class_object.rst
@@ -34,7 +34,7 @@ Property membership can be tested directly in GDScript using ``in``:
     print("position" in n) # Prints "True".
     print("other_property" in n) # Prints "False".
 
-Objects also receive notifications. Notifications are a simple way to notify the object about different events, so they can all be handled together. See :ref:`_notification<class_Object_method__notification>`.
+Objects also receive notifications. Notifications are a way to notify the object about different events, so they can all be handled together. See :ref:`_notification<class_Object_method__notification>`.
 
 Methods
 -------

--- a/classes/class_popupmenu.rst
+++ b/classes/class_popupmenu.rst
@@ -504,7 +504,7 @@ Returns the index of the item containing the specified ``id``. Index is automati
 
 - :ref:`Variant<class_Variant>` **get_item_metadata** **(** :ref:`int<class_int>` idx **)** const
 
-Returns the metadata of the specified item, which might be of any type. You can set it with :ref:`set_item_metadata<class_PopupMenu_method_set_item_metadata>`, which provides a simple way of assigning context data to items.
+Returns the metadata of the specified item, which might be of any type. You can set it with :ref:`set_item_metadata<class_PopupMenu_method_set_item_metadata>`, which provides a way of assigning context data to items.
 
 ----
 
@@ -690,7 +690,7 @@ Sets the ``id`` of the item at index ``idx``.
 
 - void **set_item_metadata** **(** :ref:`int<class_int>` idx, :ref:`Variant<class_Variant>` metadata **)**
 
-Sets the metadata of an item, which may be of any type. You can later get it with :ref:`get_item_metadata<class_PopupMenu_method_get_item_metadata>`, which provides a simple way of assigning context data to items.
+Sets the metadata of an item, which may be of any type. You can later get it with :ref:`get_item_metadata<class_PopupMenu_method_get_item_metadata>`, which provides a way of assigning context data to items.
 
 ----
 

--- a/classes/class_staticbody.rst
+++ b/classes/class_staticbody.rst
@@ -16,7 +16,7 @@ Static body for 3D physics.
 Description
 -----------
 
-Static body for 3D physics. A static body is a simple body that is not intended to move. In contrast to :ref:`RigidBody<class_RigidBody>`, they don't consume any CPU resources as long as they don't move.
+Static body for 3D physics. A static body is a body that is not intended to move. In contrast to :ref:`RigidBody<class_RigidBody>`, they don't consume any CPU resources as long as they don't move.
 
 Additionally, a constant linear or angular velocity can be set for the static body, so even if it doesn't move, it affects other bodies as if it was moving (this is useful for simulating conveyor belts or conveyor wheels).
 

--- a/classes/class_string.rst
+++ b/classes/class_string.rst
@@ -799,7 +799,7 @@ Returns a copy of the string with characters removed from the left.
 
 - :ref:`bool<class_bool>` **match** **(** :ref:`String<class_String>` expr **)**
 
-Does a simple case-sensitive expression match, where ``"*"`` matches zero or more arbitrary characters and ``"?"`` matches any single character except a period (``"."``).
+Does a case-sensitive expression match, where ``"*"`` matches zero or more arbitrary characters and ``"?"`` matches any single character except a period (``"."``).
 
 ----
 
@@ -807,7 +807,7 @@ Does a simple case-sensitive expression match, where ``"*"`` matches zero or mor
 
 - :ref:`bool<class_bool>` **matchn** **(** :ref:`String<class_String>` expr **)**
 
-Does a simple case-insensitive expression match, where ``"*"`` matches zero or more arbitrary characters and ``"?"`` matches any single character except a period (``"."``).
+Does a case-insensitive expression match, where ``"*"`` matches zero or more arbitrary characters and ``"?"`` matches any single character except a period (``"."``).
 
 ----
 

--- a/classes/class_tabs.rst
+++ b/classes/class_tabs.rst
@@ -16,7 +16,7 @@ Tabs control.
 Description
 -----------
 
-Simple tabs control, similar to :ref:`TabContainer<class_TabContainer>` but is only in charge of drawing tabs, not interact with children.
+Tabs control, similar to :ref:`TabContainer<class_TabContainer>` but is only in charge of drawing tabs, not interact with children.
 
 Properties
 ----------

--- a/classes/class_udpserver.rst
+++ b/classes/class_udpserver.rst
@@ -16,7 +16,7 @@ Helper class to implement a UDP server.
 Description
 -----------
 
-A simple server that opens a UDP socket and returns connected :ref:`PacketPeerUDP<class_PacketPeerUDP>` upon receiving new packets. See also :ref:`PacketPeerUDP.connect_to_host<class_PacketPeerUDP_method_connect_to_host>`.
+A server that opens a UDP socket and returns connected :ref:`PacketPeerUDP<class_PacketPeerUDP>` upon receiving new packets. See also :ref:`PacketPeerUDP.connect_to_host<class_PacketPeerUDP_method_connect_to_host>`.
 
 Below a small example of how it can be used:
 

--- a/classes/class_webrtcmultiplayer.rst
+++ b/classes/class_webrtcmultiplayer.rst
@@ -11,7 +11,7 @@ WebRTCMultiplayer
 
 **Inherits:** :ref:`NetworkedMultiplayerPeer<class_NetworkedMultiplayerPeer>` **<** :ref:`PacketPeer<class_PacketPeer>` **<** :ref:`Reference<class_Reference>` **<** :ref:`Object<class_Object>`
 
-A simple interface to create a peer-to-peer mesh network composed of :ref:`WebRTCPeerConnection<class_WebRTCPeerConnection>` that is compatible with the :ref:`MultiplayerAPI<class_MultiplayerAPI>`.
+A interface to create a peer-to-peer mesh network composed of :ref:`WebRTCPeerConnection<class_WebRTCPeerConnection>` that is compatible with the :ref:`MultiplayerAPI<class_MultiplayerAPI>`.
 
 Description
 -----------

--- a/community/contributing/best_practices_for_engine_contributors.rst
+++ b/community/contributing/best_practices_for_engine_contributors.rst
@@ -94,7 +94,7 @@ workaround, offering such a solution is unnecessary and it's up to the user to
 do it.
 
 The exception, however, is when the user stumbles into this problem *frequently
-enough* that having to do the simple solution every time becomes an annoyance.
+enough* that having to do the same solution every time becomes an annoyance.
 In this case, the software must offer a solution to simplify this use case.
 
 In our experience, in most cases it's usually obvious to tell when a problem is

--- a/development/cpp/binding_to_external_libraries.rst
+++ b/development/cpp/binding_to_external_libraries.rst
@@ -17,7 +17,7 @@ To bind to an external library, set up a module directory similar to the Summato
 
     godot/modules/tts/
 
-Next, you will create a header file with a simple TTS class:
+Next, you will create a header file with a TTS class:
 
 .. code-block:: cpp
 

--- a/development/cpp/core_types.rst
+++ b/development/cpp/core_types.rst
@@ -144,7 +144,7 @@ Godot provides also a set of common containers:
 -  Set
 -  Map
 
-They are simple and aim to be as minimal as possible, as templates
+They aim to be as minimal as possible, as templates
 in C++ are often inlined and make the binary size much fatter, both in
 debug symbols and code. List, Set and Map can be iterated using
 pointers, like this:

--- a/development/cpp/custom_modules_in_cpp.rst
+++ b/development/cpp/custom_modules_in_cpp.rst
@@ -52,7 +52,7 @@ located):
     C:\godot\modules> cd summator
     C:\godot\modules\summator>
 
-Inside we will create a simple summator class:
+Inside we will create a summator class:
 
 .. code-block:: cpp
 
@@ -196,8 +196,8 @@ Example `SCsub` with custom flags:
     module_env.Append(CCFLAGS=['-O2']) # Flags for C and C++ code
     module_env.Append(CXXFLAGS=['-std=c++11']) # Flags for C++ code only
 
-And finally, the configuration file for the module, this is a simple
-python script that must be named ``config.py``:
+And finally, the configuration file for the module, this is a python script 
+that must be named ``config.py``:
 
 .. code-block:: python
 
@@ -391,7 +391,7 @@ We now need to add this method to ``register_types`` header and source files:
 Improving the build system for development
 ------------------------------------------
 
-So far we defined a clean and simple SCsub that allows us to add the sources
+So far we defined a clean SCsub that allows us to add the sources
 of our new module as part of the Godot binary.
 
 This static approach is fine when we want to build a release version of our

--- a/development/cpp/custom_resource_format_loaders.rst
+++ b/development/cpp/custom_resource_format_loaders.rst
@@ -46,7 +46,7 @@ Creating a ResourceFormatLoader
 
 Each file format consist of a data container and a ``ResourceFormatLoader``.
 
-ResourceFormatLoaders are usually simple classes which return all the
+ResourceFormatLoaders are usually classes which return all the
 necessary metadata for supporting new extensions in Godot. The
 class must the return the format name and the extension string.
 

--- a/development/editor/editor_style_guide.rst
+++ b/development/editor/editor_style_guide.rst
@@ -22,7 +22,7 @@ Writing style
 - **Use contractions.** For example, use "isn't" instead of "is not". An exception
   to this rule can be made when you specifically want to emphasize one of the
   contraction's words.
-- **Use double quotes in messages** (``""``) instead of simple quotes (``''``).
+- **Use double quotes in messages** (``""``) instead of single quotes (``''``).
   Double quotes should be used to quote user input, file paths and possibly
   other things depending on the context.
 

--- a/getting_started/step_by_step/filesystem.rst
+++ b/getting_started/step_by_step/filesystem.rst
@@ -90,7 +90,7 @@ tools in Godot.
 Drawbacks
 ---------
 
-There are some drawbacks to this simple file system design. The first issue is that
+There are some drawbacks to this file system design. The first issue is that
 moving assets around (renaming them or moving them from one path to another inside
 the project) will break existing references to these assets. These references will
 have to be re-defined to point at the new asset location.
@@ -107,5 +107,4 @@ on other platforms, such as Linux, Android, etc. This may also apply to exported
 which use a compressed package to store all files.
 
 It is recommended that your team clearly define a naming convention for files when
-working with Godot. One simple fool-proof convention is to only allow lowercase
-file and path names.
+working with Godot. One convention is to only allow lowercase file and path names.

--- a/getting_started/step_by_step/godot_design_philosophy.rst
+++ b/getting_started/step_by_step/godot_design_philosophy.rst
@@ -80,9 +80,9 @@ GDscript and VisualScript, along with C#. They're designed for the needs
 of game developers and game designers, and they're tightly integrated in
 the engine and the editor.
 
-GDscript lets you write simple code using Python-like syntax,
-yet it detects types and offers a static language's quality of auto-completion.
-It is also optimized for gameplay code with built-in types like Vectors and Colors.
+GDscript lets you write code using Python-like syntax, yet it detects types and 
+offers a static language's quality of auto-completion. It is also optimized for 
+gameplay code with built-in types like Vectors and Colors.
 
 Note that with GDNative, you can write high-performance code using compiled
 languages like C, C++, Rust, or Python (using the Cython compiler)

--- a/getting_started/step_by_step/instancing_continued.rst
+++ b/getting_started/step_by_step/instancing_continued.rst
@@ -27,7 +27,7 @@ instead think about your scenes in a more natural way. Start by imagining the
 visible elements in your game, the ones that can be named not just by a
 programmer, but by anyone.
 
-For example, here's how a simple shooter game could be imagined:
+For example, here's how a shooter game could be imagined:
 
 .. image:: img/shooter_instancing.png
 

--- a/getting_started/step_by_step/resources.rst
+++ b/getting_started/step_by_step/resources.rst
@@ -314,7 +314,7 @@ Let's see some examples.
 
     1. Import a table of values from a spreadsheet and generate these key-value pairs, or...
 
-    2. Design a visualization within the editor and create a simple plugin that adds it
+    2. Design a visualization within the editor and create a plugin that adds it
        to the Inspector when you open these types of Resources.
 
     CurveTables are the same thing, except mapped to an Array of float values

--- a/getting_started/step_by_step/scene_tree.rst
+++ b/getting_started/step_by_step/scene_tree.rst
@@ -133,8 +133,7 @@ Changing current scene
 ----------------------
 
 After a scene is loaded, it is often desired to change this scene for
-another one. The simple way to do this is to use the
-:ref:`SceneTree.change_scene() <class_SceneTree_method_change_scene>`
+another one. One way to do this is to use the :ref:`SceneTree.change_scene() <class_SceneTree_method_change_scene>`
 function:
 
 .. tabs::

--- a/tutorials/2d/particle_systems_2d.rst
+++ b/tutorials/2d/particle_systems_2d.rst
@@ -6,7 +6,7 @@ Particle systems (2D)
 Intro
 -----
 
-A simple (but flexible enough for most uses) particle system is
+A basic (but flexible enough for most uses) particle system is
 provided. Particle systems are used to simulate complex physical effects,
 such as sparks, fire, magic particles, smoke, mist, etc.
 

--- a/tutorials/3d/csg_tools.rst
+++ b/tutorials/3d/csg_tools.rst
@@ -8,7 +8,7 @@ shapes or custom meshes to create more complex shapes. In 3D modelling software,
 CSG is mostly known as "Boolean Operators".
 
 Level prototyping is one of the main uses of CSG in Godot. This technique allows
-users to create simple versions of most common shapes by combining primitives.
+users to create versions of most common shapes by combining primitives.
 Interior environments can be created by using inverted primitives.
 
 .. note:: The CSG nodes in Godot are mainly intended for prototyping. There is

--- a/tutorials/3d/environment_and_post_processing.rst
+++ b/tutorials/3d/environment_and_post_processing.rst
@@ -259,7 +259,7 @@ Tweaking SSAO is possible with several parameters:
 - **Light Affect:** SSAO only affects ambient light, but increasing this slider can make it also affect direct light. Some artists prefer this effect.
 - **Ao Channel Affect:** If a value of zero is used, only the material's AO texture will be used for ambient occlusion; SSAO will not be applied. Values greater than 0 multiply the AO texture by the SSAO effect to varying degrees. This does not affect materials without an AO texture.
 - **Quality:** Depending on quality, SSAO will take more samples over a sphere for every pixel. High quality only works well on modern GPUs.
-- **Blur:** Type of blur kernel used. The 1x1 kernel is a simple blur that preserves local detail better, but is not as efficient (generally works better with the high quality setting above), while 3x3 will soften the image better (with a bit of dithering-like effect), but does not preserve local detail as well.
+- **Blur:** Type of blur kernel used. The 1x1 kernel is a blur that preserves local detail better, but is not as efficient (generally works better with the high quality setting above), while 3x3 will soften the image better (with a bit of dithering-like effect), but does not preserve local detail as well.
 - **Edge Sharpness**: This can be used to preserve the sharpness of edges (avoids areas without AO on creases).
 
 Depth of Field / Far Blur

--- a/tutorials/3d/high_dynamic_range.rst
+++ b/tutorials/3d/high_dynamic_range.rst
@@ -67,9 +67,8 @@ to light output of common desktop computing CRT displays.
 The mathematics of a scene-referred model require that we multiply the scene by
 different values to adjust the intensities and exposure to different
 light ranges. The transfer function of the display can't appropriately render
-the wider dynamic range of the game engine's scene output using the simple
-transfer function of the display. A more complex approach to encoding
-is required.
+the wider dynamic range of the game engine's scene output using the transfer 
+function of the display. A more complex approach to encoding is required.
 
 Scene linear & asset pipelines
 ------------------------------

--- a/tutorials/3d/introduction_to_3d.rst
+++ b/tutorials/3d/introduction_to_3d.rst
@@ -55,7 +55,7 @@ common one is by :ref:`doc_importing_3d_scenes`, which allows you to import
 entire scenes (just as they look in the DCC), including animation,
 skeletal rigs, blend shapes, etc.
 
-The second pipeline is by importing simple .OBJ files as mesh resources,
+The second pipeline is by importing .OBJ files as mesh resources,
 which can be then put inside a :ref:`MeshInstance <class_MeshInstance>`
 node for display.
 

--- a/tutorials/3d/lights_and_shadows.rst
+++ b/tutorials/3d/lights_and_shadows.rst
@@ -212,7 +212,7 @@ Each quadrant can be subdivided to allocate any number of shadow maps; the follo
 
 .. image:: img/shadow_quadrants2.png
 
-The allocation logic is simple. The biggest shadow map size (when no subdivision is used)
+Here is the allocation logic. The biggest shadow map size (when no subdivision is used)
 represents a light the size of the screen (or bigger).
 Subdivisions (smaller maps) represent shadows for lights that are further away
 from view and proportionally smaller.

--- a/tutorials/3d/procedural_geometry/immediategeometry.rst
+++ b/tutorials/3d/procedural_geometry/immediategeometry.rst
@@ -8,7 +8,7 @@ node. Being a node makes it quick to add to a scene and get visual output. It us
 API like SurfaceTool, but it's actually designed to create meshes on the fly.
 
 Generating complex geometry (several thousand vertices) with this node is inefficient, even if it's
-done only once. Instead, it is designed to generate simple geometry that changes every frame.
+done only once. Instead, it is designed to generate a geometry that changes every frame.
 
 Before starting, you should clear the geometry by calling ``clear()``. This ensures that
 you are not building upon the geometry from the previous frame. If you want to keep geometry between frames, do

--- a/tutorials/3d/reflection_probes.rst
+++ b/tutorials/3d/reflection_probes.rst
@@ -48,8 +48,8 @@ can be displaced to an empty place by moving the handles in the center:
 .. image:: img/refprobe_center_gizmo.png
 
 By default, shadow mapping is disabled when rendering probes (only in the
-rendered image inside the probe, not the actual scene). This is
-a simple way to save on performance and memory. If you want shadows in the probe,
+rendered image inside the probe, not the actual scene). This is 
+one way to save on performance and memory. If you want shadows in the probe,
 they can be toggled on/off with the *Enable Shadow* setting:
 
 .. image:: img/refprobe_shadows.png

--- a/tutorials/animation/animation_tree.rst
+++ b/tutorials/animation/animation_tree.rst
@@ -106,7 +106,7 @@ Allows scaling the speed of the animation (or reverse it) in any children nodes.
 Transition
 ^^^^^^^^^^
 
-Very simple state machine (when you don't want to cope with a ``StateMachine`` node). Animations can be connected to the outputs and transition times can be specified.
+Basic state machine (when you don't want to cope with a ``StateMachine`` node). Animations can be connected to the outputs and transition times can be specified.
 
 BlendSpace2D
 ^^^^^^^^^^^^

--- a/tutorials/animation/introduction.rst
+++ b/tutorials/animation/introduction.rst
@@ -10,7 +10,7 @@ In this guide you learn to:
 
 -  Work with the Animation Panel
 -  Animate any property of any node
--  Create a simple animation
+-  Create a basic animation
 -  Call functions with the powerful Call Function Tracks
 
 In Godot, you can animate anything available in the Inspector, such as

--- a/tutorials/assets_pipeline/import_process.rst
+++ b/tutorials/assets_pipeline/import_process.rst
@@ -106,7 +106,7 @@ the default setting can be saved and cleared too:
 Simplicity is key!
 ------------------
 
-This is a very simple workflow which should take very little time to get used to. It also enforces a more
+This is a workflow which should take very little time to get used to. It also enforces a more
 correct way to deal with resources.
 
 There are many types of assets available for import, so please continue reading to understand how to work

--- a/tutorials/audio/recording_with_microphone.rst
+++ b/tutorials/audio/recording_with_microphone.rst
@@ -6,7 +6,7 @@ Recording with microphone
 Godot supports in-game audio recording for Windows, macOS, Linux, Android and
 iOS.
 
-A simple demo is included in the official demo projects and will be used as
+A demo is included in the official demo projects and will be used as
 support for this tutorial:
 `<https://github.com/godotengine/godot-demo-projects/tree/master/audio/mic_record>`_.
 

--- a/tutorials/best_practices/logic_preferences.rst
+++ b/tutorials/best_practices/logic_preferences.rst
@@ -124,7 +124,7 @@ If one is creating a large level, which circumstances are most appropriate?
 Should they create the level as one static space? Or should they load the
 level in pieces and shift the world's content as needed?
 
-Well, the simple answer is , "when the performance requires it." The
+Well, one answer is , "when the performance requires it." The
 dilemma associated with the two options is one of the age-old programming
 choices: does one optimize memory over speed, or vice versa?
 

--- a/tutorials/editor/command_line_tutorial.rst
+++ b/tutorials/editor/command_line_tutorial.rst
@@ -260,7 +260,7 @@ Debugging
 
 Catching errors in the command line can be a difficult task because they
 just fly by. For this, a command line debugger is provided by adding
-``-d``. It works for running either the game or a simple scene.
+``-d``. It works for running either the game or a basic scene.
 
 ::
 
@@ -309,7 +309,7 @@ conversion of assets or custom import/export.
 
 The script must inherit from ``SceneTree`` or ``MainLoop``.
 
-Here is a simple ``sayhello.gd`` example of how it works:
+Here is a ``sayhello.gd`` example of how it works:
 
 .. code-block:: python
 

--- a/tutorials/export/exporting_projects.rst
+++ b/tutorials/export/exporting_projects.rst
@@ -31,8 +31,7 @@ Another reason is that the developer might prefer a specially-compiled
 binary, which is smaller in size, more optimized and does not include
 tools like the editor and debugger.
 
-Finally, Godot has a simple but efficient system for creating DLCs as
-extra package files.
+Finally, Godot has an efficient system for creating DLCs as extra package files.
 
 On mobile
 ~~~~~~~~~

--- a/tutorials/io/binary_serialization_api.rst
+++ b/tutorials/io/binary_serialization_api.rst
@@ -6,11 +6,11 @@ Binary serialization API
 Introduction
 ------------
 
-Godot has a simple serialization API based on Variant. It's used for
-converting data types to an array of bytes efficiently. This API is used
-in the functions ``get_var`` and ``store_var`` of :ref:`class_File`
-as well as the packet APIs for :ref:`class_PacketPeer`. This format
-is *not* used for binary scenes and resources.
+Godot has a serialization API based on Variant. It's used for converting data 
+types to an array of bytes efficiently. This API is used in the functions 
+``get_var`` and ``store_var`` of :ref:`class_File` as well as the packet APIs 
+for :ref:`class_PacketPeer`. This format is *not* used for binary scenes 
+and resources.
 
 Packet specification
 --------------------

--- a/tutorials/io/saving_games.rst
+++ b/tutorials/io/saving_games.rst
@@ -199,11 +199,10 @@ way to pull the data out of the file as well.
     }
 
 
-Game saved! Loading is fairly simple as well. For that, we'll read each
-line, use parse_json() to read it back to a dict, and then iterate over
-the dict to read our values. But we'll need to first create the object
-and we can use the filename and parent values to achieve that. Here is our
-load function:
+Game saved! For loading, we'll read each line, use parse_json() to read it back 
+to a dict, and then iterate over the dict to read our values. But we'll need to 
+first create the object and we can use the filename and parent values to achieve
+that. Here is our load function:
 
 .. tabs::
  .. code-tab:: gdscript GDScript

--- a/tutorials/math/beziers_and_curves.rst
+++ b/tutorials/math/beziers_and_curves.rst
@@ -153,7 +153,7 @@ Evaluating
 
 Just evaluating them may be an option, but in most cases it's not very useful. The big drawback with Bezier curves is that if you traverse them at constant speed, from ``t = 0`` to ``t = 1``, the actual interpolation will *not* move at constant speed. The speed is also an interpolation between the distances between points ``p0``, ``p1``, ``p2`` and ``p3`` and there is not a mathematically simple way to traverse the curve at constant speed.
 
-Let's do a simple example with the following pseudocode:
+Let's do an example with the following pseudocode:
 
 .. tabs::
  .. code-tab:: gdscript GDScript

--- a/tutorials/math/interpolation.rst
+++ b/tutorials/math/interpolation.rst
@@ -9,7 +9,7 @@ The basic idea is that you want to transition from A to B. A value ``t``, repres
 
 As an example if ``t`` is 0, then the state is A. If ``t`` is 1, then the state is B. Anything in-between is an *interpolation*.
 
-Between two real (floating-point) numbers, a simple interpolation is usually described as:
+Between two real (floating-point) numbers, an interpolation is usually described as:
 
 .. tabs::
  .. code-tab:: gdscript GDScript
@@ -23,7 +23,7 @@ And often simplified to:
 
     interpolation = A + (B - A) * t
 
-The name of this type of interpolation, which transforms a value into another at *constant speed* is *"linear"*. So, when you hear about *Linear Interpolation*, you know they are referring to this simple formula.
+The name of this type of interpolation, which transforms a value into another at *constant speed* is *"linear"*. So, when you hear about *Linear Interpolation*, you know they are referring to this formula.
 
 There are other types of interpolations, which will not be covered here. A recommended read afterwards is the :ref:`Bezier <doc_beziers_and_curves>` page.
 
@@ -35,7 +35,7 @@ Vector types (:ref:`Vector2 <class_Vector2>` and :ref:`Vector3 <class_Vector3>`)
 
 For cubic interpolation, there are also :ref:`Vector2.cubic_interpolate() <class_Vector2_method_linear_interpolate>` and :ref:`Vector3.cubic_interpolate() <class_Vector3_method_linear_interpolate>`, which do a :ref:`Bezier <doc_beziers_and_curves>` style interpolation.
 
-Here is simple pseudo-code for going from point A to B using interpolation:
+Here is a pseudo-code for going from point A to B using interpolation:
 
 .. tabs::
  .. code-tab:: gdscript GDScript

--- a/tutorials/math/matrices_and_transforms.rst
+++ b/tutorials/math/matrices_and_transforms.rst
@@ -235,7 +235,7 @@ Putting it all together
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 We're going to apply everything we mentioned so far onto one transform.
-To follow along, create a simple project with a Sprite node and use the
+To follow along, create a project with a Sprite node and use the
 Godot logo for the texture resource.
 
 Let's set the translation to (350, 150), rotate by -0.5 rad, and scale by 3.

--- a/tutorials/math/vectors_advanced.rst
+++ b/tutorials/math/vectors_advanced.rst
@@ -21,13 +21,12 @@ planes, 3D geometry (to determine where each face or vertex is siding),
 etc. A **normal** *is* a **unit vector**, but it's called *normal*
 because of its usage. (Just like we call (0,0) the Origin!).
 
-It's as simple as it looks. The plane passes by the origin and the
-surface of it is perpendicular to the unit vector (or *normal*). The
-side towards the vector points to is the positive half-space, while the
-other side is the negative half-space. In 3D this is exactly the same,
-except that the plane is an infinite surface (imagine an infinite, flat
-sheet of paper that you can orient and is pinned to the origin) instead
-of a line.
+The plane passes by the origin and the surface of it is perpendicular to the 
+unit vector (or *normal*). The side towards the vector points to is the positive
+half-space, while the other side is the negative half-space. In 3D this is 
+exactly the same, except that the plane is an infinite surface (imagine 
+an infinite, flat sheet of paper that you can orient and is pinned to the origin) 
+instead of a line.
 
 Distance to plane
 -----------------
@@ -220,7 +219,7 @@ further down.
 Some examples of planes
 -----------------------
 
-Here is a simple example of what planes are useful for. Imagine you have
+Here is an example of what planes are useful for. Imagine you have
 a `convex <https://www.mathsisfun.com/definitions/convex.html>`__
 polygon. For example, a rectangle, a trapezoid, a triangle, or just any
 polygon where no faces bend inwards.

--- a/tutorials/networking/http_client_class.rst
+++ b/tutorials/networking/http_client_class.rst
@@ -21,7 +21,7 @@ It will connect and fetch a website.
     extends SceneTree
 
     # HTTPClient demo
-    # This simple class can do HTTP requests; it will not block, but it needs to be polled.
+    # This class can do HTTP requests; it will not block, but it needs to be polled.
 
     func _init():
         var err = 0

--- a/tutorials/networking/http_request_class.rst
+++ b/tutorials/networking/http_request_class.rst
@@ -6,7 +6,7 @@ Making HTTP requests
 The :ref:`HTTPRequest <class_HTTPRequest>` node is the easiest way to make HTTP requests in Godot.
 It is backed by the more low-level :ref:`HTTPClient <class_HTTPClient>`, for which a tutorial is available :ref:`here <doc_http_client_class>`.
 
-For the sake of this example, we will create a simple UI with a button, that when pressed will start the HTTP request to the specified URL.
+For the sake of this example, we will create an UI with a button, that when pressed will start the HTTP request to the specified URL.
 
 Preparing scene
 ---------------

--- a/tutorials/networking/webrtc.rst
+++ b/tutorials/networking/webrtc.rst
@@ -13,7 +13,7 @@ This is a great opportunity for both demos and full games, but used to come with
 WebSocket
 ^^^^^^^^^
 
-When the WebSocket protocol was standardized in December 2011, it allowed browsers to create stable and bidirectional connections to a WebSocket server. The protocol is quite simple, but a very powerful tool to send push notifications to browsers, and has been used to implement chats, turn-based games, etc.
+When the WebSocket protocol was standardized in December 2011, it allowed browsers to create stable and bidirectional connections to a WebSocket server. The protocol is very powerful tool to send push notifications to browsers, and has been used to implement chats, turn-based games, etc.
 
 WebSockets, though, still use a TCP connection, which is good for reliability but not for latency, so not good for real-time applications like VoIP and fast-paced games.
 

--- a/tutorials/networking/websocket.rst
+++ b/tutorials/networking/websocket.rst
@@ -9,7 +9,7 @@ HTML5 and WebSocket
 The WebSocket protocol was standardized in 2011 with the original goal of allowing browsers to create stable and bidirectional connections with a server.
 Before that, browsers used to only support HTTPRequests, which is not well-suited for bidirectional communication.
 
-The protocol is quite simple, message based, and a very powerful tool to send push notifications to browsers, and has been used to implement chats, turn-based games, etc. It still uses a TCP connection, which is good for reliability but not for latency, so not good for real-time applications like VoIP and fast-paced games (see :ref:`WebRTC <doc_webrtc>` for those use cases).
+The protocol is message based, and a very powerful tool to send push notifications to browsers, and has been used to implement chats, turn-based games, etc. It still uses a TCP connection, which is good for reliability but not for latency, so not good for real-time applications like VoIP and fast-paced games (see :ref:`WebRTC <doc_webrtc>` for those use cases).
 
 Due to its simplicity, its wide compatibility, and being easier to use than a raw TCP connection, WebSocket soon started to spread outside the browsers, in native applications as a mean to communicate with network servers.
 

--- a/tutorials/performance/using_multiple_threads.rst
+++ b/tutorials/performance/using_multiple_threads.rst
@@ -17,7 +17,7 @@ Godot supports threads and provides many handy functions to use them.
 Creating a Thread
 -----------------
 
-Creating a thread is very simple, just use the following code:
+To create a thread, use the following code:
 
 .. tabs::
  .. code-tab:: gdscript GDScript

--- a/tutorials/performance/using_servers.rst
+++ b/tutorials/performance/using_servers.rst
@@ -10,7 +10,7 @@ resources simplifies project organization and asset management in complex games.
 There are, of course, always drawbacks:
 
 * There is an extra layer of complexity
-* Performance is lower than using simple APIs directly
+* Performance is lower than using APIs directly
 * It is not possible to use multiple threads to control them
 * More memory is needed.
 
@@ -83,7 +83,7 @@ functions should always be used for creating and controlling new ones and intera
 Creating a sprite
 -----------------
 
-This is a simple example of how to create a sprite from code and move it using the low-level
+This is an example of how to create a sprite from code and move it using the low-level
 :ref:`CanvasItem <class_CanvasItem>` API.
 
 .. tabs::

--- a/tutorials/physics/kinematic_character_2d.rst
+++ b/tutorials/physics/kinematic_character_2d.rst
@@ -40,9 +40,8 @@ So, what is the difference?:
    other physics objects, unless done by hand in code.
 
 This short tutorial will focus on the kinematic character controller.
-Basically, the old-school way of handling collisions (which is not
-necessarily simpler under the hood, but well hidden and presented as a
-nice and simple API).
+Basically, the old-school way of handling collisions (which is not necessarily 
+simpler under the hood, but well hidden and presented as a nice API).
 
 Physics process
 ~~~~~~~~~~~~~~~

--- a/tutorials/physics/ray-casting.rst
+++ b/tutorials/physics/ray-casting.rst
@@ -13,10 +13,9 @@ do this in 2D and 3D.
 
 Godot stores all the low level game information in servers, while the
 scene is just a frontend. As such, ray casting is generally a
-lower-level task. For simple raycasts, node such as
-:ref:`RayCast <class_RayCast>` and :ref:`RayCast2D <class_RayCast2D>`
-will work, as they will return every frame what the result of a raycast
-is.
+lower-level task. For raycasts, node such as :ref:`RayCast <class_RayCast>` and 
+:ref:`RayCast2D <class_RayCast2D>` will work, as they will return every frame 
+what the result of a raycast is.
 
 Many times, though, ray-casting needs to be a more interactive process
 so a way to do this by code must exist.

--- a/tutorials/plugins/editor/import_plugins.rst
+++ b/tutorials/plugins/editor/import_plugins.rst
@@ -15,7 +15,7 @@ to be imported by Godot and be treated as first-class resources. The editor
 itself comes bundled with a lot of import plugins to handle the common resources
 like PNG images, Collada and glTF models, Ogg Vorbis sounds, and many more.
 
-This tutorial will show you how to create a simple import plugin to load a
+This tutorial will show you how to create an import plugin to load a
 custom text file as a material resource. This text file will contain three
 numeric values separated by comma, which represents the three channels of a
 color, and the resulting color will be used as the albedo (main color) of the

--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -13,7 +13,7 @@ While this makes plugins less powerful, there are still many things you can
 do with them. Note that a plugin is similar to any scene you can already
 make, except it is created using a script to add editor functionality.
 
-This tutorial will guide you through the creation of two simple plugins so
+This tutorial will guide you through the creation of two plugins so
 you can understand how they work and be able to develop your own. The first
 will be a custom node that you can add to any scene in the project and the
 other will be a custom dock added to the editor.
@@ -56,7 +56,7 @@ You should end up with a directory structure like this:
 
 .. image:: img/making_plugins-my_custom_mode_folder.png
 
-``plugin.cfg`` is a simple INI file with metadata about your plugin.
+``plugin.cfg`` is an INI file with metadata about your plugin.
 The name and description help people understand what it does.
 Your name helps you get properly credited for your work.
 The version number helps others know if they have an outdated version;
@@ -148,9 +148,8 @@ that will act as the logic for the type. While that script doesn't have to use
 the ``tool`` keyword, it can be added so the script runs in the editor.
 
 For this tutorial, we'll create a simple button that prints a message when
-clicked. For that, we'll need a simple script that extends from
-:ref:`class_Button`. It could also extend
-:ref:`class_BaseButton` if you prefer:
+clicked. For that, we'll need a script that extends from :ref:`class_Button`. 
+It could also extend :ref:`class_BaseButton` if you prefer:
 
 .. tabs::
  .. code-tab:: gdscript GDScript

--- a/tutorials/plugins/editor/spatial_gizmos.rst
+++ b/tutorials/plugins/editor/spatial_gizmos.rst
@@ -61,7 +61,7 @@ is enough. If you want to store some per-gizmo data or you are porting a Godot 3
 to 3.1+, you should go with the second approach.
 
 
-Simple approach
+Possible approach
 ---------------
 
 The first step is to, in our custom gizmo plugin, override the :ref:`has_gizmo()<class_EditorSpatialGizmoPlugin_method_has_gizmo>`

--- a/tutorials/rendering/multiple_resolutions.rst
+++ b/tutorials/rendering/multiple_resolutions.rst
@@ -96,10 +96,10 @@ scene tree is always a viewport (scenes loaded are instanced as a child
 of it, and it can always be accessed by calling
 ``get_tree().get_root()`` or ``get_node("/root")``).
 
-In any case, while changing the root Viewport params is probably the
-most flexible way to deal with the problem, it can be a lot of work,
-code and guessing, so Godot provides a simple set of parameters in the
-project settings to handle multiple resolutions.
+In any case, while changing the root Viewport params is probably the most 
+flexible way to deal with the problem, it can be a lot of work, code and guessing,
+so Godot provides a set of parameters in the project settings to handle multiple 
+resolutions.
 
 Stretch settings
 ----------------

--- a/tutorials/scripting/gdnative/gdnative_cpp_example.rst
+++ b/tutorials/scripting/gdnative/gdnative_cpp_example.rst
@@ -150,7 +150,7 @@ step optional.
     You may need to add ``bits=64`` to the command on Windows or Linux. We're
     still working on better auto detection.
 
-Creating a simple plugin
+Creating a plugin
 ------------------------
 
 Now it's time to build an actual plugin. We'll start by creating an empty Godot
@@ -674,7 +674,7 @@ Now when the project is compiled we'll see another property called speed.
 Changing its value will make the animation go faster or slower.
 
 For this example there is no obvious advantage of using a setter and getter. It
-is just more code to write. For a simple example as this there may be a good
+is just more code to write. For an example as this there may be a good
 reason for a setter if you want to react on the variable being changed but in
 many cases just binding the variable will be enough.
 
@@ -848,7 +848,7 @@ show its benefits.
 Next steps
 ----------
 
-The above is only a simple example, but we hope it shows you the basics. You can
+The above is only an example, but we hope it shows you the basics. You can
 build upon this example to create full-fledged scripts to control nodes in Godot
 using C++.
 

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -25,7 +25,7 @@ Example of GDScript
 ~~~~~~~~~~~~~~~~~~~
 
 Some people can learn better by taking a look at the syntax, so
-here's a simple example of how GDScript looks.
+here's a example of how GDScript looks.
 
 ::
 

--- a/tutorials/scripting/pausing_games.rst
+++ b/tutorials/scripting/pausing_games.rst
@@ -13,8 +13,7 @@ but it might be desirable that some menus and animations continue
 working.
 
 Implementing a fine-grained control for what can be paused (and what can
-not) is a lot of work, so a simple framework for pausing is provided in
-Godot.
+not) is a lot of work, so a framework for pausing is provided in Godot.
 
 How pausing works
 -----------------

--- a/tutorials/scripting/visual_script/nodes_purposes.rst
+++ b/tutorials/scripting/visual_script/nodes_purposes.rst
@@ -57,7 +57,7 @@ Pay special attention to colors and icons, as each type has a different represen
 Connections
 ~~~~~~~~~~~
 
-Connecting is a relatively simple process. Drag an *Output Port* towards an *Input Port*.
+For connecting drag an *Output Port* towards an *Input Port*.
 
 .. image:: img/visual_script_connect.gif
 
@@ -267,7 +267,7 @@ These are nodes you can use as temporary storage for your graphs. Make sure they
 .. image:: img/visual_script41.png
 
 
-As it can be seen above, there are two nodes available: A simple getter, and a sequenced setter (setting requires a sequence port).
+As it can be seen above, there are two nodes available: A getter, and a sequenced setter (setting requires a sequence port).
 
 
 Scene Node
@@ -305,7 +305,7 @@ instancing the node, it's simpler to drag the desired resource from the filesyst
 Resource Path
 ^^^^^^^^^^^^^
 
-This node is a simple helper to get a string with a path to a resource you can pick. It's useful in functions that
+This node is a helper to get a string with a path to a resource you can pick. It's useful in functions that
 load things from disk.
 
 
@@ -330,7 +330,7 @@ given condition.
 Condition
 ^^^^^^^^^
 
-This is a simple node that checks a bool port. If ``true``, it will go via the "true" sequence port. If ``false``,
+This is a node that checks a bool port. If ``true``, it will go via the "true" sequence port. If ``false``,
 the second. After going for either of them, it goes via the "done" port. Leaving sequence
 ports disconnected is fine if not all of them are used.
 
@@ -390,7 +390,7 @@ the condition in the "cond" data port is met.
 Functions
 ~~~~~~~~~
 
-Functions are simple helpers, most of the time deterministic. They take some arguments as
+Functions are helpers, most of the time deterministic. They take some arguments as
 input and return an output. They are almost never sequenced.
 
 

--- a/tutorials/shaders/making_trees.rst
+++ b/tutorials/shaders/making_trees.rst
@@ -34,7 +34,7 @@ This is a bit exaggerated, but the idea is that color indicates how much sway af
 Write a custom shader for the leaves
 ------------------------------------
 
-This is a simple example of a shader for leaves:
+This is an example of a shader for leaves:
 
 .. code-block:: glsl
 

--- a/tutorials/shaders/screen-reading_shaders.rst
+++ b/tutorials/shaders/screen-reading_shaders.rst
@@ -23,7 +23,7 @@ SCREEN_TEXTURE built-in texture
 Godot :ref:`doc_shading_language` has a special texture, ``SCREEN_TEXTURE`` (and ``DEPTH_TEXTURE`` for depth, in the case of 3D).
 It takes as argument the UV of the screen and returns a vec3 RGB with the color. A
 special built-in varying: SCREEN_UV can be used to obtain the UV for
-the current fragment. As a result, this simple canvas_item fragment shader:
+the current fragment. As a result, this canvas_item fragment shader:
 
 .. code-block:: glsl
 
@@ -47,10 +47,9 @@ of blur at no cost.
 SCREEN_TEXTURE example
 ~~~~~~~~~~~~~~~~~~~~~~
 
-``SCREEN_TEXTURE`` can be used for many things. There is a
-special demo for *Screen Space Shaders*, that you can download to see
-and learn. One example is a simple shader to adjust brightness, contrast
-and saturation:
+``SCREEN_TEXTURE`` can be used for many things. There is a special demo for 
+*Screen Space Shaders*, that you can download to see and learn. One example 
+is a shader to adjust brightness, contrast and saturation:
 
 .. code-block:: glsl
 

--- a/tutorials/shaders/your_first_shader/your_first_2d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_first_2d_shader.rst
@@ -226,7 +226,7 @@ You can offset the vertices by directly adding to ``VERTEX``.
     VERTEX += vec2(10.0, 0.0);
   }
 
-Combined with the ``TIME`` built-in variable, this can be used for simple
+Combined with the ``TIME`` built-in variable, this can be used for basic
 animation.
 
 .. code-block:: glsl

--- a/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
@@ -19,7 +19,7 @@ set the proper parameters. This is especially true for a PBR (physically based
 rendering) workflow.
 
 This is a two-part tutorial. In this first part we are going to go through how
-to make a simple terrain using vertex displacement from a heightmap in the
+to make a terrain using vertex displacement from a heightmap in the
 vertex function. In the :ref:`second part <doc_your_second_spatial_shader>` we
 are going to take the concepts from this tutorial and walk through how to set up
 custom materials in a fragment shader by writing an ocean water shader.

--- a/tutorials/ui/gui_containers.rst
+++ b/tutorials/ui/gui_containers.rst
@@ -51,7 +51,7 @@ Size flags are independent for vertical and horizontal sizing and not all contai
   amount of space they take from each other is determined by the *Ratio* (see below).
 * **Shrink Center** When expanding (and if not filling), try to remain at the center of the expanded
   area (by default it remains at the left or top).
-* **Ratio** Simple ratio of how much expanded controls take up the available space in relation to each
+* **Ratio** a ratio of how much expanded controls take up the available space in relation to each
   other. A control with "2", will take up twice as much available space as one with "1".
 
 Experimenting with these flags and different containers is recommended to get a better grasp on how they work.
@@ -127,7 +127,7 @@ The divisor can be dragged around to change the size relation between both child
 PanelContainer
 ^^^^^^^^^^^^^^
 
-Simple container that draws a *StyleBox*, then expands children to cover its whole area
+Container that draws a *StyleBox*, then expands children to cover its whole area
 (via :ref:`PanelContainer <class_PanelContainer>`, respecting the *StyleBox* margins).
 It respects both the horizontal and vertical size flags.
 
@@ -161,7 +161,7 @@ it as if it was an image (via :ref:`ViewportContainer <class_ViewportContainer>`
 Creating custom Containers
 --------------------------
 
-It is possible to easily create a custom container using script. Here is an example of a simple container that fits children
+It is possible to easily create a custom container using script. Here is an example of a container that fits children
 to its rect size:
 
 .. tabs::

--- a/tutorials/ui/size_and_anchors.rst
+++ b/tutorials/ui/size_and_anchors.rst
@@ -4,7 +4,7 @@ Size and anchors
 ================
 
 If a game was always going to be run on the same device and at the same
-resolution, positioning controls would be a simple matter of setting the
+resolution, positioning controls would be a matter of setting the
 position and size of each one of them. Unfortunately, that is rarely the
 case.
 

--- a/tutorials/vr/vr_primer.rst
+++ b/tutorials/vr/vr_primer.rst
@@ -86,8 +86,8 @@ default, the origin point will be the center location of the room you are in. As
 physically walk around the room, the location of the HMD is tracked in relation to this
 center position and the tracking is mirror in the virtual world.
 
-To keep things simple, when you physically move around your room, the ARVR Origin point stays
-where it is, the position of the camera and controllers will be adjusted according to your
+When you physically move around your room, the ARVR Origin point stays where it is,
+the position of the camera and controllers will be adjusted according to your 
 movements. When you move through the virtual world, either through controller input or when
 you implement a teleport system, it is the position of the origin point which you will
 have to adjust.

--- a/tutorials/vr/vr_starter_tutorial/vr_starter_tutorial_part_one.rst
+++ b/tutorials/vr/vr_starter_tutorial/vr_starter_tutorial_part_one.rst
@@ -24,7 +24,7 @@ Throughout the course of this tutorial, we will cover:
 - How to make a teleportation locomotion system that uses the VR controllers.
 - How to make a artificial movement locomotion system that uses the VR controllers.
 - How to create a :ref:`RigidBody <class_RigidBody>`-based system that allows for picking up, dropping, and throwing RigidBody nodes using the VR controllers.
-- How to create simple destroyable target.
+- How to create a destroyable target.
 - How to create some special :ref:`RigidBody <class_RigidBody>`-based objects that can destroy the targets.
 
 .. tip:: While this tutorial can be completed by beginners, it is highly

--- a/tutorials/vr/vr_starter_tutorial/vr_starter_tutorial_part_two.rst
+++ b/tutorials/vr/vr_starter_tutorial/vr_starter_tutorial_part_two.rst
@@ -19,10 +19,10 @@ class called ``VR_Interactable_Rigidbody``.
 Adding destroyable targets
 --------------------------
 
-Before we make any of the special :ref:`RigidBody <class_RigidBody>`-based nodes, we need something for them to do. Let's make a simple sphere target that will break into a bunch of pieces
+Before we make any of the special :ref:`RigidBody <class_RigidBody>`-based nodes, we need something for them to do. Let's make a sphere target that will break into a bunch of pieces
 when destroyed.
 
-Open up ``Sphere_Target.tscn``, which is in the ``Scenes`` folder. The scene is fairly simple, with just a :ref:`StaticBody <class_StaticBody>` with a sphere shaped
+Open up ``Sphere_Target.tscn``, which is in the ``Scenes`` folder. The scene composes of a :ref:`StaticBody <class_StaticBody>` with a sphere shaped
 :ref:`CollisionShape <class_CollisionShape>`, a :ref:`MeshInstance <class_MeshInstance>` node displaying a sphere mesh, and an :ref:`AudioStreamPlayer3D <class_AudioStreamPlayer3D>` node.
 
 The special :ref:`RigidBody <class_RigidBody>` nodes will handle damaging the sphere, which is why we are using a :ref:`StaticBody <class_StaticBody>` node instead of something like
@@ -185,7 +185,7 @@ Let's quickly go over a few things of note in ``Pistol.tscn`` real quick before 
 All of the nodes in ``Pistol.tscn`` expect the root node are rotated. This is so the pistol is in the correct rotation relative to the VR controller when it is picked up. The root node
 is a :ref:`RigidBody <class_RigidBody>` node, which we need because we're going to use the ``VR_Interactable_Rigidbody`` class we created in the last part of this tutorial series.
 
-There is a :ref:`MeshInstance <class_MeshInstance>` node called ``Pistol_Flash``, which is a simple mesh that we will be using to simulate the muzzle flash on the end of the pistol's barrel.
+There is a :ref:`MeshInstance <class_MeshInstance>` node called ``Pistol_Flash``, which is a mesh that we will be using to simulate the muzzle flash on the end of the pistol's barrel.
 A :ref:`MeshInstance <class_MeshInstance>` node called ``LaserSight`` is used to as a guide for aiming the pistol, and it follows the direction of the :ref:`Raycast <class_Raycast>` node,
 called ``Raycast``, that the pistol uses to detect if its 'bullet' hit something. Finally, there is an :ref:`AudioStreamPlayer3D <class_AudioStreamPlayer3D>` node at the end of the
 pistol that we will use to play the sound of the pistol firing.
@@ -299,7 +299,7 @@ muzzle flash timer just finished and so we need to make ``flash_mesh`` invisible
 """"""""""""""""""""""""""""""""""""""""""""""
 
 The interact function first checks to see if the pistol's muzzle flash is invisible by checking to see if ``flash_timer`` is less than or equal to zero. We do this so we
-can limit the rate of fire of the pistol to the length of time the muzzle flash is visible, which is a simple solution for limiting how fast the player can fire.
+can limit the rate of fire of the pistol to the length of time the muzzle flash is visible, which is a possible solution for limiting how fast the player can fire.
 
 If ``flash_timer`` is zero or less, we then set ``flash_timer`` to ``FLASH_TIME`` so there is a delay before the pistol can fire again. After that we set ``flash_mesh.visible``
 to ``true`` so the muzzle flash at the end of the pistol is visible while ``flash_timer`` is more than zero.
@@ -473,7 +473,7 @@ instead of just one. All of the other class variables are the same as ``Pistol.g
 """"""""""""""""""""""""""""""""""""""""""""""
 
 The interact function first checks to see if the shotgun's muzzle flash is invisible by checking to see if ``flash_timer`` is less than or equal to zero. We do this so we
-can limit the rate of fire of the shotgun to the length of time the muzzle flash is visible, which is a simple solution for limiting how fast the player can fire.
+can limit the rate of fire of the shotgun to the length of time the muzzle flash is visible, which is a possible solution for limiting how fast the player can fire.
 
 If ``flash_timer`` is zero or less, we then set ``flash_timer`` to ``FLASH_TIME`` so there is a delay before the shotgun can fire again. After that we set ``flash_mesh.visible``
 to ``true`` so the muzzle flash at the end of the shotgun is visible while ``flash_timer`` is more than zero.
@@ -531,7 +531,7 @@ we then set the ``rumble`` property of the VR controller to ``0.25``, so there i
 Shotgun finished
 ^^^^^^^^^^^^^^^^
 
-Everything else is exactly the same as the pistol, with at most just some simple name changes.
+Everything else is exactly the same as the pistol, with at most some name changes.
 
 Now the shotgun is finished! You can find the shotgun in the sample scene by looking around the back of one of the walls (not in the building though!).
 


### PR DESCRIPTION
Removed multiple uses of word "simple" to describe tasks and examples throughout documentation where appropriate. 