### PR TITLE
Update compiling_for_osx.rst

### DIFF
--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -64,7 +64,7 @@ The above process is done using ``target=debug`` which is the standard if not de
 
 To create an ``.app`` bundle like in the official builds, you need to use the
 template located in ``misc/dist/osx_tools.app``. Typically, for an optimized
-editor binary built with ``target=release_debug``::
+editor binary built with ``target=release_debug``
 
 In order to do this inside the terminal here is the changes you need to make in order to create an ``.app`` bundle like in the official builds  
 

--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -87,7 +87,7 @@ To support both architectures in a single "Universal 2" binary, run the above tw
           :ref:`doc_data_paths_self_contained_mode` by creating a file called
           ``._sc_`` or ``_sc_`` in the ``bin/`` folder.
 
-for the ``target=debug`` version run the code below for a build.
+for the ``target=debug`` version run the code below for a build.::
 
     cp -r misc/dist/osx_tools.app ./Godot.app
     mkdir -p Godot.app/Contents/MacOS
@@ -95,7 +95,7 @@ for the ``target=debug`` version run the code below for a build.
     chmod +x Godot.app/Contents/MacOS/Godot
 
   
-for the ``target=release_debug`` version run the code below for a build.
+for the ``target=release_debug`` version run the code below for a build.::
 
     cp -r misc/dist/osx_tools.app ./Godot.app
     mkdir -p Godot.app/Contents/MacOS

--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -87,7 +87,7 @@ To support both architectures in a single "Universal 2" binary, run the above tw
           :ref:`doc_data_paths_self_contained_mode` by creating a file called
           ``._sc_`` or ``_sc_`` in the ``bin/`` folder.
 
-for the ``target=debug`` version run the code below for a build.::
+For the ``target=debug`` version, run the code below for a build::
 
     cp -r misc/dist/osx_tools.app ./Godot.app
     mkdir -p Godot.app/Contents/MacOS
@@ -95,7 +95,7 @@ for the ``target=debug`` version run the code below for a build.::
     chmod +x Godot.app/Contents/MacOS/Godot
 
   
-for the ``target=release_debug`` version run the code below for a build.::
+For the ``target=release_debug`` version, run the code below for a build::
 
     cp -r misc/dist/osx_tools.app ./Godot.app
     mkdir -p Godot.app/Contents/MacOS

--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -60,14 +60,42 @@ If all goes well, the resulting binary executable will be placed in the
 runs without any dependencies. Executing it will bring up the project
 manager.
 
+The above process is done using ``target=debug`` which is the standard if not defined.
+
+To create an ``.app`` bundle like in the official builds, you need to use the
+template located in ``misc/dist/osx_tools.app``. Typically, for an optimized
+editor binary built with ``target=release_debug``::
+
+In order to do this inside the terminal here is the changes you need to make in order to create an ``.app``. bundle like in the official builds.  
+
+To compile for Intel (x86-64) powered Macs, use::
+
+    scons platform=osx arch=x86_64 target=release_debug --jobs=$(sysctl -n hw.logicalcpu)
+
+To compile for Apple Silicon (ARM64) powered Macs, use::
+
+    scons platform=osx arch=arm64 target=release_debug --jobs=$(sysctl -n hw.logicalcpu)
+
+To support both architectures in a single "Universal 2" binary, run the above two commands and then use ``lipo`` to bundle them together::
+
+    lipo -create bin/godot.osx.opt.tools.x86_64 bin/godot.osx.opt.tools.arm64 -output bin/godot.osx.opt.tools.universal
+
+
+
 .. note:: If you want to use separate editor settings for your own Godot builds
           and official releases, you can enable
           :ref:`doc_data_paths_self_contained_mode` by creating a file called
           ``._sc_`` or ``_sc_`` in the ``bin/`` folder.
 
-To create an ``.app`` bundle like in the official builds, you need to use the
-template located in ``misc/dist/osx_tools.app``. Typically, for an optimized
-editor binary built with ``target=release_debug``::
+for the ``target=debug`` version run the code below for a build.
+
+
+    cp -r misc/dist/osx_tools.app ./Godot.app
+    mkdir -p Godot.app/Contents/MacOS
+    cp bin/godot.osx.tools.universal Godot.app/Contents/MacOS/Godot
+    chmod +x Godot.app/Contents/MacOS/Godot
+   
+for the ``target=release_debug`` version run the code below for a build.
 
     cp -r misc/dist/osx_tools.app ./Godot.app
     mkdir -p Godot.app/Contents/MacOS

--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -89,18 +89,19 @@ To support both architectures in a single "Universal 2" binary, run the above tw
 
 for the ``target=debug`` version run the code below for a build.
 
-
     cp -r misc/dist/osx_tools.app ./Godot.app
     mkdir -p Godot.app/Contents/MacOS
     cp bin/godot.osx.tools.universal Godot.app/Contents/MacOS/Godot
     chmod +x Godot.app/Contents/MacOS/Godot
-   
+
+  
 for the ``target=release_debug`` version run the code below for a build.
 
     cp -r misc/dist/osx_tools.app ./Godot.app
     mkdir -p Godot.app/Contents/MacOS
     cp bin/godot.osx.opt.tools.universal Godot.app/Contents/MacOS/Godot
     chmod +x Godot.app/Contents/MacOS/Godot
+
 
 If you are building the ``master`` branch, additionally copy the Vulkan library::
 

--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -104,6 +104,8 @@ For the ``target=release_debug`` version, run the code below for a build::
 
 
 If you are building the ``master`` branch, additionally copy the Vulkan library::
+=======
+.. note::
 
     mkdir -p Godot.app/Contents/Frameworks
     cp <Vulkan SDK path>/macOS/libs/libMoltenVK.dylib Godot.app/Contents/Frameworks/libMoltenVK.dylib

--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -66,7 +66,7 @@ To create an ``.app`` bundle like in the official builds, you need to use the
 template located in ``misc/dist/osx_tools.app``. Typically, for an optimized
 editor binary built with ``target=release_debug``::
 
-In order to do this inside the terminal here is the changes you need to make in order to create an ``.app``. bundle like in the official builds.  
+In order to do this inside the terminal here is the changes you need to make in order to create an ``.app`` bundle like in the official builds  
 
 To compile for Intel (x86-64) powered Macs, use::
 


### PR DESCRIPTION
The changes I made was to add the compile and build methods needed for both the "target = debug" version and the the "target = release_debug" version. Previously the code for the compile was the "target = debug" version and then later you are asked to build the application when you needed to compile it using the "target = release_debug" version. I made this change because it would make it simpler for the user to be able to have the code for both version's and I believe other's may miss the line talking about going back and changing to the target to the release_debug version.

*Bugsquad edit: This closes https://github.com/godotengine/godot-docs/issues/4875.*