### PR TITLE
3D Game: Fix text to reflect the context images for collision masks

### DIFF
--- a/getting_started/first_3d_game/06.jump_and_squash.rst
+++ b/getting_started/first_3d_game/06.jump_and_squash.rst
@@ -85,8 +85,8 @@ Select the *Player* node and set its *Collision -> Mask* to both "enemies" and
 Then, open the *Mob* scene by double-clicking on ``Mob.tscn`` and select the
 *Mob* node.
 
-Set its *Collision -> Layer* to "enemies" and its *Collision -> Mask* to both
-"player".
+Set its *Collision -> Layer* to "enemies" and unset its *Collision -> Mask* 
+leaving the mask empty.
 
 |image6|
 

--- a/getting_started/first_3d_game/06.jump_and_squash.rst
+++ b/getting_started/first_3d_game/06.jump_and_squash.rst
@@ -85,7 +85,7 @@ Select the *Player* node and set its *Collision -> Mask* to both "enemies" and
 Then, open the *Mob* scene by double-clicking on ``Mob.tscn`` and select the
 *Mob* node.
 
-Set its *Collision -> Layer* to "enemies" and unset its *Collision -> Mask* 
+Set its *Collision -> Layer* to "enemies" and unset its *Collision -> Mask*,
 leaving the mask empty.
 
 |image6|


### PR DESCRIPTION
The image in the instructions has an empty collision mask while the text wasn't reflecting it or in this case even making sense.
Maybe it was just a copy paste typoo or was there supposed to be said something different?

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
