### PR TITLE
Fix `emit_signal()` call in GDScript basics' coroutine example

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_basics.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics.rst
@@ -1605,7 +1605,7 @@ the arguments::
         yield(get_tree(), "idle_frame")
         print("Waiting")
         yield(get_tree(), "idle_frame")
-        emit_signal(input, "Processed " + input)
+        emit_signal("done", input, "Processed " + input)
 
 
     func _ready():


### PR DESCRIPTION
The first argument of emit_signal should be the signal name.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
