### PR TITLE
Scene tree: Show functions as code

### DIFF
--- a/tutorials/scripting/scene_tree.rst
+++ b/tutorials/scripting/scene_tree.rst
@@ -93,7 +93,7 @@ When a node is connected, directly or indirectly, to the root
 viewport, it becomes part of the *scene tree*.
 
 This means that as explained in previous tutorials, it will get the
-``_enter_tree() and ``_ready()`` callbacks (as well as ``_exit_tree()``).
+``_enter_tree()`` and ``_ready()`` callbacks (as well as ``_exit_tree()``).
 
 .. image:: img/activescene.png
 

--- a/tutorials/scripting/scene_tree.rst
+++ b/tutorials/scripting/scene_tree.rst
@@ -93,7 +93,7 @@ When a node is connected, directly or indirectly, to the root
 viewport, it becomes part of the *scene tree*.
 
 This means that as explained in previous tutorials, it will get the
-_enter_tree() and _ready() callbacks (as well as _exit_tree()).
+``_enter_tree() and ``_ready()`` callbacks (as well as ``_exit_tree()``).
 
 .. image:: img/activescene.png
 


### PR DESCRIPTION
These function callbacks should be shown as code for better readability.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
