### PR TITLE
Add information on onready annotation to C# differences page

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_differences.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_differences.rst
@@ -128,6 +128,28 @@ This attribute should be used on a `delegate`, whose name signature will be used
 
 See also: :ref:`doc_c_sharp_signals`.
 
+Onready annotation
+------------------
+
+GDScript has the ability to defer the initialization of a member variable until the ready function
+is called with `@onready`. (You can find out more :ref:`(here) <doc_onready_annotation>`.
+For example:
+
+.. code-block:: gdscript
+
+    @onready var my_label = get_node("MyLabel")
+
+However C# does not have this ability. To achieve the same effect you need to do this.
+
+.. code-block:: csharp
+
+    private Label _myLabel;
+
+    public override void _Ready()
+    {
+        _myLabel = GetNode<Label>("MyLabel");
+    }
+
 Singletons
 ----------
 

--- a/tutorials/scripting/c_sharp/c_sharp_differences.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_differences.rst
@@ -128,11 +128,11 @@ This attribute should be used on a `delegate`, whose name signature will be used
 
 See also: :ref:`doc_c_sharp_signals`.
 
-Onready annotation
-------------------
+`@onready` annotation
+---------------------
 
 GDScript has the ability to defer the initialization of a member variable until the ready function
-is called with `@onready`. (You can find out more :ref:`(here) <doc_onready_annotation>`.
+is called with `@onready` (cf. :ref:`doc_onready_annotation`).
 For example:
 
 .. code-block:: gdscript

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1726,6 +1726,8 @@ This also means that returning a signal from a function that isn't a coroutine w
           type-safety, because a function cannot say that returns an ``int`` but actually give a function state object
           during runtime.
 
+.. _doc_onready_annotation:
+
 Onready annotation
 ~~~~~~~~~~~~~~~~~~
 

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1728,8 +1728,8 @@ This also means that returning a signal from a function that isn't a coroutine w
 
 .. _doc_onready_annotation:
 
-Onready annotation
-~~~~~~~~~~~~~~~~~~
+`@onready` annotation
+~~~~~~~~~~~~~~~~~~~~~
 
 When using nodes, it's common to desire to keep references to parts
 of the scene in a variable. As scenes are only warranted to be


### PR DESCRIPTION
Adds information on onready annotation to the API differences to GDScript page. Closes #4563 