### PR TITLE
Rename generic C# function name to GDScript example equivalent

### DIFF
--- a/tutorials/best_practices/godot_interfaces.rst
+++ b/tutorials/best_practices/godot_interfaces.rst
@@ -183,8 +183,8 @@ Nodes likewise have an alternative access point: the SceneTree.
 
     public class MyNode
     {
-        // Slow, dynamic lookup with dynamic NodePath.
-        public void Method1()
+        // Slow
+        public void DynamicLookupWithDynamicNodePath()
         {
             GD.Print(GetNode(NodePath("Child")));
         }
@@ -196,7 +196,7 @@ Nodes likewise have an alternative access point: the SceneTree.
         {
             Child = GetNode(NodePath("Child"));
         }
-        public void Method2()
+        public void LookupAndCacheForFutureAccess()
         {
             GD.Print(Child);
         }


### PR DESCRIPTION
Replaces the generic/placeholder C# function names with their equivalent in the corresponding GDScript example in [Godot interfaces](https://docs.godotengine.org/en/latest/tutorials/best_practices/godot_interfaces.html) 

## Before
![Screenshot from 2021-06-19 11-56-49](https://user-images.githubusercontent.com/57055412/122648509-9af24400-d0f7-11eb-89cc-ce3bfd594a6b.png)

## After
![Screenshot from 2021-06-19 12-11-58](https://user-images.githubusercontent.com/57055412/122648513-9cbc0780-d0f7-11eb-8076-5e4fd0b894ce.png)
