### PR TITLE
Getting source: Add --depth 1 arguments

### DIFF
--- a/development/compiling/getting_source.rst
+++ b/development/compiling/getting_source.rst
@@ -43,7 +43,7 @@ With ``git``, you can also clone a stable release by specifying its branch or ta
 after the ``--branch`` (or just ``-b``) argument::
 
     # Clone the continuously maintained stable branch (`3.x` as of writing).
-    git clone https://github.com/godotengine/godot.git --branch 3.x
+    git clone https://github.com/godotengine/godot.git -b 3.x
 
     # Clone the `3.2.3-stable` tag. This is a fixed revision that will never change.
     git clone https://github.com/godotengine/godot.git -b 3.2.3-stable

--- a/development/compiling/getting_source.rst
+++ b/development/compiling/getting_source.rst
@@ -30,21 +30,21 @@ If you are using the ``git`` command line client, this is done by entering
 the following in a terminal:
 
 ::
-
-    git clone https://github.com/godotengine/godot.git
+    #Use --depth 1 argument to avoid cloning the whole unneeded commit history.
+    git clone https://github.com/godotengine/godot.git --depth 1
 
 For any stable release, visit the `release page <https://github.com/godotengine/godot/releases>`__
 and click on the link for the release you want.
 You can then download and extract the source from the download link on the page.
 
 With ``git``, you can also clone a stable release by specifying its branch or tag
-after the ``--branch`` argument::
+after the ``--branch`` (or just ``-b``) argument::
 
     # Clone the continuously maintained stable branch (`3.x` as of writing).
-    git clone https://github.com/godotengine/godot.git --branch 3.x
+    git clone https://github.com/godotengine/godot.git --branch 3.x --depth 1
 
     # Clone the `3.2.3-stable` tag. This is a fixed revision that will never change.
-    git clone https://github.com/godotengine/godot.git --branch 3.2.3-stable
+    git clone https://github.com/godotengine/godot.git -b 3.2.3-stable --depth 1
 
 There are also generally branches besides ``master`` for each major version.
 

--- a/development/compiling/getting_source.rst
+++ b/development/compiling/getting_source.rst
@@ -30,7 +30,8 @@ If you are using the ``git`` command line client, this is done by entering
 the following in a terminal:
 
 ::
-    #Use --depth 1 argument to avoid cloning the whole unneeded commit history.
+
+    # Use --depth 1 argument to avoid cloning the whole unneeded commit history.
     git clone https://github.com/godotengine/godot.git --depth 1
 
 For any stable release, visit the `release page <https://github.com/godotengine/godot/releases>`__

--- a/development/compiling/getting_source.rst
+++ b/development/compiling/getting_source.rst
@@ -46,7 +46,7 @@ after the ``--branch`` (or just ``-b``) argument::
     git clone https://github.com/godotengine/godot.git --branch 3.x
 
     # Clone the `3.2.3-stable` tag. This is a fixed revision that will never change.
-    git clone https://github.com/godotengine/godot.git -b 3.2.3-stable --depth 1
+    git clone https://github.com/godotengine/godot.git -b 3.2.3-stable
 
 There are also generally branches besides ``master`` for each major version.
 

--- a/development/compiling/getting_source.rst
+++ b/development/compiling/getting_source.rst
@@ -43,7 +43,7 @@ With ``git``, you can also clone a stable release by specifying its branch or ta
 after the ``--branch`` (or just ``-b``) argument::
 
     # Clone the continuously maintained stable branch (`3.x` as of writing).
-    git clone https://github.com/godotengine/godot.git --branch 3.x --depth 1
+    git clone https://github.com/godotengine/godot.git --branch 3.x
 
     # Clone the `3.2.3-stable` tag. This is a fixed revision that will never change.
     git clone https://github.com/godotengine/godot.git -b 3.2.3-stable --depth 1

--- a/development/compiling/getting_source.rst
+++ b/development/compiling/getting_source.rst
@@ -31,9 +31,9 @@ the following in a terminal:
 
 ::
 
-    # Use --depth 1 argument to avoid cloning the whole unneeded commit history.
-    # Don't use --depth 1 if you're cloning for engine development purposes.
-    git clone https://github.com/godotengine/godot.git --depth 1
+    git clone https://github.com/godotengine/godot.git
+    # You can add the --depth 1 argument to omit the commit history.
+    # Faster, but not all Git operations (like blame) will work.
 
 For any stable release, visit the `release page <https://github.com/godotengine/godot/releases>`__
 and click on the link for the release you want.

--- a/development/compiling/getting_source.rst
+++ b/development/compiling/getting_source.rst
@@ -32,6 +32,7 @@ the following in a terminal:
 ::
 
     # Use --depth 1 argument to avoid cloning the whole unneeded commit history.
+    # Don't use --depth 1 if you're cloning for engine development purposes.
     git clone https://github.com/godotengine/godot.git --depth 1
 
 For any stable release, visit the `release page <https://github.com/godotengine/godot/releases>`__


### PR DESCRIPTION
The whole commit history isn't needed to compile the engine, which is the category of this docs page, so mention the way to avoid cloning all of it.

Also I've changed the second ``--branch`` argument to ``-b`` so the line wouldn't get out of bounds.

