### PR TITLE
Fix proximity and distance fade alpha blend warning, move a GIF

### DIFF
--- a/tutorials/3d/standard_material_3d.rst
+++ b/tutorials/3d/standard_material_3d.rst
@@ -526,19 +526,22 @@ world triplanar, so the brick texture continues smoothly between them.
 
 .. image:: img/spatial_material25.png
 
-Proximity and distance fade
+Proximity and Distance Fade
 ----------------------------
 
 Godot allows materials to fade by proximity to each other as well as depending
 on the distance from the viewer. Proximity fade is useful for effects such as
-soft particles or a mass of water with a smooth blending to the shores. Distance
-fade is useful for light shafts or indicators that are only present after a
-given distance.
-
-Keep in mind enabling these enables alpha blending, so abusing them for an
-entire scene is usually not a good idea.
+soft particles or a mass of water with a smooth blending to the shores.
 
 .. image:: img/spatial_material_proxfade.gif
+
+Distance fade is useful for light shafts or indicators that are only present
+after a given distance.
+
+Keep in mind enabling proximity fade and distance fade with pixel alpha mode
+enables alpha blending. Alpha blending is more performance intensive, and doesn't
+allow for depth mapping so the mesh can't have a shadow. So abusing them for an
+entire scene is usually not a good idea.
 
 Render priority
 ---------------

--- a/tutorials/3d/standard_material_3d.rst
+++ b/tutorials/3d/standard_material_3d.rst
@@ -527,7 +527,7 @@ world triplanar, so the brick texture continues smoothly between them.
 .. image:: img/spatial_material25.png
 
 Proximity and Distance Fade
-----------------------------
+---------------------------
 
 Godot allows materials to fade by proximity to each other as well as depending
 on the distance from the viewer. Proximity fade is useful for effects such as

--- a/tutorials/3d/standard_material_3d.rst
+++ b/tutorials/3d/standard_material_3d.rst
@@ -539,9 +539,9 @@ Distance fade is useful for light shafts or indicators that are only present
 after a given distance.
 
 Keep in mind enabling proximity fade and distance fade with **Pixel Alpha** mode
-enables alpha blending. Alpha blending is more performance intensive, and doesn't
-allow for depth mapping so the mesh can't have a shadow. So abusing them for an
-entire scene is usually not a good idea.
+enables alpha blending. Alpha blending is more GPU-intensive and can cause transparency sorting issues.
+Alpha blending also disables many material features such as the ability to cast shadows.
+To hide a character when they get too close to the camera, consider using **Pixel Dither** or better, **Object Dither** (which is faster).
 
 Render priority
 ---------------

--- a/tutorials/3d/standard_material_3d.rst
+++ b/tutorials/3d/standard_material_3d.rst
@@ -541,7 +541,9 @@ after a given distance.
 Keep in mind enabling proximity fade and distance fade with **Pixel Alpha** mode
 enables alpha blending. Alpha blending is more GPU-intensive and can cause transparency sorting issues.
 Alpha blending also disables many material features such as the ability to cast shadows.
-To hide a character when they get too close to the camera, consider using **Pixel Dither** or better, **Object Dither** (which is faster).
+To hide a character when they get too close to the camera, consider using
+**Pixel Dither** or better, **Object Dither** (which is even faster than
+**Pixel Dither**).
 
 Render priority
 ---------------

--- a/tutorials/3d/standard_material_3d.rst
+++ b/tutorials/3d/standard_material_3d.rst
@@ -538,7 +538,7 @@ soft particles or a mass of water with a smooth blending to the shores.
 Distance fade is useful for light shafts or indicators that are only present
 after a given distance.
 
-Keep in mind enabling proximity fade and distance fade with pixel alpha mode
+Keep in mind enabling proximity fade and distance fade with **Pixel Alpha** mode
 enables alpha blending. Alpha blending is more performance intensive, and doesn't
 allow for depth mapping so the mesh can't have a shadow. So abusing them for an
 entire scene is usually not a good idea.

--- a/tutorials/3d/standard_material_3d.rst
+++ b/tutorials/3d/standard_material_3d.rst
@@ -538,9 +538,10 @@ soft particles or a mass of water with a smooth blending to the shores.
 Distance fade is useful for light shafts or indicators that are only present
 after a given distance.
 
-Keep in mind enabling proximity fade and distance fade with **Pixel Alpha** mode
-enables alpha blending. Alpha blending is more GPU-intensive and can cause transparency sorting issues.
-Alpha blending also disables many material features such as the ability to cast shadows.
+Keep in mind enabling proximity fade or distance fade with **Pixel Alpha** mode
+enables alpha blending. Alpha blending is more GPU-intensive and can cause
+transparency sorting issues. Alpha blending also disables many material
+features such as the ability to cast shadows.
 To hide a character when they get too close to the camera, consider using
 **Pixel Dither** or better, **Object Dither** (which is even faster than
 **Pixel Dither**).


### PR DESCRIPTION
Expands the warning about alpha blending with proximity and distance fading. It now specifies that alpha blending only occurs with distance fading if you're using pixel alpha mode, and why alpha blending is bad. The proximity fade gif was moved to be directly under the proximity fade description, at first I thought it was for distance fade when I first read the page. And the section title is properly capitalized now.

Closes #4295. And big thanks to @syntaxxor for explaining alpha blending to me.