### PR TITLE
Add a "see also" link to the GDScript grammar in the GDScript section

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1318,7 +1318,7 @@ the function name with the attribute operator::
         return super.overriding() # This calls the method as defined in the base class.
 
 
-Class Constructor
+Class constructor
 ^^^^^^^^^^^^^^^^^
 
 The class constructor, called on class instantiation, is named ``_init``. If you

--- a/tutorials/scripting/gdscript/index.rst
+++ b/tutorials/scripting/gdscript/index.rst
@@ -12,3 +12,8 @@ GDScript
    static_typing
    warning_system
    gdscript_format_string
+
+.. seealso::
+
+    See :ref:`doc_gdscript_grammar` if you are interested in writing a third-party
+    tool that interacts with GDScript, such as a linter or formatter.


### PR DESCRIPTION
The page is in the Development section, but it's not easy to discover.

See https://github.com/godotengine/godot-proposals/issues/2639.