### PR TITLE
Fix `emit_signal` arity in Signals tutorial

### DIFF
--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -245,7 +245,7 @@ argument names between parentheses:
     emit any number of arguments when you emit signals. So it's up to you to
     emit the correct values.
 
-To pass values, add them as the second argument to the ``emit_signal`` function:
+To pass values, add them as subsequent arguments to the ``emit_signal`` function:
 
 .. tabs::
  .. code-tab:: gdscript GDScript


### PR DESCRIPTION
Example shows three arguments, but text suggested there were only two.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
