### PR TITLE
Improve documentation around exporting projects

### DIFF
--- a/tutorials/export/exporting_basics.rst
+++ b/tutorials/export/exporting_basics.rst
@@ -12,36 +12,38 @@ just so they can open your project. Instead, you can *export* your project,
 converting it into a "package" that can be run by anyone.
 
 The way you export your game depends on what platform you are targeting. In
-this tutorial, you'll learn how to export the "Dodge the Creeps" game for a
+this tutorial, you'll learn how to export the *Dodge the Creeps* game for a
 variety of platforms. First, however, we need to make some changes to the
 way the game works.
 
-.. note:: If you haven't made "Dodge the Creeps" yourself yet, please read
+.. note:: If you haven't made *Dodge the Creeps* yourself yet, please read
           :ref:`doc_your_first_2d_game` before continuing with this tutorial.
 
 Preparing the project
 ---------------------
 
-In "Dodge the Creeps" we used keyboard controls to move the player's character.
+In *Dodge the Creeps*, we used keyboard controls to move the player's character.
 This is fine if your game is being played on a PC platform, but on a phone
 or tablet, you need to support touchscreen input. Because a click event can
 be treated the same as a touch event, we'll convert the game to a click-and-move
 input style.
 
-By default Godot emulates mouse input from touch input. That means if anything
-is coded to happen on a mouse event, touch will trigger it as well. Godot can also
-emulate touch input from mouse clicks, which we will need to be able to keep playing
-our game on our computer after we switch to touch input. In the "Project Settings"
-under *Input Devices* and *Pointing*, set *Emulate Touch From Mouse* to "On".
+By default, Godot emulates mouse input from touch input. That means that if
+anything is coded to happen on a mouse event, touch will trigger it as well.
+Godot can also emulate touch input from mouse clicks, which we will need to be
+able to keep playing our game on our computer after we switch to touch input.
+
+In **Project > Project Settings**, under **Input Devices > Pointing**, enable
+**Emulate Touch From Mouse**.
 
 .. image:: img/export_touchsettings.png
 
 We also want to ensure that the game scales consistently on different-sized screens,
-so in the project settings go to *Display*, then click on *Window*. In the *Stretch*
-options, set *Mode* to "2d" and *Aspect* to "keep".
+so in the project settings go to **Display**, then click on **Window**. In the **Stretch**
+options, set **Mode** to ``2d``" and **Aspect** to ``keep``.
 
-Since we are already in the *Window* settings, we should also set under *Handheld*
-the *Orientation* to "portrait".
+Since we are already in the **Window** settings, we should also set under **Handheld**
+the **Orientation** to ``portrait``.
 
 .. image:: img/export_handheld_stretchsettings.png
 
@@ -239,46 +241,56 @@ changed:
 Setting a main scene
 --------------------
 
-The main scene is the one that your game will start in. In *Project -> Project
-Settings -> Application -> Run*, set *Main Scene* to "Main.tscn" by clicking
-the folder icon and selecting it.
+The main scene is the one that your game will start in. For this
+*Dodge the Creeps* example, in
+**Project -> Project Settings -> Application -> Run**, set **Main Scene**
+to ``Main.tscn`` by clicking the folder icon and selecting it.
 
 Export templates
 ----------------
 
-In order to export, you need to download the *export templates* from the
+To export the project, you need to download the *export templates* from the
 http://godotengine.org/download. These templates are optimized versions of the engine
-without the editor pre-compiled for each platform . You can also
-download them in Godot by clicking on *Editor -> Manage Export Templates*:
+without the editor pre-compiled for each platform. You can also
+download them in Godot by clicking on **Editor -> Manage Export Templates**:
 
 .. image:: img/export_template_menu.png
 
-In the window that appears, you can click "Download" to get the template
+.. note::
+
+    If you've downloaded Godot from
+    `Steam <https://store.steampowered.com/app/404790/Godot_Engine/>`__,
+    export templates are already included. Therefore, you don't need to download
+    them using the **Manage Export Templates** dialog.
+
+In the window that appears, you can click **Download** to get the template
 version that matches your version of Godot.
 
 .. image:: img/export_template_manager.png
 
-.. note:: If you upgrade Godot, you must download templates that match the new version
-          or your exported projects may not work correctly.
+.. note::
+
+    Export templates are bound to a specific Godot version. If you upgrade
+    Godot, you must download templates that match the new version.
 
 Export presets
 --------------
 
-Next, you can configure the export settings by clicking on *Project -> Export*.
+Next, you can configure the export settings by clicking on **Project -> Export**.
 
