### PR TITLE
Use explicit casting for `MobScene.Instance()` in 3D game tutorial

### DIFF
--- a/getting_started/first_3d_game/05.spawning_mobs.rst
+++ b/getting_started/first_3d_game/05.spawning_mobs.rst
@@ -255,7 +255,7 @@ Let's code the mob spawning logic. We're going to:
     public void OnMobTimerTimeout()
     {
         // Create a mob instance and add it to the scene.
-        Mob mob = MobScene.Instance();
+        Mob mob = (Mob)MobScene.Instance();
 
         // Choose a random location on Path2D.
         // We stire the reference to the SpawnLocation node.
@@ -312,7 +312,7 @@ Here is the complete ``Main.gd`` script so far, for reference.
 
         public void OnMobTimerTimeout()
         {
-            Mob mob = MobScene.Instance();
+            Mob mob = (Mob)MobScene.Instance();
 
             var mobSpawnLocation = GetNode<PathFollow>("SpawnPath/SpawnLocation");
             mobSpawnLocation.UnitOffset = GD.Randf();


### PR DESCRIPTION
Implicit casting of "Godot.Node" to "Mob" is not allowed, so I tried explicit casting and it worked. Please adapt the changes, it took me quite some time to get to the solution, as I thought this was intended and I thought at first, that I did the mistake. Until this point the 3D-Guide worked perfectly fine for me.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
