### PR TITLE
Mention required steps for Godot 3.2+ in part 3 of FPS tutorial

### DIFF
--- a/tutorials/3d/fps_tutorial/part_three.rst
+++ b/tutorials/3d/fps_tutorial/part_three.rst
@@ -34,6 +34,7 @@ or :kbd:`F6` on keyboard, and give each a try.
           ``Space_Level.tscn``, try using ``Ruins_Level.tscn`` instead.
 
 .. note::
+
     Due to Godot updates since this tutorial was published, if you are using Godot 3.2 or later, you may need to apply the following changes to the Space Level and Ruins Level scenes:
 
     - Open ``res://assets/Space_Level_Objects/Space_Level.tscn``.

--- a/tutorials/3d/fps_tutorial/part_three.rst
+++ b/tutorials/3d/fps_tutorial/part_three.rst
@@ -43,7 +43,7 @@ or :kbd:`F6` on keyboard, and give each a try.
           and navigating to the file.
 	* Do the same for the Walls node.
 
-	* Open up Ruins_Level.tscn (res://assets/Ruin_Level_Objects/Ruin_Level.tscn).
+	* Open up Ruins_Level.tscn (res://assets/Ruin_Level_Objects/Ruins_Level.tscn).
 	* In the Scene dock, select the Floor node. In the Inspector dock, if the Mesh Library field under GridMap is "[empty]",
           set it to Ruin_Level_Mesh_Lib.tres, either by (1) dragging the file res://assets/Ruin_Level_Objects/Ruin_Level_Mesh_Lib.tres
           from the FileSystem dock into that field; or by (2) clicking on "[empty]" to expand the pulldown menu, selecting Load

--- a/tutorials/3d/fps_tutorial/part_three.rst
+++ b/tutorials/3d/fps_tutorial/part_three.rst
@@ -34,21 +34,15 @@ or :kbd:`F6` on keyboard, and give each a try.
           ``Space_Level.tscn``, try using ``Ruins_Level.tscn`` instead.
 
 .. note::
-          * Due to software updates since this tutorial was published, if you are using a recent version of Godot, you may need to apply the following changes to the Space Level and Ruins Level scenes:
+    Due to Godot updates since this tutorial was published, if you are using Godot 3.2 or later, you may need to apply the following changes to the Space Level and Ruins Level scenes:
 
-	* Open up Space_Level.tscn (res://assets/Space_Level_Objects/Space_Level.tscn).
-	* In the Scene dock, select the Floor_and_Celing node. In the Inspector dock, if the Mesh Library field under GridMap is "[empty]",
-          set it to Space_Level_Mesh_Lib.tres, either by (1) dragging the file res://assets/Space_Level_Objects/Space_Level_Mesh_Lib.tres
-          from the FileSystem dock into that field; or by (2) clicking on "[empty]" to expand the pulldown menu, selecting Load
-          and navigating to the file.
-	* Do the same for the Walls node.
-
-	* Open up Ruins_Level.tscn (res://assets/Ruin_Level_Objects/Ruins_Level.tscn).
-	* In the Scene dock, select the Floor node. In the Inspector dock, if the Mesh Library field under GridMap is "[empty]",
-          set it to Ruin_Level_Mesh_Lib.tres, either by (1) dragging the file res://assets/Ruin_Level_Objects/Ruin_Level_Mesh_Lib.tres
-          from the FileSystem dock into that field; or by (2) clicking on "[empty]" to expand the pulldown menu, selecting Load
-          and navigating to the file.
-	* Do the same for the Walls node.
+    - Open ``res://assets/Space_Level_Objects/Space_Level.tscn``.
+    - In the Scene tree dock, select the **Floor_and_Celing** node. In the Inspector dock, if the Mesh Library field under GridMap is ``[empty]``, set it to ``Space_Level_Mesh_Lib.tres`` by dragging the file ``res://assets/Space_Level_Objects/Space_Level_Mesh_Lib.tres`` from the FileSystem dock to that field.
+    - Do the same for the **Walls** node.
+    
+    - Open ``res://assets/Ruin_Level_Objects/Ruins_Level.tscn``.
+    - In the Scene tree dock, select the **Floor** node. In the Inspector dock, if the Mesh Library field under GridMap is ``[empty]``, set it to ``Ruin_Level_Mesh_Lib.tres`` by dragging the file ``res://assets/Ruin_Level_Objects/Ruin_Level_Mesh_Lib.tres`` from the FileSystem dock into that field.
+    - Do the same for the **Walls** node.
 
 You might have noticed there are several :ref:`RigidBody <class_RigidBody>` nodes placed throughout the level.
 We can place ``RigidBody_hit_test.gd`` on them and then they will react to being hit with bullets, so let's do that!

--- a/tutorials/3d/fps_tutorial/part_three.rst
+++ b/tutorials/3d/fps_tutorial/part_three.rst
@@ -33,6 +33,23 @@ or :kbd:`F6` on keyboard, and give each a try.
 .. warning:: ``Space_Level.tscn`` is more graphically demanding of the GPU than ``Ruins_Level.tscn``. If your computer is struggling to render
           ``Space_Level.tscn``, try using ``Ruins_Level.tscn`` instead.
 
+.. note::
+          * Due to software updates since this tutorial was published, if you are using a recent version of Godot, you may need to apply the following changes to the Space Level and Ruins Level scenes:
+
+	* Open up Space_Level.tscn (res://assets/Space_Level_Objects/Space_Level.tscn).
+	* In the Scene dock, select the Floor_and_Celing node. In the Inspector dock, if the Mesh Library field under GridMap is "[empty]",
+          set it to Space_Level_Mesh_Lib.tres, either by (1) dragging the file res://assets/Space_Level_Objects/Space_Level_Mesh_Lib.tres
+          from the FileSystem dock into that field; or by (2) clicking on "[empty]" to expand the pulldown menu, selecting Load
+          and navigating to the file.
+	* Do the same for the Walls node.
+
+	* Open up Ruins_Level.tscn (res://assets/Ruin_Level_Objects/Ruin_Level.tscn).
+	* In the Scene dock, select the Floor node. In the Inspector dock, if the Mesh Library field under GridMap is "[empty]",
+          set it to Ruin_Level_Mesh_Lib.tres, either by (1) dragging the file res://assets/Ruin_Level_Objects/Ruin_Level_Mesh_Lib.tres
+          from the FileSystem dock into that field; or by (2) clicking on "[empty]" to expand the pulldown menu, selecting Load
+          and navigating to the file.
+	* Do the same for the Walls node.
+
 You might have noticed there are several :ref:`RigidBody <class_RigidBody>` nodes placed throughout the level.
 We can place ``RigidBody_hit_test.gd`` on them and then they will react to being hit with bullets, so let's do that!
 


### PR DESCRIPTION
Explanation from TwistedTwigleg:

Something changed with GridMaps since Godot 3.0 and that caused the GridMap nodes to lose their reference to the library of GridMap tiles, which makes 98% of the level missing! Reassigning the GridMap libraries should be all that is required and once assigned the level should function like expected.

Reference: https://godotforums.org/discussion/comment/44794/#Comment_44794

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
