### PR TITLE
Update `latest` warning for godot 3.x

### DIFF
--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -219,7 +219,7 @@ $(document).ready(() => {
         <p>
           You are reading the <code class="docutils literal notranslate"><span class="pre">latest</span></code>
           (unstable) version of this documentation, which may document features not available
-          or compatible with Godot 3.3.x.
+          or compatible with Godot 3.x.
         </p>
         <p class="last">
           See <a class="reference" href="${updatedUrl}">this page</a>

--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -219,7 +219,7 @@ $(document).ready(() => {
         <p>
           You are reading the <code class="docutils literal notranslate"><span class="pre">latest</span></code>
           (unstable) version of this documentation, which may document features not available
-          or compatible with Godot 3.2.x.
+          or compatible with Godot 3.3.x.
         </p>
         <p class="last">
           See <a class="reference" href="${updatedUrl}">this page</a>


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
Bumping this after the new stable update.
Maybe it should say 3.x.x instead?