### PR TITLE
Updated incorrect keyboard shortcut

### DIFF
--- a/getting_started/introduction/learning_new_features.rst
+++ b/getting_started/introduction/learning_new_features.rst
@@ -29,7 +29,7 @@ general features, concepts, and how to use the editor, the reference is all
 about using Godot's scripting API (Application Programming Interface). You can
 access it both online and offline. We recommend browsing the reference offline,
 from within the Godot editor. To do so, go to Help -> Search or press
-:kbd:`Shift F1`.
+:kbd:`F1`.
 
 .. image:: img/manual_class_reference_search.png
 


### PR DESCRIPTION
The keyboard shortcut to open the inbuilt class reference - `Shift F1` was not working in the editor. Instead `F1` was working, so I updated it.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
