### PR TITLE
Document disabling the NVIDIA text overlay in the Troubleshooting page

### DIFF
--- a/about/troubleshooting.rst
+++ b/about/troubleshooting.rst
@@ -91,6 +91,17 @@ the system console. Godot cannot override this system-specific behavior.
 To solve this, select the system console window and press Enter to leave
 selection mode.
 
+Some text such as "NO DC" appears in the top-left corner of the project manager and editor window.
+--------------------------------------------------------------------------------------------------
+
+This is caused by the NVIDIA graphics driver injecting an overlay to display information.
+
+To disable this overlay on Windows, restore your graphics driver settings to the
+default values in the NVIDIA Control Panel.
+
+To disable this overlay on Linux, open ``nvidia-settings``, go to **X Screen 0 >
+OpenGL Settings** then uncheck **Enable Graphics API Visual Indicator**.
+
 The project window appears blurry, unlike the editor.
 -----------------------------------------------------
 


### PR DESCRIPTION
See discussion in https://old.reddit.com/r/godot/comments/lpgyyy/no_dc_in_upper_left_corner/.

For reference, the overlay looks like this on Linux:

![image](https://user-images.githubusercontent.com/180032/111035928-f50aab80-841c-11eb-86d7-d2b359dd3770.png)