### PR TITLE
GDScript: Remove reference to `@export_exp_range`

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -374,8 +374,6 @@ Here's the list of available annotations:
 |                              |                                                                                                   |
 | ``@export_range``            |                                                                                                   |
 |                              |                                                                                                   |
-| ``@export_exp_range``        |                                                                                                   |
-|                              |                                                                                                   |
 | ``@export_exp_easing``       |                                                                                                   |
 |                              |                                                                                                   |
 | ``@export_color_no_alpha``   |                                                                                                   |

--- a/tutorials/scripting/gdscript/gdscript_exports.rst
+++ b/tutorials/scripting/gdscript/gdscript_exports.rst
@@ -155,13 +155,7 @@ The limits can be only for the slider if you add the hints "or_greater" and/or "
 
     @export_range(0, 100, 1, "or_greater", "or_lesser")
 
-Allow values 'y = exp(x)' where 'y' varies between 100 and 1000
-while snapping to steps of 20. The editor will present a
-slider for easily editing the value.
-
-::
-
-    @export_exp_range(100, 1000, 20) var l
+.. TODO: Document other hint strings usable with export_range.
 
 Floats with easing hint
 -----------------------


### PR DESCRIPTION
Cf. https://github.com/godotengine/godot/pull/52800.