### PR TITLE
Fix typo in Compiling for Web: add missing '.' to file extension

### DIFF
--- a/development/compiling/compiling_for_web.rst
+++ b/development/compiling/compiling_for_web.rst
@@ -82,7 +82,7 @@ And ``webassembly_debug_threads.zip`` and ``webassembly_debug_gdnative.zip`` for
 the debug template::
 
     mv bin/godot.javascript.opt.debug.threads.zip bin/webassembly_threads_debug.zip
-    mv bin/godot.javascript.opt.debug.gdnative.zip bin/webassembly_gdnative_debugzip
+    mv bin/godot.javascript.opt.debug.gdnative.zip bin/webassembly_gdnative_debug.zip
 
 Building the editor
 -------------------


### PR DESCRIPTION
Adds missing '.' to '.zip' file extension.
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
