### PR TITLE
Update Godot version caveats in Controllers, gamepads and joysticks

### DIFF
--- a/tutorials/inputs/controllers_gamepads_joysticks.rst
+++ b/tutorials/inputs/controllers_gamepads_joysticks.rst
@@ -39,7 +39,7 @@ Input actions are explained in detail on the :ref:`doc_inputevent` page.
 Which Input singleton method should I use?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In Godot 4.0, there are 3 ways to get input in an analog-aware way:
+There are 3 ways to get input in an analog-aware way:
 
 - When you have two axes (such as joystick or WASD movement) and want both
   axes to behave as a single input, use ``Input.get_vector()``:
@@ -130,9 +130,9 @@ use ``Input.is_action_pressed()``:
     held,``Input.is_action_just_pressed()`` will only return ``true`` for one
     frame after the button has been pressed.
 
-In Godot versions before 4.0, such as 3.2, ``Input.get_vector()`` and
+In Godot versions before 3.4, such as 3.3, ``Input.get_vector()`` and
 ``Input.get_axis()`` aren't available. Only ``Input.get_action_strength()``
-and ``Input.is_action_pressed()`` are available in Godot 3.2.
+and ``Input.is_action_pressed()`` are available in Godot 3.3.
 
 Differences between keyboard/mouse and controller input
 -------------------------------------------------------


### PR DESCRIPTION
**Do not merge until https://github.com/godotengine/godot/pull/50788 is merged!**

`Input.get_vector()` and `Input.get_axis()` were backported to the `3.x` branch.

This closes https://github.com/godotengine/godot-docs/issues/5012#issuecomment-863808087.