### PR TITLE
Fix scrolling the navigation bar on mobile

### DIFF
--- a/_static/css/algolia.css
+++ b/_static/css/algolia.css
@@ -1,5 +1,5 @@
 .wy-nav-side { overflow: visible; }
-.wy-side-scroll { overflow: inherit; }
+.wy-side-scroll { overflow-x: inherit; }
 
 .algolia-autocomplete {
     display: block !important;


### PR DESCRIPTION
Prevents the `overflow-y: scroll;` property from being overridden in the sidebar on mobile. Fixes godotengine/godot-docs#5025

![Screenshot from 2021-06-25 18-29-02](https://user-images.githubusercontent.com/57055412/123490931-6c86d400-d5e3-11eb-92da-5925db3a26cb.png)
