### PR TITLE
Update 3D rendering limitations to mention Use Debanding project setting

### DIFF
--- a/tutorials/3d/3d_rendering_limitations.rst
+++ b/tutorials/3d/3d_rendering_limitations.rst
@@ -32,13 +32,17 @@ so it can be displayed on the screen. This can result in visible banding,
 especially when using untextured materials. This can also be seen in 2D projects
 when using smooth gradient textures.
 
-There are several ways to alleviate banding. Here are a few examples:
+There are two main ways to alleviate banding:
 
-- Bake some noise into your textures. This is mainly effective in 2D, e.g. for
-  vignetting effects.
-- Implement a debanding shader as a :ref:`screen-reading shader <doc_screen-reading_shaders>`.
-  Godot currently doesn't provide a built-in debanding shader, but this may be
-  added in a future release.
+- Enable **Use Debanding** in the Project Settings. This applies a
+  fullscreen debanding shader as a post-processing effect and is very cheap.
+  Fullscreen debanding is only supported when using the GLES3 or Vulkan renderers.
+  It also requires HDR to be enabled in the Project Settings (which is the default).
+- Alternatively, bake some noise into your textures. This is mainly effective in 2D,
+  e.g. for vignetting effects. In 3D, you can also use a
+  `custom debanding shader <https://github.com/fractilegames/godot-gles2-debanding-material>`__
+  to be applied on your *materials*. This technique works even if your project is
+  rendered in LDR, which means it will work when using the GLES2 renderer.
 
 .. seealso::
 


### PR DESCRIPTION
This can be cherry-picked to the `3.2` branch as this feature is also available in 3.2.4beta2 and later.

In the future, I'll open a PR to update the alpha antialiasing, but that PR will only be for `master` as alpha-to-coverage/alpha-to-one/AlphaHash support are only implemented in `master`.