### PR TITLE
Remove warning about PCK files larger than 2GB (Master)

### DIFF
--- a/tutorials/export/exporting_projects.rst
+++ b/tutorials/export/exporting_projects.rst
@@ -34,13 +34,6 @@ tools like the editor and debugger.
 Finally, Godot has a simple but efficient system for
 :ref:`creating DLCs as extra package files <doc_exporting_pcks>`.
 
-.. warning::
-
-    Godot does not support loading PCK files larger than 2 GB yet. If your
-    exported project data is larger than 2 GB, you will need to split it into
-    several PCK files by :ref:`exporting additional PCKs <doc_exporting_pcks>`
-    and loading them at run-time.
-
 On mobile
 ~~~~~~~~~
 


### PR DESCRIPTION
Removes the warning about Godot not supporting PCK files larger than 2GB. This was fixed for the master branch by akien with [this PR](https://github.com/godotengine/godot/pull/48768).