### PR TITLE
Fix typo in Differences between GLES2 and GLES3

### DIFF
--- a/tutorials/rendering/gles2_gles3_differences.rst
+++ b/tutorials/rendering/gles2_gles3_differences.rst
@@ -47,8 +47,11 @@ HDR
 ---
 
 GLES2 is not capable of using High Dynamic Range (HDR) rendering features. If HDR is set for your
-project, or for a given viewport, Godot will still user Low Dynamic Range (LDR) which limits
+project, or for a given viewport, Godot will still use Low Dynamic Range (LDR) which limits
 viewport values to the ``0-1`` range.
+
+The Viewport **Debanding** property and associated project setting will also have
+no effect when HDR is disabled. This means debanding can't be used in GLES2.
 
 StandardMaterial3D features
 ---------------------------


### PR DESCRIPTION
This also adds a note about debanding not being supported in GLES2.

This closes https://github.com/godotengine/godot-docs/issues/5019.