### PR TITLE
Update creating_script_templates.rst

### DIFF
--- a/tutorials/scripting/creating_script_templates.rst
+++ b/tutorials/scripting/creating_script_templates.rst
@@ -23,7 +23,7 @@ These are available globally throughout any project. The location of these
 templates are determined per each OS:
 
 -  Windows: ``%APPDATA%\Godot\script_templates\``
--  Linux: ``$HOME/.local/share/godot/script_templates/``
+-  Linux: ``$HOME/.config/godot/script_templates/``
 -  macOS: ``$HOME/Library/Application Support/Godot/script_templates/``
 
 If no ``script_templates`` is detected, Godot will create a default set of


### PR DESCRIPTION
Using Ubuntu and after trying on two different machines. I just want to specify that for Linux the template script files are not listed in the .local/share/godot folder but in .config/godot/.
If someone can confirm on other linux OS 😄 
It will allow other people who like me since version 3.0 use scripts_templates in the project root .😭

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
