### PR TITLE
Add link when internal rooms are first mentioned

### DIFF
--- a/tutorials/3d/portals/advanced_room_and_portal_usage.rst
+++ b/tutorials/3d/portals/advanced_room_and_portal_usage.rst
@@ -64,6 +64,8 @@ This is an example of a simple RoomGroup script to turn on and off a Directional
 
 .. tip:: You can apply the same technique for switching on and off weather effects, skyboxes and much more.
 
+.. _doc_rooms_and_portals_internal_rooms:
+
 Internal Rooms
 ~~~~~~~~~~~~~~
 

--- a/tutorials/3d/portals/first_steps_with_rooms_and_portals.rst
+++ b/tutorials/3d/portals/first_steps_with_rooms_and_portals.rst
@@ -47,7 +47,7 @@ If you accidentally create overlapping rooms, the editor will flag a warning whe
 
 The system does attempt to cope with overlapping rooms as best as possible by making the current room *"sticky"*. Each object remembers which room it was in last frame, and stays within it as long as it does not move outside the convex hull room bound. This can result in some hysteresis in these overlapping zones.
 
-There is one exception however for *internal rooms*. (These internal rooms are described later, you do not have to worry about these to start with.)
+There is one exception however for :ref:`internal rooms<doc_rooms_and_portals_internal_rooms>`. You do not have to worry about these to start with.
 
 How do I create a room?
 ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
It's quite a distance from the first mention of internal room to the actual place it's described.