### PR TITLE
[3.4] Optimizing for size: add classes that are disabled by `disable_3d`/`disable_advanced_gui`

### DIFF
--- a/development/compiling/optimizing_for_size.rst
+++ b/development/compiling/optimizing_for_size.rst
@@ -3,7 +3,7 @@
 Optimizing a build for size
 ===========================
 
-.. highlight:: shell
+.. highlight:: none
 
 Rationale
 ---------
@@ -11,41 +11,187 @@ Rationale
 Sometimes, it is desired to optimize a build for size rather than speed.
 This means not compiling unused functions from the engine, as well as using
 specific compiler flags to aid on decreasing build size.
-Common situations include creating builds for mobile and Web platforms.
+Common situations include creating builds for mobile and web platforms.
 
 This tutorial aims to give an overview on different methods to create
 a smaller binary. Before continuing, it is recommended to read the previous tutorials
 on compiling Godot for each platform.
 
-.. seealso::
-
-    You can use the online
-    `Godot build options generator <https://godot-build-options-generator.github.io/>`__
-    to generate a ``custom.py`` file containing SCons options.
-    You can then save this file and place it at the root of your Godot source directory.
-
 Disabling 3D
 ------------
 
-For 2D games, having the whole 3D engine available usually makes no sense. Because of this, there is a build flag to disable it:
+For 2D games, having the whole 3D engine available usually makes no sense. Because of this,
+there is a build flag to disable most of it. Without the 3D parts, the binary size can be
+reduced by about 15%:
 
 ::
 
-    scons p=windows target=release tools=no disable_3d=yes
+    scons p=<platform> target=release tools=no disable_3d=yes
 
