### PR TITLE
Add libstdc++-static to Fedora pre-compile one-liner

### DIFF
--- a/development/compiling/compiling_for_x11.rst
+++ b/development/compiling/compiling_for_x11.rst
@@ -51,7 +51,7 @@ Distro-specific one-liners
 |                  |                                                                                                           |
 |                  |     sudo dnf install scons pkgconfig libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel \    |
 |                  |         libXi-devel mesa-libGL-devel mesa-libGLU-devel alsa-lib-devel pulseaudio-libs-devel \             |
-|                  |         libudev-devel yasm gcc-c++                                                                        |
+|                  |         libudev-devel yasm gcc-c++ libstdc++-static                                                       |
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **FreeBSD**      | ::                                                                                                        |
 |                  |                                                                                                           |


### PR DESCRIPTION
This was required to compile version 3.2 on Fedora 33.

This might apply to other versions but I'm not sure. I can test the master branch and resubmit there if that's better/easier.