### PR TITLE
Fix :ref: formatting in Canvas layers

### DIFF
--- a/tutorials/2d/canvas_layers.rst
+++ b/tutorials/2d/canvas_layers.rst
@@ -7,10 +7,10 @@ Viewport and Canvas items
 -------------------------
 
 :ref:`CanvasItem <class_CanvasItem>` is the base for all 2D nodes, be it regular
-     2D nodes, such as :ref:`Node2D <class_Node2D>`, or :ref:`Control <class_Control>`.
-     Both inherit from :ref:`CanvasItem <class_CanvasItem>`.
-     You can arrange canvas items in trees. Each item will inherit its parent's
-     transform: when the parent moves, its children move too.
+2D nodes, such as :ref:`Node2D <class_Node2D>`, or :ref:`Control <class_Control>`.
+Both inherit from :ref:`CanvasItem <class_CanvasItem>`.
+You can arrange canvas items in trees. Each item will inherit its parent's
+transform: when the parent moves, its children move too.
 
 CanvasItem nodes, and nodes inheriting from them, are direct or indirect children of a
 :ref:`Viewport <class_Viewport>`, that display them.
@@ -25,11 +25,11 @@ To achieve effects like scrolling, manipulating the canvas transform property is
 more efficient than moving the root canvas item and the entire scene with it.
 
 Usually though, we don't want *everything* in the game or app to be subject to the canvas
-transform. Examples of this are:
+transform. For example:
 
 -  **Parallax Backgrounds**: Backgrounds that move slower than the rest
    of the stage.
--  **UI**: Think of a user interface (UI) or Heads-up display (HUD) superimposed on our view of the game world. We want a life counter, score display and other elements to retain their screen positions even when our view of the game world changes.
+-  **UI**: Think of a user interface (UI) or head-up display (HUD) superimposed on our view of the game world. We want a life counter, score display and other elements to retain their screen positions even when our view of the game world changes.
 -  **Transitions**: We may want visual effects used for transitions (fades, blends) to remain at a fixed screen location.
 
 How to solve these problems in a single scene tree?


### PR DESCRIPTION
Fixes formatting of :ref: (and a couple of minor improvements to wording/typos) in [Canvas layers](https://docs.godotengine.org/en/latest/tutorials/2d/canvas_layers.html).

## Before
![Screenshot from 2021-07-15 22-03-31](https://user-images.githubusercontent.com/57055412/125881083-9e0fdeb2-409b-4cab-aece-85a95bf39049.png)

## After
![Screenshot from 2021-07-15 22-04-13](https://user-images.githubusercontent.com/57055412/125881093-c5d8eb71-fa4a-46ba-8079-5e2d322fe3e0.png)
