### PR TITLE
Add missing C# example semicolon in Using AnimationTree

### DIFF
--- a/tutorials/animation/animation_tree.rst
+++ b/tutorials/animation/animation_tree.rst
@@ -283,7 +283,7 @@ Once retrieved, it can be used by calling one of the many functions it offers:
 
  .. code-tab:: csharp
 
-    stateMachine.Travel("SomeState")
+    stateMachine.Travel("SomeState");
 
 The state machine must be running before you can travel. Make sure to either call ``start()`` or choose a node to **Autoplay on Load**.
 


### PR DESCRIPTION
Adds a missing semicolon in the C# code example of [Using AnimationTree](https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html#state-machine-travel).

## Before
![Screenshot from 2021-06-21 10-40-43](https://user-images.githubusercontent.com/57055412/122781696-13830d00-d27e-11eb-8a8e-7b4279928f6d.png)

## After
![Screenshot from 2021-06-21 10-42-42](https://user-images.githubusercontent.com/57055412/122781714-17169400-d27e-11eb-8cd2-c223a93c902f.png)

