### PR TITLE
Clarify 'bgr' swizzle example in Shading language

### DIFF
--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -169,13 +169,13 @@ explained:
     vec4 a = vec4(0.0, 1.0, 2.0, 3.0);
     vec3 b = a.rgb; // Creates a vec3 with vec4 components.
     vec3 b = a.ggg; // Also valid; creates a vec3 and fills it with a single vec4 component.
-    vec3 b = a.bgr; // Order does not matter.
+    vec3 b = a.bgr; // b will be vec3(2.0, 1.0, 0.0).
     vec3 b = a.xyz; // Also rgba, xyzw are equivalent.
     vec3 b = a.stp; // And stpq (for texture coordinates).
     float c = b.w; // Invalid, because "w" is not present in vec3 b.
     vec3 c = b.xrt; // Invalid, mixing different styles is forbidden.
     b.rrr = a.rgb; // Invalid, assignment with duplication.
-    b.bgr = a.rgb; // Valid assignment.
+    b.bgr = a.rgb; // Valid assignment. B's "blue" component will be A's "red" and vice versa.
 
 Precision
 ~~~~~~~~~

--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -169,13 +169,13 @@ explained:
     vec4 a = vec4(0.0, 1.0, 2.0, 3.0);
     vec3 b = a.rgb; // Creates a vec3 with vec4 components.
     vec3 b = a.ggg; // Also valid; creates a vec3 and fills it with a single vec4 component.
-    vec3 b = a.bgr; // b will be vec3(2.0, 1.0, 0.0).
+    vec3 b = a.bgr; // "b" will be vec3(2.0, 1.0, 0.0).
     vec3 b = a.xyz; // Also rgba, xyzw are equivalent.
     vec3 b = a.stp; // And stpq (for texture coordinates).
     float c = b.w; // Invalid, because "w" is not present in vec3 b.
     vec3 c = b.xrt; // Invalid, mixing different styles is forbidden.
     b.rrr = a.rgb; // Invalid, assignment with duplication.
-    b.bgr = a.rgb; // Valid assignment. B's "blue" component will be A's "red" and vice versa.
+    b.bgr = a.rgb; // Valid assignment. "b"'s "blue" component will be "a"'s "red" and vice versa.
 
 Precision
 ~~~~~~~~~


### PR DESCRIPTION
Saying that "order does not matter" is wrong or at least misleading.

This commit changes the comment to show that vector components can be
combined freely, and the order matters.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
