### PR TITLE
Update C# Connect method: `binds` is a Godot array

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_features.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_features.rst
@@ -128,7 +128,7 @@ Emitting signals is done with the ``EmitSignal`` method.
 
 Notice that you can always reference a signal name with the ``nameof`` keyword (applied on the delegate itself).
 
-It is possible to bind values when establishing a connection by passing an object array.
+It is possible to bind values when establishing a connection by passing a Godot array.
 
 .. code-block:: csharp
 
@@ -144,8 +144,8 @@ It is possible to bind values when establishing a connection by passing an objec
         var plusButton = (Button)GetNode("PlusButton");
         var minusButton = (Button)GetNode("MinusButton");
 
-        plusButton.Connect("pressed", this, "ModifyValue", new object[] { 1 });
-        minusButton.Connect("pressed", this, "ModifyValue", new object[] { -1 });
+        plusButton.Connect("pressed", this, "ModifyValue", new Godot.Collections.Array(1));
+        minusButton.Connect("pressed", this, "ModifyValue", new Godot.Collections.Array(-1));
     }
 
 Signals support parameters and bound values of all the `built-in types <https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/built-in-types-table>`_ and Classes derived from :ref:`Godot.Object <class_Object>`.

--- a/tutorials/scripting/c_sharp/c_sharp_features.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_features.rst
@@ -144,8 +144,8 @@ It is possible to bind values when establishing a connection by passing a Godot 
         var plusButton = (Button)GetNode("PlusButton");
         var minusButton = (Button)GetNode("MinusButton");
 
-        plusButton.Connect("pressed", this, "ModifyValue", new Godot.Collections.Array(1));
-        minusButton.Connect("pressed", this, "ModifyValue", new Godot.Collections.Array(-1));
+        plusButton.Connect("pressed", this, "ModifyValue", new Godot.Collections.Array { 1 });
+        minusButton.Connect("pressed", this, "ModifyValue", new Godot.Collections.Array { -1 });
     }
 
 Signals support parameters and bound values of all the `built-in types <https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/built-in-types-table>`_ and Classes derived from :ref:`Godot.Object <class_Object>`.


### PR DESCRIPTION
It looks like since ~3.0.6, `Connect` takes a `Godot.Collections.Array`, not `object[]`, for `binds`. I think it's because we got `Godot.Collections.Array` around then: https://github.com/godotengine/godot/pull/15880.

(Someone tried to use this code as-is with `object[]` and asked about it in Discord, so I figured I'd follow up here. 🙂)

@neikeq 