### PR TITLE
Fix variable casing for class `load()` in GDScript basics

### DIFF
--- a/getting_started/scripting/gdscript/gdscript_basics.rst
+++ b/getting_started/scripting/gdscript/gdscript_basics.rst
@@ -1233,7 +1233,7 @@ either the ``load`` or ``preload`` functions (see below). Instancing of a loaded
 class resource is done by calling the ``new`` function on the class object::
 
     # Load the class resource when calling load().
-    var my_class = load("myclass.gd")
+    var MyClass = load("myclass.gd")
 
     # Preload the class only once at compile time.
     const MyClass = preload("myclass.gd")


### PR DESCRIPTION
*Bugsquad edit: This closes #5308.*