### PR TITLE
Fix incorrect code block tab syntax in Controllers documentation

### DIFF
--- a/development/compiling/introduction_to_the_buildsystem.rst
+++ b/development/compiling/introduction_to_the_buildsystem.rst
@@ -299,7 +299,7 @@ For instance, you may want to build Godot in parallel with the aforementioned
 
      set SCONSFLAGS=-j4
 
- .. code-tab:: powershell Windows (powershell)
+ .. code-tab:: powershell Windows (PowerShell)
 
      $env:SCONSFLAGS="-j4"
 

--- a/tutorials/inputs/controllers_gamepads_joysticks.rst
+++ b/tutorials/inputs/controllers_gamepads_joysticks.rst
@@ -108,7 +108,6 @@ use ``Input.is_action_pressed()``:
     # `jumping` will be a boolean with a value of `true` or `false`.
     var jumping = Input.is_action_pressed("jump")
 
-.. tabs::
  .. code-tab:: csharp
 
     // `jumping` will be a boolean with a value of `true` or `false`.
@@ -206,7 +205,7 @@ the ``SDL_GAMECONTROLLERCONFIG`` environment variable before running Godot:
     set SDL_GAMECONTROLLERCONFIG=your:mapping:here
     path\to\godot.exe
 
- .. code-tab:: powershell Windows (powershell)
+ .. code-tab:: powershell Windows (PowerShell)
 
     $env:SDL_GAMECONTROLLERCONFIG="your:mapping:here"
     path\to\godot.exe


### PR DESCRIPTION
This also changes "powershell" to "PowerShell" where it's displayed.