### PR TITLE
Replace C# if statement with switch statement to match GDScript

### DIFF
--- a/tutorials/best_practices/data_preferences.rst
+++ b/tutorials/best_practices/data_preferences.rst
@@ -257,7 +257,7 @@ tree structures.
 
         public override void Notification(int what)
         {
-            switch(what)
+            switch (what)
             {
                 case NotificationPredelete:
                     foreach (object child in _children)

--- a/tutorials/best_practices/data_preferences.rst
+++ b/tutorials/best_practices/data_preferences.rst
@@ -257,14 +257,18 @@ tree structures.
 
         public override void Notification(int what)
         {
-            if (what == NotificationPredelete)
+            switch(what)
             {
-                foreach (object child in _children)
-                {
-                    TreeNode node = child as TreeNode;
-                    if (node != null)
-                        node.Free();
-                }
+                case NotificationPredelete:
+                    foreach (object child in _children)
+                    {
+                        TreeNode node = child as TreeNode;
+                        if (node != null)
+                            node.Free();
+                    }
+                    break;
+                default:
+                    break;
             }
         }
     }


### PR DESCRIPTION
The GDScript example uses a match statement with variable **p_what**, so the C# example should ideally also follow the same logic as the GDScript example and use a switch for int **what** instead of an if statement in [Data preferences](https://docs.godotengine.org/en/latest/tutorials/best_practices/data_preferences.html).

A similar situation can be seen in [Godot notifications](https://docs.godotengine.org/en/latest/tutorials/best_practices/godot_notifications.html#process-vs-physics-process-vs-input), where an switch statement is used instead of an if statement when there's only one case. To stay consistent, this example should also use a switch statement.

## Before
![Screenshot from 2021-06-19 12-47-02](https://user-images.githubusercontent.com/57055412/122649797-afd1d600-d0fd-11eb-8f5a-a629587356ae.png)

## After
![Screenshot from 2021-06-19 12-46-51](https://user-images.githubusercontent.com/57055412/122649800-b2ccc680-d0fd-11eb-9040-8bf3b689e159.png)
