### PR TITLE
Fix error in Vector2.reflect() description

### DIFF
--- a/classes/class_vector2.rst
+++ b/classes/class_vector2.rst
@@ -394,7 +394,7 @@ Returns the vector projected onto the vector ``b``.
 
 - :ref:`Vector2<class_Vector2>` **reflect** **(** :ref:`Vector2<class_Vector2>` n **)**
 
-Returns the vector reflected from a plane defined by the given normal.
+Returns the vector reflected (ie mirrored, or symmetric) over a line defined by the given direction vector ``n``.
 
 ----
 


### PR DESCRIPTION
(This is a small fix)

The description was probably copied from Vector3.reflect(), and
unfortunately did not match the 2D behaviour (where n is apparently the
direction vector of the symmetry line, not the normal).