### PR TITLE
Fixed "GetNode" inconsistency

### DIFF
--- a/tutorials/math/vector_math.rst
+++ b/tutorials/math/vector_math.rst
@@ -69,7 +69,7 @@ pixels down, use the following code:
 
  .. code-tab:: csharp
 
-    var node2D = (Node2D) GetNode("Node2D");
+    var node2D = GetNode<Node2D>("Node2D");
     node2D.Position = new Vector2(400, 300);
 
 Godot supports both :ref:`Vector2 <class_Vector2>` and :ref:`Vector3


### PR DESCRIPTION
See #4794

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->

This is a C# issue. `(Node2D) GetNode("Node2D");` should be `GetNode<Node2D>("Node2D");` like other articles use.
