### PR TITLE
Community channels: fix User groups link

### DIFF
--- a/community/channels.rst
+++ b/community/channels.rst
@@ -43,7 +43,7 @@ Other chats
 Language-based communities
 --------------------------
 
-See the `User groups <https://godotengine.org/community/user-groups>` page of
+See the `User groups <https://godotengine.org/community/user-groups>`_ page of
 the website for a list of local communities.
 
 Social networks


### PR DESCRIPTION
Add a missing _ at the end of user groups link.
