### PR TITLE
add GDnative code with C ++ to official documentation.

### DIFF
--- a/getting_started/step_by_step/scripting.rst
+++ b/getting_started/step_by_step/scripting.rst
@@ -238,6 +238,15 @@ the following underneath the ``_ready()`` function:
     {
         GetNode("Button");
     }
+    
+ .. code-tab:: GDnative C++
+    
+    #include "Label.hpp"
+    
+    void MyClas::_ready() 
+    {
+        get_node<godot::Label>("Label");
+    }
 
 Next, write a function which will be called when the button is pressed:
 
@@ -253,6 +262,15 @@ Next, write a function which will be called when the button is pressed:
     {
         GetNode<Label>("Label").Text = "HELLO!";
     }
+ .. code-tab:: GDnative C++
+    
+    #include "Label.hpp"
+    
+    void MyClas::_ready() 
+    {
+        get_node<godot::Label>("Label")->set_text("HELLO!");;
+    }
+
 
 Finally, connect the button's "pressed" signal to ``_on_Button_pressed()`` by
 using :ref:`Object.connect() <class_Object_method_connect>`.


### PR DESCRIPTION
I am using Gdnative with Godot and it is very good.
It is a pity that in the official documentation there is no information about the use of the C ++ API in the fundamental explanations of the engine.
Leave 2 small examples, but I could add a lot more.
What if, I did not find a way to search for the update and ready methods in C ++, I only declared the functions, I implement them and register them as methods.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
