### PR TITLE
Revert "Add more porting providers to Console support in Godot"

### DIFF
--- a/tutorials/platform/consoles.rst
+++ b/tutorials/platform/consoles.rst
@@ -62,16 +62,11 @@ your games to various consoles.
 
 Following is the list of providers:
 
-- `Deck13 Interactive <https://www.deck13.com/>`_ offers Switch porting
-  and publishing of Godot games.
 - `Lone Wolf Technology <http://www.lonewolftechnology.com/>`_ offers
-  Switch and PlayStation 4 porting and publishing of Godot games.
+  Switch and PS4 porting and publishing of Godot games.
 - `Pineapple Works <https://pineapple.works/>`_ offers
   Switch and Xbox One porting and publishing of Godot games.
-- `Ratalaika Games <https://www.ratalaikagames.com/>`_ offers
-  Switch, Xbox One, Xbox Series, PlayStation 4, and PlayStation 5 porting
-  and publishing of Godot games.
-  
+
 If your company offers porting and/or publishing services for Godot games,
 feel free to
 `open an issue or pull request <https://github.com/godotengine/godot-docs>`_


### PR DESCRIPTION
Reverts godotengine/godot-docs#5267

These were assumptions, it's not confirmed.

Ratalaika seems to be *working* on a Godot port for *Switch*, no further information is available at this time to confirm that they are actually able to port Godot games currently.

Deck13 is a publisher and there's no compelling information that they do console porting. (Publishing a Godot game on console doesn't mean they did the port.)