### PR TITLE
Fix `height()` functions missing `return` in Your second 3D shader

### DIFF
--- a/tutorials/shaders/your_first_shader/your_second_3d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_second_3d_shader.rst
@@ -296,7 +296,7 @@ We can now replace the contents of our ``height()`` function with ``wave()``.
     return h;
   }
 
-Using this you get:
+Using this, you get:
 
 .. image:: img/wave1.png
 
@@ -306,7 +306,7 @@ We do this by scaling ``position``.
 .. code-block:: glsl
 
   float height(vec2 position, float time) {
-    float h = wave(position*0.4);
+    float h = wave(position * 0.4);
     return h;
   }
 

--- a/tutorials/shaders/your_first_shader/your_second_3d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_second_3d_shader.rst
@@ -293,6 +293,7 @@ We can now replace the contents of our ``height()`` function with ``wave()``.
 
   float height(vec2 position, float time) {
     float h = wave(position);
+    return h;
   }
 
 Using this you get:
@@ -306,6 +307,7 @@ We do this by scaling ``position``.
 
   float height(vec2 position, float time) {
     float h = wave(position*0.4);
+    return h;
   }
 
 Now it looks much better.


### PR DESCRIPTION
Added a return statement so that your changes can be seen.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
