### PR TITLE
Remove another easily misunderstood joke

### DIFF
--- a/tutorials/assets_pipeline/importing_translations.rst
+++ b/tutorials/assets_pipeline/importing_translations.rst
@@ -6,10 +6,9 @@ Importing translations
 Games and internationalization
 ------------------------------
 
-The world is full of different markets and cultures and, to maximize
-profits™, nowadays games are released in several languages. To solve
-this, internationalized text must be supported in any modern game
-engine.
+The world is full of different languages and cultures, so nowadays games
+are released in several languages. To handle this, internationalized text
+must be supported in any modern game engine.
 
 In regular desktop or mobile applications, internationalized text is
 usually located in resource files (or .po files for GNU stuff). Games,


### PR DESCRIPTION
While I know that the Godot community is made of a diverse group of people from all over the world, and that all (I think?) the core maintainers have a native language other than English, people outside the community don't know that.

So, I could easy imagine someone seeing this line:

> The world is full of different markets and cultures and, to maximize profits™, nowadays games are released in several languages.

... and interpreting that to mean that games are _only_ translated to other languages other than English to maximize profits, implying that other languages are somehow lesser.

Again, I know that isn't the intended meaning of the line! I know it's a little joke. :-)

However, in light of people outside the community recently getting the wrong idea about Godot from a joke in the documentation, it might be a good idea to remove this one before that happens again. Also, unlike the previous example which was buried in a deep corner of the documentation where new folks are unlikely to find it, this one is in a tutorial that is much more likely to be seen.