### PR TITLE
Rename documentation pages that have the same name as classref pages

### DIFF
--- a/tutorials/2d/using_tilemaps.rst
+++ b/tutorials/2d/using_tilemaps.rst
@@ -1,6 +1,6 @@
 .. _doc_using_tilemaps:
 
-Using tilemaps
+Using TileMaps
 ==============
 
 Introduction

--- a/tutorials/3d/gi_probes.rst
+++ b/tutorials/3d/gi_probes.rst
@@ -1,7 +1,7 @@
 .. _doc_gi_probes:
 
-GI Probes
-=========
+Using GIProbe
+=============
 
 Introduction
 ------------

--- a/tutorials/3d/using_gridmaps.rst
+++ b/tutorials/3d/using_gridmaps.rst
@@ -1,6 +1,6 @@
 .. _doc_using_gridmaps:
 
-Using gridmaps
+Using GridMaps
 ~~~~~~~~~~~~~~
 
 Introduction

--- a/tutorials/animation/animation_tree.rst
+++ b/tutorials/animation/animation_tree.rst
@@ -1,7 +1,7 @@
 .. _doc_animation_tree:
 
-AnimationTree
-=============
+Using AnimationTree
+===================
 
 Introduction
 ------------

--- a/tutorials/inputs/inputevent.rst
+++ b/tutorials/inputs/inputevent.rst
@@ -1,7 +1,7 @@
 .. _doc_inputevent:
 
-InputEvent
-==========
+Using InputEvent
+================
 
 What is it?
 -----------

--- a/tutorials/physics/rigid_body.rst
+++ b/tutorials/physics/rigid_body.rst
@@ -1,7 +1,7 @@
 .. _doc_rigid_body:
 
-RigidBody
-=========
+Using RigidBody
+===============
 
 What is a rigid body?
 ---------------------

--- a/tutorials/physics/soft_body.rst
+++ b/tutorials/physics/soft_body.rst
@@ -1,7 +1,7 @@
 .. _doc_soft_body:
 
-SoftBody
-========
+Using SoftBody
+==============
 
 Soft bodies (or *soft-body dynamics*) simulate movement, changing shape and other physical properties of deformable objects.
 This can for example be used to simulate cloth or to create more realistic characters.

--- a/tutorials/rendering/viewports.rst
+++ b/tutorials/rendering/viewports.rst
@@ -1,7 +1,7 @@
 .. _doc_viewports:
 
-Viewports
-=========
+Using Viewports
+===============
 
 Introduction
 ------------

--- a/tutorials/scripting/scene_tree.rst
+++ b/tutorials/scripting/scene_tree.rst
@@ -1,7 +1,7 @@
 .. _doc_scene_tree:
 
-SceneTree
-=========
+Using SceneTree
+===============
 
 Introduction
 ------------

--- a/tutorials/shaders/visual_shaders.rst
+++ b/tutorials/shaders/visual_shaders.rst
@@ -1,7 +1,7 @@
 .. _doc_visual_shaders:
 
-VisualShaders
-=============
+Using VisualShaders
+===================
 
 Just as VisualScript is an alternative for users that prefer a graphical
 approach to coding, VisualShaders are the visual alternative for creating

--- a/tutorials/ui/gui_containers.rst
+++ b/tutorials/ui/gui_containers.rst
@@ -1,7 +1,7 @@
 .. _doc_gui_containers:
 
-Containers
-==========
+Using Containers
+================
 
 :ref:`Anchors <doc_size_and_anchors>` are an efficient way to handle
 different aspect ratios for basic multiple resolution handling in GUIs,


### PR DESCRIPTION
This prevents confusion in search engine results. I kept the existing file names as to not break URLs.

This PR can be cherry-picked to stable branches without conflicts.

This closes https://github.com/godotengine/godot-docs/issues/4866.