### PR TITLE
Fix text formatting in Contributing to the documentation 

### DIFF
--- a/community/contributing/contributing_to_the_documentation.rst
+++ b/community/contributing/contributing_to_the_documentation.rst
@@ -49,9 +49,9 @@ contribute, you should also read:
 Contributing changes
 --------------------
 
-**Pull Requests should use the ``master`` branch by default.** Only make Pull
- Requests against other branches (e.g. ``2.1`` or ``3.0``) if your changes only
- apply to that specific version of Godot.
+**Pull Requests should use the** ``master`` **branch by default.** Only make Pull
+Requests against other branches (e.g. ``2.1`` or ``3.0``) if your changes only
+apply to that specific version of Godot.
 
 Though less convenient to edit than a wiki, this Git repository is where we
 write the documentation. Having direct access to the source files in a revision
@@ -62,7 +62,7 @@ Editing existing pages
 
 To edit an existing page, locate its ``.rst`` source file and open it in your
 favorite text editor. You can then commit the changes, push them to your fork,
-and make a pull request. **Note that the pages in ``classes/`` should not be
+and make a pull request. **Note that the pages in** ``classes/`` **should not be
 edited here.** They are automatically generated from Godot’s `XML class
 reference <https://github.com/godotengine/godot/tree/master/doc/classes>`__.
 See `Contribute to the Class Reference
@@ -70,7 +70,7 @@ See `Contribute to the Class Reference
 for details.
 
 .. seealso:: To build the manual and test changes on your computer, see
-             :ref:`doc_building_the_manual`
+             :ref:`doc_building_the_manual`.
 
 Editing pages online
 --------------------


### PR DESCRIPTION
https://docs.godotengine.org/en/latest/community/contributing/contributing_to_the_documentation.html

**Before**
![Screenshot from 2021-07-07 23-59-55](https://user-images.githubusercontent.com/57055412/124860323-76afb780-df7f-11eb-85c7-a5d66730d189.png)
![Screenshot from 2021-07-07 23-59-57](https://user-images.githubusercontent.com/57055412/124860328-77484e00-df7f-11eb-9f23-ae79fb3da5ce.png)

**After**
![Screenshot from 2021-07-07 23-53-04](https://user-images.githubusercontent.com/57055412/124860338-7b746b80-df7f-11eb-92db-da8147abef51.png)
![Screenshot from 2021-07-07 23-53-11](https://user-images.githubusercontent.com/57055412/124860349-7f07f280-df7f-11eb-929c-419d672ebab6.png)
