### PR TITLE
Add recommendations for 3D light shadow bias

### DIFF
--- a/tutorials/3d/lights_and_shadows.rst
+++ b/tutorials/3d/lights_and_shadows.rst
@@ -75,7 +75,7 @@ although that may lead to decreased performance.
       The main downside is that it may cause lighting to leak in some corners.
       The other downside is that materials that have their cull mode set to
       **Disabled** or MeshInstances with Cast Shadow set to **Double-Sided**
-      will exhibit shadow acne.
+      may exhibit shadow acne.
     - Set **Bias** to ``-0.01``. The bias should be a negative value when
       **Reverse Cull Face** is enabled, but it should be a positive value when it's disabled.
     - For DirectionalLight, set the directional shadow **Normal Bias** to ``0.0``


### PR DESCRIPTION
These are the settings I usually recommend based on my personal experience.

Contact shadows should generally be avoided as per https://github.com/godotengine/godot/pull/35316.

These tips also apply to 3.3, but not 4.0 as shadow mapping code was rewritten there.

## Preview

### Before

| DirectionalLight | Point lights |
|-|-|
| ![image](https://user-images.githubusercontent.com/180032/138599996-957ce914-4d7e-494d-8eeb-218ec2503ab7.png) | ![image](https://user-images.githubusercontent.com/180032/138600141-324cc2b8-47a5-4ba2-a008-d9c86b51a308.png) |

### After

| DirectionalLight | Point lights |
|-|-|
| ![image](https://user-images.githubusercontent.com/180032/138600008-b7264b55-0493-47b2-9a40-9407ed7b585f.png) | ![image](https://user-images.githubusercontent.com/180032/138600148-1a5da47d-aa3b-4536-8250-99ea891e7f1d.png) |