### PR TITLE
4 to four in list_of_features.rst

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -153,7 +153,7 @@ Vulkan renderer.
 
 **Real-time lighting:**
 
-- Directional lights (sun/moon). Up to 4 per scene.
+- Directional lights (sun/moon). Up to four per scene.
 - Omnidirectional lights.
 - Spot lights with adjustable cone angle and attenuation.
 - Adjustable light "size" for fake area lights (will also make shadows blurrier).


### PR DESCRIPTION
Any number under 10 is spelled instead of putting the number.