### PR TITLE
Make example code less misleading in Optimization using Servers

### DIFF
--- a/tutorials/performance/using_servers.rst
+++ b/tutorials/performance/using_servers.rst
@@ -93,7 +93,7 @@ This is a simple example of how to create a sprite from code and move it using t
 
 
     # VisualServer expects references to be kept around.
-    var sprite
+    var texture
 
 
     func _ready():
@@ -101,11 +101,11 @@ This is a simple example of how to create a sprite from code and move it using t
         var ci_rid = VisualServer.canvas_item_create()
         # Make this node the parent.
         VisualServer.canvas_item_set_parent(ci_rid, get_canvas_item())
-        # Draw a sprite on it.
+        # Draw a texture on it.
         # Remember, keep this reference.
-        sprite = load("res://mysprite.png")
+        texture = load("res://my_texture.png")
         # Add it, centered.
-        VisualServer.canvas_item_add_texture_rect(ci_rid, Rect2(sprite.get_size() / 2, sprite.get_size()), sprite)
+        VisualServer.canvas_item_add_texture_rect(ci_rid, Rect2(texture.get_size() / 2, texture.get_size()), texture)
         # Add the item, rotated 45 degrees and translated.
         var xform = Transform2D().rotated(deg2rad(45)).translated(Vector2(20, 30))
         VisualServer.canvas_item_set_transform(ci_rid, xform)


### PR DESCRIPTION
The variable used to be called "sprite", but it wasn't a Sprite. It was
a StreamTexture. Also, I added an underscore to the example path so that
it matches the documentation's recommendation for file names:
https://docs.godotengine.org/en/stable/getting_started/workflow/project_setup/project_organization.html#style-guide

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
