### PR TITLE
Clarify that GDScript is not based on Python

### DIFF
--- a/about/faq.rst
+++ b/about/faq.rst
@@ -95,7 +95,7 @@ What is GDScript and why should I use it?
 GDScript is Godot's integrated scripting language. It was built from the ground
 up to maximize Godot's potential in the least amount of code, affording both novice
 and expert developers alike to capitalize on Godot's strengths as fast as possible.
-If you've ever written anything in a language like Python before then you'll feel
+If you've ever written anything in a language like Python before, then you'll feel
 right at home. For examples and a complete overview of the power GDScript offers
 you, check out the :ref:`GDScript scripting guide <doc_gdscript>`.
 
@@ -126,11 +126,11 @@ languages can be found in the :ref:`doc_gdscript_more_efficiently` tutorial.
 What were the motivations behind creating GDScript?
 ---------------------------------------------------
 
-In the early days, the engine used the `Lua <https://www.lua.org>`__
-scripting language. Lua is fast, but creating bindings to an object
-oriented system (by using fallbacks) was complex and slow and took an
-enormous amount of code. After some experiments with
-`Python <https://www.python.org>`__, it also proved difficult to embed.
+In the early days, the engine used the `Lua <https://www.lua.org>`__ scripting
+language. Lua can be fast thanks to LuaJIT, but creating bindings to an object
+oriented system (by using fallbacks) was complex and slow and took an enormous
+amount of code. After some experiments with `Python <https://www.python.org>`__,
+it also proved difficult to embed.
 
 The main reasons for creating a custom scripting language for Godot were:
 

--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -300,7 +300,7 @@ Scripting
 
 - :ref:`High-level interpreted language <doc_gdscript>` with
   :ref:`optional static typing <doc_gdscript_static_typing>`.
-- Syntax inspired by Python.
+- Syntax inspired by Python. However, GDScript is **not** based on Python.
 - Syntax highlighting is provided on GitHub.
 - :ref:`Use threads <doc_using_multiple_threads>` to perform asynchronous actions
   or make use of multiple processor cores.

--- a/getting_started/step_by_step/godot_design_philosophy.rst
+++ b/getting_started/step_by_step/godot_design_philosophy.rst
@@ -76,11 +76,11 @@ there is an import plugin for it. Or you can create one, like the `Tiled
 Map Importer <https://github.com/vnen/godot-tiled-importer>`__.
 
 That is also partly why Godot offers its own programming languages
-GDscript and VisualScript, along with C#. They're designed for the needs
+GDScript and VisualScript, along with C#. They're designed for the needs
 of game developers and game designers, and they're tightly integrated in
 the engine and the editor.
 
-GDscript lets you write simple code using Python-like syntax,
+GDScript lets you write simple code using an indentation-based syntax,
 yet it detects types and offers a static language's quality of auto-completion.
 It is also optimized for gameplay code with built-in types like Vectors and Colors.
 

--- a/tutorials/assets_pipeline/escn_exporter/index.rst
+++ b/tutorials/assets_pipeline/escn_exporter/index.rst
@@ -41,7 +41,8 @@ Build pipeline integration
 
 If you have hundreds of model files, you don't want your artists to waste time
 manually exporting their blend files. To combat this, the exporter provides a
-python function ``io_scene_godot.export(out_file_path)`` that can be called to
+Python function ``io_scene_godot.export(out_file_path)`` that can be called to
 export a file. This allows easy integration with other build systems. An
-example Makefile and python script that exports all the blends in a directory
-are present in the Godot-Blender-exporter repository.
+example Makefile and Python script that exports all the blends in a directory
+are present in the
+`godot-blender-exporter repository <https://github.com/godotengine/godot-blender-exporter>`__.

--- a/tutorials/physics/ray-casting.rst
+++ b/tutorials/physics/ray-casting.rst
@@ -52,7 +52,7 @@ must be used.
 Use the following code in 2D:
 
 .. tabs::
- .. code-tab:: gdscript GDscript
+ .. code-tab:: gdscript GDScript
 
     func _physics_process(delta):
         var space_rid = get_world_2d().space

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -7,11 +7,12 @@ Introduction
 ------------
 
 *GDScript* is a high-level, dynamically typed programming language used to
-create content. It uses a syntax similar to
-`Python <https://en.wikipedia.org/wiki/Python_%28programming_language%29>`_
-(blocks are indent-based and many keywords are similar). Its goal is
-to be optimized for and tightly integrated with Godot Engine, allowing great
-flexibility for content creation and integration.
+create content. It uses an indentation-based syntax similar to languages like
+`Python <https://en.wikipedia.org/wiki/Python_%28programming_language%29>`_.
+Its goal is to be optimized for and tightly integrated with Godot Engine,
+allowing great flexibility for content creation and integration.
+
+GDScript is entirely independent from Python and is not based on it.
 
 History
 ~~~~~~~


### PR DESCRIPTION
This also fixes capitalization where "GDscript" was used instead of "GDScript".

This closes #4378.