### PR TITLE
Fix inline code going out of bounds

### DIFF
--- a/tutorials/platform/ios/ios_plugin.rst
+++ b/tutorials/platform/ios/ios_plugin.rst
@@ -56,19 +56,19 @@ To build an iOS plugin:
 
     - You should use the same header files for iOS plugins and for the iOS export template.
 
-3. In the ``Build Settings`` tab, specify the compilation flags for your static library in ``OTHER_CFLAGS``. The most important ones are ``-fcxx-modules``, ``-fmodules``, and ``-DDEBUG`` if you need debug support. Other flags should be the same you use to compile Godot. For instance:
+3. In the ``Build Settings`` tab, specify the compilation flags for your static library in ``OTHER_CFLAGS``. The most important ones are ``-fcxx-modules``, ``-fmodules``, and ``-DDEBUG`` if you need debug support. Other flags should be the same you use to compile Godot. For instance: 
 
-+--------------------------------------------------------------------------------------------------------+
-| ``-DPTRCALL_ENABLED -DDEBUG_ENABLED -DDEBUG_MEMORY_ALLOC -DDISABLE_FORCED_INLINE -DTYPED_METHOD_BIND`` |
-+--------------------------------------------------------------------------------------------------------+
+::
+
+    -DPTRCALL_ENABLED -DDEBUG_ENABLED -DDEBUG_MEMORY_ALLOC -DDISABLE_FORCED_INLINE -DTYPED_METHOD_BIND
 
 4. Add the required logic for your plugin and build your library to generate a ``.a`` file. You will probably need to build both ``debug`` and ``release`` target ``.a`` files. Depending on your needs, pick either or both. If you need both debug and release ``.a`` files, their name should match following pattern: ``[PluginName].[TargetType].a``. You can also build the static library with your SCons configuration.
 
 5. The iOS plugin system also supports ``.xcframework`` files. To generate one, you can use a command such as:
 
-+-----------------------------------------------------------------------------------------------------------------------------+
-| ``xcodebuild -create-xcframework -library [DeviceLibrary].a -library [SimulatorLibrary].a -output [PluginName].xcframework``|
-+-----------------------------------------------------------------------------------------------------------------------------+
+::
+
+    xcodebuild -create-xcframework -library [DeviceLibrary].a -library [SimulatorLibrary].a -output [PluginName].xcframework
 
 6. Create a Godot iOS Plugin configuration file to help the system detect and load your plugin:
 

--- a/tutorials/platform/ios/ios_plugin.rst
+++ b/tutorials/platform/ios/ios_plugin.rst
@@ -56,11 +56,19 @@ To build an iOS plugin:
 
     - You should use the same header files for iOS plugins and for the iOS export template.
 
-3. In the ``Build Settings`` tab, specify the compilation flags for your static library in ``OTHER_CFLAGS``. The most important ones are ``-fcxx-modules``, ``-fmodules``, and ``-DDEBUG`` if you need debug support. Other flags should be the same you use to compile Godot. For instance, ``-DPTRCALL_ENABLED -DDEBUG_ENABLED -DDEBUG_MEMORY_ALLOC -DDISABLE_FORCED_INLINE -DTYPED_METHOD_BIND``.
+3. In the ``Build Settings`` tab, specify the compilation flags for your static library in ``OTHER_CFLAGS``. The most important ones are ``-fcxx-modules``, ``-fmodules``, and ``-DDEBUG`` if you need debug support. Other flags should be the same you use to compile Godot. For instance:
+
++--------------------------------------------------------------------------------------------------------+
+| ``-DPTRCALL_ENABLED -DDEBUG_ENABLED -DDEBUG_MEMORY_ALLOC -DDISABLE_FORCED_INLINE -DTYPED_METHOD_BIND`` |
++--------------------------------------------------------------------------------------------------------+
 
 4. Add the required logic for your plugin and build your library to generate a ``.a`` file. You will probably need to build both ``debug`` and ``release`` target ``.a`` files. Depending on your needs, pick either or both. If you need both debug and release ``.a`` files, their name should match following pattern: ``[PluginName].[TargetType].a``. You can also build the static library with your SCons configuration.
 
-5. The iOS plugin system also supports ``.xcframework`` files. To generate one, you can use a command such as: ``xcodebuild -create-xcframework -library [DeviceLibrary].a -library [SimulatorLibrary].a -output [PluginName].xcframework``.
+5. The iOS plugin system also supports ``.xcframework`` files. To generate one, you can use a command such as:
+
++-----------------------------------------------------------------------------------------------------------------------------+
+| ``xcodebuild -create-xcframework -library [DeviceLibrary].a -library [SimulatorLibrary].a -output [PluginName].xcframework``|
++-----------------------------------------------------------------------------------------------------------------------------+
 
 6. Create a Godot iOS Plugin configuration file to help the system detect and load your plugin:
 


### PR DESCRIPTION
Fixes godotengine/godot-docs#4981. Puts the inline code block in a table so that it stays within the page in [Creating iOS plugins](https://docs.godotengine.org/en/stable/tutorials/platform/ios/ios_plugin.html).

## Before
![Screenshot from 2021-06-17 08-39-19](https://user-images.githubusercontent.com/57055412/122398885-51afc200-cf48-11eb-93d0-3e63a4052970.png)

## After
![Screenshot from 2021-06-17 08-39-51](https://user-images.githubusercontent.com/57055412/122398909-583e3980-cf48-11eb-84d5-62dbec003c36.png)
