### PR TITLE
Specify to use the 3.x branch

### DIFF
--- a/tutorials/scripting/gdnative/gdnative_cpp_example.rst
+++ b/tutorials/scripting/gdnative/gdnative_cpp_example.rst
@@ -46,6 +46,10 @@ between 3.0 and 3.1) but not vice versa, so make sure you download the correct
 branch. Also, note that the version of Godot you use to generate the ``api.json``
 with becomes your minimum version.
 
+.. note::
+
+    Currently, GDExtentions has been merged into the master branch of godot-cpp. Therefore use the 3.x branch to use GDNative and follow this example. 
+
 If you are versioning your project using Git, it is a good idea to add them as
 Git submodules:
 
@@ -55,7 +59,7 @@ Git submodules:
     mkdir gdnative_cpp_example
     cd gdnative_cpp_example
     git init
-    git submodule add https://github.com/godotengine/godot-cpp
+    git submodule add -b 3.x https://github.com/godotengine/godot-cpp
     cd godot-cpp
     git submodule update --init
 

--- a/tutorials/scripting/gdnative/gdnative_cpp_example.rst
+++ b/tutorials/scripting/gdnative/gdnative_cpp_example.rst
@@ -87,7 +87,7 @@ Do make sure you clone recursive to pull in both repositories:
 
     mkdir gdnative_cpp_example
     cd gdnative_cpp_example
-    git clone --recursive https://github.com/godotengine/godot-cpp
+    git clone --recursive -b 3.x https://github.com/godotengine/godot-cpp
 
  .. code-tab:: none Godot 3.0
 

--- a/tutorials/scripting/gdnative/gdnative_cpp_example.rst
+++ b/tutorials/scripting/gdnative/gdnative_cpp_example.rst
@@ -48,7 +48,10 @@ with becomes your minimum version.
 
 .. note::
 
-    Currently, GDExtentions has been merged into the master branch of godot-cpp. Therefore use the 3.x branch to use GDNative and follow this example. 
+    `GDExtension <https://godotengine.org/article/introducing-gd-extensions>`__ has been merged in the ``master`` branch of godot-cpp,
+    but it is only compatible with the upcoming Godot 4.0.
+    Therefore, you need to use the ``3.x`` branch of godot-cpp to use GDNative
+    and follow this example.
 
 If you are versioning your project using Git, it is a good idea to add them as
 Git submodules:


### PR DESCRIPTION
GDExtensions has been merged into the godot-cpp master branch. The tutorial should specify to use the 3.x branch if the reader is creating GDNative scripts.
