### PR TITLE
Rename var "character_dir" to "character_dict" in GDScript style guide

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -165,7 +165,7 @@ indentation level to distinguish continuation lines:
         "Steve",
     ]
 
-    var character_dir = {
+    var character_dict = {
         "Name": "Bob",
         "Age": 27,
         "Job": "Mechanic",
@@ -190,7 +190,7 @@ indentation level to distinguish continuation lines:
             "Steve",
     ]
 
-    var character_dir = {
+    var character_dict = {
             "Name": "Bob",
             "Age": 27,
             "Job": "Mechanic",


### PR DESCRIPTION
As this variable is a Dictionary, this seems more logical.
May have been related to #5269 
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
