### PR TITLE
Change name of exported variable

### DIFF
--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -104,7 +104,7 @@ Add a script to ``Main``. At the top of the script, we use ``export
         }
     }
 
-Click the ``Main`` node and you will see the ``Mob`` property in the Inspector
+Click the ``Main`` node and you will see the ``Mob Scene`` property in the Inspector
 under "Script Variables".
 
 You can assign this property's value in two ways:


### PR DESCRIPTION
Since the exported `PackedScene` variable is named `mob_scene`, the generated script variable is called `Mob Scene`, not `Mob`.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
