### PR TITLE
Fix "shinning" typo in Shading language

### DIFF
--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -629,7 +629,7 @@ It's also possible to send data from *fragment* to *light* processors using *var
     varying vec3 some_light;
 
     void fragment() {
-        some_light = ALBEDO * 100.0; // Make a shinning light.
+        some_light = ALBEDO * 100.0; // Make a shining light.
     }
 
     void light() {


### PR DESCRIPTION
See https://github.com/godotengine/godot-docs/pull/5116#issuecomment-944278440.

This doesn't need to cherry-picked to `3.4` as I already fixed it there.