### PR TITLE
Fix JavaScript class reference dark mode

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -320,7 +320,7 @@ hr,
 .rst-content dl:not(.docutils) dl dt {
     background-color: var(--admonition-attention-background-color);
     border-color: var(--admonition-attention-title-background-color);
-    color: var(--admonition-attention-color);
+    color: var(--admonition-attention-color) !important;
 }
 .rst-content dl:not(.docutils).class dt,
 .rst-content dl:not(.docutils).function dt,
@@ -349,7 +349,7 @@ hr,
 }
 .rst-content dl:not(.docutils) .sig-paren,
 .rst-content dl:not(.docutils) .optional {
-    color: var(--highlight-operator-color);
+    color: var(--highlight-operator-color) !important;
     font-weight: normal;
     padding: 0 2px;
 }
@@ -375,7 +375,7 @@ hr,
     color: var(--highlight-keyword-color);
 }
 .rst-content dl:not(.docutils) dt a.headerlink {
-    color: var(--link-color);
+    color: var(--link-color) !important;
 }
 .rst-content dl:not(.docutils) dt a.headerlink:visited {
     color: var(--link-color-visited);


### PR DESCRIPTION
Addresses further issues related to godotengine/godot-docs#4940. Fixes permalink icon dark mode, square bracket dark mode, and comma dark mode in the JavaScript class reference.

## Before
![Screenshot from 2021-06-17 00-23-30](https://user-images.githubusercontent.com/57055412/122333409-1be9e980-cf06-11eb-9e4b-cf081fc17df2.png)
![Screenshot from 2021-06-17 00-52-40](https://user-images.githubusercontent.com/57055412/122333582-64a1a280-cf06-11eb-8038-86154ea871ad.png)


## After
![Screenshot from 2021-06-17 00-51-55](https://user-images.githubusercontent.com/57055412/122333508-463ba700-cf06-11eb-82aa-ce7f3da0da44.png)
![Screenshot from 2021-06-17 00-52-56](https://user-images.githubusercontent.com/57055412/122333600-69665680-cf06-11eb-8f00-d819514e72f5.png)


