### PR TITLE
Bump required Mono version to 6.12

### DIFF
--- a/development/compiling/compiling_with_mono.rst
+++ b/development/compiling/compiling_with_mono.rst
@@ -8,7 +8,7 @@ Compiling with Mono
 Requirements
 ------------
 
-- Mono 5.12.0 or greater
+- Mono 6.12.0 or greater
 - MSBuild
 - NuGet
 - **On Linux/macOS only:** pkg-config


### PR DESCRIPTION
Fixes #4870.

I don't know what the minimum version technically is, but I don't think we should support anything older anyway.