### PR TITLE
Heading Capitalization in the “about” Folder

### DIFF
--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -1,6 +1,6 @@
 .. _doc_complying_with_licenses:
 
-Complying with licenses
+Complying with Licenses
 =======================
 
 What are licenses?

--- a/about/docs_changelog.rst
+++ b/about/docs_changelog.rst
@@ -1,6 +1,6 @@
 .. _doc_docs_changelog:
 
-Documentation changelog
+Documentation Changelog
 =======================
 
 The documentation is continually being improved. The release of version 3.2

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -3,7 +3,7 @@
 
 .. _doc_faq:
 
-Frequently asked questions
+Frequently Asked Questions
 ==========================
 
 What can I do with Godot? How much does it cost? What are the license terms?

--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -1,6 +1,6 @@
 .. _doc_list_of_features:
 
-List of features
+List of Features
 ================
 
 This page aims to list all features currently supported by Godot.

--- a/about/release_policy.rst
+++ b/about/release_policy.rst
@@ -1,6 +1,6 @@
 .. _doc_release_policy:
 
-Godot release policy
+Godot Release Policy
 ====================
 
 Godot versioning


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
This capitalizes main headings in the about folder.