### PR TITLE
Fix a typo in Logic preferences

### DIFF
--- a/tutorials/best_practices/logic_preferences.rst
+++ b/tutorials/best_practices/logic_preferences.rst
@@ -101,7 +101,7 @@ consider:
 
 3. If one wishes only to 'import' another class resource (script or scene),
    then using a preloaded constant is often the best course of action. However,
-   in exceptional cases, one my wish not to do this:
+   in exceptional cases, one may wish not to do this:
 
    1. If the 'imported' class is liable to change, then it should be a property
       instead, initialized either using an ``export`` or a ``load`` (and


### PR DESCRIPTION
At first I thought it was another example of first person usage, but it was just a typo.

This replaces a "my" where it should be "may".

