### PR TITLE
Fixed formatting for "Contributing changes" section

### DIFF
--- a/community/contributing/contributing_to_the_documentation.rst
+++ b/community/contributing/contributing_to_the_documentation.rst
@@ -49,9 +49,9 @@ contribute, you should also read:
 Contributing changes
 --------------------
 
-**Pull Requests should use the ``master`` branch by default.** Only make Pull
- Requests against other branches (e.g. ``2.1`` or ``3.0``) if your changes only
- apply to that specific version of Godot.
+.. warning:: Pull Requests should use the ``master`` branch by default.
+             Only make pull requests against other branches (e.g. ``2.1`` or ``3.0``) 
+             if your changes only apply to that specific version of Godot.
 
 Though less convenient to edit than a wiki, this Git repository is where we
 write the documentation. Having direct access to the source files in a revision


### PR DESCRIPTION
Previous format looked wrong and was a hard to understand.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
