### PR TITLE
Fix "SurfaceTool" link pointing to itself in Using the SurfaceTool

### DIFF
--- a/tutorials/3d/procedural_geometry/surfacetool.rst
+++ b/tutorials/3d/procedural_geometry/surfacetool.rst
@@ -3,7 +3,7 @@
 Using the SurfaceTool
 =====================
 
-The :ref:`SurfaceTool <doc_surfacetool>` provides a useful interface for constructing geometry.
+The :ref:`SurfaceTool <class_surfacetool>` provides a useful interface for constructing geometry.
 The interface is similar to the :ref:`ImmediateGeometry <class_immediategeometry>` node. You
 set each per-vertex attribute (e.g. normal, uv, color) and then when you add a vertex it
 captures the attributes.


### PR DESCRIPTION
This closes https://github.com/godotengine/godot-docs/issues/4831.