### PR TITLE
Document compiling a debug server build

### DIFF
--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -161,6 +161,11 @@ projects in an automated manner, use::
 
     scons -j8 platform=server tools=yes target=release_debug
 
+To compile a debug *server* build which can be used with
+:ref:`remote debugging tools <doc_command_line_tutorial>`, use::
+
+    scons -j8 platform=server tools=no target=release_debug
+
 To compile a *server* build which is optimized to run dedicated game servers,
 use::
 

--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -91,7 +91,12 @@ projects in an automated manner, use::
 
     scons platform=server tools=yes target=release_debug --jobs=$(sysctl -n hw.logicalcpu)
 
-To compile a *server* build which is optimized to run dedicated game servers,
+To compile a debug *server* build which can be used with
+:ref:`remote debugging tools <doc_command_line_tutorial>`, use::
+
+    scons platform=server tools=no target=release_debug --jobs=$(sysctl -n hw.logicalcpu)
+
+To compile a release *server* build which is optimized to run dedicated game servers,
 use::
 
     scons platform=server tools=no target=release --jobs=$(sysctl -n hw.logicalcpu)


### PR DESCRIPTION
A debug server build is lighter than an editor headless build, but still allows debugging tools to be used.

This closes https://github.com/godotengine/godot-docs/issues/5360.