### PR TITLE
Use "code editor" instead of "IDE" to refer to Visual Studio Code

### DIFF
--- a/development/cpp/configuring_an_ide/visual_studio_code.rst
+++ b/development/cpp/configuring_an_ide/visual_studio_code.rst
@@ -3,7 +3,7 @@
 Visual Studio Code
 ==================
 
-`Visual Studio Code <https://code.visualstudio.com>`_ is a free cross-platform IDE
+`Visual Studio Code <https://code.visualstudio.com>`_ is a free cross-platform source-code editor
 by `Microsoft <https://microsoft.com>`_ (not to be confused with :ref:`doc_configuring_an_ide_vs`).
 
 Importing the project

--- a/development/cpp/configuring_an_ide/visual_studio_code.rst
+++ b/development/cpp/configuring_an_ide/visual_studio_code.rst
@@ -3,7 +3,7 @@
 Visual Studio Code
 ==================
 
-`Visual Studio Code <https://code.visualstudio.com>`_ is a free cross-platform source-code editor
+`Visual Studio Code <https://code.visualstudio.com>`_ is a free cross-platform code editor
 by `Microsoft <https://microsoft.com>`_ (not to be confused with :ref:`doc_configuring_an_ide_vs`).
 
 Importing the project


### PR DESCRIPTION
Visual Studio Code is NOT an IDE.
