### PR TITLE
Fix styling for keyboard shortcuts

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -750,6 +750,16 @@ kbd, .kbd {
     vertical-align: middle;
 }
 
+/* Unset excessive styles for nested kbd tags. */
+kbd.compound > kbd,
+kbd.compound > .kbd,
+.kbd.compound > kbd,
+.kbd.compound > .kbd {
+    border: none;
+    box-shadow: none;
+    padding: 0;
+}
+
 /* Buttons */
 
 .btn-neutral {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-docs/issues/4879.

I couldn't reproduce it locally for some reason, even though I've updated all the packages, so tested with the devtools.

**Before**
![chrome_2021-07-13_14-45-15](https://user-images.githubusercontent.com/11782833/125446480-992c636e-45d4-4531-b514-b01648abbe59.png)

**After**
![chrome_2021-07-13_14-45-06](https://user-images.githubusercontent.com/11782833/125446491-48c6f0d7-0e2f-4b06-9e8f-bd636e83e2a3.png)
