### PR TITLE
Fix Sphinx `add_lexer()` deprecation in the GDScript extension

### DIFF
--- a/_extensions/gdscript.py
+++ b/_extensions/gdscript.py
@@ -341,7 +341,7 @@ class GDScriptLexer(RegexLexer):
 
 
 def setup(sphinx):
-    sphinx.add_lexer("gdscript", GDScriptLexer())
+    sphinx.add_lexer("gdscript", GDScriptLexer)
 
     return {
         "parallel_read_safe": True,


### PR DESCRIPTION
This closes #4593.