### PR TITLE
Add a mention of the PR review process and proposals to the contribution guide

### DIFF
--- a/community/contributing/ways_to_contribute.rst
+++ b/community/contributing/ways_to_contribute.rst
@@ -95,15 +95,15 @@ A good place to start is by searching for issues tagged as `junior jobs <https:/
              :ref:`doc_code_style_guidelines`.
 
 All pull requests must go through a review process before being accepted.
-Depending on the scope of the changes it may take some time for a maintainer
+Depending on the scope of the changes, it may take some time for a maintainer
 responsible for the modified part of the engine to provide their review.
 We value all of our contributors and ask them to be patient in the meantime,
-as it is expected that in an open source project like Godot there is going to be
+as it is expected that in an open source project like Godot, there is going to be
 way more contributions than people validating them.
 
-To make sure that your time and efforts aren't wasted it is recommended to vet the idea
-first before implementing it and putting it for a review as a PR. To that end Godot
-has a `proposal system <https://github.com/godotengine/godot-proposals>`_, and its
+To make sure that your time and efforts aren't wasted, it is recommended to vet the idea
+first before implementing it and putting it for a review as a PR. To that end, Godot
+has a `proposal system <https://github.com/godotengine/godot-proposals>`_. Its
 usage is encouraged to plan changes and discuss them with the community. Implementation
 details can also be discussed with other contributors on the `Godot Contributors Chat <https://chat.godotengine.org/>`_.
 

--- a/community/contributing/ways_to_contribute.rst
+++ b/community/contributing/ways_to_contribute.rst
@@ -84,7 +84,8 @@ To ensure good collaboration and overall quality, the Godot developers
 enforce some rules for code contributions, for example regarding the style to
 use in the C++ code (indentation, brackets, etc.) or the Git and PR workflow.
 
-A good place to start is by searching for issues tagged as `junior jobs <https://github.com/godotengine/godot/issues?q=is%3Aissue+is%3Aopen+label%3A%22junior+job%22>`_ (or `Hacktoberfest <https://github.com/godotengine/godot/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3AHacktoberfest+>`_ during October) on GitHub.
+A good place to start is by searching for issues tagged as `junior jobs <https://github.com/godotengine/godot/issues?q=is%3Aissue+is%3Aopen+label%3A%22junior+job%22>`_
+(or `Hacktoberfest <https://github.com/godotengine/godot/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3AHacktoberfest+>`_ during October) on GitHub.
 
 .. seealso:: Technical details about the PR workflow are outlined in a
              specific section, :ref:`doc_pr_workflow`.
@@ -92,6 +93,22 @@ A good place to start is by searching for issues tagged as `junior jobs <https:/
              Details about the code style guidelines and the ``clang-format``
              tool used to enforce them are outlined in
              :ref:`doc_code_style_guidelines`.
+
+All pull requests must go through a review process before being accepted.
+Depending on the scope of the changes it may take some time for a maintainer
+responsible for the modified part of the engine to provide their review.
+We value all of our contributors and ask them to be patient in the meantime,
+as it is expected that in an open source project like Godot there is going to be
+way more contributions than people validating them.
+
+To make sure that your time and efforts aren't wasted it is recommended to vet the idea
+first before implementing it and putting it for a review as a PR. To that end Godot
+has a `proposal system <https://github.com/godotengine/godot-proposals>`_, and its
+usage is encouraged to plan changes and discuss them with the community. Implementation
+details can also be discussed with other contributors on the `Godot Contributors Chat <https://chat.godotengine.org/>`_.
+
+.. note:: Proposals are only required when working on an enhancement or a new feature.
+          Bug reports are sufficient for fixing issues.
 
 Testing and reporting issues
 ----------------------------


### PR DESCRIPTION
This should hopefully help new contributors manage their expectations when it comes to the wait time for PR reviews. Also proposals weren't mentioned anywhere in the article, so it addresses this as well.