### PR TITLE
Update the estimated release date for Godot 4.0

### DIFF
--- a/about/release_policy.rst
+++ b/about/release_policy.rst
@@ -139,6 +139,6 @@ Maintenance (patch) releases will be released as needed with potentially very
 short development cycles, to provide users of the current stable branch with
 the latest bug fixes for their production needs.
 
-As for the upcoming Godot 4.0, we can only say that we aim for a **2021**
-release, but any closer estimate is likely to be hard to uphold. Alpha builds
-will be published as soon as the main features for Godot 4.0 are finalized.
+As for the upcoming Godot 4.0, we can only say that we aim for a release in
+the **first half of 2022**, but any closer estimate is likely to be hard to uphold.
+Alpha builds will be published as soon as the main features for Godot 4.0 are finalized.


### PR DESCRIPTION
Given how the first alpha isn't even released yet, it is very unlikely that a stable 4.0 release is out in 2021.


<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->