### PR TITLE
Update Compiling for Android JDK version specification

### DIFF
--- a/development/compiling/compiling_for_android.rst
+++ b/development/compiling/compiling_for_android.rst
@@ -31,9 +31,8 @@ For compiling under Windows, Linux or macOS, the following is required:
       **do not use an Android SDK provided by your distribution's repositories as it will often be outdated**.
 
 -  Gradle (will be downloaded and installed automatically if missing).
--  JDK 8 (either OpenJDK or Oracle JDK).
+-  JDK 11 (either OpenJDK or Oracle JDK).
 
-   -  JDK 9 or later are not currently supported.
    -  You can download a build from `ojdkbuild <https://github.com/ojdkbuild/ojdkbuild>`_.
 
 .. seealso:: For a general overview of SCons usage for Godot, see


### PR DESCRIPTION
Currently, the Compiling for Android documentation specifies JDK version 8; stating that JDK version 9 or later are not supported. However, this was based on Gradle version 2, which, indeed, did not support JDK version 9 or later. The current version of Gradle used is 6.7.1, which supports JDK 15[[1](https://docs.gradle.org/current/userguide/compatibility.html)].

JDK 11 is required to upgrade the Android Gradle plug-in to Gradle 7.0. The current OpenJDK and (previous) Oracle LTS JDK version is 11. Therefore, this PR updates the documentation to specify using JDK version 11.

BTW: Oracle has recently (September 2021) released a new LTS: JDK 17[[2](https://en.wikipedia.org/wiki/Java_version_history#Java_17)]) but both OpenJDK and Gradle need to catchup before we can specify this.

[1] https://docs.gradle.org/current/userguide/compatibility.html
[2] https://en.wikipedia.org/wiki/Java_version_history#Java_17