### PR TITLE
Improve link to importing 3D scenes page

### DIFF
--- a/tutorials/assets_pipeline/importing_scenes.rst
+++ b/tutorials/assets_pipeline/importing_scenes.rst
@@ -360,8 +360,6 @@ In inherited scenes, the only limitations for modifications are:
 
 Other than that, everything is allowed!
 
-.. _doc_importing_scenes_import_hints:
-
 Import hints
 ------------
 

--- a/tutorials/physics/collision_shapes_3d.rst
+++ b/tutorials/physics/collision_shapes_3d.rst
@@ -122,7 +122,7 @@ editor exposes two options:
 .. seealso::
 
     See :ref:`doc_importing_3d_scenes` for information on how to export models
-    for Godot, and automatically generate collision shapes on import.
+    for Godot and automatically generate collision shapes on import.
 
 Performance caveats
 -------------------

--- a/tutorials/physics/collision_shapes_3d.rst
+++ b/tutorials/physics/collision_shapes_3d.rst
@@ -121,9 +121,8 @@ editor exposes two options:
 
 .. seealso::
 
-    Godot can generate collision shapes for your imported 3D scenes
-    automatically. See :ref:`doc_importing_scenes_import_hints` in the
-    documentation for more information.
+    See :ref:`doc_importing_3d_scenes` for information on how to export models
+    for Godot, and automatically generate collision shapes on import.
 
 Performance caveats
 -------------------


### PR DESCRIPTION
Because the default blender exporter for collada doesn't work, linking directly to the import hints and skipping the entire article can lead to someone incorrectly assuming that the default exporter for Blender is fine. This fixes that by linking to the top of the page and emphasizing that you need to read the page to know how to export for Godot, and given how weird support for everything besides gltf 2.0 is I'd say that's accurate.