### PR TITLE
Remove mentions of IRC in favor of the new Contributors Chat platform

### DIFF
--- a/about/introduction.rst
+++ b/about/introduction.rst
@@ -26,7 +26,7 @@ those may be worth a look.
 
 In case you have trouble with one of the tutorials or your project,
 you can find help on the various :ref:`Community channels <doc_community_channels>`,
-especially the Godot Discord community, Q&A, and IRC.
+especially the Godot Discord community and Q&A.
 
 About Godot Engine
 ------------------
@@ -80,7 +80,7 @@ unbalanced distribution of contents – but the way it is split up should be
 relatively intuitive:
 
 - The :ref:`sec-general` section contains this introduction as well as
-  information about the engine, its history, its licensing, authors, etc. It
+  the information about the engine, its history, its licensing, authors, etc. It
   also contains the :ref:`doc_faq`.
 - The :ref:`sec-learn` section is the *raison d'être* of this
   documentation, as it contains all the necessary information on using the
@@ -90,13 +90,13 @@ relatively intuitive:
 - The :ref:`sec-tutorials` section can be read as needed,
   in any order. It contains feature-specific tutorials and documentation.
 - The :ref:`sec-devel` section is intended for advanced users and contributors
-  to the engine development, with information on compiling the engine,
-  developing C++ modules or editor plugins.
-- The :ref:`sec-community` section gives information related to contributing to
-  engine development and the life of its community, e.g. how to report bugs,
+  to the engine development, with the information on compiling the engine,
+  contributing to the editor, or developing C++ modules.
+- The :ref:`sec-community` section gives the information related to contributing to
+  the engine development and the life of its community, e.g. how to report bugs,
   help with the documentation, etc. It also points to various community channels
-  like IRC and Discord and contains a list of recommended third-party tutorials
-  outside of this documentation.
+  like Godot Contributors Chat and Discord and contains a list of recommended 
+  third-party tutorials outside of this documentation.
 - Finally, the :ref:`sec-class-ref` is the documentation of the Godot API,
   which is also available directly within the engine's script editor. It is
   generated automatically from a file in the main source repository, therefore

--- a/community/asset_library/submitting_to_assetlib.rst
+++ b/community/asset_library/submitting_to_assetlib.rst
@@ -161,14 +161,19 @@ submission boxes to enable them.
     preview. This option will be removed eventually, and thumbnails will be automatically
     computed instead.
 
-Once you are done, hit Submit. Your asset will be entered into the pending queue,
-which you can visit on the AssetLib `here <https://godotengine.org/asset-library/asset/edit?&asset=-1>`_ . The approval process is manual and may
-take up to a few days for your addon to be accepted (or rejected), so please
-be patient! You will be informed when your asset is reviewed. If it was rejected,
+Once you are done, press "Submit". Your asset will be entered into the review queue.
+You can check all assets currently pending a review `here <https://godotengine.org/asset-library/asset/edit?&asset=-1>`_ .
+The approval process is manual and may take up to a few days for your asset to be accepted (or rejected), so please
+be patient! 
+
+.. note::
+    
+    You may have some luck accelerating the approval process by messaging the
+    moderators and AssetLib reviewers on the `Contributors Chat <https://chat.godotengine.org/>`_,
+    or the official Discord server.
+
+You will be informed when your asset is reviewed. If it was rejected,
 you will be told why that may have been, and you will be able to submit it again
 with the appropriate changes.
