### PR TITLE
Update class_array.rst

### DIFF
--- a/classes/class_array.rst
+++ b/classes/class_array.rst
@@ -296,7 +296,8 @@ Returns ``true`` if the array contains the given value.
 
 - :ref:`int<class_int>` **hash** **(** **)**
 
-Returns a hashed integer value representing the array contents.
+Returns a hashed integer value representing the array and its contents.
+**Note:** Different arrays containing equal values can still yield different hashes. Only the very same array yields the same hash.
 
 ----
 


### PR DESCRIPTION
Updating description for hash()-method. Strictly speaking it does not "Returns a hashed integer value **representing the array contents.**". This information is incomplete and therefore misleading.
It "Returns a hashed integer value representing the array **and** its contents." which also contains the special case, where two different arrays contain exactly the same values but still yield different hash result.

User could be tempted to believe, that hash() yields same values for same array-contents. 
(which I was tempted to. Testing showed **different hashes** for different arrays where values of the arrays where exactly the same)

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
