### PR TITLE
Complying with licenses: Explain what the FreeType <year> should be

### DIFF
--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -105,6 +105,9 @@ requires attribution, so the following text must be included together with the
 Godot license:
 
     Portions of this software are copyright © <year> The FreeType Project (www.freetype.org).  All rights reserved.
+    
+Note that <year> should correspond to the value from the FreeType version
+used in your build.
 
 ENet
 ^^^^


### PR DESCRIPTION
According to the FreeType License itself:

```
   """
    Portions of this software are copyright © <year> The FreeType
    Project (www.freetype.org).  All rights reserved.
   """

  Please replace <year> with the value from the FreeType version you
  actually use.

```
While this may be not much a problem, I think end users should know about this.