### PR TITLE
Updated description for PhysicalBone.

### DIFF
--- a/classes/class_physicalbone.rst
+++ b/classes/class_physicalbone.rst
@@ -12,6 +12,9 @@ PhysicalBone
 **Inherits:** :ref:`PhysicsBody<class_PhysicsBody>` **<** :ref:`CollisionObject<class_CollisionObject>` **<** :ref:`Spatial<class_Spatial>` **<** :ref:`Node<class_Node>` **<** :ref:`Object<class_Object>`
 
 
+Description
+----------
+Center of mass for PhysicalBone is located in the origin of PhysicalBone. When creating PhysicalBone, make sure to correctly place it in the center of mass.
 
 Properties
 ----------


### PR DESCRIPTION
I've finally figured out what causes most problems with wrong ragdoll behavior, and it's that center of mass is located in Physicalbone and you're free to change it. I've never seen anyone say that, haven't seen it anywhere in the docs and no one was able to help me. But here it is, solution was very simple in the end. 
If you create PhysicalBone and select a bone it is attached too, it automatically moves to the HEAD of a selected bone, making it look like it has to be there, and if you change it's position, it'll be oribiting the bone. Turns out that no, you are free to move it to change it's center of mass. And you HAVE to move it to the center of bone if you're making a ragdoll, otherwise your physbox would have center of mass out of collision shape's bounds and ragdoll would do weird things.

(However it creates a bug that if you partially ragdoll only 1 bone that has it's origin (PhysicalBone) offesetted from HEAD of the bone it is attached it, whole physical bone would offset itself to match it's origin to the head of a bone. That can't be intended, so I guess it would be fixed later.)

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