-Create a new export preset by clicking "Add..." and selecting a platform. You
+Create a new export preset by clicking **Add...** and selecting a platform. You
 can make as many presets as you like with different settings.
 
 .. image:: img/export_presets_window.png
 
-At the bottom of the window are two buttons. "Export PCK/ZIP" only creates
+At the bottom of the window are two buttons. **Export PCK/ZIP** only creates
 a packed version of your project's data. This doesn't include an executable
 so the project can't be run on its own.
 
-The second button, "Export Project", creates a complete executable version
-of your game, such as an `.apk` for Android or an `.exe` for Windows.
+The second button, **Export Project**, creates a complete executable version
+of your game, such as an ``.apk`` for Android or an ``.exe`` for Windows.
 
-In the "Resources" and "Features" tabs, you can customize how the game is
+In the **Resources** and **Features** tabs, you can customize how the game is
 exported for each platform. We can leave those settings alone for now.
 
 Exporting by platform
@@ -291,39 +303,44 @@ PC (Linux/macOS/Windows)
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Exporting PC platforms works the same across the three supported operating
-systems. Open the export window and click "Add.." to create the preset(s) you
-want to make. Then click "Export Project" and choose a name and destination
+systems. Open the export window and click **Add...** to create the preset(s) you
+want to make. Then click **Export Project** and choose a name and destination
 folder. Choose a location *outside* of your project folder.
 
-Click "Save" and the engine will build the export files.
+Click **Save** and the engine will build the export files.
 
-.. note:: When exporting for macOS, if you export on a macOS computer, you'll
-          end up with a `.dmg` file, while using Linux or Windows
-          produces a `.zip`. In either case, the compressed file contains
-          a macOS `.app` that you can double-click and run.
+.. note::
 
-.. note:: On Windows, if you want your exported executable to have a different
-          icon than the default one, you need to change it manually. See:
-          :ref:`doc_changing_application_icon_for_windows`.
+    When exporting for macOS, if you export from a macOS computer, you'll end up
+    with a ``.dmg`` file, while using Linux or Windows produces a ``.zip``. In
+    either case, the compressed file contains a macOS ``.app`` that you can
+    double-click and run.
+
+.. note::
+
+    On Windows, if you want your exported executable to have a different icon
+    than the default one, you need to change it manually. See
+    :ref:`doc_changing_application_icon_for_windows`.
 
 Android
 ~~~~~~~
 
-.. tip:: Mobile devices come with a wide variety of capabilities.
-          In most cases, Godot's default settings will work, but mobile
-          development is sometimes more art than science, and you may
-          need to do some experimenting and searching for help in order
-          to get everything working.
+.. tip::
+
+    Mobile devices come with a wide variety of capabilities. In most cases,
+    Godot's default settings will work, but mobile development is sometimes more
+    art than science, and you may need to do some experimenting and searching
+    for help in order to get everything working.
 
 Before you can export your project for Android, you must download the following
 software:
 
 * Android SDK: https://developer.android.com/studio/
