### PR TITLE
Add notes about Blender backface culling when exporting to glTF

### DIFF
--- a/getting_started/workflow/assets/importing_scenes.rst
+++ b/getting_started/workflow/assets/importing_scenes.rst
@@ -57,6 +57,13 @@ either of those glTF binary files are fine.
     Blender does not export emissive textures with the glTF file. If your model
     uses one, it must be brought in separately.
 
+    By default, Blender has backface culling disabled on materials and will
+    export materials to match how they render in Blender. This means that
+    materials in Godot will have their cull mode set to **Disabled**. This can
+    decrease performance since backfaces will be rendered, even when they are
+    being culled by other faces. To resolve this, enable **Backface Culling** in
+    Blender's Materials tab, then export the scene to glTF again.
+
 Exporting DAE files from Blender
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tutorials/3d/spatial_material.rst
+++ b/tutorials/3d/spatial_material.rst
@@ -223,6 +223,15 @@ Determines which side of the object is not drawn when backfaces are rendered:
 * **Front:** The front of the object is culled when not visible.
 * **Disabled:** Used for objects that are double-sided (no culling is performed).
 
+.. note::
+
+    By default, Blender has backface culling disabled on materials and will
+    export materials to match how they render in Blender. This means that
+    materials in Godot will have their cull mode set to **Disabled**. This can
+    decrease performance since backfaces will be rendered, even when they are
+    being culled by other faces. To resolve this, enable **Backface Culling** in
+    Blender's Materials tab, then export the scene to glTF again.
+
 Depth Draw Mode
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
`3.3` version of https://github.com/godotengine/godot-docs/pull/5102.