### PR TITLE
Update Sphinx to 4.0.2 to match RTD

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,11 @@
 
 # Sync with readthedocs:
 # https://github.com/readthedocs/readthedocs.org/blob/master/requirements/pip.txt
-# https://github.com/readthedocs/readthedocs.org/blob/master/requirements/local-docs-build.txt
-sphinx==3.5.2
+# https://github.com/readthedocs/readthedocs.org/blob/master/requirements/docs.txt
+sphinx==4.0.2
 sphinx_rtd_theme==0.5.2
 
 # Code tabs extension for GDScript/C#
-# Stay on 1.3.0 until https://github.com/readthedocs/readthedocs-sphinx-search/issues/82 is fixed.
 sphinx-tabs==3.1.0
 
 # Custom 404 error page (more useful than the default)


### PR DESCRIPTION
Currently https://github.com/readthedocs/readthedocs.org/blob/master/requirements/pip.txt and https://github.com/readthedocs/readthedocs.org/blob/master/requirements/docs.txt point to Sphinx 4 (4.0.2 to be precise). I've tested it locally and it builds fine even with 4.1.2, so I think it should be safe to update the requirement.

Also updated obsolete comments in the file.