### PR TITLE
Fix C# code for changing scene

### DIFF
--- a/tutorials/scripting/change_scenes_manually.rst
+++ b/tutorials/scripting/change_scenes_manually.rst
@@ -25,7 +25,7 @@ scenes which one instances and adds to the tree at runtime:
 
     public MyClass()
     {
-        simultaneousScene = ((PackedScene) ResourceLoader.Load("res://levels/level2.tscn")).Instance();
+        simultaneousScene = ResourceLoader.Load<PackedScene>("res://levels/level2.tscn").Instance();
     }
 
     public void _AddASceneManually()

--- a/tutorials/scripting/change_scenes_manually.rst
+++ b/tutorials/scripting/change_scenes_manually.rst
@@ -21,11 +21,11 @@ scenes which one instances and adds to the tree at runtime:
 
  .. code-tab:: csharp
 
-    public PackedScene simultaneousScene;
+    public Node simultaneousScene;
 
     public MyClass()
     {
-        simultaneousScene = (PackedScene)ResourceLoader.Load("res://levels/level2.tscn").instance();
+        simultaneousScene = ((PackedScene) ResourceLoader.Load("res://levels/level2.tscn")).Instance();
     }
 
     public void _AddASceneManually()


### PR DESCRIPTION
This pull request aims to fix an issue in the C# example code of "Changing Scenes Manually".

Previously the code called the `addChild()` method with a `PackedScene`; however `addChild()` accepts a Node.

This pull request changes the Type of `simultaneousScene` to a `Node` while fixing a typo in the way the `Instance()` method was called.

