### PR TITLE
Add missing C++17 flag for Windows build in GDNative SConstruct

### DIFF
--- a/tutorials/plugins/gdnative/files/cpp_example/SConstruct
+++ b/tutorials/plugins/gdnative/files/cpp_example/SConstruct
@@ -76,6 +76,7 @@ elif env['platform'] == "windows":
 
     env.Append(CPPDEFINES=['WIN32', '_WIN32', '_WINDOWS', '_CRT_SECURE_NO_WARNINGS'])
     env.Append(CCFLAGS=['-W3', '-GR'])
+    env.Append(CXXFLAGS='/std:c++17')
     if env['target'] in ('debug', 'd'):
         env.Append(CPPDEFINES=['_DEBUG'])
         env.Append(CCFLAGS=['-EHsc', '-MDd', '-ZI'])


### PR DESCRIPTION
The SConstruct file doesn't appear to be in the master branch so this PR is for 3.2.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
