### PR TITLE
[3.x] Add example of error handling with load_resource_pack

### DIFF
--- a/getting_started/workflow/export/exporting_pcks.rst
+++ b/getting_started/workflow/export/exporting_pcks.rst
@@ -89,27 +89,33 @@ process will build that type of file for the chosen platform.
 Opening PCK files at runtime
 ----------------------------
 
-To import a PCK file, one uses a one-liner. Keep in mind, there is no
-error or exception if the import fails. Instead, one might have to create some
-validation code as a layer on top. The following example expects a “mod.pck”
-file in the directory of the games executable. The PCK file contains a
-“mod_scene.tscn” test scene in its root.
+To import a PCK file, one uses the ProjectSettings singleton. The following
+example expects a “mod.pck” file in the directory of the games executable.
+The PCK file contains a “mod_scene.tscn” test scene in its root.
 
 .. tabs::
  .. code-tab:: gdscript GDScript
 
     func _your_function():
-        ProjectSettings.load_resource_pack("res://mod.pck")
-        # Now one can use the assets as if they had them in the project from the start
-        var imported_scene = load("res://mod_scene.tscn")
+        # This could fail if, for example, mod.pck cannot be found
+        var success = ProjectSettings.load_resource_pack("res://mod.pck")
+
+        if success:
+            # Now one can use the assets as if they had them in the project from the start
+            var imported_scene = load("res://mod_scene.tscn")
 
  .. code-tab:: csharp
 
     private void YourFunction()
     {
-        ProjectSettings.LoadResourcePack("res://mod.pck");
-        // Now one can use the assets as if they had them in the project from the start
-        var importedScene = (PackedScene)ResourceLoader.Load("res://mod_scene.tscn");
+        # This could fail if, for example, mod.pck cannot be found
+        var success = ProjectSettings.LoadResourcePack("res://mod.pck");
+
+        if (success)
+        {
+            // Now one can use the assets as if they had them in the project from the start
+            var importedScene = (PackedScene)ResourceLoader.Load("res://mod_scene.tscn");
+        }
     }
 
 .. warning::


### PR DESCRIPTION
The current stable documentation says that ProjectSettings.load_resource_pack() does not provide any error or exception if the import fails, yet the same stable documentation for the function [found here](https://docs.godotengine.org/en/stable/classes/class_projectsettings.html#class-projectsettings-method-load-resource-pack) says that the function returns true on success. I updated the example to reflect this.

Same change as #5274 but now with commits made against correct branch. 
Additionally, the entire "Workflow" category of pages doesn't appear in the latest documentation, thus this change is only relevant for 3.x.