### PR TITLE
Remove reference to xbuild in Compiling with Mono

### DIFF
--- a/development/compiling/compiling_with_mono.rst
+++ b/development/compiling/compiling_with_mono.rst
@@ -377,10 +377,6 @@ the Mono module:
 
   - Path to the Mono installation directory for the target platform and architecture.
 
-- **xbuild_fallback**\ =yes | **no**
-
-  - Whether to fallback to xbuild if MSBuild is not available.
-
 - **mono_static**\ =yes | no
 
   - Whether to link the Mono runtime statically.


### PR DESCRIPTION
Removes reference to xbuild from the compiling with mono page. Xbuild was removed with https://github.com/godotengine/godot/pull/30842. Closes #4999 
