### PR TITLE
Small GDScript pow fix

### DIFF
--- a/classes/class_@gdscript.rst
+++ b/classes/class_@gdscript.rst
@@ -961,7 +961,7 @@ Produces:
 
 - :ref:`float<class_float>` **pow** **(** :ref:`float<class_float>` base, :ref:`float<class_float>` exp **)**
 
-Returns the result of ``x`` raised to the power of ``y``.
+Returns the result of ``base`` raised to the power of ``exp``.
 
 ::
 


### PR DESCRIPTION
Replaced `x` and `y` with `base` and `exp` since that's what the example code uses. Closes #4445.