### PR TITLE
Update one-click_deploy.rst - Enabled USB debugging on android devices.

### DIFF
--- a/tutorials/export/one-click_deploy.rst
+++ b/tutorials/export/one-click_deploy.rst
@@ -45,8 +45,8 @@ Support for more platforms such as iOS is planned.
 Using one-click deploy
 ----------------------
 
-- If deploying to Android, enable developer mode on the your mobile device then
-  connect the device to your PC using an USB cable.
+- If deploying to Android, enable developer mode on the your mobile device and turn on usb debugging. 
+- Then connect the device to your PC using an USB cable.
 
    - For advanced users, it should also be possible to use wireless ADB.
 

--- a/tutorials/export/one-click_deploy.rst
+++ b/tutorials/export/one-click_deploy.rst
@@ -45,7 +45,7 @@ Support for more platforms such as iOS is planned.
 Using one-click deploy
 ----------------------
 
-- If deploying to Android, enable developer mode on the your mobile device and turn on usb debugging. 
+- If deploying to Android, enable developer mode on the your mobile device and turn on USB debugging. 
 - Then connect the device to your PC using an USB cable.
 
    - For advanced users, it should also be possible to use wireless ADB.

--- a/tutorials/export/one-click_deploy.rst
+++ b/tutorials/export/one-click_deploy.rst
@@ -45,8 +45,8 @@ Support for more platforms such as iOS is planned.
 Using one-click deploy
 ----------------------
 
-- If deploying to Android, enable developer mode on the your mobile device and turn on USB debugging. 
-- Then connect the device to your PC using an USB cable.
+- If deploying to Android, enable developer mode on your mobile device then enable USB debugging.
+- After enabling USB debugging, connect the device to your PC using an USB cable.
 
    - For advanced users, it should also be possible to use wireless ADB.
 

--- a/tutorials/export/one-click_deploy.rst
+++ b/tutorials/export/one-click_deploy.rst
@@ -45,7 +45,8 @@ Support for more platforms such as iOS is planned.
 Using one-click deploy
 ----------------------
 
-- If deploying to Android, enable developer mode on your mobile device then enable USB debugging.
+- If deploying to Android, enable developer mode on your mobile device
+  then enable USB debugging in the device's settings.
 - After enabling USB debugging, connect the device to your PC using an USB cable.
 
    - For advanced users, it should also be possible to use wireless ADB.


### PR DESCRIPTION
The android icon did not show up in Godot until I enabled usb debugging on my phone.
