### PR TITLE
Update class_array.rst hash()-description

### DIFF
--- a/classes/class_array.rst
+++ b/classes/class_array.rst
@@ -300,7 +300,8 @@ Returns ``true`` if the array contains the given value.
 
 - :ref:`int<class_int>` **hash** **(** **)**
 
-Returns a hashed integer value representing the array contents.
+Returns a hashed integer value representing the array and it's contents.
+**Note:** Arrays containing equal contents can still produce different hashes. Only the exact same array produces the same hashed integer value.
 
 ----
 
@@ -447,8 +448,7 @@ Sorts the array using a custom method. The arguments are an object that holds th
             if a[0] < b[0]:
                 return true
             return false
-    
+
     var my_items = [[5, "Potato"], [9, "Rice"], [4, "Tomato"]]
     my_items.sort_custom(MyCustomSorter, "sort_ascending")
     print(my_items) # Prints [[4, Tomato], [5, Potato], [9, Rice]].
-


### PR DESCRIPTION
Strictly speaking hash() does not return a hashed integer value representing the array contents, rather "array **and** it's contents".

For the original description it would mean that two different arrays A = [0,1] and B = [0,1] produce the same hashed integer value.
This is in fact not true, rather hash() includes not only the array content, but also the array referencial value itself.
This leads to A and B producing different hashes even though they contain the same values.

Hashing A and A yields the same hash though.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
