### PR TITLE
Fixed class_name keyword ordering in GDScript style guide

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -484,14 +484,14 @@ Use snake_case for file names. For named classes, convert the PascalCase class
 name to snake_case::
 
     # This file should be saved as `weapon.gd`.
+    class_name Weapon    
     extends Node
-    class_name Weapon
 
 ::
 
     # This file should be saved as `yaml_parser.gd`.
-    extends Object
     class_name YAMLParser
+    extends Object
 
 This is consistent with how C++ files are named in Godot's source code. This
 also avoids case sensitivity issues that can crop up when exporting a project


### PR DESCRIPTION
Fixes two examples to follow rules described in "Code order" section of this page (`class_name` must be placed before `extends`).

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
