### PR TITLE
fix the doc for skip_vertex_transform.

### DIFF
--- a/tutorials/shading/shading_reference/spatial_shader.rst
+++ b/tutorials/shading/shading_reference/spatial_shader.rst
@@ -115,7 +115,7 @@ it manually with the following code:
 
     void vertex() {
         VERTEX = (MODELVIEW_MATRIX * vec4(VERTEX, 1.0)).xyz;
-        NORMAL = (MODELVIEW_MATRIX * vec4(NORMAL, 0.0)).xyz;
+        NORMAL = normalize((MODELVIEW_MATRIX * vec4(NORMAL, 0.0)).xyz);
         // same as above for binormal and tangent, if normal mapping is used
     }
 


### PR DESCRIPTION
Make documentation consistent with https://github.com/godotengine/godot/blob/f72c91e0b17e6070051dec8fe4b0425dbb02c6d6/drivers/gles3/shaders/scene.glsl#L463