### PR TITLE
Add data path location for macOS starting from 10.15 (Catalina)

### DIFF
--- a/tutorials/io/data_paths.rst
+++ b/tutorials/io/data_paths.rst
@@ -37,8 +37,8 @@ when the game is running, the project's file system will likely be read-only.
 
 The ``user://`` prefix points to a different directory on the user's device. On
 mobile and consoles, this path is unique to the project. On desktop, the engine
-stores user files in ``~/.local/share/godot/app_userdata/Name`` on macOS and
-Linux, and ``%APPDATA%/Name`` on Windows. ``Name`` is based on the application
+stores user files in ``~/.local/share/godot/app_userdata/Name`` on
+Linux, ``Library/Application\ Support/Godot/app_userdata`` on Mac OSX (since Catalina) and ``%APPDATA%/Name`` on Windows. ``Name`` is based on the application
 name defined in the Project Settings, but you can override it on a per-platform
 basis using :ref:`feature tags <doc_feature_tags>`.
 

--- a/tutorials/io/data_paths.rst
+++ b/tutorials/io/data_paths.rst
@@ -38,7 +38,7 @@ when the game is running, the project's file system will likely be read-only.
 The ``user://`` prefix points to a different directory on the user's device. On
 mobile and consoles, this path is unique to the project. On desktop, the engine
 stores user files in ``~/.local/share/godot/app_userdata/Name`` on
-Linux, ``~/Library/Application Support/Godot/app_userdata`` on macOS (since Catalina) and ``%APPDATA%/Name`` on Windows. ``Name`` is based on the application
+Linux, ``~/Library/Application Support/Godot/app_userdata/Name`` on macOS (since Catalina) and ``%APPDATA%/Name`` on Windows. ``Name`` is based on the application
 name defined in the Project Settings, but you can override it on a per-platform
 basis using :ref:`feature tags <doc_feature_tags>`.
 

--- a/tutorials/io/data_paths.rst
+++ b/tutorials/io/data_paths.rst
@@ -38,7 +38,7 @@ when the game is running, the project's file system will likely be read-only.
 The ``user://`` prefix points to a different directory on the user's device. On
 mobile and consoles, this path is unique to the project. On desktop, the engine
 stores user files in ``~/.local/share/godot/app_userdata/Name`` on
-Linux, ``Library/Application\ Support/Godot/app_userdata`` on Mac OSX (since Catalina) and ``%APPDATA%/Name`` on Windows. ``Name`` is based on the application
+Linux, ``~/Library/Application Support/Godot/app_userdata`` on macOS (since Catalina) and ``%APPDATA%/Name`` on Windows. ``Name`` is based on the application
 name defined in the Project Settings, but you can override it on a per-platform
 basis using :ref:`feature tags <doc_feature_tags>`.
 


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
