### PR TITLE
Fix instructions for installing SCons on Windows

### DIFF
--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -52,7 +52,13 @@ Setting up SCons
 
 To install SCons open the command prompt and run the following command.
 
-``python -m pip3 install scons``
+``python -m pip install scons``
+
+In case during the installation you are prompted with the following message
+``Defaulting to user installation because normal site-packages is not 
+writeable`` you may have to run that command again using elevated
+permissions (i.e. opening the command prompt as an Administrator) to
+ensure that SCons is available from the ``PATH``.
 
 To check whether you have installed Python and SCons correctly, you can
 type ``python --version`` and ``scons --version`` into a command prompt


### PR DESCRIPTION
Updated the instruction for installing SCons on Windows 10 with Python 3.10, as described in #5341

_Closes #5341_