### PR TITLE
Fixed GetNode inconsistencies

### DIFF
--- a/tutorials/physics/ray-casting.rst
+++ b/tutorials/physics/ray-casting.rst
@@ -261,7 +261,7 @@ To obtain it using a camera, the following code can be used:
     {
         if (@event is InputEventMouseButton eventMouseButton && eventMouseButton.Pressed && eventMouseButton.ButtonIndex == 1)
         {
-            var camera = (Camera)GetNode("Camera");
+            var camera = GetNode<Camera>("Camera");
             var from = camera.ProjectRayOrigin(eventMouseButton.Position);
             var to = from + camera.ProjectRayNormal(eventMouseButton.Position) * RayLength;
         }

--- a/tutorials/scripting/resources.rst
+++ b/tutorials/scripting/resources.rst
@@ -83,7 +83,7 @@ There are two ways to load resources from code. First, you can use the ``load()`
     public override void _Ready()
     {
         var texture = (Texture)GD.Load("res://robi.png"); // Godot loads the Resource when it reads the line.
-        var sprite = (Sprite)GetNode("sprite");
+        var sprite = GetNode<Sprite>("sprite");
         sprite.Texture = texture;
     }
 

--- a/tutorials/scripting/singletons_autoload.rst
+++ b/tutorials/scripting/singletons_autoload.rst
@@ -76,7 +76,7 @@ This means that any node can access a singleton named "PlayerVariables" with:
 
  .. code-tab:: csharp
 
-    var playerVariables = (PlayerVariables)GetNode("/root/PlayerVariables");
+    var playerVariables = GetNode<PlayerVariables>("/root/PlayerVariables");
     playerVariables.Health -= 10; // Instance field.
 
 If the **Enable** column is checked (which is the default), then the singleton can
@@ -254,7 +254,7 @@ Finally, we need to fill the empty callback functions in the two scenes:
 
     public void OnButtonPressed()
     {
-        var global = (Global)GetNode("/root/Global");
+        var global = GetNode<Global>("/root/Global");
         global.GotoScene("res://Scene2.tscn");
     }
 
@@ -274,7 +274,7 @@ and
 
     public void OnButtonPressed()
     {
-        var global = (Global)GetNode("/root/Global");
+        var global = GetNode<Global>("/root/Global");
         global.GotoScene("res://Scene1.tscn");
     }
 


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->

See #4794. This fixed 5 occurences across 3 files, where type casting is used instead of a generic method.