### PR TITLE
Adjust GDscript example formatting in Using Containers

### DIFF
--- a/tutorials/ui/gui_containers.rst
+++ b/tutorials/ui/gui_containers.rst
@@ -170,11 +170,11 @@ to its rect size:
     extends Container
 
     func _notification(what):
-        if (what==NOTIFICATION_SORT_CHILDREN):
+        if what == NOTIFICATION_SORT_CHILDREN:
             # Must re-sort the children
             for c in get_children():
                 # Fit to own size
-                fit_child_in_rect( c, Rect2( Vector2(), rect_size ) )
+                fit_child_in_rect(c, Rect2(Vector2(), rect_size))
 
     func set_some_setting():
         # Some setting changed, ask for children re-sort

--- a/tutorials/ui/gui_containers.rst
+++ b/tutorials/ui/gui_containers.rst
@@ -174,7 +174,7 @@ to its rect size:
             # Must re-sort the children
             for c in get_children():
                 # Fit to own size
-                fit_child_in_rect(c, Rect2(Vector2(), rect_size))
+                fit_child_in_rect( c, Rect2( Vector2(), rect_size ) )
 
     func set_some_setting():
         # Some setting changed, ask for children re-sort


### PR DESCRIPTION
Alters the GDScript example in [Using Containers](https://docs.godotengine.org/en/latest/tutorials/ui/gui_containers.html) so that it follows more of the [GDScript style guide](https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/gdscript_styleguide.html).

## Before
![Screenshot from 2021-06-19 15-09-20](https://user-images.githubusercontent.com/57055412/122653662-119d3a80-d114-11eb-974c-bd2c84a21756.png)

## After
![Screenshot from 2021-06-19 15-09-26](https://user-images.githubusercontent.com/57055412/122653664-12ce6780-d114-11eb-980f-1c501d636f5d.png)

