### PR TITLE
Update SCons package for FreeBSD in Compiling for Linux, *BSD

### DIFF
--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -55,8 +55,8 @@ Distro-specific one-liners
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **FreeBSD**      | ::                                                                                                        |
 |                  |                                                                                                           |
-|                  |     sudo pkg install scons pkgconf xorg-libraries libXcursor libXrandr libXi xorgproto libGLU alsa-lib \  |
-|                  |         pulseaudio yasm                                                                                   |
+|                  |     sudo pkg install py37-scons pkgconf xorg-libraries libXcursor libXrandr libXi xorgproto libGLU \      |
+|                  |         alsa-lib pulseaudio yasm                                                                          |
 |                  |                                                                                                           |
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **Gentoo**       | ::                                                                                                        |


### PR DESCRIPTION
This was an issue I had while running nomadbsd, which is just a usb only freebsd.
