### PR TITLE
Fix "physics time" instead of "physics frame" in The Profiler

### DIFF
--- a/tutorials/scripting/debug/the_profiler.rst
+++ b/tutorials/scripting/debug/the_profiler.rst
@@ -40,7 +40,7 @@ The measured data
 The profiler's interface is split into two. There is a list of functions on the
 left and the performance graph on the right.
 
-The main measurements are frame time, physics time, idle time, and physics time.
+The main measurements are frame time, physics frame, idle time, and physics time.
 
 - The **frame time** is the time it takes Godot to execute all the logic for an
   entire image, from physics to rendering.


### PR DESCRIPTION
it was saying time instead of frame

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