-You may have some luck accelerating the approval process by messaging the
-moderators/assetlib reviewers on IRC (the ``#godotengine-atelier`` channel on Freenode),
-or the official Discord server.
 
 .. |image0| image:: img/assetlib_submit.png

--- a/community/channels.rst
+++ b/community/channels.rst
@@ -14,8 +14,17 @@ Q&A
 
 - `Official Godot Questions & Answers <https://godotengine.org/qa/>`_
 
+Rocket.Chat
+-----------
+
+- `Godot Contributors Chat <https://chat.godotengine.org/>`_
+
 IRC on Freenode
 ---------------
+
+.. note::
+
+    As of January 2021, core developer chat has moved to the Godot Contributors Chat platform listed above.
 
 - `General: #godotengine <https://webchat.freenode.net/?channels=#godotengine>`_
 - `Engine development: #godotengine-devel <https://webchat.freenode.net/?channels=#godotengine-devel>`_

--- a/community/contributing/bug_triage_guidelines.rst
+++ b/community/contributing/bug_triage_guidelines.rst
@@ -69,8 +69,7 @@ The following labels are currently defined in the Godot repository:
    feature requests. Please use
    `godot-proposals <https://github.com/godotengine/godot-proposals>`__ instead.
 -  *For PR meeting*: the issue needs to be discussed in a pull request meeting.
-   These meetings are public and are held regularly on the ``#godotengine-meeting``
-   IRC channel.
+   These meetings are public and are held on the `Godot Contributors Chat <https://chat.godotengine.org/>`_.
 -  *Junior job*: the issue is *assumed* to be an easy one to fix, which makes
    it a great fit for junior contributors who need to become familiar with
    the code base.

--- a/community/contributing/class_reference_writing_guidelines.rst
+++ b/community/contributing/class_reference_writing_guidelines.rst
@@ -251,4 +251,4 @@ pull of your changes. Another writer will take care of it.
 
 You can still look at the methods' implementation in Godot's source code on
 GitHub. If you have doubts, feel free to ask on the `Q&A website
-<https://godotengine.org/qa/>`__ and IRC (Freenode, #godotengine).
+<https://godotengine.org/qa/>`__ and `Godot Contributors Chat <https://chat.godotengine.org/>`_.

--- a/community/contributing/pr_workflow.rst
+++ b/community/contributing/pr_workflow.rst
@@ -364,7 +364,8 @@ On that line, there is a "Pull request" link. Clicking it will open a form
 that will let you issue a pull request on the ``godotengine/godot`` upstream
 repository. It should show you your two commits, and state "Able to merge".
 If not (e.g. it has way more commits, or says there are merge conflicts),
-don't create the PR, something went wrong. Go to IRC and ask for support :)
+don't create the PR yet, something went wrong. Go to our `Contributors Chat 
+<https://chat.godotengine.org/>`_ and ask for support :)
 
 Use an explicit title for the PR and put the necessary details in the comment
 area. You can drag and drop screenshots, GIFs or zipped projects if relevant,

--- a/community/contributing/updating_the_class_reference.rst
+++ b/community/contributing/updating_the_class_reference.rst
@@ -148,8 +148,8 @@ branch with the Godot repository, and create a new branch:
     # Creates a new branch and checks out to it
     git checkout -b your-new-branch-name
 
-If you're feeling lost by now, come to our `IRC channels
-<https://webchat.freenode.net/?channels=#godotengine>`_ and ask for help.
+If you're feeling lost by now, come to our `Contributors Chat 
+<https://chat.godotengine.org/>`_ and ask for help.
 Experienced Git users will give you a hand.
 
 Alternatively, you can join the `Godot Discord server

--- a/community/contributing/ways_to_contribute.rst
+++ b/community/contributing/ways_to_contribute.rst
@@ -16,8 +16,8 @@ positive to the engine, regardless of their skill set:
 -  **Be part of the community.** The best way to contribute to Godot and help
    it become ever better is simply to use the engine and promote it by
    word-of-mouth, in the credits or splash screen of your games, blog posts, tutorials,
-   videos, demos, gamedev or free software events, support on the Q&A, IRC,
-   forums, Discord, etc. Participate!
+   videos, demos, gamedev or free software events, support on the Q&A, forums,
+   Contributors Chat, Discord, etc. Participate!
    Being a user and advocate helps spread the word about our great engine,
    which has no marketing budget and can therefore only rely on its community
    to become more mainstream.

--- a/index.rst
+++ b/index.rst
@@ -55,8 +55,8 @@ DevDocs, you need to:
           <https://hosted.weblate.org/engage/godot-engine/>`_ into your
           language, or talk to us on either the ``#documentation``
           channel on `Discord <https://discord.gg/zH7NUgz>`_, or the
-          ``#godotengine-doc`` channel on `irc.freenode.net
-          <http://webchat.freenode.net/?channels=#godotengine-doc>`_!
+          ``#documentation`` channel on the `Godot Contributors Chat 
+          <https://chat.godotengine.org/>`_!
 
 .. centered:: |weblate_widget|
 


### PR DESCRIPTION
I couldn't help myself and adjusted some texts around the parts I've edited, so if a version for `3.2` is desired, I can make a separate PR.
