### PR TITLE
Remove Q2 from 3.4 release date

### DIFF
--- a/about/release_policy.rst
+++ b/about/release_policy.rst
@@ -85,7 +85,7 @@ the latest 3.x stable branch by the time Godot 4.0 is released.
 +-------------+-------------------+--------------------------------------------------------------------------+
 | Godot 4.0   | ~2021 (see below) | |unstable| *Current focus of development (unstable).*                    |
 +-------------+-------------------+--------------------------------------------------------------------------+
-| Godot 3.4   | Q2 or Q3 2021     | |supported| *Beta.* Receives new features as well as bug fixes while     |
+| Godot 3.4   | Q3 2021           | |supported| *Beta.* Receives new features as well as bug fixes while     |
 |             |                   | under development.                                                       |
 +-------------+-------------------+--------------------------------------------------------------------------+
 | Godot 3.3   | April 2021        | |supported| Receives fixes for bugs, security and platform support       |

--- a/about/release_policy.rst
+++ b/about/release_policy.rst
@@ -85,7 +85,7 @@ the latest 3.x stable branch by the time Godot 4.0 is released.
 +-------------+-------------------+--------------------------------------------------------------------------+
 | Godot 4.0   | ~2021 (see below) | |unstable| *Current focus of development (unstable).*                    |
 +-------------+-------------------+--------------------------------------------------------------------------+
-| Godot 3.4   | Q3 2021           | |supported| *Beta.* Receives new features as well as bug fixes while     |
+| Godot 3.4   | Q3 or Q4 2021     | |supported| *Beta.* Receives new features as well as bug fixes while     |
 |             |                   | under development.                                                       |
 +-------------+-------------------+--------------------------------------------------------------------------+
 | Godot 3.3   | April 2021        | |supported| Receives fixes for bugs, security and platform support       |


### PR DESCRIPTION
Q2 ended more than two months ago, update it.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
