### PR TITLE
Slight clarify in optimization tutorial

### DIFF
--- a/tutorials/performance/cpu_optimization.rst
+++ b/tutorials/performance/cpu_optimization.rst
@@ -225,8 +225,11 @@ SceneTree
 
 Although Nodes are an incredibly powerful and versatile concept, be aware that
 every node has a cost. Built-in functions such as `_process()` and
-`_physics_process()` propagate through the tree. This housekeeping does start to reduce
-performance when you have very large numbers of nodes (depending on platform, but about 10% of frame time per ten thousand nodes on a desktop CPU).
+`_physics_process()` propagate through the tree. This housekeeping can reduce 
+performance when you have a very large numbers of nodes (how many exactly 
+depends on the target platform and can range from thousands to tens of 
+thousands so ensure that you profile performance on all target platforms 
+during development).
 
 Each node is handled individually in the Godot renderer. Therefore, a smaller
 number of nodes with more in each can lead to better performance.

--- a/tutorials/performance/cpu_optimization.rst
+++ b/tutorials/performance/cpu_optimization.rst
@@ -225,8 +225,8 @@ SceneTree
 
 Although Nodes are an incredibly powerful and versatile concept, be aware that
 every node has a cost. Built-in functions such as `_process()` and
-`_physics_process()` propagate through the tree. This housekeeping can reduce
-performance when you have very large numbers of nodes (usually in the thousands).
+`_physics_process()` propagate through the tree. This housekeeping does start to reduce
+performance when you have very large numbers of nodes (depending on platform, but about 10% of frame time per ten thousand nodes on a desktop CPU).
 
 Each node is handled individually in the Godot renderer. Therefore, a smaller
 number of nodes with more in each can lead to better performance.


### PR DESCRIPTION
I just tested colliding two rigid bodies each having 5000 Collision shapes and 5000 mesh instances with cube meshes , resulting in a total of 20 000 nodes in the tree. Godot does not seem to care the slightest... It takes a solid 10 seconds to spawn everything, but from there I have a solid 83% idle time according to the profiler (running a 4GHz desktop CPU that is).

Therefore this update should give a bit more guidance on when the scene tree may be a bottleneck. 
