### PR TITLE
Fix broken links in development/cpp section

### DIFF
--- a/development/cpp/common_engine_methods_and_macros.rst
+++ b/development/cpp/common_engine_methods_and_macros.rst
@@ -237,10 +237,10 @@ Godot features many error macros to make error reporting more convenient.
 
 .. seealso::
 
-    See `core/error_macros.h <https://github.com/godotengine/godot/blob/master/core/error_macros.h>`__
+    See `core/error_macros.h <https://github.com/godotengine/godot/blob/3.x/core/error_macros.h>`__
     in Godot's codebase for more information about each error macro.
 
     Some functions return an error code (materialized by a return type of
     ``Error``). This value can be returned directly from an error macro.
     See the list of available error codes in
-    `core/error_list.h <https://github.com/godotengine/godot/blob/master/core/error_list.h>`__.
+    `core/error_list.h <https://github.com/godotengine/godot/blob/3.x/core/error_list.h>`__.

--- a/development/cpp/core_types.rst
+++ b/development/cpp/core_types.rst
@@ -34,7 +34,7 @@ directly to wchar_t.
 References:
 ~~~~~~~~~~~
 
--  `core/typedefs.h <https://github.com/godotengine/godot/blob/master/core/typedefs.h>`__
+-  `core/typedefs.h <https://github.com/godotengine/godot/blob/3.x/core/typedefs.h>`__
 
 Memory model
 ------------
@@ -131,8 +131,8 @@ large amount of accesses.
 References:
 ~~~~~~~~~~~
 
--  `core/os/memory.h <https://github.com/godotengine/godot/blob/master/core/os/memory.h>`__
--  `core/pool_vector.h <https://github.com/godotengine/godot/blob/master/core/pool_vector.cpp>`__
+-  `core/os/memory.h <https://github.com/godotengine/godot/blob/3.x/core/os/memory.h>`__
+-  `core/pool_vector.h <https://github.com/godotengine/godot/blob/3.x/core/pool_vector.cpp>`__
 
 Containers
 ----------
@@ -165,10 +165,10 @@ The Vector<> class also has a few nice features:
 References:
 ~~~~~~~~~~~
 
--  `core/vector.h <https://github.com/godotengine/godot/blob/master/core/vector.h>`__
--  `core/list.h <https://github.com/godotengine/godot/blob/master/core/list.h>`__
--  `core/set.h <https://github.com/godotengine/godot/blob/master/core/set.h>`__
--  `core/map.h <https://github.com/godotengine/godot/blob/master/core/map.h>`__
+-  `core/vector.h <https://github.com/godotengine/godot/blob/3.x/core/vector.h>`__
+-  `core/list.h <https://github.com/godotengine/godot/blob/3.x/core/list.h>`__
+-  `core/set.h <https://github.com/godotengine/godot/blob/3.x/core/set.h>`__
+-  `core/map.h <https://github.com/godotengine/godot/blob/3.x/core/map.h>`__
 
 String
 ------
@@ -181,7 +181,7 @@ conversion and visualization.
 References:
 ~~~~~~~~~~~
 
--  `core/ustring.h <https://github.com/godotengine/godot/blob/master/core/ustring.h>`__
+-  `core/ustring.h <https://github.com/godotengine/godot/blob/3.x/core/ustring.h>`__
 
 StringName
 ----------
@@ -197,7 +197,7 @@ is fast.
 References:
 ~~~~~~~~~~~
 
--  `core/string_name.h <https://github.com/godotengine/godot/blob/master/core/string_name.h>`__
+-  `core/string_name.h <https://github.com/godotengine/godot/blob/3.x/core/string_name.h>`__
 
 Math types
 ----------
@@ -208,7 +208,7 @@ directory.
 References:
 ~~~~~~~~~~~
 
--  `core/math <https://github.com/godotengine/godot/tree/master/core/math>`__
+-  `core/math <https://github.com/godotengine/godot/tree/3.x/core/math>`__
 
 NodePath
 --------
@@ -219,7 +219,7 @@ referencing them fast.
 References:
 ~~~~~~~~~~~
 
--  `core/node_path.h <https://github.com/godotengine/godot/blob/master/core/node_path.h>`__
+-  `core/node_path.h <https://github.com/godotengine/godot/blob/3.x/core/node_path.h>`__
 
 RID
 ---
@@ -232,4 +232,4 @@ referenced data.
 References:
 ~~~~~~~~~~~
 
--  `core/rid.h <https://github.com/godotengine/godot/blob/master/core/rid.h>`__
+-  `core/rid.h <https://github.com/godotengine/godot/blob/3.x/core/rid.h>`__

--- a/development/cpp/custom_godot_servers.rst
+++ b/development/cpp/custom_godot_servers.rst
@@ -76,7 +76,7 @@ an initialization state and a cleanup procedure.
 	private:
 		uint64_t counter;
 		RID_Owner<InfiniteBus> bus_owner;