-Tools must be disabled in order to use this flag, as the editor is not designed
-to operate without 3D support. Without it, the binary size can be reduced
-by about 15%.
+The following classes are not available when building with ``disable_3d=yes``:
+
+- :ref:`class_ARVRAnchor`
+- :ref:`class_ARVRCamera`
+- :ref:`class_ARVRController`
+- :ref:`class_ARVROrigin`
+- :ref:`class_AnimatedSprite3D`
+- :ref:`class_Area`
+- :ref:`class_AudioStreamPlayer3D`
+- :ref:`class_BakedLightmap`
+- :ref:`class_BakedLightmapData`
+- :ref:`class_BoneAttachment`
+- :ref:`class_BoxShape`
+- :ref:`class_CPUParticles`
+- :ref:`class_CSGBox`
+- :ref:`class_CSGCombiner`
+- :ref:`class_CSGCylinder`
+- :ref:`class_CSGMesh`
+- :ref:`class_CSGPolygon`
+- :ref:`class_CSGPrimitive`
+- :ref:`class_CSGShape`
+- :ref:`class_CSGSphere`
+- :ref:`class_CSGTorus`
+- :ref:`class_Camera`
+- :ref:`class_CapsuleMesh`
+- :ref:`class_CapsuleShape`
+- :ref:`class_ClippedCamera`
+- :ref:`class_CollisionObject`
+- :ref:`class_CollisionPolygon`
+- :ref:`class_CollisionShape`
+- :ref:`class_ConcavePolygonShape`
+- :ref:`class_ConeTwistJoint`
+- :ref:`class_ConvexPolygonShape`
+- :ref:`class_CubeMesh`
+- :ref:`class_CullInstance`
+- :ref:`class_Curve3D`
+- :ref:`class_CylinderMesh`
+- :ref:`class_CylinderShape`
+- :ref:`class_DirectionalLight`
+- :ref:`class_EditorSceneImporterGLTF`
+- :ref:`class_GIProbe`
+- :ref:`class_GIProbeData`
+- :ref:`class_GLTFAccessor`
+- :ref:`class_GLTFAnimation`
+- :ref:`class_GLTFBufferView`
+- :ref:`class_GLTFCamera`
+- :ref:`class_GLTFDocument`
+- :ref:`class_GLTFLight`
+- :ref:`class_GLTFMesh`
+- :ref:`class_GLTFNode`
+- :ref:`class_GLTFSkeleton`
+- :ref:`class_GLTFSkin`
+- :ref:`class_GLTFSpecGloss`
+- :ref:`class_GLTFState`
+- :ref:`class_GLTFTexture`
+- :ref:`class_Generic6DOFJoint`
+- :ref:`class_GeometryInstance`
+- :ref:`class_GridMap`
+- :ref:`class_HeightMapShape`
+- :ref:`class_HingeJoint`
+- :ref:`class_ImmediateGeometry`
+- :ref:`class_InterpolatedCamera`
+- :ref:`class_Joint`
+- :ref:`class_KinematicBody`
+- :ref:`class_KinematicCollision`
+- :ref:`class_Light`
+- :ref:`class_Listener`
+- :ref:`class_Material`
+- :ref:`class_MeshInstance`
+- :ref:`class_MeshLibrary`
+- :ref:`class_MultiMeshInstance`
+- :ref:`class_Navigation`
+- :ref:`class_NavigationMesh`
+- :ref:`class_NavigationMeshInstance`
+- :ref:`class_OmniLight`
+- :ref:`class_PackedSceneGLTF`
+- :ref:`class_Particles`
+- :ref:`class_Path`
+- :ref:`class_PathFollow`
+- :ref:`class_PhysicalBone`
+- :ref:`class_PhysicsBody`
+- :ref:`class_PinJoint`
+- :ref:`class_PlaneMesh`
+- :ref:`class_PlaneShape`
+- :ref:`class_PointMesh`
+- :ref:`class_Portal`
+- :ref:`class_Position3D`
+- :ref:`class_PrimitiveMesh`
+- :ref:`class_PrismMesh`
+- :ref:`class_ProximityGroup`
+- :ref:`class_QuadMesh`
+- :ref:`class_RayCast`
+- :ref:`class_RayShape`
+- :ref:`class_ReflectionProbe`
+- :ref:`class_RemoteTransform`
+- :ref:`class_RigidBody`
+- :ref:`class_Room`
+- :ref:`class_RoomGroup`
+- :ref:`class_RoomManager`
+- :ref:`class_RootMotionView`
+- :ref:`class_Shape`
+- :ref:`class_SkeletonIK`
+- :ref:`class_SliderJoint`
+- :ref:`class_SoftBody`
+- :ref:`class_SpatialMaterial`
+- :ref:`class_SpatialVelocityTracker`
+- :ref:`class_SphereMesh`
+- :ref:`class_SphereShape`
+- :ref:`class_SpotLight`
+- :ref:`class_SpringArm`
+- :ref:`class_Sprite3D`
+- :ref:`class_SpriteBase3D`
+- :ref:`class_StaticBody`
+- :ref:`class_VehicleBody`
+- :ref:`class_VehicleWheel`
+- :ref:`class_VisibilityEnabler`
+- :ref:`class_VisibilityNotifier`
+- :ref:`class_VisualInstance`
+- :ref:`class_WorldEnvironment`
+
+.. note::
+
+    The editor is not designed to operate without 3D support, so this flag only works
+    in combination with ``tools=no``.
 
 Disabling advanced GUI nodes
 ----------------------------
 
-Most small games don't require complex GUI controls such as Tree, ItemList,
-TextEdit or GraphEdit. They can be disabled using a build flag:
+If your game doesn't require complex GUI controls, they can be disabled using a build flag:
 
 ::
 
