### PR TITLE
Mention that you can link to the Godot license to comply with it

### DIFF
--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -78,6 +78,13 @@ Printed manual
 
 If the game includes printed manuals, license text can be included there.
 
+Link to the license
+^^^^^^^^^^^^^^^^^^^
+
+The Godot Engine developers consider that a link to godotengine.org/license
+in your game documentation or credits would be an acceptable way to satisfy
+the license terms. 
+
 Third-party licenses
 --------------------
 


### PR DESCRIPTION
Adds that you can add a link to the website page https://godotengine.org/license to comply with the Godot license. That page says this is acceptable. Closes #4828 
