### PR TITLE
Remove known bugs notice about 2D skeletons on Android

### DIFF
--- a/tutorials/animation/2d_skeletons.rst
+++ b/tutorials/animation/2d_skeletons.rst
@@ -3,11 +3,6 @@
 2D skeletons
 ============
 
-.. warning::
-
-    There are known issues with 2D skeletons on mobile and web platforms with the GLES2 renderer. We
-    recommend using the GLES3 renderer if your project relies on Skeleton2D for now.
-
 Introduction
 ------------
 


### PR DESCRIPTION
Follow-up to #3989. **Do not merge before 3.2.4 is released!**

The 2D skeleton skinning path has been rewritten in 3.2.4 thanks to https://github.com/godotengine/godot/pull/42119 and should now correctly work on Android.