### PR TITLE
Fix GDNative demo projects repository link

### DIFF
--- a/tutorials/plugins/gdnative/gdnative-c-example.rst
+++ b/tutorials/plugins/gdnative/gdnative-c-example.rst
@@ -13,7 +13,7 @@ that is to come after this.
 
 Before we begin, you can download the source code to the example object we
 describe below in the `GDNative-demos repository
-<https://docs.godotengine.org/en/latest/tutorials/scripting/gdnative/gdnative_c_example.html>`_.
+<https://github.com/GodotNativeTools/GDNative-demos/tree/master/c/simple>`_.
 
 This example project also contains a SConstruct file that makes compiling a
 little easier, but in this tutorial we'll be doing things by hand to

--- a/tutorials/plugins/gdnative/gdnative-c-example.rst
+++ b/tutorials/plugins/gdnative/gdnative-c-example.rst
@@ -13,7 +13,7 @@ that is to come after this.
 
 Before we begin, you can download the source code to the example object we
 describe below in the `GDNative-demos repository
-<https://github.com/GodotNativeTools/GDNative-demos/tree/master/c/simple>`_.
+<https://github.com/godotengine/gdnative-demos/tree/master/c/simple>`_.
 
 This example project also contains a SConstruct file that makes compiling a
 little easier, but in this tutorial we'll be doing things by hand to


### PR DESCRIPTION
The link on `master` is correct.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->