### PR TITLE
Update `--no-window` option description in Command line tutorial

### DIFF
--- a/tutorials/editor/command_line_tutorial.rst
+++ b/tutorials/editor/command_line_tutorial.rst
@@ -92,8 +92,7 @@ Command line reference
 +------------------------------------+----------------------------------------------------------------------------+
 | ``--low-dpi``                      | Force low-DPI mode (macOS and Windows only).                               |
 +------------------------------------+----------------------------------------------------------------------------+
-| ``--no-window``                    | Run with invisible window. Useful together with --script.  |
-|                                    |``--script``.                                                               |
+| ``--no-window``                    | Run with invisible window. Useful together with --script.                  |
 +------------------------------------+----------------------------------------------------------------------------+
 | ``--enable-vsync-via-compositor``  | When vsync is enabled, vsync via the OS' window compositor (Windows only). |
 +------------------------------------+----------------------------------------------------------------------------+

--- a/tutorials/editor/command_line_tutorial.rst
+++ b/tutorials/editor/command_line_tutorial.rst
@@ -92,7 +92,8 @@ Command line reference
 +------------------------------------+----------------------------------------------------------------------------+
 | ``--low-dpi``                      | Force low-DPI mode (macOS and Windows only).                               |
 +------------------------------------+----------------------------------------------------------------------------+
-| ``--no-window``                    | Disable window creation (Windows only). Useful together with ``--script``. |
+| ``--no-window``                    | Disable window creation (Windows, macOS, and Linux). Useful together with  |
+|                                    |``--script``.                                                               |
 +------------------------------------+----------------------------------------------------------------------------+
 | ``--enable-vsync-via-compositor``  | When vsync is enabled, vsync via the OS' window compositor (Windows only). |
 +------------------------------------+----------------------------------------------------------------------------+

--- a/tutorials/editor/command_line_tutorial.rst
+++ b/tutorials/editor/command_line_tutorial.rst
@@ -92,7 +92,7 @@ Command line reference
 +------------------------------------+----------------------------------------------------------------------------+
 | ``--low-dpi``                      | Force low-DPI mode (macOS and Windows only).                               |
 +------------------------------------+----------------------------------------------------------------------------+
-| ``--no-window``                    | Run with invisible window. Useful together with --script.                  |
+| ``--no-window``                    | Run with invisible window. Useful together with ``--script``.              |
 +------------------------------------+----------------------------------------------------------------------------+
 | ``--enable-vsync-via-compositor``  | When vsync is enabled, vsync via the OS' window compositor (Windows only). |
 +------------------------------------+----------------------------------------------------------------------------+

--- a/tutorials/editor/command_line_tutorial.rst
+++ b/tutorials/editor/command_line_tutorial.rst
@@ -92,7 +92,7 @@ Command line reference
 +------------------------------------+----------------------------------------------------------------------------+
 | ``--low-dpi``                      | Force low-DPI mode (macOS and Windows only).                               |
 +------------------------------------+----------------------------------------------------------------------------+
-| ``--no-window``                    | Disable window creation (Windows, macOS, and Linux). Useful together with  |
+| ``--no-window``                    | Run with invisible window. Useful together with --script.  |
 |                                    |``--script``.                                                               |
 +------------------------------------+----------------------------------------------------------------------------+
 | ``--enable-vsync-via-compositor``  | When vsync is enabled, vsync via the OS' window compositor (Windows only). |


### PR DESCRIPTION
Updated documentation for this option to reflect the supported platforms. This option has been tested on all the mentioned platforms as of Godot engine version 3.3.2.