### PR TITLE
Update exporting string enum to include default value

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_exports.rst
+++ b/tutorials/scripting/gdscript/gdscript_exports.rst
@@ -57,8 +57,9 @@ Examples
 
     # Editor will enumerate as 0, 1 and 2.
     @export_enum("Warrior", "Magician", "Thief") var character_class
-    # If type is String, editor will enumerate with string names.
-    @export_enum("Rebecca", "Mary", "Leah") var character_name: String
+    # If type is String, editor will enumerate with string names. 
+    # A default value is required to apply values from editor.
+    @export_enum("Rebecca", "Mary", "Leah") var character_name = "": String
 
     # Named enum values
 


### PR DESCRIPTION
In Godot v3.2.3.stable.official when exporting a var as a String enum, a default value must be provided or else the variable remains empty when running the scene. Setting a default value of `""` resolves this issue. 

This documentation appears to be for a newer syntax of GDScript though so I don't know if what I've proposed is exactly right.