### PR TITLE
Simplify C# NuGet package doc to match 3.2.3+

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -285,8 +285,8 @@ the ``.csproj`` file located in the project root:
         ...
     </Project>
 
-When Godot builds your project, the .NET Core SDK automatically downloads any
-new packages. As of Godot 3.2.3, no special commands are necessary.
+As of Godot 3.2.3, Godot automatically downloads and sets up newly added NuGet
+packages the next time it builds the project.
 
 Profiling your C# code
 ----------------------

--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -280,23 +280,13 @@ the ``.csproj`` file located in the project root:
     :emphasize-lines: 2
 
         <ItemGroup>
-            <PackageReference Include="Newtonsoft.Json">
-              <Version>11.0.2</Version>
-            </PackageReference>
+            <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
         </ItemGroup>
         ...
     </Project>
 
-.. note::
-    By default, tools like NuGet put ``Version`` as an attribute of the ```PackageReference``` Node. **You must manually create a Version node as shown above.**  This is because the version of MSBuild used requires this. (This will be fixed in Godot 4.0.)
-
-Whenever packages are added or modified, run ``nuget restore`` (*not* ``dotnet restore``) in the root of the
-project directory. To ensure that NuGet packages will be available for
-msbuild to use, run:
-
-.. code-block:: none
-
-    msbuild /t:restore
+When Godot builds your project, the .NET Core SDK automatically downloads any
+new packages. As of Godot 3.2.3, no special commands are necessary.
 
 Profiling your C# code
 ----------------------


### PR DESCRIPTION
Now that 3.2.3+ uses the new csproj system and strongly requires .NET Core SDK 3.1+ (which has a modern MSBuild version), `PackageReference` got simpler for everyone. 🙂

I don't think I've actually used a `PackageReference` in a custom build of Godot Mono `master`, but I expect it's the same as 3.2.3. This change would make sense to cherry-pick back to 3.2 and 3.3, IMO.