### PR TITLE
Recommend adding Godot folder to AV exceptions in Compiling for Windows

### DIFF
--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -91,6 +91,18 @@ Downloading it (cloning) using `Git <https://git-scm.com/>`_ is recommended.
 The tutorial will assume from now on that you placed the source code in
 ``C:\godot``.
 
+.. warning::
+
+    To prevent slowdowns caused by continuous virus scanning during compilation,
+    add the Godot source folder to the list of exceptions in your antivirus
+    software.
+
+    For Windows Defender, hit the :kbd:`Windows` key, type
+    "Windows Defender Settings" then hit :kbd:`Enter`.
+    Under **Virus & threat protection**, go to **Virus & threat protection setting**
+    and scroll down to **Exclusions**. Click **Add or remove exclusions** then
+    add the Godot source folder.
+
 Compiling
 ---------
 
@@ -100,8 +112,8 @@ Selecting a compiler
 SCons will automatically find and use an existing Visual Studio installation.
 If you do not have Visual Studio installed, it will attempt to use
 MinGW instead. If you already have Visual Studio installed and want to
-use MinGW, pass ``use_mingw=yes`` to the SCons command line. Note that MSVC 
-builds cannot be performed from the MSYS2 or MinGW shells. Use either 
+use MinGW, pass ``use_mingw=yes`` to the SCons command line. Note that MSVC
+builds cannot be performed from the MSYS2 or MinGW shells. Use either
 ``cmd.exe`` or PowerShell instead.
 
 During development, using the Visual Studio compiler is usually a better idea,


### PR DESCRIPTION
Antivirus programs will spend precious CPU time scanning the Godot source folder as files are added to it by the compiler.