### PR TITLE
Make pragma once sub-header clearer in C++ usage guidelines

### DIFF
--- a/community/contributing/cpp_usage_guidelines.rst
+++ b/community/contributing/cpp_usage_guidelines.rst
@@ -92,8 +92,8 @@ Lambdas should be used conservatively when they make code effectively faster or
 simpler, and do not impede readability. Please ask before using lambdas in a
 pull request.
 
-``#pragma once``
-^^^^^^^^^^^^^^^^
+``#pragma once`` directive
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To follow the existing style, please use standard ``#ifdef``-based include
 guards instead of ``#pragma once`` in new files.


### PR DESCRIPTION
https://docs.godotengine.org/en/latest/community/contributing/cpp_usage_guidelines.html#pragma-once

Currently, it looks more like it's misplaced than a sub-header due to inline code blocks remaining a constant font size.

## Before
![Screenshot from 2021-08-19 02-26-28](https://user-images.githubusercontent.com/57055412/130019250-76084071-37e6-495a-8042-896870d9f6cb.png)

## After
![Screenshot from 2021-08-19 02-26-45](https://user-images.githubusercontent.com/57055412/130019270-d528e373-37d0-48c5-8746-008e9c940e33.png)
