### PR TITLE
Replace various links with `ref` roles

### DIFF
--- a/community/contributing/contributing_to_the_documentation.rst
+++ b/community/contributing/contributing_to_the_documentation.rst
@@ -65,9 +65,7 @@ favorite text editor. You can then commit the changes, push them to your fork,
 and make a pull request. **Note that the pages in** ``classes/`` **should not be
 edited here.** They are automatically generated from Godot’s `XML class
 reference <https://github.com/godotengine/godot/tree/master/doc/classes>`__.
-See `Contribute to the Class Reference
-<https://docs.godotengine.org/en/latest/community/contributing/updating_the_class_reference.html>`__
-for details.
+See :ref:`doc_updating_the_class_reference` for details.
 
 .. seealso:: To build the manual and test changes on your computer, see
              :ref:`doc_building_the_manual`.

--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -121,8 +121,8 @@ On \*BSD, you can use ``sysctl -n hw.ncpu``:
 .. note::
 
     Prior to Godot 4.0, the Linux/\*BSD target was called ``x11`` instead of
-    ``linuxbsd``. If you are looking to compile Godot 3.2, make sure to use the
-    `3.2 branch of this documentation <https://docs.godotengine.org/en/3.2/development/compiling/compiling_for_x11.html>`__.
+    ``linuxbsd``. If you are looking to compile Godot 3.x, make sure to use the
+    `stable branch of this documentation <https://docs.godotengine.org/en/stable/development/compiling/compiling_for_x11.html>`__.
 
 If all goes well, the resulting binary executable will be placed in the
 "bin" subdirectory. This executable file contains the whole engine and

--- a/development/cpp/configuring_an_ide/clion.rst
+++ b/development/cpp/configuring_an_ide/clion.rst
@@ -3,18 +3,18 @@
 CLion
 =====
 
-`CLion <https://www.jetbrains.com/clion/>`_ is a commercial 
+`CLion <https://www.jetbrains.com/clion/>`_ is a commercial
 `JetBrains <https://www.jetbrains.com/>`_ IDE for C++.
 
 Importing the project
 ---------------------
 
 CLion requires a ``CMakeLists.txt`` file as a project file, which is problematic
-for Godot because it uses the SCons buildsystem instead of CMake. However, 
-there is a ``CMakeLists.txt`` configuration for :ref:`Android Studio <doc_configuring_an_ide_android_studio>` 
+for Godot because it uses the SCons buildsystem instead of CMake. However,
+there is a ``CMakeLists.txt`` configuration for :ref:`Android Studio <doc_configuring_an_ide_android_studio>`
 which can also be used by CLion.
 
-- From the CLion's welcome window choose the option to import an existing 
+- From the CLion's welcome window choose the option to import an existing
   project. If you've already opened another project, choose **File > Open**
   from the top menu.
 - Navigate to ``<Godot root directory>/platform/android/java/nativeSrcsConfigs`` (the
@@ -31,7 +31,7 @@ which can also be used by CLion.
 .. figure:: img/clion_2_this_window.png
    :align: center
 
-- Choose **Tools > CMake > Change Project Root** from the top menu and select 
+- Choose **Tools > CMake > Change Project Root** from the top menu and select
   the Godot root folder.
 
 .. figure:: img/clion_3_change_project_root.png
@@ -47,7 +47,7 @@ Debugging the project
 ---------------------
 
 Since CLion does not support SCons, you won't be able to compile, launch, and debug Godot from CLion in one step.
-You will first need to `compile godot yourself <https://docs.godotengine.org/en/stable/development/compiling/index.html>`__ and run the binary without CLion. You will then be able to debug Godot by using the `Attach to process <https://www.jetbrains.com/help/clion/attaching-to-local-process.html>`__ feature.
+You will first need to :ref:`compile Godot yourself <toc-devel-compiling>` and run the binary without CLion. You will then be able to debug Godot by using the `Attach to process <https://www.jetbrains.com/help/clion/attaching-to-local-process.html>`__ feature.
 
 - Run the compilation in debug mode by entering ``scons``.
 

--- a/getting_started/first_2d_game/01.project_setup.rst
+++ b/getting_started/first_2d_game/01.project_setup.rst
@@ -26,7 +26,7 @@ Launch Godot and create a new project.
 
     Ensure that you have the required dependencies to use C# in Godot.
     You need the .NET Core 3.1 SDK, and an editor such as VS Code.
-    See https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/c_sharp_basics.html#setting-up-c-for-godot
+    See :ref:`doc_c_sharp_setup`.
 
  .. tab:: GDNative C++
 
@@ -41,8 +41,8 @@ Launch Godot and create a new project.
     You need a C++ compiler such as GCC or Clang or MSVC that supports C++14.
     On Windows you can download Visual Studio 2019 and select the C++ workload.
     You also need SCons to use the build system (the SConstruct file).
-    Then you need to download the Godot C++ bindings from
-    https://github.com/godotengine/godot-cpp and place them in your project.
+    Then you need to `download the Godot C++ bindings <https://github.com/godotengine/godot-cpp>`_
+    and place them in your project.
 
 Your project folder should look like this.
 

--- a/tutorials/best_practices/data_preferences.rst
+++ b/tutorials/best_practices/data_preferences.rst
@@ -40,10 +40,10 @@ Array vs. Dictionary vs. Object
 -------------------------------
 
 Godot stores all variables in the scripting API in the
-`Variant <https://docs.godotengine.org/en/latest/development/cpp/variant_class.html>`_
-class. Variants can store Variant-compatible data structures such as
-:ref:`Array <class_Array>` and :ref:`Dictionary <class_Dictionary>` as well 
-as :ref:`Object <class_Object>`\ s.
+:ref:`Variant <doc_variant_class>` class.
+Variants can store Variant-compatible data structures such as
+:ref:`Array <class_Array>` and :ref:`Dictionary <class_Dictionary>` as well
+as :ref:`Objects <class_Object>`.
 
 Godot implements Array as a ``Vector<Variant>``. The engine stores the Array
 contents in a contiguous section of memory, i.e. they are in a row adjacent

--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -35,6 +35,8 @@ page in the Mono documentation.
         `Microsoft C# guide <https://docs.microsoft.com/en-us/dotnet/csharp/index>`_
         or look for a suitable introduction elsewhere.
 
+.. _doc_c_sharp_setup:
+
 Setting up C# for Godot
 -----------------------
 


### PR DESCRIPTION
Update some links to other documentation pages to use `ref` instead of hardcoded links and do some other small link cleanup that was on the same pages (Point to stable branch instead of 3.2; use a link instead of slapping a URL in the running text).
