### PR TITLE
Prevent the "ref" badge from appearing in the sidebar

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -313,6 +313,11 @@ a[href*="classes/"]::before {
     display: none;
 }
 
+/* Prevent the "ref" badge from appearing in the sidebar. */
+.wy-menu-vertical a[href*="classes/"]::before {
+    display: none;
+}
+
 hr,
 #search-results .search li:first-child,
 #search-results .search li {


### PR DESCRIPTION
Before it looked like this:

![ref](https://user-images.githubusercontent.com/17676847/127538396-b395e2a0-7921-4e71-921c-cd5350e441bf.png)