-    scons p=windows target=release tools=no disable_advanced_gui=yes
+    scons p=<platform> target=release tools=no disable_advanced_gui=yes
+
+The following classes are not available when building with ``disable_advanced_gui=yes``:
+
+- :ref:`class_AcceptDialog`
+- :ref:`class_CharFXTransform`
+- :ref:`class_ColorPicker`
+- :ref:`class_ColorPickerButton`
+- :ref:`class_ConfirmationDialog`
+- :ref:`class_FileDialog`
+- :ref:`class_GraphEdit`
+- :ref:`class_GraphNode`
+- :ref:`class_HSplitContainer`
+- :ref:`class_MarginContainer`
+- :ref:`class_OptionButton`
+- :ref:`class_PopupDialog`
+- :ref:`class_PopupMenu`
+- :ref:`class_RichTextEffect`
+- :ref:`class_RichTextLabel`
+- :ref:`class_SpinBox`
+- :ref:`class_SplitContainer`
+- :ref:`class_TextEdit`
+- :ref:`class_Tree`
+- :ref:`class_TreeItem`
+- :ref:`class_VSplitContainer`
+- :ref:`class_ViewportContainer`
+- :ref:`class_WindowDialog`
+
+.. note::
+
+    The editor uses many of these GUI controls, so this flag only works
+    in combination with ``tools=no``.
 
 Disabling unwanted modules
 --------------------------
@@ -63,16 +209,30 @@ a lot of them:
 
 ::
 
-    scons p=windows target=release tools=no module_arkit_enabled=no module_assimp_enabled=no module_bmp_enabled=no module_bullet_enabled=no module_camera_enabled=no module_csg_enabled=no module_dds_enabled=no module_enet_enabled=no module_etc_enabled=no module_gdnative_enabled=no module_gridmap_enabled=no module_hdr_enabled=no module_jsonrpc_enabled=no module_mbedtls_enabled=no module_mobile_vr_enabled=no module_opensimplex_enabled=no module_opus_enabled=no module_pvr_enabled=no module_recast_enabled=no module_regex_enabled=no module_squish_enabled=no module_svg_enabled=no module_tga_enabled=no module_theora_enabled=no module_tinyexr_enabled=no module_upnp_enabled=no module_vhacd_enabled=no module_vorbis_enabled=no module_webm_enabled=no module_webp_enabled=no module_webrtc_enabled=no module_websocket_enabled=no module_xatlas_unwrap_enabled=no
+    scons p=<platform> target=release tools=no \
+    module_bmp_enabled=no module_bullet_enabled=no module_camera_enabled=no module_csg_enabled=no \
+    module_dds_enabled=no module_enet_enabled=no module_etc_enabled=no module_gdnative_enabled=no \
+    module_gridmap_enabled=no module_hdr_enabled=no module_jsonrpc_enabled=no module_mbedtls_enabled=no \
+    module_mobile_vr_enabled=no module_opensimplex_enabled=no module_opus_enabled=no module_pvr_enabled=no \
+    module_recast_enabled=no module_regex_enabled=no module_squish_enabled=no module_svg_enabled=no \
+    module_tga_enabled=no module_theora_enabled=no module_tinyexr_enabled=no module_upnp_enabled=no \
+    module_vhacd_enabled=no module_vorbis_enabled=no module_webm_enabled=no module_webrtc_enabled=no \
+    module_websocket_enabled=no module_webxr_enabled=no module_xatlas_unwrap_enabled=no
 
 If this proves not to work for your use case, you should review the list of
 modules and see which ones you actually still need for your game (e.g. you
 might want to keep networking-related modules, regex support, or theora/webm
 to play videos).
 
-Alternatively, you can supply a list of disabled modules by creating
-``custom.py`` at the root of the source, with the contents similar to the
-following:
+.. important::
+
+    While you can disable most modules, some are required for core functionally,
+    especially when building with ``tools=yes``. SCons will warn you if your desired
+    module configuration is impossible and abort the build process.
+
+If you don't want to add them to the commandline every time you do a build,
+you can supply a list of disabled modules by creating a ``custom.py`` file at the root
+of your Godot source directory, with the contents similar to the following:
 
 .. code-block:: python
 
@@ -107,10 +267,16 @@ following:
     module_vhacd_enabled = "no"
     module_vorbis_enabled = "no"
     module_webm_enabled = "no"
-    module_webp_enabled = "no"
     module_webrtc_enabled = "no"
     module_websocket_enabled = "no"