-		// https://github.com/godotengine/godot/blob/master/core/rid.h#L196
+		// https://github.com/godotengine/godot/blob/3.x/core/rid.h#L196
 		Set<RID> buses;
 		void _emit_occupy_room(uint64_t room, RID rid);
 
@@ -204,7 +204,7 @@ an initialization state and a cleanup procedure.
 		return ret;
 	}
 
-	// https://github.com/godotengine/godot/blob/master/core/rid.h#L187
+	// https://github.com/godotengine/godot/blob/3.x/core/rid.h#L187
 	bool HilbertHotel::delete_bus(RID id) {
 		if (bus_owner.owns(id)) {
 			lock();
@@ -316,7 +316,7 @@ References
 ~~~~~~~~~~~
 
 - :ref:`RID<class_rid>`
-- `core/rid.h <https://github.com/godotengine/godot/blob/master/core/rid.h>`__
+- `core/rid.h <https://github.com/godotengine/godot/blob/3.x/core/rid.h>`__
 
 Registering the class in GDScript
 ---------------------------------
@@ -474,7 +474,7 @@ to execute the desired behavior. The queue will be flushed whenever either
 References:
 ~~~~~~~~~~~
 
-- `core/message_queue.cpp <https://github.com/godotengine/godot/blob/master/core/message_queue.cpp>`__
+- `core/message_queue.cpp <https://github.com/godotengine/godot/blob/3.x/core/message_queue.cpp>`__
 
 Summing it up
 -------------

--- a/development/cpp/object_class.rst
+++ b/development/cpp/object_class.rst
@@ -35,7 +35,7 @@ This makes Objects gain a lot of functionality, like for example
 References:
 ~~~~~~~~~~~
 
--  `core/object.h <https://github.com/godotengine/godot/blob/master/core/object.h>`__
+-  `core/object.h <https://github.com/godotengine/godot/blob/3.x/core/object.h>`__
 
 Registering an Object
 ---------------------
@@ -93,7 +93,7 @@ string passing the name can be passed for brevity.
 References:
 ~~~~~~~~~~~
 
--  `core/class_db.h <https://github.com/godotengine/godot/blob/master/core/class_db.h>`__
+-  `core/class_db.h <https://github.com/godotengine/godot/blob/3.x/core/class_db.h>`__
 
 Constants
 ---------
@@ -258,7 +258,7 @@ templates point to it.
 References:
 ~~~~~~~~~~~
 
--  `core/reference.h <https://github.com/godotengine/godot/blob/master/core/reference.h>`__
+-  `core/reference.h <https://github.com/godotengine/godot/blob/3.x/core/reference.h>`__
 
 Resources:
 ----------
@@ -274,7 +274,7 @@ Resources without a path are fine too.
 References:
 ~~~~~~~~~~~
 
--  `core/resource.h <https://github.com/godotengine/godot/blob/master/core/resource.h>`__
+-  `core/resource.h <https://github.com/godotengine/godot/blob/3.x/core/resource.h>`__
 
 Resource loading
 ----------------
@@ -295,7 +295,7 @@ the same time.
 References:
 ~~~~~~~~~~~
 
--  `core/io/resource_loader.h <https://github.com/godotengine/godot/blob/master/core/io/resource_loader.h>`__
+-  `core/io/resource_loader.h <https://github.com/godotengine/godot/blob/3.x/core/io/resource_loader.h>`__
 
 Resource saving
 ---------------
@@ -314,4 +314,4 @@ be bundled with the saved resource and assigned sub-IDs, like
 References:
 ~~~~~~~~~~~
 
--  `core/io/resource_saver.h <https://github.com/godotengine/godot/blob/master/core/io/resource_saver.h>`__
+-  `core/io/resource_saver.h <https://github.com/godotengine/godot/blob/3.x/core/io/resource_saver.h>`__

--- a/development/cpp/variant_class.rst
+++ b/development/cpp/variant_class.rst
@@ -37,7 +37,7 @@ of C++ with little effort. Become a friend of Variant today.
 References:
 ~~~~~~~~~~~
 
--  `core/variant.h <https://github.com/godotengine/godot/blob/master/core/variant.h>`__
+-  `core/variant.h <https://github.com/godotengine/godot/blob/3.x/core/variant.h>`__
 
 Containers: Dictionary and Array
 --------------------------------
@@ -56,5 +56,5 @@ Copy-on-write (COW) mode support for containers was dropped with Godot 3.0.
 References:
 ~~~~~~~~~~~
 
--  `core/dictionary.h <https://github.com/godotengine/godot/blob/master/core/dictionary.h>`__
--  `core/array.h <https://github.com/godotengine/godot/blob/master/core/array.h>`__
+-  `core/dictionary.h <https://github.com/godotengine/godot/blob/3.x/core/dictionary.h>`__
+-  `core/array.h <https://github.com/godotengine/godot/blob/3.x/core/array.h>`__


### PR DESCRIPTION
Links directed to master/core were broken and all such links has been modified to the 3.x/core. Now all such links are working.