### PR TITLE
Rename the Locales pages to Locale codes for better SEO

### DIFF
--- a/tutorials/i18n/locales.rst
+++ b/tutorials/i18n/locales.rst
@@ -1,12 +1,12 @@
 .. _doc_locales:
 
-Locales
-=======
+Locale codes
+============
 
 .. Note: This list is synced with core/translation.cpp in the engine.
 
 This is the list of supported locales and variants in the engine. It's
-based on the Unix standard locale strings:
+based on the UNIX standard locale strings:
 
 +--------------+------------------------------------+
 | Locale       | Language and Variant               |


### PR DESCRIPTION
I had trouble finding this page using the built-in documentation search before. This should make it easier to find, including in third-party search engines.