### PR TITLE
Compiling: Drop yasm dependency and references to WebM

### DIFF
--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -24,7 +24,6 @@ required:
 -  ALSA development libraries.
 -  PulseAudio development libraries.
 -  *Optional* - libudev (build with ``udev=yes``).
--  *Optional* - yasm (for WebM SIMD optimizations).
 
 .. seealso:: For a general overview of SCons usage for Godot, see
              :ref:`doc_introduction_to_the_buildsystem`.
@@ -40,55 +39,55 @@ Distro-specific one-liners
 | **Arch Linux**   | ::                                                                                                        |
 |                  |                                                                                                           |
 |                  |     pacman -S --needed scons pkgconf gcc libxcursor libxinerama libxi libxrandr mesa glu libglvnd \       |
-|                  |         alsa-lib pulseaudio yasm                                                                          |
+|                  |         alsa-lib pulseaudio                                                                               |
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **Debian** /     | ::                                                                                                        |
 | **Ubuntu**       |                                                                                                           |
 |                  |     sudo apt-get install build-essential scons pkg-config libx11-dev libxcursor-dev libxinerama-dev \     |
-|                  |         libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm   |
+|                  |         libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev        |
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **Fedora**       | ::                                                                                                        |
 |                  |                                                                                                           |
 |                  |     sudo dnf install scons pkgconfig libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel \    |
 |                  |         libXi-devel mesa-libGL-devel mesa-libGLU-devel alsa-lib-devel pulseaudio-libs-devel \             |
-|                  |         libudev-devel yasm gcc-c++ libstdc++-static                                                       |
+|                  |         libudev-devel gcc-c++ libstdc++-static                                                            |
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **FreeBSD**      | ::                                                                                                        |
 |                  |                                                                                                           |
 |                  |     sudo pkg install py37-scons pkgconf xorg-libraries libXcursor libXrandr libXi xorgproto libGLU \      |
-|                  |         alsa-lib pulseaudio yasm                                                                          |
+|                  |         alsa-lib pulseaudio                                                                               |
 |                  |                                                                                                           |
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **Gentoo**       | ::                                                                                                        |
 |                  |                                                                                                           |
 |                  |     emerge -an dev-util/scons x11-libs/libX11 x11-libs/libXcursor x11-libs/libXinerama x11-libs/libXi \   |
-|                  |         media-libs/mesa media-libs/glu media-libs/alsa-lib media-sound/pulseaudio dev-lang/yasm           |
+|                  |         media-libs/mesa media-libs/glu media-libs/alsa-lib media-sound/pulseaudio                         |
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **Mageia**       | ::                                                                                                        |
 |                  |                                                                                                           |
 |                  |     urpmi scons task-c++-devel pkgconfig "pkgconfig(alsa)" "pkgconfig(glu)" "pkgconfig(libpulse)" \       |
 |                  |         "pkgconfig(udev)" "pkgconfig(x11)" "pkgconfig(xcursor)" "pkgconfig(xinerama)" "pkgconfig(xi)" \   |
-|                  |         "pkgconfig(xrandr)" yasm                                                                          |
+|                  |         "pkgconfig(xrandr)"                                                                               |
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **OpenBSD**      | ::                                                                                                        |
 |                  |                                                                                                           |
-|                  |     pkg_add python scons llvm yasm                                                                        |
+|                  |     pkg_add python scons llvm                                                                             |
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **openSUSE**     | ::                                                                                                        |
 |                  |                                                                                                           |
 |                  |     sudo zypper install scons pkgconfig libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel \ |
-|                  |             libXi-devel Mesa-libGL-devel alsa-devel libpulse-devel libudev-devel libGLU1 yasm             |
+|                  |             libXi-devel Mesa-libGL-devel alsa-devel libpulse-devel libudev-devel libGLU1                  |
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **NetBSD**       | ::                                                                                                        |
 |                  |                                                                                                           |
-|                  |     pkg_add pkg-config py37-scons yasm                                                                    |
+|                  |     pkg_add pkg-config py37-scons                                                                         |
 |                  |                                                                                                           |
 |                  | For audio support, you can optionally install ``pulseaudio``.                                             |
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **Solus**        | ::                                                                                                        |
 |                  |                                                                                                           |
 |                  |     sudo eopkg install -c system.devel scons libxcursor-devel libxinerama-devel libxi-devel \             |
-|                  |         libxrandr-devel mesalib-devel libglu alsa-lib-devel pulseaudio-devel yasm                         |
+|                  |         libxrandr-devel mesalib-devel libglu alsa-lib-devel pulseaudio-devel                              |
 +------------------+-----------------------------------------------------------------------------------------------------------+
 
 Compiling

--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -14,7 +14,6 @@ For compiling under macOS, the following is required:
 - `SCons 3.0+ <https://www.scons.org>`_ build system.
 - `Xcode <https://apps.apple.com/us/app/xcode/id497799835>`_
   (or the more lightweight Command Line Tools for Xcode).
-- *Optional* - `yasm <https://yasm.tortall.net/>`_ (for WebM SIMD optimizations).
 
 .. important::
 
@@ -22,18 +21,18 @@ For compiling under macOS, the following is required:
     `Vulkan SDK for macOS <https://vulkan.lunarg.com/sdk/home>`__.
 
 .. note:: If you have `Homebrew <https://brew.sh/>`_ installed, you can easily
