### PR TITLE
Fix Hide() in _ready() first player example code

### DIFF
--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -213,14 +213,12 @@ which is a good time to find the size of the game window:
 
     func _ready():
         screen_size = get_viewport_rect().size
-        hide() # Start the player hidden.
 
  .. code-tab:: csharp
 
     public override void _Ready()
     {
         screenSize = GetViewportRect().Size;
-        Hide(); // Start the player hidden.
     }
 
 Now we can use the ``_process()`` function to define what the player will do.


### PR DESCRIPTION
Hide() on line 216 and 223 give an unintended result when the user following the tutorial is requested on line 354 to Play the Scene. The Player will not be shown.
Removing Hide() on line 216 and 223 will fix this.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
