### PR TITLE
Update Bug triage guidelines for newly added labels

### DIFF
--- a/community/contributing/bug_triage_guidelines.rst
+++ b/community/contributing/bug_triage_guidelines.rst
@@ -80,6 +80,9 @@ The following labels are currently defined in the Godot repository:
    and thus need further testing. This can mean that it needs to be tested
    on different hardware/software configurations or even that the steps to
    reproduce are not certain.
+-  *Performance*: issues that directly impact engine or editor performance.
+   Can also be used for pull requests that improve performance or add low-end-friendly options.
+   Should not be coupled with *Usability*.
 -  *PR welcome / Hero wanted!*: Contributions for issues with these labels
    are especially welcome. Note that this **doesn't** mean you can't work
    on issues without these labels.
@@ -91,7 +94,7 @@ The following labels are currently defined in the Godot repository:
    To do so, you need to open a new pull request based on the original pull request.
 -  *Tracker*: issue used to track other issues (like all issues related to
    the plugin system).
--  *Usability*: issues that directly impact user usability.
+-  *Usability*: issues that directly impact user usability. Should not be coupled with *Performance*.
 
 The categories are used for general triage of the issues. They can be
 combined in some way when relevant, e.g. an issue can be labelled
@@ -101,6 +104,8 @@ feature request, or one that is not precise enough to be worked on.
 
 **Topics:**
 
+-  *2D*: relates to 2D-specific issues. Should be coupled with one of the labels below, and should not be coupled with *3D*.
+-  *3D*: relates to 3D-specific issues. Should be coupled with one of the labels below, and should not be coupled with *2D*.
 -  *Assetlib*: relates to issues with the asset library.
 -  *Audio*: relates to the audio features (low and high level).
 -  *Buildsystem*: relates to building issues, either linked to the SCons


### PR DESCRIPTION
`topic:2d`, `topic:3d` and `performance` labels were recently added to the main Godot repository's issue tracker.