### PR TITLE
Remove an incorrect distinction drawn with Objective-C

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_advanced.rst
+++ b/tutorials/scripting/gdscript/gdscript_advanced.rst
@@ -515,8 +515,8 @@ Yes, we should call it Hulk typing instead.
 
 It's possible that the object being hit doesn't have a smash() function.
 Some dynamically typed languages simply ignore a method call when it
-doesn't exist (like Objective C), but GDScript is stricter, so
-checking if the function exists is desirable:
+doesn't exist, but GDScript is stricter, so checking if the function
+exists is desirable:
 
 ::
 


### PR DESCRIPTION
Hello from mobile dev land :) This paragraph draws a distinction between GDScript and Objective-C, but it's not accurate. Readers with Objective-C familiarity are likely to be confused by it. I recommend just not mentioning Objective-C here.

---

An Objective-C method call **will not** be ignored when the object doesn't define the method. It will crash with a runtime exception.

The author may have been thinking of the way an Objective-C method call will be ignored when the object is `nil`. But that's not the case when the object is there and lacks the method. In that case, the runtime will call [`-doesNotRecognizeSelector:`](https://developer.apple.com/documentation/objectivec/nsobject/1418637-doesnotrecognizeselector?language=objc). The default behavior in the root class `NSObject` is to raise an exception (not the try/catch kind; a similar case is array bounds checks) and deliberately crash.