### PR TITLE
3D game: Fix translation/rotation values to be the same as in images

### DIFF
--- a/getting_started/first_3d_game/09.adding_animations.rst
+++ b/getting_started/first_3d_game/09.adding_animations.rst
@@ -90,7 +90,7 @@ Two tracks appear in the editor with a diamond icon representing each keyframe.
 |image11|
 
 You can click and drag on the diamonds to move them in time. Move the
-translation key to ``0.1`` seconds and the rotation key to ``0.2`` seconds.
+translation key to ``0.2`` seconds and the rotation key to ``0.1`` seconds.
 
 |image12|
 


### PR DESCRIPTION
Quick fix to values for translation and rotation since the images show the values in reverse.
(In the picture translation is 0.2 and rotation 0.1)

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
