### PR TITLE
Fix entry type in C# example for loading savegames

### DIFF
--- a/tutorials/io/saving_games.rst
+++ b/tutorials/io/saving_games.rst
@@ -277,7 +277,7 @@ load function:
             newObject.Set("Position", new Vector2((float)nodeData["PosX"], (float)nodeData["PosY"]));
 
             // Now we set the remaining variables.
-            foreach (KeyValuePair<object, object> entry in nodeData)
+            foreach (KeyValuePair<string, object> entry in nodeData)
             {
                 string key = entry.Key.ToString();
                 if (key == "Filename" || key == "Parent" || key == "PosX" || key == "PosY")


### PR DESCRIPTION
Fixes a small bug in the documentation of loading savegames using C#.

`nodeData` has type `Godot.Collections.Dictionary<string, object>`, so en element of the dictionary has type `KeyValuePair<string, object>`