### PR TITLE
Add libatomic-static dependency for Fedora in Compiling for Linux, *BSD

### DIFF
--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -50,7 +50,7 @@ Distro-specific one-liners
 |                  |                                                                                                           |
 |                  |     sudo dnf install scons pkgconfig libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel \    |
 |                  |         libXi-devel mesa-libGL-devel mesa-libGLU-devel alsa-lib-devel pulseaudio-libs-devel \             |
-|                  |         libudev-devel gcc-c++ libstdc++-static                                                            |
+|                  |         libudev-devel gcc-c++ libstdc++-static libatomic-static                                           |
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **FreeBSD**      | ::                                                                                                        |
 |                  |                                                                                                           |


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot-docs/pull/5377.

This closes https://github.com/godotengine/godot-docs/issues/5375.