### PR TITLE
Update link to `awesome-godot` repository

### DIFF
--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -52,5 +52,5 @@ Devlogs
 Resources
 ---------
 
-- `awesome-godot: A curated list of resources by Calinou <https://github.com/Calinou/awesome-godot>`_
+- `awesome-godot: A curated list of free/libre plugins, scripts and add-ons <https://github.com/godotengine/awesome-godot>`_
 - `Zeef Godot Engine: A curated directory of resources by Andre Schmitz <https://godot-engine.zeef.com/andre.antonio.schmitz>`_


### PR DESCRIPTION
#4641 version for the `stable` docs, which most devs should use.