### PR TITLE
Fix Sphinx warning about GDScriptLexer

### DIFF
--- a/_extensions/gdscript.py
+++ b/_extensions/gdscript.py
@@ -341,7 +341,7 @@ class GDScriptLexer(RegexLexer):
 
 
 def setup(sphinx):
-    sphinx.add_lexer("gdscript", GDScriptLexer())
+    sphinx.add_lexer("gdscript", GDScriptLexer)
 
     return {
         "parallel_read_safe": True,


### PR DESCRIPTION
Just fixes a Sphinx warning, because adding lexers was changed to require passing a Class, not an Instance of that Class.