### PR TITLE
Added missing dot in 2d_lights_and_shadows.rst

### DIFF
--- a/tutorials/2d/2d_lights_and_shadows.rst
+++ b/tutorials/2d/2d_lights_and_shadows.rst
@@ -162,7 +162,7 @@ for a polygon and some other information. For this demo, since our wall is a squ
 set ``Polygon`` to a square. The other default settings are fine.
 
 The first setting, ``Closed`` can be either ``on`` or ``off``. A closed polygon occludes light
-coming from all directions. An open polygon only occludes light from one direction
+coming from all directions. An open polygon only occludes light from one direction.
 
 ``Cull Mode`` lets you select which direction gets culled. The default is ``Disabled``, meaning the occluder
 will cast a shadow no matter which side the light is on. The other two settings ``Clockwise`` and


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->

Adds the missing dot in `2d_lights_and_shadows.rst`, on line 165. 

I know it's a very small change, but I've been going over the 2D lighting documentation and it really bothered me! 🙂 
