### PR TITLE
Remove misplaced (?) character in Data preferences

### DIFF
--- a/tutorials/best_practices/data_preferences.rst
+++ b/tutorials/best_practices/data_preferences.rst
@@ -43,7 +43,7 @@ Godot stores all variables in the scripting API in the
 `Variant <https://docs.godotengine.org/en/latest/development/cpp/variant_class.html>`_
 class. Variants can store Variant-compatible data structures such as
 :ref:`Array <class_Array>` and :ref:`Dictionary <class_Dictionary>` as well 
-as :ref:`Object <class_Object>`s.
+as :ref:`Object <class_Object>`\ s.
 
 Godot implements Array as a ``Vector<Variant>``. The engine stores the Array
 contents in a contiguous section of memory, i.e. they are in a row adjacent

--- a/tutorials/best_practices/data_preferences.rst
+++ b/tutorials/best_practices/data_preferences.rst
@@ -42,8 +42,8 @@ Array vs. Dictionary vs. Object
 Godot stores all variables in the scripting API in the
 `Variant <https://docs.godotengine.org/en/latest/development/cpp/variant_class.html>`_
 class. Variants can store Variant-compatible data structures such as
-:ref:`Array <class_Array>` and :ref:`Dictionary <class_Dictionary>` as well as
-:ref:`Object <class_Object>`s.
+:ref:`Array <class_Array>` and :ref:`Dictionary <class_Dictionary>` as well 
+as :ref:`Object <class_Object>`s.
 
 Godot implements Array as a ``Vector<Variant>``. The engine stores the Array
 contents in a contiguous section of memory, i.e. they are in a row adjacent

--- a/tutorials/best_practices/data_preferences.rst
+++ b/tutorials/best_practices/data_preferences.rst
@@ -43,7 +43,7 @@ Godot stores all variables in the scripting API in the
 `Variant <https://docs.godotengine.org/en/latest/development/cpp/variant_class.html>`_
 class. Variants can store Variant-compatible data structures such as
 :ref:`Array <class_Array>` and :ref:`Dictionary <class_Dictionary>` as well as
-:ref:`Object <class_Object>`.
+:ref:`Object <class_Object>`s.
 
 Godot implements Array as a ``Vector<Variant>``. The engine stores the Array
 contents in a contiguous section of memory, i.e. they are in a row adjacent

--- a/tutorials/best_practices/data_preferences.rst
+++ b/tutorials/best_practices/data_preferences.rst
@@ -43,7 +43,7 @@ Godot stores all variables in the scripting API in the
 `Variant <https://docs.godotengine.org/en/latest/development/cpp/variant_class.html>`_
 class. Variants can store Variant-compatible data structures such as
 :ref:`Array <class_Array>` and :ref:`Dictionary <class_Dictionary>` as well as
-:ref:`Object <class_Object>` s.
+:ref:`Object <class_Object>`.
 
 Godot implements Array as a ``Vector<Variant>``. The engine stores the Array
 contents in a contiguous section of memory, i.e. they are in a row adjacent


### PR DESCRIPTION
While I don't know if it was misplaced an isolated "s" there is odd.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
