### PR TITLE
Add C# variant tab to Pausing games example

### DIFF
--- a/tutorials/scripting/pausing_games.rst
+++ b/tutorials/scripting/pausing_games.rst
@@ -59,6 +59,13 @@ You can achieve the same result in code:
     func _ready():
         pause_mode = Node.PAUSE_MODE_PROCESS
 
+ .. code-tab:: csharp
+
+    public override void _Ready()
+    {
+        PauseMode = Node.PauseModeEnum.Process;
+    }
+
 By default all nodes have this property in the "Inherit" state. This
 means, that they will only process (or not) depending on what this same
 property is set on the parent node. If the parent is set to "Inherit" ,

--- a/tutorials/scripting/pausing_games.rst
+++ b/tutorials/scripting/pausing_games.rst
@@ -66,7 +66,7 @@ You can achieve the same result in code:
         PauseMode = Node.PauseModeEnum.Process;
     }
 
-By default all nodes have this property in the "Inherit" state. This
+By default, all nodes have this property in the "Inherit" state. This
 means, that they will only process (or not) depending on what this same
 property is set on the parent node. If the parent is set to "Inherit" ,
 then the grandparent will be checked and so on. Ultimately, if a state


### PR DESCRIPTION
Adds the C# code variant for changing the pause mode of a node in [Pausing games](https://docs.godotengine.org/en/latest/tutorials/scripting/pausing_games.html). All the other code examples on this page had the C# variant other than this one.

### Before
![Screenshot from 2021-06-17 21-52-09](https://user-images.githubusercontent.com/57055412/122494023-ac800280-cfb6-11eb-9040-5998378ff39a.png)

### After 
![Screenshot from 2021-06-17 21-51-20](https://user-images.githubusercontent.com/57055412/122494026-adb12f80-cfb6-11eb-9a8a-9cc707657c35.png)

