### PR TITLE
Remove misplaced (?) characters in Exporting for iOS

### DIFF
--- a/tutorials/export/exporting_for_ios.rst
+++ b/tutorials/export/exporting_for_ios.rst
@@ -22,7 +22,7 @@ Export window opens, click **Add..** and select **iOS**.
 The following export options are required. Leaving any blank will cause the
 exporter to throw an error:
 
-  * In the **Application** category **App Store Team ID** and (Bundle) **Identifier**
+  * In the **Application** category: **App Store Team ID** and (Bundle) **Identifier**
   * Everything in the **Required Icons** category
   * Everything in the **Landscape Launch Screens** category
   * Everything in the **Portrait Launch Screens** category

--- a/tutorials/export/exporting_for_ios.rst
+++ b/tutorials/export/exporting_for_ios.rst
@@ -22,8 +22,7 @@ Export window opens, click **Add..** and select **iOS**.
 The following export options are required. Leaving any blank will cause the
 exporter to throw an error:
 
-  * In the **Application** category
-    * **App Store Team ID** and (Bundle) **Identifier**
+  * In the **Application** category **App Store Team ID** and (Bundle) **Identifier**
   * Everything in the **Required Icons** category
   * Everything in the **Landscape Launch Screens** category
   * Everything in the **Portrait Launch Screens** category


### PR DESCRIPTION
It's just weird, an asterisk and enter there doesn't seem to make any sense.

There was this weird string while I was translating, I opened page source to copy it better and it looked even weirder.