### PR TITLE
Add notes about Blender backface culling when exporting to glTF

### DIFF
--- a/tutorials/3d/standard_material_3d.rst
+++ b/tutorials/3d/standard_material_3d.rst
@@ -223,6 +223,15 @@ Determines which side of the object is not drawn when backfaces are rendered:
 * **Front:** The front of the object is culled when not visible.
 * **Disabled:** Used for objects that are double-sided (no culling is performed).
 
+.. note::
+
+    By default, Blender has backface culling disabled on materials and will
+    export materials to match how they render in Blender. This means that
+    materials in Godot will have their cull mode set to **Disabled**. This can
+    decrease performance since backfaces will be rendered, even when they are
+    being culled by other faces. To resolve this, enable **Backface Culling** in
+    Blender's Materials tab, then export the scene to glTF again.
+
 Depth Draw Mode
 ~~~~~~~~~~~~~~~
 

--- a/tutorials/assets_pipeline/importing_scenes.rst
+++ b/tutorials/assets_pipeline/importing_scenes.rst
@@ -47,6 +47,13 @@ either of those glTF binary files are fine.
     Blender does not export emissive textures with the glTF file. If your model
     uses one, it must be brought in separately.
 
+    By default, Blender has backface culling disabled on materials and will
+    export materials to match how they render in Blender. This means that
+    materials in Godot will have their cull mode set to **Disabled**. This can
+    decrease performance since backfaces will be rendered, even when they are
+    being culled by other faces. To resolve this, enable **Backface Culling** in
+    Blender's Materials tab, then export the scene to glTF again.
+
 Exporting DAE files from Blender
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot-docs/pull/5103.

This closes https://github.com/godotengine/godot/issues/50552.