### PR TITLE
GitHub Actions: Upload ZIPs of compiled HTML documentation for reading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: Continuous integration
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    # Every week on Monday at midnight (UTC).
+    # This keeps the generated HTML documentation fresh.
+    - cron: '0 0 * * 1'
 
 jobs:
   build:
@@ -17,11 +23,25 @@ jobs:
           sudo pip3 install codespell
 
       - name: Linter checks
+        if: github.event_name != 'schedule'
         run: |
           bash _tools/format.sh
           codespell -I _tools/codespell-ignore.txt -x _tools/codespell-ignore-lines.txt {about,community,development,getting_started,tutorials}/**/*.rst
 
       - name: Sphinx build
         run: |
-          # Use dummy builder to improve performance.
-          sphinx-build --color -b dummy -d _build/doctrees -W . _build/html
+          if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
+            # Build HTML to upload it.
+            sphinx-build --color -d _build/doctrees -W . _build/html
+          else
+            # Use dummy builder to improve performance.
+            sphinx-build --color -b dummy -d _build/doctrees -W . _build/html
+          fi
+
+      - uses: actions/upload-artifact@v2
+        if: github.event_name == 'schedule'
+        with:
+          name: godot-docs-html
+          path: _build/html
+          # Keep the current build and the previous build (in case a scheduled build failed).
+          retention-days: 15


### PR DESCRIPTION
This can be used to read the documentation without an Internet connection.

Builds are made every week and are kept for 15 days. This ensures an artifact is still available in case a scheduled build fails.

**Example:** https://github.com/Calinou/godot-docs/actions/runs/481583437
Note that the size displayed on the artifact download is the *uncompressed* size. The actual download size is much lower (~200 MB) thanks to compression.