### PR TITLE
Add code example for weakref

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1507,8 +1507,22 @@ freed when no longer in use. No garbage collector exists, just
 reference counting. By default, all classes that don't define
 inheritance extend **Reference**. If this is not desired, then a class
 must inherit :ref:`class_Object` manually and must call ``instance.free()``. To
-avoid reference cycles that can't be freed, a ``weakref`` function is
-provided for creating weak references.
+avoid reference cycles that can't be freed, a :ref:`class_WeakRef` function is
+provided for creating weak references. Here is an example:
+
+::
+
+    extends Node
+
+    var my_node_ref
+
+    func _ready():
+        my_node_ref = weakref(get_node("MyNode"))
+
+    func _this_is_called_later():
+        var my_node = my_node_ref.get_ref()
+        if my_node:
+            my_node.do_something()
 
 Alternatively, when not using references, the
 ``is_instance_valid(instance)`` can be used to check if an object has been


### PR DESCRIPTION
Adds a weakref code example to the gdscript basics docs, also adds a link to the weakref class docs. The code example comes from neikeq in #948. I always find an example to be helpful, so with this I would consider weakref fully documented. Closes #580
