### PR TITLE
Update BBCode in RichTextLabel `[color]` for RGBA color change

### DIFF
--- a/tutorials/ui/bbcode_in_richtextlabel.rst
+++ b/tutorials/ui/bbcode_in_richtextlabel.rst
@@ -171,9 +171,11 @@ Hexadecimal color codes
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 For opaque RGB colors, any valid 6-digit hexadecimal code is supported, e.g. ``[color=#ffffff]white[/color]``.
+Short RGB color codes such as ``#6f2`` (equivalent to ``#66ff22``) are also supported.
 
-For transparent RGB colors, any 8-digit hexadecimal code can be used, e.g. ``[color=#88ffffff]translucent white[/color]``.
-In this case, note that the alpha channel is the **first** component of the color code, not the last one.
+For transparent RGB colors, any RGBA 8-digit hexadecimal code can be used, e.g. ``[color=#ffffff88]translucent white[/color]``.
+In this case, note that the alpha channel is the **last** component of the color code, not the first one.
+Short RGBA color codes such as ``#6f28`` (equivalent to ``#66ff2288``) are also supported.
 
 Image vertical offset
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot-docs/pull/5248.

Color codes are now RGBA instead of ARGB in Godot 4.0.

This also mentions support for short RGB and RGBA color codes.

Unlike https://github.com/godotengine/godot-docs/pull/5246, this PR shouldn't be cherry-picked to stable branches.