-* Open JDK(version 8 is required, more recent versions won't work): https://adoptopenjdk.net/index.html
+* Open JDK (**version 8 is required**, more recent versions won't work): https://adoptopenjdk.net/index.html
 
-When you run Android Studio for the first time, click on *Configure -> SDK Manager*
-and install "Android SDK Platform Tools". This installs the `adb` command-line
-tool that Godot uses to communicate with your device.
+When you run Android Studio for the first time, click on **Configure -> SDK Manager**
+and install **Android SDK Platform Tools**. This installs the ``adb``
+command-line tool that Godot uses to communicate with your device.
 
 Next, create a debug keystore by running the following command on your
 system's command line:
@@ -338,11 +355,13 @@ your system and the location of the keystore you just created.
 
 .. image:: img/export_editor_android_settings.png
 
-Now you're ready to export. Click on *Project -> Export* and add a preset
-for Android (see above). Select the Android Presets and under *Options* go to
-*Screen* and set *Orientation* to "Portrait".
+Now you're ready to export. Click on **Project -> Export** and add a preset
+for Android (see above). Select the newly added Android preset. Under **Options**,
+go to **Screen** and set **Orientation** to **Portrait**. If your game is in
+landscape mode (i.e. the window width in pixels is greater than the window height),
+leave this on **Landscape**.
 
-Click the "Export Project" button and Godot will build an APK you can download
+Click the **Export Project** button and Godot will build an APK you can download
 on your device. To do this on the command line, use the following:
 
 .. code-block:: shell
@@ -353,7 +372,7 @@ on your device. To do this on the command line, use the following:
           device's documentation for details.
 
 If your system supports it, connecting a compatible Android device will cause
-a "One-click Deploy" button to appear in Godot's playtest button area:
+a **One-click Deploy** button to appear in Godot's playtest button area:
 
 .. image:: img/export_android_oneclick.png
 
@@ -362,33 +381,35 @@ Clicking this button builds the APK and copies it onto your device in one step.
 iOS
 ~~~
 
-.. note:: In order to build your game for iOS, you must have a computer running
-          macOS with Xcode installed.
+.. note::
+
+    To build your game for iOS, you must have a computer running macOS with
+    Xcode installed.
 
 Before exporting, there are some settings that you *must* complete for the project
-to export successfully. First, the "App Store Team Id", which you can find by
-logging in to your Apple developer account and looking in the "Membership" section.
+to export successfully. First, the **App Store Team Id**, which you can find by
+logging in to your Apple developer account and looking in the **Membership** section.
 
 You must also provide icons and splash screen images as shown below:
 
 .. image:: img/export_ios_settings.png
 
-Click "Export Project" and select a destination folder.
+Click **Export Project** and select a destination folder.
 
 Once you have successfully exported the project, you'll find the following
 folders and files have been created in your selected location:
 
 .. image:: img/export_xcode_project_folders.png
 
-You can now open the project in Xcode and build the project for iOS. Xcode
-build procedure is beyond the scope of this tutorial. See
-https://help.apple.com/xcode/mac/current/#/devc8c2a6be1 for
-more information.
+You can now open the project in Xcode and build the project for iOS.
+The Xcode build procedure is beyond the scope of this tutorial.
+See https://help.apple.com/xcode/mac/current/#/devc8c2a6be1
+for more information.
 
 HTML5 (web)
 ~~~~~~~~~~~
 
-Click "Export Project" on the HTML5 preset. We don't need to change any
+Click **Export Project** on the HTML5 preset. We don't need to change any
 of the default settings.
 
 When the export is complete, you'll have a folder containing the following
@@ -396,23 +417,26 @@ files:
 
 .. image:: img/export_web_files.png
 
-Viewing the `.html` file in your browser lets you play the game. However, you
-can't open the file directly, it needs to be served by a web server. If you don't
-have one set up on your computer, you can search online to find suggestions for
-your specific OS.
+Viewing the ``.html`` file in your browser lets you play the game. However, you
+can't open the file directly. Instead, it needs to be served by a web server. If
+you don't have one set up on your computer, you can search online to find
+suggestions for your specific OS.
 
-Point your browser at the URL where you've placed the html file. You may have
+Point your browser at the URL where you've placed the HTML file. You may have
 to wait a few moments while the game loads before you see the start screen.
 
 .. image:: img/export_web_example.png
 
 The console window beneath the game tells you if anything goes wrong. You can
-disable it by setting "Export With Debug" off when you export the project.
+disable it by disabling **Export With Debug** in the final file dialog that appears
+when you export the project.
 
 .. image:: img/export_web_export_with_debug_disabled.png
 
-.. note:: While WASM is supported in all major browsers, it is still an emerging
-          technology and you may find some things that don't work. Make sure
-          you have updated your browser to the most recent version, and report
-          any bugs you find at the `Godot GitHub repository
-          <https://github.com/godotengine/godot/issues>`_.
+.. note::
+
+    While WebAssembly is supported in all major browsers, it is still an
+    emerging technology and you may find some things that don't work. Make sure
+    you have updated your browser to the most recent version, and report any
+    bugs you find on the
+    `Godot GitHub repository <https://github.com/godotengine/godot/issues>`_.

--- a/tutorials/export/exporting_projects.rst
+++ b/tutorials/export/exporting_projects.rst
@@ -31,8 +31,15 @@ Another reason is that the developer might prefer a specially-compiled
 binary, which is smaller in size, more optimized and does not include
 tools like the editor and debugger.
 
-Finally, Godot has a simple but efficient system for creating DLCs as
-extra package files.
+Finally, Godot has a simple but efficient system for
+:ref:`creating DLCs as extra package files <doc_exporting_pcks>`.
+
+.. warning::
+
+    Godot does not support loading PCK files larger than 2 GB yet. If your
+    exported project data is larger than 2 GB, you will need to split it into
+    several PCK files by :ref:`exporting additional PCKs <doc_exporting_pcks>`
+    and loading them at run-time.
 
 On mobile
 ~~~~~~~~~


### PR DESCRIPTION
- Add a warning about Godot not supporting PCK files larger than 2 GB.
- Improve formatting and grammar.