### PR TITLE
your_first_game: Rust example for screen_size

### DIFF
--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -221,6 +221,18 @@ which is a good time to find the size of the game window:
         screenSize = GetViewportRect().Size;
     }
 
+ .. code-tab:: rust
+
+    #[methods]
+    impl Player {
+        #[export]
+        fn _ready(&mut self, owner: &Area2D) {
+            let viewport = unsafe { owner.get_viewport().unwrap().assume_safe() };
+            self.screen_size = viewport.size();
+            owner.hide();
+        }
+    }
+
 Now we can use the ``_process()`` function to define what the player will do.
 ``_process()`` is called every frame, so we'll use it to update
 elements of our game, which we expect will change often. For the player, we


### PR DESCRIPTION
Grabbed this from https://github.com/godot-rust/godot-rust/blob/master/examples/dodge_the_creeps/src/player.rs#L34

To fit the examples in other languages this should be used:

```rs
impl Player {
  #[export]
    fn _ready(&mut self, owner: &Area2D) {
      self.screen_size = viewport.size();
    }
}
```

But in rustlang we don't have access to 'viewport' from this scope:

```
error[E0425]: cannot find value `viewport` in this scope
  --> examples/dodge_the_creeps/src/player.rs:36:28
   |
36 |         self.screen_size = viewport.size();
   |                            ^^^^^^^^ not found in this scope
```

Thus it requires use of unsafe code.

Should be peer-reviewed by godot-rust, provided as-is to the best of my
ability

Signed-off-by: Jacob Hrbek <kreyren@fsfe.org>

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
