### PR TITLE
Update class reference link on Scene organization

### DIFF
--- a/tutorials/best_practices/scene_organization.rst
+++ b/tutorials/best_practices/scene_organization.rst
@@ -306,7 +306,7 @@ If one has a system that...
 If one has systems that modify other systems' data, one should define those as
 their own scripts or scenes rather than autoloads. For more information on the
 reasons, please see the
-:ref:`'Autoloads vs. Internal Nodes' <doc_autoloads_versus_internal_nodes>`
+:ref:`Autoloads versus regular nodes <doc_autoloads_versus_internal_nodes>`
 documentation.
 
 Each subsystem within one's game should have its own section within the


### PR DESCRIPTION
doc_autoloads_versus_internal_nodes points to Autoloads versus regular nodes, so name it correctly.