### PR TITLE
Fix cubic interpolation method reference links

### DIFF
--- a/tutorials/math/interpolation.rst
+++ b/tutorials/math/interpolation.rst
@@ -33,7 +33,7 @@ Vector interpolation
 Vector types (:ref:`Vector2 <class_Vector2>` and :ref:`Vector3 <class_Vector3>`) can also be interpolated, they come with handy functions to do it
 :ref:`Vector2.linear_interpolate() <class_Vector2_method_linear_interpolate>` and :ref:`Vector3.linear_interpolate() <class_Vector3_method_linear_interpolate>`.
 
-For cubic interpolation, there are also :ref:`Vector2.cubic_interpolate() <class_Vector2_method_linear_interpolate>` and :ref:`Vector3.cubic_interpolate() <class_Vector3_method_linear_interpolate>`, which do a :ref:`Bezier <doc_beziers_and_curves>` style interpolation.
+For cubic interpolation, there are also :ref:`Vector2.cubic_interpolate() <class_Vector2_method_cubic_interpolate>` and :ref:`Vector3.cubic_interpolate() <class_Vector3_method_cubic_interpolate>`, which do a :ref:`Bezier <doc_beziers_and_curves>` style interpolation.
 
 Here is example pseudo-code for going from point A to B using interpolation:
 


### PR DESCRIPTION
The references to `Vector2.cubic_interpolate()` and `Vector3.cubic_interpolate()` methods in the [interpolation tutorial](https://docs.godotengine.org/en/stable/tutorials/math/interpolation.html#vector-interpolation) incorrectly points to `Vector2.linear_interpolate()` and `Vector3.linear_interpolate()` despite having the correct label. This PR applies a minor patch to fix those references.