### PR TITLE
Change estimated release date for Godot 3.4 and Godot 4.0

### DIFF
--- a/about/release_policy.rst
+++ b/about/release_policy.rst
@@ -80,34 +80,34 @@ encountered by users of that branch who cannot port complex projects to the new
 major version. This is the case for the 2.1 branch, and will be the case for
 the latest 3.x stable branch by the time Godot 4.0 is released.
 
-+-------------+-------------------+--------------------------------------------------------------------------+
-| **Version** | **Release date**  | **Support level**                                                        |
-+-------------+-------------------+--------------------------------------------------------------------------+
-| Godot 4.0   | ~2021 (see below) | |unstable| *Current focus of development (unstable).*                    |
-+-------------+-------------------+--------------------------------------------------------------------------+
-| Godot 3.4   | Q3 or Q4 2021     | |supported| *Beta.* Receives new features as well as bug fixes while     |
-|             |                   | under development.                                                       |
-+-------------+-------------------+--------------------------------------------------------------------------+
-| Godot 3.3   | April 2021        | |supported| Receives fixes for bugs, security and platform support       |
-|             |                   | issues, as well as backwards-compatible usability enhancements.          |
-+-------------+-------------------+--------------------------------------------------------------------------+
-| Godot 3.2   | January 2020      | |eol| No longer supported as fully superseded by the compatible 3.3      |
-|             |                   | release (last update: 3.2.3).                                            |
-+-------------+-------------------+--------------------------------------------------------------------------+
-| Godot 3.1   | March 2019        | |partial| Only critical, security and platform support fixes             |
-|             |                   | (last update: 3.1.2).                                                    |
-+-------------+-------------------+--------------------------------------------------------------------------+
-| Godot 3.0   | January 2018      | |eol| No longer supported (last update: 3.0.6).                          |
-+-------------+-------------------+--------------------------------------------------------------------------+
-| Godot 2.1   | July 2016         | |partial| Only critical, security and platform support fixes             |
-|             |                   | (last update: 2.1.6).                                                    |
-+-------------+-------------------+--------------------------------------------------------------------------+
-| Godot 2.0   | February 2016     | |eol| No longer supported (last update: 2.0.4.1).                        |
-+-------------+-------------------+--------------------------------------------------------------------------+
-| Godot 1.1   | May 2015          | |eol| No longer supported.                                               |
-+-------------+-------------------+--------------------------------------------------------------------------+
-| Godot 1.0   | December 2014     | |eol| No longer supported.                                               |
-+-------------+-------------------+--------------------------------------------------------------------------+
++-------------+----------------------+--------------------------------------------------------------------------+
+| **Version** | **Release date**     | **Support level**                                                        |
++-------------+----------------------+--------------------------------------------------------------------------+
+| Godot 4.0   | ~2022 (see below)    | |unstable| *Current focus of development (unstable).*                    |
++-------------+----------------------+--------------------------------------------------------------------------+
+| Godot 3.4   | Q4 2021              | |supported| *Beta.* Receives new features as well as bug fixes while     |
+|             |                      | under development.                                                       |
++-------------+----------------------+--------------------------------------------------------------------------+
+| Godot 3.3   | April 2021           | |supported| Receives fixes for bugs, security and platform support       |
+|             |                      | issues, as well as backwards-compatible usability enhancements.          |
++-------------+----------------------+--------------------------------------------------------------------------+
+| Godot 3.2   | January 2020         | |eol| No longer supported as fully superseded by the compatible 3.3      |
+|             |                      | release (last update: 3.2.3).                                            |
++-------------+----------------------+--------------------------------------------------------------------------+
+| Godot 3.1   | March 2019           | |partial| Only critical, security and platform support fixes             |
+|             |                      | (last update: 3.1.2).                                                    |
++-------------+----------------------+--------------------------------------------------------------------------+
+| Godot 3.0   | January 2018         | |eol| No longer supported (last update: 3.0.6).                          |
++-------------+----------------------+--------------------------------------------------------------------------+
+| Godot 2.1   | July 2016            | |partial| Only critical, security and platform support fixes             |
+|             |                      | (last update: 2.1.6).                                                    |
++-------------+----------------------+--------------------------------------------------------------------------+
+| Godot 2.0   | February 2016        | |eol| No longer supported (last update: 2.0.4.1).                        |
++-------------+----------------------+--------------------------------------------------------------------------+
+| Godot 1.1   | May 2015             | |eol| No longer supported.                                               |
++-------------+----------------------+--------------------------------------------------------------------------+
+| Godot 1.0   | December 2014        | |eol| No longer supported.                                               |
++-------------+----------------------+--------------------------------------------------------------------------+
 
 .. |supported| image:: img/supported.png
 .. |partial| image:: img/partial.png
@@ -139,6 +139,6 @@ Maintenance (patch) releases will be released as needed with potentially very
 short development cycles, to provide users of the current stable branch with
 the latest bug fixes for their production needs.
 
-As for the upcoming Godot 4.0, we can only say that we aim for a **2021**
+As for the upcoming Godot 4.0, we can only say that we aim for a **2022**
 release, but any closer estimate is likely to be hard to uphold. Alpha builds
 will be published as soon as the main features for Godot 4.0 are finalized.


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot-docs/pull/5058 and https://github.com/godotengine/godot-docs/pull/5233.

Godot 3.4 will most likely be released in October 2021 since it didn't reach RC stage yet (it's at beta 4 right now).

Godot 4.0 hasn't had an alpha released yet, so it's fair to say that it won't release in 2021 by now. The first half of 2022 is a more likely estimate.