### PR TITLE
Document that compiling a binary with Clang on Linux adds a `.llvm` suffix

### DIFF
--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -238,5 +238,8 @@ then use the following SCons command::
 
     scons platform=linuxbsd use_llvm=yes use_lld=yes
 
+After the build is completed, a new binary with a ``.llvm`` suffix will be
+created in the ``bin/`` folder.
+
 It's still recommended to use GCC for production builds as they can be compiled using
 link-time optimization, making the resulting binaries smaller and faster.


### PR DESCRIPTION
This can result in people running old binaries unexpectedly, so it's important to mention this suffix.


<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->