### PR TITLE
Fix heading capitalization in class_ysort.rst

### DIFF
--- a/classes/class_ysort.rst
+++ b/classes/class_ysort.rst
@@ -27,7 +27,7 @@ Properties
 | :ref:`bool<class_bool>` | :ref:`sort_enabled<class_YSort_property_sort_enabled>` | ``true`` |
 +-------------------------+--------------------------------------------------------+----------+
 
-Property Descriptions
+Property descriptions
 ---------------------
 
 .. _class_YSort_property_sort_enabled:


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
According to #4751 only the first word needs capitalized in a heading.
