### PR TITLE
Add note about shadow casting and light cull masks in 3D lights and shadows

### DIFF
--- a/tutorials/3d/lights_and_shadows.rst
+++ b/tutorials/3d/lights_and_shadows.rst
@@ -38,7 +38,7 @@ Each one has a specific function:
 -  **Bake Mode**: Sets the bake mode for the light. For more information see :ref:`doc_baked_lightmaps`
 -  **Cull Mask**: Objects that are in the selected layers below will be affected by this light.
    Note that objects disabled via this cull mask will still cast shadows.
-   If you don't want them to cast shadows, adjust the ``cast_shadow`` property on the
+   If you don't want disabled objects to cast shadows, adjust the ``cast_shadow`` property on the
    GeometryInstance to the desired value.
 
 Shadow mapping

--- a/tutorials/3d/lights_and_shadows.rst
+++ b/tutorials/3d/lights_and_shadows.rst
@@ -36,7 +36,7 @@ Each one has a specific function:
 -  **Negative**: Light becomes subtractive instead of additive. It's sometimes useful to manually compensate some dark corners.
 -  **Specular**: Affects the intensity of the specular blob in objects affected by this light. At zero, this light becomes a pure diffuse light.
 -  **Bake Mode**: Sets the bake mode for the light. For more information see :ref:`doc_baked_lightmaps`
--  **Cull Mask**: Objects that are in the selected layers below will be affected by this light.
+-  **Cull Mask**: Objects that are in the selected layers below will be affected by this light. Note that even disabled objects will still cast shadows. You'll need to modify the `cast_shadow` property on the GeometryInstance itself to change this.
 
 Shadow mapping
 ^^^^^^^^^^^^^^

--- a/tutorials/3d/lights_and_shadows.rst
+++ b/tutorials/3d/lights_and_shadows.rst
@@ -36,7 +36,10 @@ Each one has a specific function:
 -  **Negative**: Light becomes subtractive instead of additive. It's sometimes useful to manually compensate some dark corners.
 -  **Specular**: Affects the intensity of the specular blob in objects affected by this light. At zero, this light becomes a pure diffuse light.
 -  **Bake Mode**: Sets the bake mode for the light. For more information see :ref:`doc_baked_lightmaps`
--  **Cull Mask**: Objects that are in the selected layers below will be affected by this light. Note that even disabled objects will still cast shadows. You'll need to modify the `cast_shadow` property on the GeometryInstance itself to change this.
+-  **Cull Mask**: Objects that are in the selected layers below will be affected by this light.
+   Note that objects disabled via this cull mask will still cast shadows.
+   If you don't want them to cast shadows, adjust the ``cast_shadow`` property on the
+   GeometryInstance to the desired value.
 
 Shadow mapping
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
It was a tad counterintuitive to me at first that disabled objects still cast shadows, so I added a quick note to address it.