### PR TITLE
Add Format String to operator/precedence list

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -240,7 +240,9 @@ The following is the list of supported operators and their precedence.
 |                                                                        | as C++. Integer division is truncated   |
 |                                                                        | rather than returning a fractional      |
 |                                                                        | number, and the % operator is only      |
-|                                                                        | available for ints ("fmod" for floats)  |
+|                                                                        | available for ints ("fmod" for floats), |
+|                                                                        | and is additionally used for Format     |
+|                                                                        | Strings                                 |
 +------------------------------------------------------------------------+-----------------------------------------+
 | ``+``                                                                  | Addition / Concatenation of arrays      |
 +------------------------------------------------------------------------+-----------------------------------------+


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
resolves https://github.com/godotengine/godot-docs/issues/5193
I verified that it is between `-` (Unary negation) and `*` `/` `%`.

`print(-"Hello %s" % "eee")` causes an error in the editor: `Invalid operands to operator %, Nil and String` meaning that the `-` applied to the string before the format string was evaluated.

`print("Hello %d" % 1 / 2)` also gives an in-editor error: `Invalid operands to operator /, String and int` meaning that the format string was evaluated before dividing.