### PR TITLE
Show example of casting get_node() for static typing in style guide

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -889,6 +889,18 @@ should set the type explicitly.
 
    onready var health_bar: ProgressBar = get_node("UI/LifeBar")
 
+Alternatively, you can use the ``as`` keyword to cast the return type, and
+that type will be used to infer the type of the var.
+
+.. rst-class:: code-example-good
+
+::
+
+   onready var health_bar := get_node("UI/LifeBar") as ProgressBar
+   # health_bar will be typed as ProgressBar
+
+This option is also considered more :ref:`type-safe<doc_gdscript_static_typing_safe_lines>` than the first.
+
 **Bad**:
 
 .. rst-class:: code-example-bad

--- a/tutorials/scripting/gdscript/static_typing.rst
+++ b/tutorials/scripting/gdscript/static_typing.rst
@@ -178,6 +178,8 @@ get full autocompletion on the player variable thanks to that cast.
 
     If you try to cast with a built-in type and it fails, Godot will throw an error.
 
+.. _doc_gdscript_static_typing_safe_lines:
+
 Safe lines
 ^^^^^^^^^^
 


### PR DESCRIPTION
~~Before possibly merging:
the part that mentions being `type-safe` should ideally link to the bit on Safe Lines in the docs page on static typing, but I couldn't figure out how to do that.~~

Since the style guide hasn't been updated to use annotations (`@onready` instead of `onready`) yet, this new section can be added to stable docs as-is (though probably not through simple cherry-pick, due to the restructuring).
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
