### PR TITLE
Document how to avoid light leaks in GI Probes

### DIFF
--- a/tutorials/3d/gi_probes.rst
+++ b/tutorials/3d/gi_probes.rst
@@ -50,6 +50,12 @@ toolbar to begin the pre-baking process:
 
 .. image:: img/giprobe_bake.png
 
+.. warning::
+
+    Meshes should have sufficiently thick walls to avoid light leaks (avoid
+    one-sided walls). For interior levels, enclose your level geometry in a
+    sufficiently large box and bridge the loops to close the mesh.
+
 Adding lights
 -------------
 


### PR DESCRIPTION
This advice applies both to the new GIProbe in `master` and old GIProbe in `3.x`.
See discussion on Rocket.Chat: https://chat.godotengine.org/channel/rendering?msg=KoaoQZzvkojiHrdwi

See also https://github.com/godotengine/godot/pull/47428.