### PR TITLE
Remove main screen keyboard shortcuts from introduction

### DIFF
--- a/getting_started/introduction/first_look_at_the_editor.rst
+++ b/getting_started/introduction/first_look_at_the_editor.rst
@@ -98,13 +98,12 @@ There are four main screen buttons centered at the top of the editor:
 2D, 3D, Script, and AssetLib.
 
 You'll use the **2D screen** for all types of games. In addition to 2D games,
-the 2D screen is where you'll build your interfaces. Press :kbd:`Ctrl + F1` (or
-:kbd:`Alt + 1` on macOS) to access it.
+the 2D screen is where you'll build your interfaces.
 
 .. image:: img/editor_intro_workspace_2d.png
 
 In the **3D screen**, you can work with meshes, lights, and design levels for
-3D games. Press :kbd:`Ctrl + F2` (:kbd:`Alt + 2` on macOS) to access it.
+3D games.
 
 .. image:: img/editor_intro_workspace_3d.png
 
@@ -117,8 +116,7 @@ options related to the 3D view.
           main screen**.
 
 The **Script screen** is a complete code editor with a debugger, rich
-auto-completion, and built-in code reference. Press :kbd:`Ctrl + F3` (:kbd:`Alt + 3`
-on macOS) to access it.
+auto-completion, and built-in code reference.
 
 .. image:: img/editor_intro_workspace_script.png
 


### PR DESCRIPTION
This information is worth documenting somewhere, but for beginners it can be unhelpful noise. We don't need to micro-optimize people's workflows right when they get started with Godot. I encountered a real world situation today where I was teaching a young kid and they were confused with these keyboard shortcuts that they didn't need.

Maybe the Godot editor should have hover hints that show the keyboard shortcuts?
