### PR TITLE
use only right-click to remove tile from gridmap

### DIFF
--- a/tutorials/3d/using_gridmaps.rst
+++ b/tutorials/3d/using_gridmaps.rst
@@ -85,8 +85,9 @@ The "Cell/Size" property should be set to the size of your meshes. You can leave
 it at the default value for the demo. Set the "Center Y" property to "Off".
 
 Now you can start designing the level by choosing a tile from the palette and
-placing it with Left-Click in the editor window. To remove a tile, hold :kbd:`Shift`
-and use Right-click.
+placing it with Left-Click in the editor window. Use Right-click to remove a tile.
+
+Use the arrows next to the "GridMap" menu to change the floor that you are working on.
 
 Click on the "GridMap" menu to see options and shortcuts. For example, pressing
 :kbd:`S` rotates a tile around the y-axis.


### PR DESCRIPTION
The docs suggest to use shift + RMB. Which works too, but only RMB also works. This might confuse as later in the documentation shift + LMB is used for bulk selection.

Edit: This PR also adds a line to explain how to change floors when using gridmap.
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
