### PR TITLE
Update offline documentation download URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ They are meant to be parsed with the [Sphinx](https://www.sphinx-doc.org/) docum
 
 ## Download for offline use
 
-You can [download an HTML copy](https://nightly.link/godotengine/godot-docs/workflows/build_offline_docs/3.2/godot-docs-html.zip)
+You can [download an HTML copy](https://nightly.link/godotengine/godot-docs/workflows/build_offline_docs/master/godot-docs-html-stable.zip)
 for offline reading (updated every Monday). Extract the ZIP archive then open
 the top-level `index.html` in a web browser.
 


### PR DESCRIPTION
This is actually documentation of the `stable` branch (currently `3.3`), but it's pretty close in practice.

See https://github.com/godotengine/godot-docs/issues/4934.