### PR TITLE
Document Firefox WebGL being slow on Linux and workaround

### DIFF
--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -17,6 +17,13 @@ in the user's browser.
                :ref:`iOS' native export functionality <doc_exporting_for_ios>`
                instead, as it will also result in better performance.
 
+.. note::
+
+    If you use Linux, due to
+    `poor Firefox WebGL performance <https://bugzilla.mozilla.org/show_bug.cgi?id=1010527>`__,
+    it's recommended to play the exported project using a Chromium-based browser
+    instead of Firefox.
+
 WebGL 2
 -------
 


### PR DESCRIPTION
There's nothing we can do about it except instruct people to use a Chromium-based browser for their HTML5 gaming needs :slightly_frowning_face:

We could perhaps use `console.warn()` to display a similar message to the console based on the user agent.