### PR TITLE
Add reference to build-in variables in Shader Language overview

### DIFF
--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -748,7 +748,17 @@ Uniforms can also be assigned default values:
     uniform vec4 some_vector = vec4(0.0);
     uniform vec4 some_color : hint_color = vec4(1.0);
 
-Built-in functions
+Built-in variables
+------------------
+
+A large number of built-in variables are available, like ``UV``, ``COLOR`` and ``VERTEX``. What variables are available depends on the type of shader (``spacial``, ``canvas_item`` or ``particle``) and the function used (``vertex``, ``fragment`` or ``light``).
+For a list of the build-in variables that are available, please see the corresponding pages:
+
+    :ref:`Spatial shaders <doc_spatial_shader>`
+    :ref:`Canvas item shaders <doc_canvas_item_shader>`
+    :ref:`Particle shaders <doc_particle_shader>`
+
+    Built-in functions
 ------------------
 
 A large number of built-in functions are supported, conforming to GLSL ES 3.0.

--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -754,9 +754,9 @@ Built-in variables
 A large number of built-in variables are available, like ``UV``, ``COLOR`` and ``VERTEX``. What variables are available depends on the type of shader (``spacial``, ``canvas_item`` or ``particle``) and the function used (``vertex``, ``fragment`` or ``light``).
 For a list of the build-in variables that are available, please see the corresponding pages:
 
-    :ref:`Spatial shaders <doc_spatial_shader>`
-    :ref:`Canvas item shaders <doc_canvas_item_shader>`
-    :ref:`Particle shaders <doc_particle_shader>`
+- :ref:`Spatial shaders <doc_spatial_shader>`
+- :ref:`Canvas item shaders <doc_canvas_item_shader>`
+- :ref:`Particle shaders <doc_particle_shader>`
 
 Built-in functions
 ------------------

--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -758,7 +758,7 @@ For a list of the build-in variables that are available, please see the correspo
     :ref:`Canvas item shaders <doc_canvas_item_shader>`
     :ref:`Particle shaders <doc_particle_shader>`
 
-    Built-in functions
+Built-in functions
 ------------------
 
 A large number of built-in functions are supported, conforming to GLSL ES 3.0.

--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -751,7 +751,7 @@ Uniforms can also be assigned default values:
 Built-in variables
 ------------------
 
-A large number of built-in variables are available, like ``UV``, ``COLOR`` and ``VERTEX``. What variables are available depends on the type of shader (``spacial``, ``canvas_item`` or ``particle``) and the function used (``vertex``, ``fragment`` or ``light``).
+A large number of built-in variables are available, like ``UV``, ``COLOR`` and ``VERTEX``. What variables are available depends on the type of shader (``spatial``, ``canvas_item`` or ``particle``) and the function used (``vertex``, ``fragment`` or ``light``).
 For a list of the build-in variables that are available, please see the corresponding pages:
 
 - :ref:`Spatial shaders <doc_spatial_shader>`


### PR DESCRIPTION
While reading and learning about shaders, I was looking for a list of the build-in variables (like `UV`, `FRAGCOORD` etc) - but had a hard time finding them.

A lot of references in the documentation point toward the Shader Language Reference - so therefor I figured it would be logic to add a small reference to the subpages in this reference as well.
