### PR TITLE
Add note about deploying to Android device where relevant

### DIFF
--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -15,7 +15,7 @@ Download and install the Android SDK.
 
   - Run it once to complete the SDK setup using these `instructions <https://developer.android.com/studio/intro/update#sdk-manager>`__.
   - Ensure that the `required packages <https://developer.android.com/studio/intro/update#recommended>`__ are installed as well.
-    
+
     - Android SDK Platform-Tools version 30.0.5 or later
     - Android SDK Build-Tools version 30.0.3
     - Android SDK Platform 29
@@ -78,6 +78,17 @@ In that screen, 2 paths need to be set:
   - It can be found in the folder where you put the ``debug.keystore`` file you created above.
 
 Once that is configured, everything is ready to export to Android!
+
+.. note::
+
+    If you get an error saying *"Could not install to device."*, make sure
+    you do not have an application with the same Android package name already
+    installed on the device (but signed with a different key).
+
+    If you have an application with the same Android package name but a
+    different signing key already installed on the device, you **must** remove
+    the application in question from the Android device before exporting to
+    Android again.
 
 Providing launcher icons
 ------------------------


### PR DESCRIPTION
This is a common roadblock when exporting to Android.

This closes https://github.com/godotengine/godot/issues/49408.