### PR TITLE
Reword in Box Containers section in Using Containers

### DIFF
--- a/tutorials/ui/gui_containers.rst
+++ b/tutorials/ui/gui_containers.rst
@@ -64,7 +64,7 @@ Godot provides several container types out of the box as they serve different pu
 Box Containers
 ^^^^^^^^^^^^^^
 
-Arrange child controls vertically or horizontally (via :ref:`HBoxContainer <class_HBoxContainer>` and
+Arranges child controls vertically or horizontally (via :ref:`HBoxContainer <class_HBoxContainer>` and
 :ref:`VBoxContainer <class_VBoxContainer>`). In the opposite of the designated direction
 (as in, vertical for an horizontal container), it just expands the children.
 


### PR DESCRIPTION
_Arranges_ sounds more fitting and is also used in the **Grid Containers** section in [Using Containers](https://docs.godotengine.org/en/latest/tutorials/ui/gui_containers.html)
