### PR TITLE
One phrase fix for idle_and_physics_processing.rst

### DIFF
--- a/tutorials/scripting/idle_and_physics_processing.rst
+++ b/tutorials/scripting/idle_and_physics_processing.rst
@@ -54,7 +54,7 @@ possible to keep the physics interactions stable. You can change the interval
 between physics steps in the Project Settings, under Physics -> Common ->
 Physics Fps. By default, it's set to run 60 times per second.
 
-The engine calls this method every time it draws a frame:
+The engine calls this method before every physics step:
 
 .. tabs::
  .. code-tab:: gdscript GDScript


### PR DESCRIPTION
Both, the _process() and _physics_process() are not called every time the engine draws a frame like its written here, only -process() does. _physics_process() gets called before each physics step like it's explained on this same page.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
