### PR TITLE
Update iOS plugins documentation

### DIFF
--- a/tutorials/export/exporting_for_ios.rst
+++ b/tutorials/export/exporting_for_ios.rst
@@ -93,8 +93,8 @@ you will be able to continue to edit your Godot project in its current location.
 That's it! You can now edit your project in the Godot editor and build it
 in Xcode when you want to run it on a device.
 
-Services for iOS
-----------------
+Plugins for iOS
+---------------
 
-Special iOS services can be used in Godot. Check out the
-:ref:`doc_services_for_ios` page.
+Special iOS plugins can be used in Godot. Check out the
+:ref:`doc_plugins_for_ios` page.

--- a/tutorials/platform/index.rst
+++ b/tutorials/platform/index.rst
@@ -7,6 +7,5 @@ Platform-specific
 
    android/index
    ios/index
-   services_for_ios
    platform_html5
    consoles

--- a/tutorials/platform/ios/index.rst
+++ b/tutorials/platform/ios/index.rst
@@ -6,3 +6,4 @@ iOS plugins
    :name: toc-tutorials-plugins-ios
 
    ios_plugin
+   plugins_for_ios

--- a/tutorials/platform/ios/ios_plugin.rst
+++ b/tutorials/platform/ios/ios_plugin.rst
@@ -29,7 +29,7 @@ When a plugin is active, you can access it in your using ``Engine.get_singleton(
 Creating an iOS plugin
 ----------------------
 
-At its core, a Godot iOS plugin is an iOS library (*.a* archive file or *.xcframework* that contains static libraries) with the following requirements:
+At its core, a Godot iOS plugin is an iOS library (*.a* archive file or *.xcframework* containing static libraries) with the following requirements:
 
 - The library must have a dependency on the Godot engine headers.
 
@@ -58,9 +58,9 @@ To build an iOS plugin:
 
 3. In the ``Build Settings`` tab, specify the compilation flags for your static library in ``OTHER_CFLAGS``. The most important ones are ``-fcxx-modules``, ``-fmodules``, and ``-DDEBUG`` if you need debug support. Other flags should be the same you use to compile Godot. For instance, ``-DPTRCALL_ENABLED -DDEBUG_ENABLED, -DDEBUG_MEMORY_ALLOC -DDISABLE_FORCED_INLINE -DTYPED_METHOD_BIND``.
 
-4. Add the required logic for your plugin and build your library to generate a ``.a`` file. You will probably need to build both ``debug`` and ``release`` targeted ``.a`` files. Depending on your need, pick only one or both. If you need both ``.a`` files their name should match following pattern: ``[PluginName].[TargetType].a``. You can also build the static library with your SCons configuration.
+4. Add the required logic for your plugin and build your library to generate a ``.a`` file. You will probably need to build both ``debug`` and ``release`` target ``.a`` files. Depending on your needs, pick either or both. If you need both debug and release ``.a`` files, their name should match following pattern: ``[PluginName].[TargetType].a``. You can also build the static library with your SCons configuration.
 
-5. iOS plugin system also support ``.xcframework`` files. To generate one you can use a command such as: ``xcodebuild -create-xcframework -library [DeviceLibrary].a -library [SimulatorLibrary].a -output [PluginName].xcframework``.
+5. The iOS plugin system also supports ``.xcframework`` files. To generate one, you can use a command such as: ``xcodebuild -create-xcframework -library [DeviceLibrary].a -library [SimulatorLibrary].a -output [PluginName].xcframework``.
 
 6.  Create a Godot iOS Plugin configuration file to help the system detect and load your plugin:
 
@@ -95,10 +95,10 @@ To build an iOS plugin:
 
             -   **binary**: this should be the filepath of the plugin library (``a`` or ``xcframework``) file.
 
-                -   The filepath can be relative (e.g.: ``MyPlugin.a``, ``MyPlugin.xcframework``) in which case it's relative to the directory where ``gdip`` file is located.
+                -   The filepath can be relative (e.g.: ``MyPlugin.a``, ``MyPlugin.xcframework``) in which case it's relative to the directory where the ``gdip`` file is located.
                 -   The filepath can be absolute: ``res://some_path/MyPlugin.a`` or ``res://some_path/MyPlugin.xcframework``.
-                -   In case you need multitarget library usage, filename should be ``MyPlugin.a`` and ``a`` files should be named as ``MyPlugin.release.a`` and ``MyPlugin.debug.a``.
-                -   In case of using multitarget ``xcframework`` libraries filename in configuration should be ``MyPlugin.xcframework`` and ``xcframework`` files should be named as ``MyPlugin.release.xcframework`` and ``MyPlugin.debug.xcframework``.
+                -   In case you need multitarget library usage, the filename should be ``MyPlugin.a`` and ``.a`` files should be named as ``MyPlugin.release.a`` and ``MyPlugin.debug.a``.
+                -   In case you use multitarget ``xcframework`` libraries, their filename in the configuration should be ``MyPlugin.xcframework``. The ``.xcframework`` files should be named as ``MyPlugin.release.xcframework`` and ``MyPlugin.debug.xcframework``.
 
         The ``dependencies`` and ``plist`` sections are optional and defined as follow:
 
@@ -114,6 +114,6 @@ To build an iOS plugin:
 
                 -   **files**: contains a list of files that should be copied on export. This is useful for data files or images.
 
-                -   **linker_flags**: containts a list of linker flags that should be added to the Xcode project if plugin is exported.
+                -   **linker_flags**: contains a list of linker flags to add to the Xcode project when exporting the plugin.
 
             -   **plist**: should have keys and values that should be present in ``Info.plist`` file following pattern: ``KeyName="key value"``

--- a/tutorials/platform/ios/plugins_for_ios.rst
+++ b/tutorials/platform/ios/plugins_for_ios.rst
@@ -11,10 +11,11 @@ ARKit and Camera access are also provided as plugins.
 Accessing plugin singletons
 ---------------------------
 
-To access plugin functionality it's first required to use check if plugin
-is exported and available with `Engine.has_singleton` function. After
-that calling a `Engine.get_singleton` will return a singleton. This
-is an example of how this can be done:
+To access plugin functionality, you first need to check that the plugin is
+exported and available by calling the `Engine.has_singleton()` function, which
+returns a registered singleton.
+
+Here's an example of how to do this in GDScript:
 
 ::
 
@@ -24,7 +25,6 @@ is an example of how this can be done:
         if Engine.has_singleton("InAppStore"):
             in_app_store = Engine.get_singleton("InAppStore")
             
-            # Plugin setup
         else:
             print("iOS IAP plugin is not exported.")
 

--- a/tutorials/platform/ios/plugins_for_ios.rst
+++ b/tutorials/platform/ios/plugins_for_ios.rst
@@ -1,11 +1,32 @@
-.. _doc_services_for_ios:
+.. _doc_plugins_for_ios:
 
-Services for iOS
-================
+Plugins for iOS
+===============
 
-At the moment, there are two iOS APIs partially implemented, GameCenter
-and Storekit. Both use the same model of asynchronous calls explained
-below.
+At the moment Godot provides StoreKit, GameCenter, iCloud services plugins.
+They are using same model of asynchronous calls explained below.
+
+ARKit and Camera access are also provided as plugins.
+
+Accessing plugin singletons
+---------------------------
+
+To access plugin functionality it's first required to use check if plugin
+is exported and available with `Engine.has_singleton` function. After
+that calling a `Engine.get_singleton` will return a singleton. This
+is an example of how this can be done:
+
+::
+
+    var in_app_store
+
+    func _ready():
+        if Engine.has_singleton("InAppStore"):
+            in_app_store = Engine.get_singleton("InAppStore")
+            
+            # Plugin setup
+        else:
+            print("iOS IAP plugin is not exported.")
 
 Asynchronous methods
 --------------------
@@ -28,7 +49,7 @@ the 'pending events' queue. Example:
 ::
 
     func on_purchase_pressed():
-        var result = InAppStore.purchase({ "product_id": "my_product" })
+        var result = in_app_store.purchase({ "product_id": "my_product" })
         if result == OK:
             animation.play("busy") # show the "waiting for response" animation
         else:
@@ -36,8 +57,8 @@ the 'pending events' queue. Example:
 
     # put this on a 1 second timer or something
     func check_events():
-        while InAppStore.get_pending_event_count() > 0:
-            var event = InAppStore.pop_pending_event()
+        while in_app_store.get_pending_event_count() > 0:
+            var event = in_app_store.pop_pending_event()
             if event.type == "purchase":
                 if event.result == "ok":
                     show_success(event.product_id)
@@ -61,10 +82,10 @@ The pending event interface consists of two methods:
 Store Kit
 ---------
 
-Implemented in ``platform/iphone/in_app_store.mm``.
+Implemented in `Godot iOS InAppStore plugin <https://github.com/godotengine/godot-ios-plugins/blob/master/plugins/inappstore/in_app_store.mm>`_.
 
-The Store Kit API is accessible through the ``InAppStore`` singleton (will
-always be available from GDScript on iOS). It is initialized automatically.
+The Store Kit API is accessible through the ``InAppStore`` singleton. 
+It is initialized automatically.
 
 The following methods are available and documented below:
 
@@ -213,9 +234,9 @@ finalize the purchase on. Example:
 Game Center
 -----------
 
-Implemented in ``platform/iphone/game_center.mm``.
+Implemented in `Godot iOS GameCenter plugin <https://github.com/godotengine/godot-ios-plugins/blob/master/plugins/gamecenter/game_center.mm>`_.
 
-The Game Center API is available through the "GameCenter" singleton. It
+The Game Center API is available through the ``GameCenter`` singleton. It
 has the following methods:
 
 ::
@@ -495,34 +516,3 @@ On close:
       "type": "show_game_center",
       "result": "ok",
     }
-
-Multi-platform games
---------------------
-
-When working on a multi-platform game, you won't always have the
-"GameCenter" singleton available (for example when running on PC or
-Android). Because the gdscript compiler looks up the singletons at
-compile time, you can't just query the singletons to see and use what
-you need inside a conditional block, you need to also define them as
-valid identifiers (local variable or class member). This is an example
-of how to work around this in a class:
-
-::
-
-    var GameCenter = null # define it as a class member
-
-    func post_score(score):
-        if GameCenter == null:
-            return
-        GameCenter.post_score({ "value": score, "category": "my_leaderboard" })
-
-    func check_events():
-        while GameCenter.get_pending_event_count() > 0:
-            # do something with events here
-            pass
-
-    func _ready():
-        # check if the singleton exists
-        if Globals.has_singleton("GameCenter"):
-            GameCenter = Globals.get_singleton("GameCenter")
-            # connect your timer here to the "check_events" function


### PR DESCRIPTION
Updates documentation to reflect latest changes to iOS plugins made for 3.2.4 release.

Closes https://github.com/godotengine/godot-docs/issues/4623.

