### PR TITLE
Remove obsolete C++11 flag from C++ module examples

### DIFF
--- a/development/cpp/binding_to_external_libraries.rst
+++ b/development/cpp/binding_to_external_libraries.rst
@@ -191,7 +191,6 @@ Example `SCsub` with custom flags:
     env_tts = env.Clone()
     env_tts.add_source_files(env.modules_sources, "*.cpp")
     env_tts.Append(CCFLAGS=['-O2']) # Flags for C and C++ code
-    env_tts.Append(CXXFLAGS=['-std=c++11']) # Flags for C++ code only
 
 The final module should look like this:
 

--- a/development/cpp/binding_to_external_libraries.rst
+++ b/development/cpp/binding_to_external_libraries.rst
@@ -190,7 +190,11 @@ Example `SCsub` with custom flags:
 
     env_tts = env.Clone()
     env_tts.add_source_files(env.modules_sources, "*.cpp")
-    env_tts.Append(CCFLAGS=['-O2']) # Flags for C and C++ code
+	# Append CCFLAGS flags for both C and C++ code.
+    env_tts.Append(CCFLAGS=['-O2'])
+    # If you need to, you can:
+    # - Append CFLAGS for C code only.
+    # - Append CXXFLAGS for C++ code only.
 
 The final module should look like this:
 

--- a/development/cpp/custom_modules_in_cpp.rst
+++ b/development/cpp/custom_modules_in_cpp.rst
@@ -478,7 +478,6 @@ using the `ARGUMENT` command:
 
     module_env = env.Clone()
     module_env.Append(CCFLAGS=['-O2'])
-    module_env.Append(CXXFLAGS=['-std=c++11'])
 
     if ARGUMENTS.get('summator_shared', 'no') == 'yes':
         # Shared lib compilation


### PR DESCRIPTION
Top level SConstruct already sets C++ standard to C++14. When C++11 is
enabled by copy&pasting these examples, it leads to compilation errors.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
