### PR TITLE
Document a workaround for testing scripts without `test()`

### DIFF
--- a/development/cpp/unit_testing.rst
+++ b/development/cpp/unit_testing.rst
@@ -347,3 +347,10 @@ If no errors are printed and everything goes well, you're done!
     recommend writing new tests for already resolved
     `issues related to GDScript at GitHub <https://github.com/godotengine/godot/issues?q=is%3Aissue+label%3Atopic%3Agdscript+is%3Aclosed>`_,
     or writing tests for currently working features.
+
+.. note::
+
+    If your test case requires that there is no ``test()``
+    function present inside the script file,
+    you can disable the runtime section of the test by naming the script file so that it matches the pattern ``*.noscript.gd``.
+    For example, "test_empty_file.notest.gd".


### PR DESCRIPTION
This is a rather obscure feature that's unlikely to ever by used by anything other than the PR that implements it https://github.com/godotengine/godot/pull/52068.

Nevertheless, I think it's worth documenting.