### PR TITLE
Add a note to set default values for custom resources

### DIFF
--- a/tutorials/scripting/resources.rst
+++ b/tutorials/scripting/resources.rst
@@ -266,6 +266,9 @@ Let's see some examples.
             }
         }
 
+Be sure to set a default value for every parameter of the ``_init`` function.
+Otherwise, there will be problems with creating and editing your resource over the inspector.
+
 .. note::
 
     Resource scripts are similar to Unity's ScriptableObjects. The Inspector

--- a/tutorials/scripting/resources.rst
+++ b/tutorials/scripting/resources.rst
@@ -241,8 +241,9 @@ Let's see some examples.
                 [Export]
                 public String[] Strings { get; set; }
 
-                // Make sure that every variable gets a default value. 
-                // Otherwise, there will be problems with creating and editing your resource via the inspector.
+                // Make sure that every parameter has a default value. 
+                // Otherwise, there will be problems with creating and editing
+                // your resource via the inspector.
                 public BotStats(int health = 0, Resource subResource = null, String[] strings = null)
                 {
                     Health = health;

--- a/tutorials/scripting/resources.rst
+++ b/tutorials/scripting/resources.rst
@@ -206,7 +206,8 @@ Let's see some examples.
     export(Resource) var sub_resource
     export(Array, String) var strings
 
-    # Make sure that every variable gets a default value. Otherwise, there will be problems with creating and editing your resource via the inspector.
+    # Make sure that every variable gets a default value. 
+    # Otherwise, there will be problems with creating and editing your resource via the inspector.
     func _init(p_health = 0, p_sub_resource = null, p_strings = []):
         health = p_health
         sub_resource = p_sub_resource
@@ -239,7 +240,8 @@ Let's see some examples.
                 [Export]
                 public String[] Strings { get; set; }
 
-                // Make sure that every variable gets a default value. Otherwise, there will be problems with creating and editing your resource via the inspector.
+                // Make sure that every variable gets a default value. 
+                // Otherwise, there will be problems with creating and editing your resource via the inspector.
                 public BotStats(int health = 0, Resource subResource = null, String[] strings = null)
                 {
                     Health = health;

--- a/tutorials/scripting/resources.rst
+++ b/tutorials/scripting/resources.rst
@@ -206,8 +206,9 @@ Let's see some examples.
     export(Resource) var sub_resource
     export(Array, String) var strings
 
-    # Make sure that every variable gets a default value. 
-    # Otherwise, there will be problems with creating and editing your resource via the inspector.
+    # Make sure that every parameter has a default value. 
+    # Otherwise, there will be problems with creating and editing
+    # your resource via the inspector.
     func _init(p_health = 0, p_sub_resource = null, p_strings = []):
         health = p_health
         sub_resource = p_sub_resource

--- a/tutorials/scripting/resources.rst
+++ b/tutorials/scripting/resources.rst
@@ -206,6 +206,7 @@ Let's see some examples.
     export(Resource) var sub_resource
     export(Array, String) var strings
 
+    # Make sure that every variable gets a default value. Otherwise, there will be problems with creating and editing your resource via the inspector.
     func _init(p_health = 0, p_sub_resource = null, p_strings = []):
         health = p_health
         sub_resource = p_sub_resource
@@ -238,6 +239,7 @@ Let's see some examples.
                 [Export]
                 public String[] Strings { get; set; }
 
+                // Make sure that every variable gets a default value. Otherwise, there will be problems with creating and editing your resource via the inspector.
                 public BotStats(int health = 0, Resource subResource = null, String[] strings = null)
                 {
                     Health = health;
@@ -265,9 +267,6 @@ Let's see some examples.
                 }
             }
         }
-
-Be sure to set a default value for every parameter of the ``_init`` function.
-Otherwise, there will be problems with creating and editing your resource over the inspector.
 
 .. note::
 


### PR DESCRIPTION
I had the problem today that I don't specified a default for a value. It took me some time to figure out what was going wrong. Because this is one of the few resources on creating custom resources, I thought it would be good to mention this here.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
