### PR TITLE
Rename intro to 2D animation page (3.3)

### DIFF
--- a/tutorials/2d/2d_lights_and_shadows.rst
+++ b/tutorials/2d/2d_lights_and_shadows.rst
@@ -132,7 +132,7 @@ node, which is why we want the blob to be centered on its parent :ref:`Light <cl
 
 .. note:: At the time of writing, 3.0 is the stable release version. The 3.1 development branch contains
           many changes to the animation system, so the animations in the demo will not be covered here.
-          See :ref:`doc_introduction_2d_animation` for more information.
+          See :ref:`doc_introduction_animation` for more information.
 
 Right now the scene should look too bright. This is because all three lights are adding color to the scene.
 This is why the demo uses a :ref:`CanvasModulate <class_CanvasModulate>` in the scene. The

--- a/tutorials/animation/index.rst
+++ b/tutorials/animation/index.rst
@@ -5,7 +5,7 @@ Animation
    :maxdepth: 1
    :name: toc-learn-features-animation
 
-   introduction_2d
+   introduction
    cutout_animation
    2d_skeletons
    animation_tree

--- a/tutorials/animation/introduction.rst
+++ b/tutorials/animation/introduction.rst
@@ -1,7 +1,7 @@
-.. _doc_introduction_2d_animation:
+.. _doc_introduction_animation:
 
-Introduction to the 2D animation features
-=========================================
+Introduction to the animation features
+======================================
 
 Overview
 --------


### PR DESCRIPTION
Rename the page "introduction to 2D animation features" page to "introduction to animation features." This was already changed on the master branch. Given that 4.0 is taking a while and this is causing confusion I've renamed it for the 3.0 branch. Closes #4761 
