### PR TITLE
Fix hyperlink formatting in Building the manual

### DIFF
--- a/community/contributing/building_the_manual.rst
+++ b/community/contributing/building_the_manual.rst
@@ -16,7 +16,7 @@ To get started, you need to:
 4. Install the Sphinx extensions defined in the `godot-docs repository
    <https://github.com/godotengine/godot-docs/>`__ ``requirements.txt`` file.
 
-We recommend using `pip <https://pip.pypa.io>` _, Python’s package manager to
+We recommend using `pip <https://pip.pypa.io>`__, Python’s package manager to
 install all these tools. It comes pre-installed with `Python
 <https://www.python.org/>`__. Ensure that you install and use Python 3. Here are
 the commands to clone the repository and then install all requirements.


### PR DESCRIPTION
**Before**
![Screenshot from 2021-07-07 23-42-32](https://user-images.githubusercontent.com/57055412/124859280-9f36b200-df7d-11eb-89fc-72fc52efd7d2.png)

**After**
![Screenshot from 2021-07-07 23-44-47](https://user-images.githubusercontent.com/57055412/124859284-a1007580-df7d-11eb-8395-62d06904d4be.png)
