### PR TITLE
Removed "core/pool_vector.h" reference

### DIFF
--- a/development/cpp/core_types.rst
+++ b/development/cpp/core_types.rst
@@ -132,7 +132,6 @@ References:
 ~~~~~~~~~~~
 
 -  `core/os/memory.h <https://github.com/godotengine/godot/blob/master/core/os/memory.h>`__
--  `core/pool_vector.h <https://github.com/godotengine/godot/blob/master/core/pool_vector.cpp>`__
 
 Containers
 ----------


### PR DESCRIPTION
I couldn't find any reference to it in master

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
