### PR TITLE
Update GDScript EBNF grammar

### DIFF
--- a/development/file_formats/gdscript_grammar.rst
+++ b/development/file_formats/gdscript_grammar.rst
@@ -108,7 +108,8 @@ for reference purposes.
         | "return" [ expression ] stmtEnd
         ;
 
-    assignmentStmt = subscription "=" expression stmtEnd;
+    assignmentStmt = subscription ( "=" | "+=" | "-=" | "*=" | "/=" 
+    | "%=" | "&=" | "|=" | "^=" ) expression stmtEnd;
     varDeclStmt = "var" IDENTIFIER [ "=" expression ] stmtEnd;
 
     assertStmt = "assert" "(" expression [ "," STRING ] ")" stmtEnd ;
@@ -136,7 +137,10 @@ for reference purposes.
     sign = ( "-" | "+" ) sign | bitNot ;
     bitNot = "~" bitNot | is ;
     is = call [ "is" ( IDENTIFIER | BUILTINTYPE ) ] ;
-    call = attribute [ "(" [ argList ] ")" ];
+    call 
+        = (attribute [ "(" [ argList ] ")" ]) 
+        | "." IDENTIFIER "(" [ argList ] ")" 
+        | "$" ( STRING | IDENTIFIER { '/' IDENTIFIER } );
     attribute = subscription { "." IDENTIFIER } ;
     subscription = primary [ "[" expression "]" ] ;
     primary = "true" | "false" | "null" | "self" | literal | arrayDecl


### PR DESCRIPTION
- More assignment operator
- $ get_node shorthand
- base class function call

I found official grammar is incomplete when I'm working on https://github.com/antlr/grammars-v4/pull/2230

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
