### PR TITLE
Fixed a not needed ';' in GDScript sample code

### DIFF
--- a/getting_started/step_by_step/your_first_game.rst
+++ b/getting_started/step_by_step/your_first_game.rst
@@ -864,7 +864,7 @@ Note that a new instance must be added to the scene using ``add_child()``.
 
     func _on_MobTimer_timeout():
         # Choose a random location on Path2D.
-        var mob_spawn_location = get_node("MobPath/MobSpawnLocation");
+        var mob_spawn_location = get_node("MobPath/MobSpawnLocation")
         mob_spawn_location.offset = randi()
 
         # Create a Mob instance and add it to the scene.


### PR DESCRIPTION
At the end of line 867 there was an unneeded semicolon in the GDScript sample code.
Semicolon is not used in any other lines in the GDScript sample code in this tutorial. 
I removed the semicolon because I think that it might irritate beginners.
I've checked all GDscript sample codes in this file for unnecessary semicolons and didn't find any other than the one in line 867.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
