### PR TITLE
[3.4] Make GLTF module togglable when compiling release templates

### DIFF
--- a/development/compiling/optimizing_for_size.rst
+++ b/development/compiling/optimizing_for_size.rst
@@ -63,7 +63,7 @@ a lot of them:
 
 ::
 
-    scons p=windows target=release tools=no module_arkit_enabled=no module_assimp_enabled=no module_bmp_enabled=no module_bullet_enabled=no module_camera_enabled=no module_csg_enabled=no module_dds_enabled=no module_enet_enabled=no module_etc_enabled=no module_gdnative_enabled=no module_gridmap_enabled=no module_hdr_enabled=no module_jsonrpc_enabled=no module_mbedtls_enabled=no module_mobile_vr_enabled=no module_opensimplex_enabled=no module_opus_enabled=no module_pvr_enabled=no module_recast_enabled=no module_regex_enabled=no module_squish_enabled=no module_svg_enabled=no module_tga_enabled=no module_theora_enabled=no module_tinyexr_enabled=no module_upnp_enabled=no module_vhacd_enabled=no module_vorbis_enabled=no module_webm_enabled=no module_webp_enabled=no module_webrtc_enabled=no module_websocket_enabled=no module_xatlas_unwrap_enabled=no
+    scons p=windows target=release tools=no module_arkit_enabled=no module_assimp_enabled=no module_bmp_enabled=no module_bullet_enabled=no module_camera_enabled=no module_csg_enabled=no module_dds_enabled=no module_enet_enabled=no module_etc_enabled=no module_gdnative_enabled=no module_gridmap_enabled=no module_gltf_enabled=no module_hdr_enabled=no module_jsonrpc_enabled=no module_mbedtls_enabled=no module_mobile_vr_enabled=no module_opensimplex_enabled=no module_opus_enabled=no module_pvr_enabled=no module_recast_enabled=no module_regex_enabled=no module_squish_enabled=no module_svg_enabled=no module_tga_enabled=no module_theora_enabled=no module_tinyexr_enabled=no module_upnp_enabled=no module_vhacd_enabled=no module_vorbis_enabled=no module_webm_enabled=no module_webp_enabled=no module_webrtc_enabled=no module_websocket_enabled=no module_xatlas_unwrap_enabled=no
 
 If this proves not to work for your use case, you should review the list of
 modules and see which ones you actually still need for your game (e.g. you
@@ -89,6 +89,7 @@ following:
     module_etc_enabled = "no"
     module_gdnative_enabled = "no"
     module_gridmap_enabled = "no"
+    module_gltf_enabled = "no"
     module_hdr_enabled = "no"
     module_jsonrpc_enabled = "no"
     module_mbedtls_enabled = "no"


### PR DESCRIPTION
The GLTF module is excluded from release templates by default. This PR adds a build flag to enable/disable the GLTF when compiling Godot and release templates.

This change was needed for my project on 3.x [openseeface-gd](https://github.com/you-win/openseeface-gd), which loads in `gltf`/`glb` models at runtime.

Associated PRs:
- master
  - [godot](https://github.com/godotengine/godot/pull/51383)
  - [godot-docs](https://github.com/godotengine/godot-docs/pull/5161)
- 3.4
  - [godot](https://github.com/godotengine/godot/pull/51382)
  - [godot-docs](https://github.com/godotengine/godot-docs/pull/5160)