### PR TITLE
Fix dark mode in JavaScript class reference

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -313,7 +313,7 @@ hr,
 
 /* JavaScript documentation directives */
 .rst-content dl:not(.docutils) dt {
-    background-color: var(--admonition-note-background-color);
+    background-color: var(--admonition-note-background-color) !important;
     border-color: var(--admonition-note-title-background-color);
     color: var(--admonition-note-color);
 }


### PR DESCRIPTION
Fixes godotengine/godot-docs#4940 .

## Before

![Screenshot from 2021-06-16 18-18-23](https://user-images.githubusercontent.com/57055412/122301854-44a2bc80-cecf-11eb-8849-b4f1b396dc9c.png)

## After

![Screenshot from 2021-06-16 18-05-26](https://user-images.githubusercontent.com/57055412/122301865-4a000700-cecf-11eb-891b-cded69b671be.png)
