### PR TITLE
Add missing punctuation to FPS tutorial part 1

### DIFF
--- a/tutorials/3d/fps_tutorial/part_one.rst
+++ b/tutorials/3d/fps_tutorial/part_one.rst
@@ -103,7 +103,7 @@ For now let's open up ``Player.tscn``.
 Making the FPS movement logic
 -----------------------------
 
-Once you have ``Player.tscn`` open, let's take a quick look at how it is set up
+Once you have ``Player.tscn`` open, let's take a quick look at how it is set up:
 
 .. image:: img/PlayerSceneTree.png
 


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
Hi! Just going through this tutorial as a first-time user and noticed that there's no punctuation at the end of a sentence, which feels weird. Wasn't sure if it should be a period or a colon so I decided to use a colon, since it's inviting the reader to look at the visual aid... feel free to ignore if you disagree though.

Thanks for creating this tool and writing this documentation!