### PR TITLE
Add `.editorconfig` and `.gitattributes` files for automatic settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# YAML requires indentation with spaces instead of tabs.
+[*.{js,yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# Makefile requires tab indentation.
+[Makefile]
+indent_style = tab
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Properly detect languages on GitHub
 *.rst linguist-detectable=true
+
+# Normalize EOL for all files that Git considers text files
+* text=auto eol=lf


### PR DESCRIPTION
This smoothens the contribtor experience by automatically configuring editors that support EditorConfig.

The `.gitattributes` file ensures that all files use LF line endings when committed to Git.