### PR TITLE
Minor change to section on for loop syntax

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_advanced.rst
+++ b/tutorials/scripting/gdscript/gdscript_advanced.rst
@@ -318,7 +318,7 @@ states and quick structs:
 For & while
 -----------
 
-Iterating in some statically typed languages can be quite complex:
+Iterating in C-derived languages can be quite complex:
 
 .. code-block:: cpp
 
@@ -338,7 +338,7 @@ Iterating in some statically typed languages can be quite complex:
         std::cout << *it << std::endl;
     }
 
-This is usually greatly simplified in dynamically typed languages:
+This is usually greatly simplified in modern languages using for loops over iterables:
 
 ::
 

--- a/tutorials/scripting/gdscript/gdscript_advanced.rst
+++ b/tutorials/scripting/gdscript/gdscript_advanced.rst
@@ -338,7 +338,7 @@ Iterating in C-derived languages can be quite complex:
         std::cout << *it << std::endl;
     }
 
-This is usually greatly simplified in modern languages using for loops over iterables:
+This is usually greatly simplified in modern languages using for-in loops over iterables:
 
 ::
 

--- a/tutorials/scripting/gdscript/gdscript_advanced.rst
+++ b/tutorials/scripting/gdscript/gdscript_advanced.rst
@@ -318,7 +318,7 @@ states and quick structs:
 For & while
 -----------
 
-Iterating in C-derived languages can be quite complex:
+Iterating using the C-style for loop in C-derived languages can be quite complex:
 
 .. code-block:: cpp
 
@@ -338,7 +338,7 @@ Iterating in C-derived languages can be quite complex:
         std::cout << *it << std::endl;
     }
 
-This is usually greatly simplified in modern languages using for-in loops over iterables:
+Because of this, GDScript makes the opinonated decision to have a for-in loop over iterables instead:
 
 ::
 
@@ -368,7 +368,7 @@ The range() function can take 3 arguments:
     range(b, n) # Will go from b to n-1.
     range(b, n, s) # Will go from b to n-1, in steps of s.
 
-Some statically typed programming language examples:
+Some examples involving C-style for loops:
 
 .. code-block:: cpp
 
@@ -391,7 +391,7 @@ Translate to:
     for i in range(5, 10, 2):
         pass
 
-And backwards looping is done through a negative counter:
+And backwards looping done through a negative counter:
 
 ::
 


### PR DESCRIPTION
Modified a section that seemed slightly confusing.

The C-like for loop is specific to languages that wanted to copy C syntax and has nothing to do with static vs dynamic typing. Most new languages do not have it and have a foreach loop over iterators instead, regardless of whether they are statically typed or not.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
