### PR TITLE
Fix C# IntersectRay usage: 'exclude' is a Godot Array

### DIFF
--- a/tutorials/physics/ray-casting.rst
+++ b/tutorials/physics/ray-casting.rst
@@ -182,7 +182,7 @@ collision object node:
         public override void _PhysicsProcess(float delta)
         {
             var spaceState = GetWorld2d().DirectSpaceState;
-            var result = spaceState.IntersectRay(globalPosition, enemyPosition, new object[] { this });
+            var result = spaceState.IntersectRay(globalPosition, enemyPosition, new Godot.Collections.Array { this });
         }
     }
 
@@ -217,7 +217,7 @@ member variable:
         {
             var spaceState = GetWorld2d().DirectSpaceState;
             var result = spaceState.IntersectRay(globalPosition, enemyPosition,
-                            new object[] { this }, CollisionMask);
+                            new Godot.Collections.Array { this }, CollisionMask);
         }
     }
 


### PR DESCRIPTION
Fix a couple instances in the raycast tutorial where the C# code used `object[]` instead of `Godot.Collections.Array`. This is similar to https://github.com/godotengine/godot-docs/pull/4777, the API change seems to have happened a while back and the tutorial hadn't been updated.

After this PR, a global search for `new object[]` has 0 results, so hopefully this is all for that particular API change. 😄 