### PR TITLE
Update the pixel snap project setting name in Using tileMaps

### DIFF
--- a/tutorials/2d/using_tilemaps.rst
+++ b/tutorials/2d/using_tilemaps.rst
@@ -341,7 +341,7 @@ Tips and tricks
 
 - If you're using a :ref:`Camera2D <class_Camera2D>` to scroll your level, you
   may notice lines appearing between your tiles. To fix this, open Project
-  Settings and enable "Use Pixel Snap" in the "Rendering/Quality" section.
+  Settings and enable "Use Gpu Pixel Snap" in the "Rendering/2d/snapping" section.
 
 - You can flip and rotate tiles using the icons at the top right of the editor.
 

--- a/tutorials/2d/using_tilemaps.rst
+++ b/tutorials/2d/using_tilemaps.rst
@@ -341,7 +341,7 @@ Tips and tricks
 
 - If you're using a :ref:`Camera2D <class_Camera2D>` to scroll your level, you
   may notice lines appearing between your tiles. To fix this, open Project
-  Settings and enable "Use Gpu Pixel Snap" in the "Rendering/2d/snapping" section.
+  Settings and enable **Use Gpu Pixel Snap** in the **Rendering > 2d > Snapping** section.
 
 - You can flip and rotate tiles using the icons at the top right of the editor.
 


### PR DESCRIPTION
Changed the tip on how to enable pixel snapping as it changed in 3.3 (see https://github.com/godotengine/godot/pull/46552)

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
