### PR TITLE
Update Exporting for Android JDK version specification

### DIFF
--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -36,10 +36,10 @@ Download and install the Android SDK.
     If you are using Linux,
     **do not use an Android SDK provided by your distribution's repositories as it will often be outdated**.
 
-Install OpenJDK 8
------------------
+Install OpenJDK 11
+------------------
 
-Download and install  `OpenJDK 8 <https://adoptopenjdk.net/index.html?variant=openjdk8&jvmVariant=hotspot>`__.
+Download and install  `OpenJDK 11 <https://adoptium.net/?variant=openjdk11>`__.
 
 Create a debug.keystore
 -----------------------


### PR DESCRIPTION
As identified by @skyace65 [here](https://github.com/godotengine/godot-docs/pull/5312#issuecomment-939363327), the exporting to android documentation also needs to be updated following #5312.

Includes updating the link address, because AdoptOpenJDK has moved[[1](https://blog.adoptopenjdk.net/2021/03/transition-to-eclipse-an-update/)].

[1] https://blog.adoptopenjdk.net/2021/03/transition-to-eclipse-an-update/