### PR TITLE
Hide "Edit on GitHub" link on the class reference TOC page

### DIFF
--- a/classes/index.rst
+++ b/classes/index.rst
@@ -1,3 +1,5 @@
+:github_url: hide
+
 Godot API
 =========
 


### PR DESCRIPTION
Noticed that the "Edit on GitHub" link on `classes/index.rst` is another place that has "classes/" in its URL but shouldn't have a "ref" badge, it also breaks the original style which uses `before` for the icon.
The index page wasn't edited in 4 years and is mostly autogenerated by Sphinx anyway, so there's no real need for the link and it's easier to just hide it rather than add yet another exception to custom.css.
