### PR TITLE
Make Vulkan requirement an important note in Compiling for macOS

### DIFF
--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -16,8 +16,8 @@ For compiling under macOS, the following is required:
   (or the more lightweight Command Line Tools for Xcode).
 - *Optional* - `yasm <https://yasm.tortall.net/>`_ (for WebM SIMD optimizations).
 
-If you are building the ``master`` branch:
-- Download and install the `Vulkan SDK for macOS <https://vulkan.lunarg.com/sdk/home>`__.
+.. note:: If you are building the ``master`` branch:
+          - Download and install the `Vulkan SDK for macOS <https://vulkan.lunarg.com/sdk/home>`__.
 
 .. note:: If you have `Homebrew <https://brew.sh/>`_ installed, you can easily
           install SCons and yasm using the following command::

--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -16,8 +16,10 @@ For compiling under macOS, the following is required:
   (or the more lightweight Command Line Tools for Xcode).
 - *Optional* - `yasm <https://yasm.tortall.net/>`_ (for WebM SIMD optimizations).
 
-.. note:: If you are building the ``master`` branch:
-          - Download and install the `Vulkan SDK for macOS <https://vulkan.lunarg.com/sdk/home>`__.
+.. important::
+
+    If you are building the ``master`` branch, download and install the
+    `Vulkan SDK for macOS <https://vulkan.lunarg.com/sdk/home>`__.
 
 .. note:: If you have `Homebrew <https://brew.sh/>`_ installed, you can easily
           install SCons and yasm using the following command::


### PR DESCRIPTION
It is more clear to make a **note** for vulkan usage.

I started reread the page after seeing the copy command for creating the app which was way more down the my `./bin/godot.osx.tools.x86_64` intend
> `cp <Vulkan SDK path>/macOS/libs/libMoltenVK.dylib Godot.app/Contents/Frameworks/libMoltenVK.dylib`

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->
