### PR TITLE
Remove pleonasm in Localization using gettext

### DIFF
--- a/tutorials/i18n/localization_using_gettext.rst
+++ b/tutorials/i18n/localization_using_gettext.rst
@@ -156,8 +156,8 @@ Updating message files to follow the PO template
 
 After updating the PO template, you will have to update message files so
 that they contain new strings, while removing strings that are no longer
-present in the PO template removed in the PO template. This can be done
-automatically using the ``msgmerge`` tool:
+present in the PO template. This can be doneautomatically using the 
+``msgmerge`` tool:
 
 .. code-block:: shell
 

--- a/tutorials/i18n/localization_using_gettext.rst
+++ b/tutorials/i18n/localization_using_gettext.rst
@@ -156,7 +156,7 @@ Updating message files to follow the PO template
 
 After updating the PO template, you will have to update message files so
 that they contain new strings, while removing strings that are no longer
-present in the PO template. This can be doneautomatically using the 
+present in the PO template. This can be done automatically using the
 ``msgmerge`` tool:
 
 .. code-block:: shell


### PR DESCRIPTION
I think "removing strings that are no longer present in the PO template removed in the PO template." could just be simplified to "removing strings that are no longer present in the PO template".