### PR TITLE
Update issue template with links to doc tutorials

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,3 +11,9 @@ assignees: ''
 **Issue description:**
 
 **URL to the documentation page:**
+
+If you know how to fix the issue you are reporting please
+consider opening a pull request. We provide a tutorial on
+using git [here](https://docs.godotengine.org/en/stable/community/contributing/pr_workflow.html),
+writing documentation [here](https://docs.godotengine.org/en/stable/community/contributing/docs_writing_guidelines.html)
+and contributing to the class reference [here](https://docs.godotengine.org/en/stable/community/contributing/updating_the_class_reference.html).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,6 +14,6 @@ assignees: ''
 
 If you know how to fix the issue you are reporting please
 consider opening a pull request. We provide a tutorial on
-using git [here](https://docs.godotengine.org/en/stable/community/contributing/pr_workflow.html),
-writing documentation [here](https://docs.godotengine.org/en/stable/community/contributing/docs_writing_guidelines.html)
-and contributing to the class reference [here](https://docs.godotengine.org/en/stable/community/contributing/updating_the_class_reference.html).
+using git here: https://docs.godotengine.org/en/stable/community/contributing/pr_workflow.html,
+writing documentation at https://docs.godotengine.org/en/stable/community/contributing/docs_writing_guidelines.html
+and contributing to the class reference here: https://docs.godotengine.org/en/stable/community/contributing/updating_the_class_reference.html


### PR DESCRIPTION
I've seen too many issues opened by people who know how to fix the issue. I think updating the issue template is a good way to give these tutorials visibility.
