### PR TITLE
Remove mentions of Perforce and PlasticSCM as they're seldom tested

### DIFF
--- a/tutorials/scripting/filesystem.rst
+++ b/tutorials/scripting/filesystem.rst
@@ -21,9 +21,9 @@ included. If a resource has sub-resources that are built-in, the resource is
 saved in a single file together with all the bundled sub-resources. For
 example, a font resource is often bundled together with the font textures.
 
-The Godot file system avoids using metadata files. Existing asset managers and VCSs 
-are better than anything we can implement, so Godot tries its best to play along 
-with SVN, Git, Mercurial, Perforce, etc.
+The Godot file system avoids using metadata files. Existing asset managers and VCSs
+are better than anything we can implement, so Godot tries its best to play along
+with Subversion, Git, Mercurial, etc.
 
 Example of file system contents:
 
@@ -38,12 +38,12 @@ Example of file system contents:
 project.godot
 -------------
 
-The ``project.godot`` file is the project description file, and it is always found 
+The ``project.godot`` file is the project description file, and it is always found
 at the root of the project. In fact, its location defines where the root is. This
 is the first file that Godot looks for when opening a project.
 
 This file contains the project configuration in plain text, using the win.ini
-format. Even an empty ``project.godot`` can function as a basic definition of 
+format. Even an empty ``project.godot`` can function as a basic definition of
 a blank project.
 
 Path delimiter
@@ -73,10 +73,10 @@ read-only and writing will no longer be permitted.
 User path
 ---------
 
-Writing to disk is still needed for tasks such as saving game state or 
+Writing to disk is still needed for tasks such as saving game state or
 downloading content packs. To this end, the engine ensures that there is a
-special path ``user://`` that is always writable. This path resolves 
-differently depending on the OS the project is running on. Local path 
+special path ``user://`` that is always writable. This path resolves
+differently depending on the OS the project is running on. Local path
 resolution is further explained in :ref:`doc_data_paths`.
 
 Host file system
@@ -95,8 +95,8 @@ moving assets around (renaming them or moving them from one path to another insi
 the project) will break existing references to these assets. These references will
 have to be re-defined to point at the new asset location.
 
-To avoid this, do all your move, delete and rename operations from within Godot, on 
-the FileSystem dock. Never move assets from outside Godot, or dependencies will have 
+To avoid this, do all your move, delete and rename operations from within Godot, on
+the FileSystem dock. Never move assets from outside Godot, or dependencies will have
 to be fixed manually (Godot detects this and helps you fix them anyway, but why
 go the hard route?).
 


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot-website/pull/275.

This closes https://github.com/godotengine/godot-docs/issues/4584.