-          install SCons and yasm using the following command::
+          install SCons using the following command::
 
-              brew install scons yasm
+              brew install scons
 
           Installing Homebrew will also fetch the Command Line Tools
           for Xcode automatically if you don't have them already.
 
           Similarly, if you have `MacPorts <https://www.macports.org/>`_
-          installed, you can easily install SCons and yasm using the
+          installed, you can easily install SCons using the
           following command::
 
-              sudo port install scons yasm
+              sudo port install scons
 
 .. seealso:: For a general overview of SCons usage for Godot, see
              :ref:`doc_introduction_to_the_buildsystem`.

--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -22,20 +22,17 @@ For compiling under Windows, the following is required:
 - `Python 3.5+ <https://www.python.org/downloads/windows/>`_.
 - `SCons 3.0 <https://www.scons.org/>`_ build system. If using Visual Studio 2019,
   you need at least SCons 3.1.1.
-- *Optional* - `yasm <https://yasm.tortall.net/>`_ (for WebM SIMD optimizations)
 
 .. note:: If you have `Scoop <https://scoop.sh/>`_ installed, you can easily
           install MinGW and other dependencies using the following command::
 
-              scoop install gcc python scons yasm make
+              scoop install gcc python scons make
 
 .. note:: If you have `MSYS2 <https://www.msys2.org/>`_ installed, you can easily
           install MinGW and other dependencies using the following command::
 
-              pacman -S mingw-w64-x86_64-python3-pip \
-                  mingw-w64-x86_64-gcc mingw-w64-x86_64-yasm \
-                  mingw-w64-i686-python3-pip mingw-w64-i686-gcc \
-                  mingw-w64-i686-yasm make
+              pacman -S mingw-w64-x86_64-python3-pip mingw-w64-x86_64-gcc  \
+                  mingw-w64-i686-python3-pip mingw-w64-i686-gcc make
 
           For each MSYS2 MinGW subsystem, you should then run
           `pip3 install scons` in its shell.

--- a/development/compiling/optimizing_for_size.rst
+++ b/development/compiling/optimizing_for_size.rst
@@ -63,11 +63,11 @@ a lot of them:
 
 ::
 
-    scons p=windows target=release tools=no module_arkit_enabled=no module_assimp_enabled=no module_bmp_enabled=no module_bullet_enabled=no module_camera_enabled=no module_csg_enabled=no module_dds_enabled=no module_enet_enabled=no module_etc_enabled=no module_gdnative_enabled=no module_gridmap_enabled=no module_hdr_enabled=no module_jsonrpc_enabled=no module_mbedtls_enabled=no module_mobile_vr_enabled=no module_opensimplex_enabled=no module_opus_enabled=no module_pvr_enabled=no module_recast_enabled=no module_regex_enabled=no module_squish_enabled=no module_svg_enabled=no module_tga_enabled=no module_theora_enabled=no module_tinyexr_enabled=no module_upnp_enabled=no module_vhacd_enabled=no module_vorbis_enabled=no module_webm_enabled=no module_webrtc_enabled=no module_websocket_enabled=no module_xatlas_unwrap_enabled=no
+    scons p=windows target=release tools=no module_arkit_enabled=no module_assimp_enabled=no module_bmp_enabled=no module_bullet_enabled=no module_camera_enabled=no module_csg_enabled=no module_dds_enabled=no module_enet_enabled=no module_etc_enabled=no module_gdnative_enabled=no module_gridmap_enabled=no module_hdr_enabled=no module_jsonrpc_enabled=no module_mbedtls_enabled=no module_mobile_vr_enabled=no module_opensimplex_enabled=no module_pvr_enabled=no module_recast_enabled=no module_regex_enabled=no module_squish_enabled=no module_svg_enabled=no module_tga_enabled=no module_theora_enabled=no module_tinyexr_enabled=no module_upnp_enabled=no module_vhacd_enabled=no module_vorbis_enabled=no module_webrtc_enabled=no module_websocket_enabled=no module_xatlas_unwrap_enabled=no
 
 If this proves not to work for your use case, you should review the list of
 modules and see which ones you actually still need for your game (e.g. you
-might want to keep networking-related modules, regex support, or theora/webm
+might want to keep networking-related modules, regex support, or theora
 to play videos).
 
 Alternatively, you can supply a list of disabled modules by creating
@@ -94,7 +94,6 @@ following:
     module_mbedtls_enabled = "no"
     module_mobile_vr_enabled = "no"
     module_opensimplex_enabled = "no"
-    module_opus_enabled = "no"
     module_pvr_enabled = "no"
     module_recast_enabled = "no"
     module_regex_enabled = "no"
@@ -106,7 +105,6 @@ following:
     module_upnp_enabled = "no"
     module_vhacd_enabled = "no"
     module_vorbis_enabled = "no"
-    module_webm_enabled = "no"
     module_webrtc_enabled = "no"
     module_websocket_enabled = "no"
     module_xatlas_unwrap_enabled = "no"


### PR DESCRIPTION
WebM support is dropped from the core engine with
https://github.com/godotengine/godot/pull/53833

The list of modules in Optimizing for size could be improved further as it still refers to various obsolete modules (e.g. `arkit` or `assimp`, both are not included since 3.3).