### PR TITLE
Revert "Fix Sphinx `add_lexer()` deprecation in the GDScript extension (#4594)"

### DIFF
--- a/_extensions/gdscript.py
+++ b/_extensions/gdscript.py
@@ -341,7 +341,7 @@ class GDScriptLexer(RegexLexer):
 
 
 def setup(sphinx):
-    sphinx.add_lexer("gdscript", GDScriptLexer)
+    sphinx.add_lexer("gdscript", GDScriptLexer())
 
     return {
         "parallel_read_safe": True,


### PR DESCRIPTION
This broke the build.

This reverts commit 1f8dcbeee7f6944cb365975ff12309647f50ac6c.