### PR TITLE
Fix indentation in using_kinematic_body_2d.rst

### DIFF
--- a/tutorials/physics/using_kinematic_body_2d.rst
+++ b/tutorials/physics/using_kinematic_body_2d.rst
@@ -92,9 +92,9 @@ other parameters allowing you to customize the slide behavior:
 
 - ``infinite_inertia`` - *default value:* ``true``
 
-When this parameter is ``true``, the body can push :ref:`RigidBody2D <class_RigidBody2D>`
-nodes, ignoring their mass, but won't detect collisions with them. If it's ``false``
-the body will collide with rigid bodies and stop.
+    When this parameter is ``true``, the body can push :ref:`RigidBody2D <class_RigidBody2D>`
+    nodes, ignoring their mass, but won't detect collisions with them. If it's ``false``
+    the body will collide with rigid bodies and stop.
 
 ``move_and_slide_with_snap``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This section of prose describes the bullet point above, but it isn't indented like the sections describing previous bullet points. 

Screenshot:

 ![screenshot](https://user-images.githubusercontent.com/2939691/119347266-94f57880-bc9b-11eb-9b9b-f1b07eadd5ab.png)
