### PR TITLE
Fix `:ref:` link typo in C# basics

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -83,7 +83,7 @@ external editors:
 .. note::
 
     If you are using Visual Studio 2019, you must follow the instructions found
-    in the `:ref:doc_c_sharp_configuring_vs_2019_for_debugging` section below.
+    in the :ref:`doc_c_sharp_configuring_vs_2019_for_debugging` section below.
 
 Windows (Visual Studio)
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->

The note `If you are using Visual Studio 2019, you must follow the instructions found in the :ref:doc_c_sharp_configuring_vs_2019_for_debugging section below` appears with the link as text instead than a proper `<a href="...">` element because of a misplaced backtick 
