### PR TITLE
Dependabot: Ignore Sphinx upgrades due to ReadTheDocs on v1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      # read the docs is staying on v1
+      - dependency-name: "sphinx"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,5 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      # read the docs is staying on v1
+      # ReadTheDocs is staying on v1.
       - dependency-name: "sphinx"


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->

This change ignores sphinx from being upgraded due to read the docs staying on v1. A related pull request is linked below.

https://github.com/godotengine/godot-docs/pull/4485