### PR TITLE
Clarify the meaning of the `height` property of lights.

### DIFF
--- a/classes/class_directionallight2d.rst
+++ b/classes/class_directionallight2d.rst
@@ -37,7 +37,7 @@ Property Descriptions
 | *Getter*  | get_height()      |
 +-----------+-------------------+
 
-The height of the light. Used with 2D normal mapping.
+The height of the light. Used with 2D normal mapping. Ranges from 0 (level with the plane) to 1 (perpendicular to the plane).
 
 ----
 

--- a/classes/class_pointlight2d.rst
+++ b/classes/class_pointlight2d.rst
@@ -41,7 +41,7 @@ Property Descriptions
 | *Getter*  | get_height()      |
 +-----------+-------------------+
 
-The height of the light. Used with 2D normal mapping.
+The height of the light. Used with 2D normal mapping. The units are in pixels, e.g. if the height is 100, then it will illuminate an object 100 pixels away at a 45° angle.
 
 ----
 


### PR DESCRIPTION
It's easy to assume they are the same, but they are quite different for the two types of 2D lights. For myself, it took a bit of confusion and experimentation for me to figure out why this behaviour changed when I changed from point to directional. Hopefully it can save somebody else the trouble.
