### PR TITLE
Change the order and text of UI workflows list

### DIFF
--- a/getting_started/step_by_step/ui_introduction_to_the_ui_system.rst
+++ b/getting_started/step_by_step/ui_introduction_to_the_ui_system.rst
@@ -172,7 +172,7 @@ There are two workflows to build responsive UIs
 There are two workflows to build scalable and flexible interfaces in Godot:
 
 1. **Place UI elements precisely with anchors:** Use the **Layout** menu to place and resize a UI element relative to its parent.
-2. **Arrange control nodes automatically with containers:** Use container nodes to automatically scale and place UI elements. 
+2. **Arrange control nodes automatically with containers:** Use container nodes to automatically scale and place UI elements.
 
 The two approaches are not always compatible. Because a container controls its children, you cannot use the layout menu on them. Each container has a specific effect, so you may need to nest several of them to get a working interface. With the layout approach you work from the bottom up, on the children. As you don't insert extra containers in the scene it can make for cleaner hierarchies, but it's harder to arrange items in a row, column, grid, etc.
 

--- a/getting_started/step_by_step/ui_introduction_to_the_ui_system.rst
+++ b/getting_started/step_by_step/ui_introduction_to_the_ui_system.rst
@@ -171,8 +171,8 @@ There are two workflows to build responsive UIs
 
 There are two workflows to build scalable and flexible interfaces in Godot:
 
-1. You have many container nodes at your disposal that scale and place UI elements for you. They take control over their children.
-2. On the other side, you have the layout menu. It helps you to anchor, place and resize a UI element within its parent.
+1. **Place UI elements precisely with anchors**: Use the layout menu to place and resize a UI element relative to its parent.
+2. **Arrange control nodes automatically with containers**: Use container nodes to automatically scale and place UI elements. 
 
 The two approaches are not always compatible. Because a container controls its children, you cannot use the layout menu on them. Each container has a specific effect, so you may need to nest several of them to get a working interface. With the layout approach you work from the bottom up, on the children. As you don't insert extra containers in the scene it can make for cleaner hierarchies, but it's harder to arrange items in a row, column, grid, etc.
 

--- a/getting_started/step_by_step/ui_introduction_to_the_ui_system.rst
+++ b/getting_started/step_by_step/ui_introduction_to_the_ui_system.rst
@@ -171,8 +171,8 @@ There are two workflows to build responsive UIs
 
 There are two workflows to build scalable and flexible interfaces in Godot:
 
-1. **Place UI elements precisely with anchors**: Use the layout menu to place and resize a UI element relative to its parent.
-2. **Arrange control nodes automatically with containers**: Use container nodes to automatically scale and place UI elements. 
+1. **Place UI elements precisely with anchors:** Use the **Layout** menu to place and resize a UI element relative to its parent.
+2. **Arrange control nodes automatically with containers:** Use container nodes to automatically scale and place UI elements. 
 
 The two approaches are not always compatible. Because a container controls its children, you cannot use the layout menu on them. Each container has a specific effect, so you may need to nest several of them to get a working interface. With the layout approach you work from the bottom up, on the children. As you don't insert extra containers in the scene it can make for cleaner hierarchies, but it's harder to arrange items in a row, column, grid, etc.
 


### PR DESCRIPTION
When the two UI workflows are introduced, they are presented in a list in the inversed order of the detailed text that follows.
This is confusing for someone who's approaching this topic for the first time. 

This proposal changes the text and the order of the list to be similar to the main titles of the detailed text.

PS: proposing the change to `3.2` because this page does not exist on `master`.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
