### PR TITLE
Function key bindings per platform

### DIFF
--- a/getting_started/introduction/first_look_at_the_editor.rst
+++ b/getting_started/introduction/first_look_at_the_editor.rst
@@ -98,13 +98,13 @@ There are four main screen buttons centered at the top of the editor:
 2D, 3D, Script, and AssetLib.
 
 You'll use the **2D screen** for all types of games. In addition to 2D games,
-the 2D screen is where you'll build your interfaces. Press :kbd:`F1` (or
-:kbd:`Alt + 1` on macOS) to access it.
+the 2D screen is where you'll build your interfaces. Press :kbd:`F1`
+(:kbd:`Ctrl + F1` on Linux, :kbd:`Alt + 1` on macOS) to access it.
 
 .. image:: img/editor_intro_workspace_2d.png
 
 In the **3D screen**, you can work with meshes, lights, and design levels for
-3D games. Press :kbd:`F2` (:kbd:`Alt + 2` on macOS) to access it.
+3D games. Press :kbd:`F2` (:kbd:`Ctrl + F2` on Linux, :kbd:`Alt + 2` on macOS) to access it.
 
 .. image:: img/editor_intro_workspace_3d.png
 
@@ -117,7 +117,7 @@ options related to the 3D view.
           main screen**.
 
 The **Script screen** is a complete code editor with a debugger, rich
-auto-completion, and built-in code reference. Press :kbd:`F3` (:kbd:`Alt + 3`
+auto-completion, and built-in code reference. Press :kbd:`F3` (:kbd:`Ctrl + F3` on Linux, :kbd:`Alt + 3`
 on macOS) to access it.
 
 .. image:: img/editor_intro_workspace_script.png


### PR DESCRIPTION
The shortcuts F1, F2, F3, F4 work only on Windows.
The mac bindings Alt+1, Alt+2.. were already mentioned in the docs.
Also mention the default bindings on Linux Ctrl+F1, Ctrl+F2.