### PR TITLE
Fix URL typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To get started, head to the [Contributing section](https://docs.godotengine.org/
 
 Here are some quick links to the areas you might be interested in:
 
-1. [Contributing to the online manual](https://docs.godotengine.org/en/latest/community/contributing/contibuting_to_the_documentation.html)
+1. [Contributing to the online manual](https://docs.godotengine.org/en/latest/community/contributing/contributing_to_the_documentation.html)
 2. [Contributing to the class reference](https://docs.godotengine.org/en/latest/community/contributing/updating_the_class_reference.html)
 3. [Content guidelines](https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html)
 4. [Writing guidelines](https://docs.godotengine.org/en/latest/community/contributing/docs_writing_guidelines.html)


### PR DESCRIPTION
Missing the r letter is in the /contributing/

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
