### PR TITLE
Fix GDScript example formating

### DIFF
--- a/tutorials/plugins/editor/inspector_plugins.rst
+++ b/tutorials/plugins/editor/inspector_plugins.rst
@@ -43,6 +43,7 @@ you should remove the instance you have added by calling
 
 .. tabs::
   .. code-tab:: gdscript GDScript
+  
     # plugin.gd
     tool
     extends EditorPlugin


### PR DESCRIPTION
First 3 lines of actual code appeared in the tab title instead of in the code block.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
