### PR TITLE
Add note about content guidelines in writing guidelines page

### DIFF
--- a/community/contributing/docs_writing_guidelines.rst
+++ b/community/contributing/docs_writing_guidelines.rst
@@ -32,6 +32,11 @@ There are 3 rules to describe classes:
     the smallest and clearest sentences possible. These guidelines will help
     you work towards that goal.
 
+.. seealso::
+
+    See the :ref:`content guidelines <doc_content_guidelines>` for information
+    on the types of documentation you can write in the official documentation.
+
 7 rules for clear English
 -------------------------
 


### PR DESCRIPTION
Adds a note to the beginning of the writing guidelines page about the content guidelines. Closes #4066 
