### PR TITLE
Remove the note about GLES2 exclusive 2D batching

### DIFF
--- a/tutorials/optimization/batching.rst
+++ b/tutorials/optimization/batching.rst
@@ -16,10 +16,6 @@ of work for the user in the GPU driver at the cost of more expensive draw calls.
 As a result, applications can often be sped up by reducing the number of draw
 calls.
 
-.. note::
-
-    2D batching is currently only supported when using the GLES2 renderer.
-
 Draw calls
 ^^^^^^^^^^
 


### PR DESCRIPTION
Unified GLES3 / GLES2 was merged in 3.2.4 beta (3.3 stable)

https://github.com/godotengine/godot/pull/42119

Closes #4966 

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
