### PR TITLE
Fix list formatting and outdated information in Ways to contribute

### DIFF
--- a/community/contributing/updating_the_class_reference.rst
+++ b/community/contributing/updating_the_class_reference.rst
@@ -25,9 +25,9 @@ the entire reference on their own. Godot needs you, and all of us, to
 contribute.
 
 **Important:** If you plan to make large changes, you should create an issue on
- the `godot-docs repository <https://github.com/godotengine/godot-docs/>`_
- or comment on an existing issue. Doing so lets others know you're already
- taking care of a given class.
+the `godot-docs repository <https://github.com/godotengine/godot-docs/>`_
+or comment on an existing issue. Doing so lets others know you're already
+taking care of a given class.
 
 .. seealso::
 

--- a/community/contributing/ways_to_contribute.rst
+++ b/community/contributing/ways_to_contribute.rst
@@ -127,7 +127,7 @@ Filing an issue on GitHub
 
 Godot uses `GitHub's issue tracker <https://github.com/godotengine/godot/issues>`_
 for bug reports and enhancement suggestions. You will need a GitHub account to
-be able to open a new issue there, and click on the "New issue" button.
+be able to open a new issue there, and click on the **New issue** button.
 
 When you report a bug, you should keep in mind that the process is similar
 to an appointment with your doctor. You noticed *symptoms* that make you think
@@ -150,7 +150,7 @@ always provide:
    only on certain processors, graphic cards, etc. If you are able to,
    it can be helpful to include information on your hardware.
 
--  **Godot version.** This is a must have. Some issues might be relevant in the
+-  **Godot version.** This is a must-have. Some issues might be relevant in the
    current stable release, but fixed in the development branch, or the other
    way around. You might also be using an obsolete version of Godot and
    experiencing a known issue fixed in a later version, so knowing this from
@@ -167,7 +167,7 @@ always provide:
    mind that there are thousands of issues in the tracker, and developers can
    only dedicate little time to each issue.
 
-When you click the "New issue" button, you should be presented with a text area
+When you click the **New issue** button, you should be presented with a text area
 prefilled with our issue template. Please try to follow it so that all issues
 are consistent and provide the required information.
 
@@ -177,19 +177,19 @@ Contributing to the documentation
 There are two separate resources referred to as "documentation" in Godot:
 
 - **The class reference.** This is the documentation for the complete Godot API
-   as exposed to GDScript and the other scripting languages. It can be consulted
-   offline, directly in Godot's code editor, or online at :ref:`Godot API
-   <toc-class-ref>`. To contribute to the class reference, you have to edit the
-   `doc/base/classes.xml` in Godot's Git repository, and make a pull request.
-   See :ref:`doc_updating_the_class_reference_with_git` and
-   :ref:`doc_class_reference_writing_guidelines` for more details.
+  as exposed to GDScript and the other scripting languages. It can be consulted
+  offline, directly in Godot's code editor, or online at :ref:`Godot API
+  <toc-class-ref>`. To contribute to the class reference, you have to edit the
+  XML file corresponding to the class and make a pull request.
+  See :ref:`doc_updating_the_class_reference_with_git` and
+  :ref:`doc_class_reference_writing_guidelines` for more details.
 
--  **The tutorials and engine documentation and its translations.** This is the part you are reading
-   now, which is distributed in the HTML, PDF and EPUB formats. Its contents
-   are generated from plain text files in the reStructured Text (rst) format,
-   to which you can contribute via pull requests on the
-   `godot-docs <https://github.com/godotengine/godot-docs>`_ GitHub repository.
-   See :ref:`doc_contributing_to_the_documentation` for more details.
+- **The tutorials and engine documentation and its translations.**
+  This is the part you are reading now, which is distributed in the HTML format.
+  Its contents are generated from plain text files in the reStructured Text
+  (rst) format, to which you can contribute via pull requests on the
+  `godot-docs <https://github.com/godotengine/godot-docs>`_ GitHub repository.
+  See :ref:`doc_contributing_to_the_documentation` for more details.
 
 Contributing translations
 -------------------------


### PR DESCRIPTION
`doc/base/classes.xml` was removed since Godot 3.0. The documentation isn't distributed anymore as PDF or EPUB either due to long build times and formatting issues.

This also fixes formatting ion Contributing to the class reference with Git.