### PR TITLE
Discourage using Linux distribution packages for Android SDKs

### DIFF
--- a/development/compiling/compiling_for_android.rst
+++ b/development/compiling/compiling_for_android.rst
@@ -27,6 +27,8 @@ For compiling under Windows, Linux or macOS, the following is required:
    (command-line tools are sufficient).
 
    -  Required SDK components will be automatically installed by Gradle (except the NDK).
+   -  On Linux,
+      **do not use an Android SDK provided by your distribution's repositories as it will often be outdated**.
 
 -  `Android NDK <https://developer.android.com/ndk/downloads/>`_ r17 or later.
 -  Gradle (will be downloaded and installed automatically if missing).

--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -24,6 +24,11 @@ Download and install the Android SDK.
 
     sdkmanager --sdk_root=<android_sdk_path> "platform-tools" "build-tools;30.0.1" "platforms;android-29" "cmdline-tools;latest"
 
+.. note::
+
+    If you are using Linux,
+    **do not use an Android SDK provided by your distribution's repositories as it will often be outdated**.
+
 Install OpenJDK
 -----------------
 


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/45844.