### PR TITLE
Use pip3 instead of pip

### DIFF
--- a/community/contributing/building_the_manual.rst
+++ b/community/contributing/building_the_manual.rst
@@ -21,15 +21,14 @@ install all these tools. It comes pre-installed with `Python
 <https://www.python.org/>`__. Ensure that you install and use Python 3. Here are
 the commands to clone the repository and then install all requirements.
 
+.. note:: You may need to write ``python3 -m pip`` (Unix) or  ``py -m pip`` (Windows) instead of ``pip3``. 
+          If both approaches fail, `check that you have pip3 installed <https://pip.pypa.io/en/stable/installation/>`__.
+
 .. code:: sh
 
     git clone https://github.com/godotengine/godot-docs.git
-    pip install -r requirements.txt
+    pip3 install -r requirements.txt
 
-.. note:: On Linux distributions, you may need to write ``pip3`` instead of
-          ``pip`` because you generally have both Python 2 and 3 installed on
-          your system. Alternatively, you can explicitly ask Python 3 to execute
-          its version of pip as a module like so: ``python3 -m pip``.
 
 With the programs installed, you can build the HTML documentation from the root
 folder of this repository with the following command:
@@ -94,6 +93,6 @@ root folder:
 
    virtualenv --system-site-packages env/
    . env/bin/activate
-   pip install -r requirements.txt
+   pip3 install -r requirements.txt
 
 Then, run ``make html`` as shown above.

--- a/community/contributing/code_style_guidelines.rst
+++ b/community/contributing/code_style_guidelines.rst
@@ -273,7 +273,7 @@ Here's how to install black:
 
 ::
 
-    pip install black --user
+    pip3 install black --user
 
 
 You then have different possibilities to apply black to your changes:

--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -38,7 +38,7 @@ For compiling under Windows, the following is required:
                   mingw-w64-i686-yasm make
 
           For each MSYS2 MinGW subsystem, you should then run
-          `pip install scons` in its shell.
+          `pip3 install scons` in its shell.
 
 .. seealso:: For a general overview of SCons usage for Godot, see
              :ref:`doc_introduction_to_the_buildsystem`.
@@ -55,7 +55,7 @@ Setting up SCons
 
 To install SCons open the command prompt and run the following command.
 
-``python -m pip install scons``
+``python -m pip3 install scons``
 
 To check whether you have installed Python and SCons correctly, you can
 type ``python --version`` and ``scons --version`` into a command prompt

--- a/tutorials/i18n/localization_using_gettext.rst
+++ b/tutorials/i18n/localization_using_gettext.rst
@@ -97,7 +97,7 @@ After installing ``babel`` and ``babel-godot``, for example using pip:
 
 .. code-block:: shell
 
-    pip install babel babel-godot
+    pip3 install babel babel-godot
 
 Write a mapping file (for example ``babelrc``) which will indicate which files
 pybabel needs to process (note that we process GDScript as Python, which is


### PR DESCRIPTION
`pip` may refer to the old Python 2 package manager, possibly causing confusion. Missing `pip3` causes a straight-forward that's easily googlable and accounted for by a note.