### PR TITLE
Fixed small mistake in example (Thread Safe APIs)

### DIFF
--- a/tutorials/performance/thread_safe_apis.rst
+++ b/tutorials/performance/thread_safe_apis.rst
@@ -34,7 +34,7 @@ However, creating scene chunks (nodes in tree arrangement) outside the active tr
 
 ::
 
-    var enemy_scene = load("res://enemy_scene.scn").instance()
+    var enemy_scene = load("res://enemy_scene.scn")
     var enemy = enemy_scene.instance()
     enemy.add_child(weapon) # Set a weapon.
     world.call_deferred("add_child", enemy)


### PR DESCRIPTION
The example previously demonstrated creating an instance of an instance of a scene.