### PR TITLE
Pin docutils to <0.18 to fix CI due to new warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 # https://github.com/readthedocs/readthedocs.org/blob/master/requirements/docs.txt
 sphinx==4.0.2
 sphinx_rtd_theme==0.5.2
+docutils<0.18
 
 # Code tabs extension for GDScript/C#
 sphinx-tabs==3.2.0


### PR DESCRIPTION
This pins `docutils` to versions below `0.18`, which should fix the current CI issues in some branches due to the warning `node class 'meta' is already registered, its visitors will be overridden` (with the CI aborting, as we treat warnings as errors). This is due to an update to `docutils`, which `sphinx` is semingly not (yet) compatible with. According to the `sphinx` Github, there are further incompatabilities besides this warning.
Upstream `sphinx` also pins the version to [<0.18](https://github.com/sphinx-doc/sphinx/blob/4.x/setup.py#L26), with work happening recently in the master branch to support `docutils>=18`.

For reference, see also [this docutils issue](https://sourceforge.net/p/docutils/bugs/431/) and [this sphinx issue](https://github.com/sphinx-doc/sphinx/issues/9777).

We should reconsider this pin when updating `sphinx` in the future.