### PR TITLE
"Web" to "web"

### DIFF
--- a/tutorials/platform/customizing_html5_shell.rst
+++ b/tutorials/platform/customizing_html5_shell.rst
@@ -1,9 +1,9 @@
 .. _doc_customizing_html5_shell:
 
-Custom HTML page for Web export
+Custom HTML page for web export
 ====================================
 
-While Web export templates provide a default HTML page fully capable of launching
+While web export templates provide a default HTML page fully capable of launching
 the project without any further customization, it may be beneficial to create a custom
 HTML page. While the game itself cannot easily be directly controlled from the outside yet,
 such page allows to customize the initialization process for the engine.
@@ -67,7 +67,7 @@ The following optional placeholders will enable some extra features in your cuss
   A custom string to include in the HTML document just before the end of the ``<head>`` tag. It
   is customized in the export options under the *Html / Head Include* section. While you fully
   control the HTML page you create, this variable can be useful for configuring parts of the
-  HTML ``head`` element from the Godot Editor, e.g. for different Web export presets.
+  HTML ``head`` element from the Godot Editor, e.g. for different web export presets.
 
 When the custom page is ready, it can be selected in the export options under the *Html / Custom Html Shell*
 section.
@@ -140,13 +140,13 @@ this method is static, multiple engine instances can be spawned if the share the
 
 Customizing the behavior
 ------------------------
-In the Web environment several methods can be used to guarantee that the game will work as intended.
+In the web environment several methods can be used to guarantee that the game will work as intended.
 
 If you target a specific version of WebGL, or just want to check if WebGL is available at all,
 you can call the :js:meth:`Engine.isWebGLAvailable` method. It optionally takes an argument that
 allows to test for a specific major version of WebGL.
 
-As the real executable file does not exist in the Web environment, the engine only stores a virtual
+As the real executable file does not exist in the web environment, the engine only stores a virtual
 filename formed from the base name of loaded engine files. This value affects the output of the
 :ref:`OS.get_executable_path() <class_OS_method_get_executable_path>` method and defines the name of
 the automatically started main pack. The :js:attr:`executable` override option can be

--- a/tutorials/platform/html5_shell_classref.rst
+++ b/tutorials/platform/html5_shell_classref.rst
@@ -3,7 +3,7 @@
 HTML5 shell class reference
 ===========================
 
-Projects exported for the Web expose the :js:class:`Engine` class to the JavaScript environment, that allows
+Projects exported for the web expose the :js:class:`Engine` class to the JavaScript environment, that allows
 fine control over the engine's start-up process.
 
 This API is built in an asynchronous manner and requires basic understanding
@@ -14,7 +14,7 @@ Engine
 
 The ``Engine`` class provides methods for loading and starting exported projects on the Web. For default export
 settings, this is already part of the exported HTML page. To understand practical use of the ``Engine`` class,
-see :ref:`Custom HTML page for Web export <doc_customizing_html5_shell>`.
+see :ref:`Custom HTML page for web export <doc_customizing_html5_shell>`.
 
 Static Methods
 ^^^^^^^^^^^^^^
@@ -295,7 +295,7 @@ Properties
 
       A callback function for handling Godot's ``OS.execute`` calls.
 
-      This is for example used in the Web Editor template to switch between project manager and editor, and for running the game.
+      This is for example used in the web Editor template to switch between project manager and editor, and for running the game.
 
       :param string path:
          The path that Godot's wants executed.


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
This changes "Web" to "web" because according to [here](https://www.brookings.edu/blog/techtank/2016/06/01/associated-press-style-change-marks-growth-of-internet-and-web/) it should be "web not "Web.