### PR TITLE
Fix description of area_shape_exited() signal

### DIFF
--- a/classes/class_area.rst
+++ b/classes/class_area.rst
@@ -130,7 +130,7 @@ Emitted when one of another Area's :ref:`Shape<class_Shape>`\ s enters one of th
 
 - **area_shape_exited** **(** :ref:`int<class_int>` area_id, :ref:`Area<class_Area>` area, :ref:`int<class_int>` area_shape, :ref:`int<class_int>` local_shape **)**
 
-Emitted when one of another Area's :ref:`Shape<class_Shape>`\ s enters one of this Area's :ref:`Shape<class_Shape>`\ s. Requires :ref:`monitoring<class_Area_property_monitoring>` to be set to ``true``.
+Emitted when one of another Area's :ref:`Shape<class_Shape>`\ s exits one of this Area's :ref:`Shape<class_Shape>`\ s. Requires :ref:`monitoring<class_Area_property_monitoring>` to be set to ``true``.
 
 ``area_id`` the :ref:`RID<class_RID>` of the other Area's :ref:`CollisionObject<class_CollisionObject>` used by the :ref:`PhysicsServer<class_PhysicsServer>`.
 


### PR DESCRIPTION
area_shape_entered() and area_shape_exited() had the exact same description. Changed area_shape_exited()'s description to specify that the signal is emitted when another area's shape exits rather than enter this area.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
