### PR TITLE
Properly format file paths in Import process tutorial

### DIFF
--- a/tutorials/assets_pipeline/import_process.rst
+++ b/tutorials/assets_pipeline/import_process.rst
@@ -15,7 +15,7 @@ In Godot 3.0+, we use a more modern approach to importing: Simply drop
 your assets (image files, scenes, audio files, fonts, etc) directly in the
 project folder (copy them manually with your OS file explorer).
 Godot will automatically import these files internally
-and keep the imported resources hidden in a res://.import folder.
+and keep the imported resources hidden in a ``res://.import`` folder.
 
 This means that when trying to access imported assets through code you
 need to use the :ref:`Resource Loader<class_ResourceLoader>` as it will
@@ -68,12 +68,12 @@ asset.
 Files generated
 -----------------
 
-Importing will add an extra <asset>.import file, containing the import
+Importing will add an extra ``<asset>.import`` file, containing the import
 configuration. Make sure to commit these to your version control system!
 
 .. image:: img/asset_workflow4.png
 
-Additionally, extra assets will be preset in the hidden res://.import folder:
+Additionally, extra assets will be preset in the hidden ``res://.import`` folder:
 
 .. image:: img/asset_workflow5.png
 


### PR DESCRIPTION
Replaces plain text file paths with code blocks in [Import process](https://docs.godotengine.org/en/latest/tutorials/assets_pipeline/import_process.html).

## Before
![Screenshot from 2021-06-21 10-52-40](https://user-images.githubusercontent.com/57055412/122784235-4af2b900-d280-11eb-9cc5-d024afc047c9.png)

## After
![Screenshot from 2021-06-21 10-53-26](https://user-images.githubusercontent.com/57055412/122784239-4c23e600-d280-11eb-84ba-0bfb83178f7e.png)
