### PR TITLE
Update Sphinx to 3.5.2, sphinx_rtd_theme to 0.5.1 and sphinx-tabs to 2.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # Sync with readthedocs:
 # https://github.com/readthedocs/readthedocs.org/blob/master/requirements/pip.txt
 # https://github.com/readthedocs/readthedocs.org/blob/master/requirements/local-docs-build.txt
-sphinx==1.8.5  # pyup: <2.0.0
+sphinx==3.4.3  # pyup: <2.0.0
 sphinx_rtd_theme==0.4.3
 
 # Code tabs extension for GDScript/C#

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,11 @@
 # Sync with readthedocs:
 # https://github.com/readthedocs/readthedocs.org/blob/master/requirements/pip.txt
 # https://github.com/readthedocs/readthedocs.org/blob/master/requirements/local-docs-build.txt
-sphinx==3.4.3  # pyup: <2.0.0
-sphinx_rtd_theme==0.4.3
+sphinx==3.5.2
+sphinx_rtd_theme==0.5.1
 
 # Code tabs extension for GDScript/C#
-sphinx-tabs==2.0.0
+sphinx-tabs==2.1.0
 
 # Full-page search UI for RTD: https://readthedocs-sphinx-search.readthedocs.io
 readthedocs-sphinx-search==0.1.0rc3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ sphinx==3.4.3  # pyup: <2.0.0
 sphinx_rtd_theme==0.4.3
 
 # Code tabs extension for GDScript/C#
-sphinx-tabs==1.1.13
+sphinx-tabs==2.0.0
 
 # Full-page search UI for RTD: https://readthedocs-sphinx-search.readthedocs.io
 readthedocs-sphinx-search==0.1.0rc3


### PR DESCRIPTION
Updating sphinx-tabs gives us the ability to have collapsible code tabs.
See https://github.com/executablebooks/sphinx-tabs/pull/94 and https://github.com/executablebooks/sphinx-tabs/pull/73.