### PR TITLE
Fix "SchlickGGX" typo in Standard Material 3D

### DIFF
--- a/tutorials/3d/standard_material_3d.rst
+++ b/tutorials/3d/standard_material_3d.rst
@@ -191,7 +191,7 @@ Specular Mode
 Specifies how the specular blob will be rendered. The specular blob
 represents the shape of a light source reflected in the object.
 
-* **ShlickGGX:** The most common blob used by PBR 3D engines nowadays.
+* **SchlickGGX:** The most common blob used by PBR 3D engines nowadays.
 * **Blinn:** Common in previous-generation engines.
   Not worth using nowadays, but left here for the sake of compatibility.
 * **Phong:** Same as above.


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
