### PR TITLE
Fix Github hyperlink formatting in Using SoftBody

### DIFF
--- a/tutorials/physics/soft_body.rst
+++ b/tutorials/physics/soft_body.rst
@@ -32,7 +32,7 @@ Cloak simulation
 
 Let's make a cloak in the Platformer3D demo.
 
-.. note:: You can download the Platformer3D demo on `GitHub <https://github.com/godotengine/godot-demo-projects/tree/master/3d/platformer>` or `the Asset Library <https://godotengine.org/asset-library/asset/125>`_.
+.. note:: You can download the Platformer3D demo on `GitHub <https://github.com/godotengine/godot-demo-projects/tree/master/3d/platformer>`_ or `the Asset Library <https://godotengine.org/asset-library/asset/125>`_.
 
 Open the ``Player`` scene, add a ``SoftBody`` node and assign a ``PlaneMesh`` to it.
 


### PR DESCRIPTION
https://docs.godotengine.org/en/latest/tutorials/physics/soft_body.html

## Before
![Screenshot from 2021-07-17 22-51-17](https://user-images.githubusercontent.com/57055412/126054168-cbfd48e4-2e69-49bb-ad36-e62d4d732d6a.png)

## After
![Screenshot from 2021-07-17 22-53-03](https://user-images.githubusercontent.com/57055412/126054170-862baf25-e1bb-4cb9-9fb6-457585083fcb.png)
