### PR TITLE
Add a workaround for VerySleepy freezing when loading symbols

### DIFF
--- a/development/cpp/using_cpp_profilers.rst
+++ b/development/cpp/using_cpp_profilers.rst
@@ -19,6 +19,18 @@ Recommended profilers
 These profilers may not be the most powerful or flexible options, but their
 standalone operation and limited feature set tends to make them easier to use.
 
+.. note::
+
+    In its latest stable release (0.90 as of writing), VerySleepy will freeze
+    when loading debug symbols. To solve this, exit VerySleepy then save
+    `this dbghelpms.dll file <https://github.com/AlanIWBFT/verysleepy/raw/0523fde86f24139fd4a041319f8b59ace12f602b/dbghelp_x64/dbghelpms.dll>`__
+    at the root of the VerySleepy installation folder.
+    This folder is generally located at ``C:\Program Files\Very Sleepy CS``.
+
+    If you are debugging a 32-bit application instead of 64-bit, save
+    `this dbghelpms.dll file <https://github.com/AlanIWBFT/verysleepy/raw/0523fde86f24139fd4a041319f8b59ace12f602b/dbghelp_x86/dbghelpms.dll>`__
+    in the ``32`` folder of the VerySleepy installation folder.
+
 Setting up Godot
 ----------------
 


### PR DESCRIPTION
This is fixed in the latest nightly builds of VerySleepy, but nightly builds for VerySleepy are currently unavailable. Also, it'll likely be a while until a new stable release is made.

This is something I encountered when writing the article. Someone else also stumbled upon this bug in https://github.com/godotengine/godot-proposals/issues/2820#issuecomment-853931795, so I figure we have to document this workaround.

No need to cherry-pick this to the `3.3` branch as https://github.com/godotengine/godot-docs/pull/4951 already includes this notice.