### PR TITLE
Specify that only collada files can use -colonly with empty shapes

### DIFF
--- a/tutorials/assets_pipeline/importing_scenes.rst
+++ b/tutorials/assets_pipeline/importing_scenes.rst
@@ -413,7 +413,7 @@ This helps the visual mesh and actual collision to be separated.
 
 The option ``-convcolonly`` works in a similar way, but will create a :ref:`class_convexpolygonshape` instead.
 
-The option ``-colonly`` can also be used with Blender's empty objects.
+With Collada files the option ``-colonly`` can also be used with Blender's empty objects.
 On import, it will create a :ref:`class_staticbody` with
 a collision node as a child. The collision node will have one of a number of predefined shapes,
 depending on Blender's empty draw type:


### PR DESCRIPTION
Specifies that only collada files can use the -colonly import hint with empty shapes. Closes #4374. I was tempted to remove it since gltf 2.0 is what everyone should be using now. But as long as collada is still supported I feel like it should remain fully documented.