### PR TITLE
Use "Prefer local solutions" in best practices for engine contributors

### DIFF
--- a/community/contributing/best_practices_for_engine_contributors.rst
+++ b/community/contributing/best_practices_for_engine_contributors.rst
@@ -191,8 +191,8 @@ In real-life scenarios, these use cases will be at most rare and uncommon
 anyway, so it makes sense a custom solution needs to be written. This is why
 it's important to still provide users the basic building blocks to do it.
 
-#7: Solutions must be local
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#7: Prefer local solutions
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When looking for a solution to a problem, be it implementing a new feature or
 fixing a bug, sometimes the easiest path is to add data or a new function in the


### PR DESCRIPTION
Stating that "Solution must be local" is denying the fact that some problems cannot be solved locally. Therefore, documentation should at least provide a hint to first look at solutions which are closer to the problem first, and only go for solution that touch core if a problem cannot be solved locally, for instance.

See for example this suggestion: https://github.com/godotengine/godot/issues/52011#issuecomment-905541068.

See also some other rationale in my previous changes to best practices: #4071 (it's about how one conveys messages subconsciously).