### PR TITLE
Fix grammar issue in "Ways to contribute" page

### DIFF
--- a/community/contributing/ways_to_contribute.rst
+++ b/community/contributing/ways_to_contribute.rst
@@ -180,7 +180,7 @@ always provide:
    project that reproduces this issue out of the box, zip it and attach it to
    the issue (you can do this by drag and drop).
    Even if you think that the issue is trivial to reproduce, adding a minimal
-   project that lets reproduce it is a big added value. You have to keep in
+   project that lets everyone reproduce it is a big added value. You have to keep in
    mind that there are thousands of issues in the tracker, and developers can
    only dedicate little time to each issue.
 


### PR DESCRIPTION
In the section "Filing an issue on GitHub", the subsection "How to reproduce the bug" says "Even if you think that the issue is trivial to reproduce, adding a minimal project that lets reproduce it is a big added value." which is missing a word. Changing it to "...lets everyone reproduce it..." fixes the grammatical error.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