+    module_webxr_enabled = "no"
     module_xatlas_unwrap_enabled = "no"
+
+.. seealso::
+
+    You can use the online
+    `Godot build options generator <https://godot-build-options-generator.github.io/>`__
+    to generate a ``custom.py`` file containing SCons options.
 
 .. seealso::
 
@@ -124,23 +290,23 @@ To enable this, set the ``optimize`` flag to ``size``:
 
 ::
 
-    scons p=windows target=release tools=no optimize=size
+    scons p=<platform> target=release tools=no optimize=size
 
 Some platforms such as WebAssembly already use this mode by default.
 
 Compiling with link-time optimization
 -------------------------------------
 
-Enabling link-time optimization produces more efficient binaries, both in
+Enabling link-time optimization (LTO) produces more efficient binaries, both in
 terms of performance and file size. It works by eliminating duplicate
 template functions and unused code. It can currently be used with the GCC
 and MSVC compilers:
 
 ::
 
-    scons p=windows target=release tools=no use_lto=yes
+    scons p=<platform> target=release tools=no use_lto=yes
 
-Linking becomes much slower and more RAM consuming with this option, so it should be used only for
+Linking becomes much slower and more RAM is consumed with this option, so it should be used only for
 release builds.
 
 Stripping binaries


### PR DESCRIPTION
Adds a list of classes that are disabled when the explained build options are used.
Generated by parsing `scene/register_scene_types.cpp` and `register_types.cpp` of
all modules with this script:
<details><summary>script</summary>

```python
#!/usr/bin/env python3

import glob
import os
import re
import sys

pattern = re.compile(r'ClassDB::register_(?:virtual_)?class<([A-Z_][\w]+)>\(\);')

def find_classes(filename, build_flag, define):
    excluded_classes = []
    ifdef_count = 0 # Keep track of potential inner #if/#ifdef/#ifndef blocks.

    with open(filename, "r") as f:
        lines = f.readlines()

    for line in lines:
        line = line.split("//", 1)[0]
        line = line.strip()
        if ifdef_count > 0:
            if line.startswith("#endif"):
                ifdef_count -= 1
            elif line.startswith("#if"):
                ifdef_count += 1
            else:
                match = pattern.search(line)
                if match is not None:
                    excluded_classes.append(match.group(1))
        else:
            if line.startswith(f"#ifndef {define}"):
                ifdef_count = 1

    return excluded_classes

def print_excluded_classes(godot_path, docs_path, build_flag, define):
    excluded_classes = []
    warnings = []

    excluded_classes += find_classes(os.path.join(godot_path, "scene", "register_scene_types.cpp"), build_flag, define)
    for module in glob.glob(os.path.join(godot_path, "modules", "**", "register_types.cpp")):
        excluded_classes += find_classes(module, build_flag, define)

    print(f"\nThe following classes are not available when building with ``{build_flag}=yes``:\n")
    for i in sorted(excluded_classes):
        if not os.path.exists(os.path.join(docs_path, "classes", f"class_{i.lower()}.rst")):
            warnings.append(f"WARNING: Added class `{i}` but no rst file `classes/class_{i.lower()}.rst` exists. Sphinx will complain about this.")
        print(f"- :ref:`class_{i}`")

    return warnings

if len(sys.argv) != 3:
    print(f"Usage: {sys.argv[0]} path/to/godot path/to/godot-docs")
    sys.exit(1)

warnings = []
warnings += print_excluded_classes(sys.argv[1], sys.argv[2], "disable_3d", "_3D_DISABLED")
warnings += print_excluded_classes(sys.argv[1], sys.argv[2], "disable_advanced_gui", "ADVANCED_GUI_DISABLED")
if len(warnings) > 0:
    print("\n".join(errors), file=sys.stderr)
```
</details>

Also moves the mention of the online build options generator to the section where
`custom.py` is introduced and do some general reformatting and rewording.

---

Making a PR like this for the `master` branch doesn't make sense at the moment since the generated class reference is out of sync.