### PR TITLE
Add Open Graph tags for better link preview on social media

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,5 +1,6 @@
 {% extends "!layout.html" -%}
 {% block linktags -%}
+  <meta name="theme-color" content="#3d8fcc">
   {% if godot_inject_language_links -%}
   {% for alternate_lang in godot_docs_supported_languages -%}
   {# Convert to ISO 639-1 format, e.g. zh_CN -> zh-cn -#}

--- a/conf.py
+++ b/conf.py
@@ -15,6 +15,7 @@ sys.path.append(os.path.abspath("_extensions"))
 extensions = [
     "sphinx_tabs.tabs",
     "notfound.extension",
+    "sphinxext.opengraph",
 ]
 
 # Warning when the Sphinx Tabs extension is used with unknown
@@ -53,6 +54,9 @@ on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 # on a local web server.
 if not on_rtd:
     notfound_urls_prefix = ''
+
+# Specify the site name for the Open Graph extension.
+ogp_site_name = "Godot Engine documentation"
 
 if not os.getenv("SPHINX_NO_GDSCRIPT"):
     extensions.append("gdscript")

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,8 @@ sphinx-tabs==2.1.0
 # Custom 404 error page (more useful than the default)
 sphinx-notfound-page==0.6
 
+# Adds Open Graph tags in the HTML `<head>` tag
+sphinxext-opengraph==0.4.1
+
 # Full-page search UI for RTD: https://readthedocs-sphinx-search.readthedocs.io
 readthedocs-sphinx-search==0.1.0


### PR DESCRIPTION
This is provided by the [sphinxext-opengraph](https://github.com/wpilibsuite/sphinxext-opengraph) extension.

This also adds a theme color property in the HTML layout file.