### PR TITLE
Add info on freetype copyright year

### DIFF
--- a/tutorials/legal/complying_with_licenses.rst
+++ b/tutorials/legal/complying_with_licenses.rst
@@ -107,7 +107,7 @@ Godot license:
     Portions of this software are copyright © <year> The FreeType Project (www.freetype.org).  All rights reserved.
     
 Note that <year> should correspond to the value from the FreeType version
-used in your build. This can be found in the project menu Help > About > Third-party Licenses
+used in your build. This can be found in the project menu Help > About > Third-party Licenses.
 
 ENet
 ^^^^

--- a/tutorials/legal/complying_with_licenses.rst
+++ b/tutorials/legal/complying_with_licenses.rst
@@ -107,7 +107,7 @@ Godot license:
     Portions of this software are copyright © <year> The FreeType Project (www.freetype.org).  All rights reserved.
     
 Note that <year> should correspond to the value from the FreeType version
-used in your build.
+used in your build. This can be found in the project menu Help > About > Third-party Licenses
 
 ENet
 ^^^^


### PR DESCRIPTION
This addition will make it easier to find the exact year for FreeType copyright. I've found this information useful for myself and I think it can be useful to clear ambiguities for others.

One thing I am not certain about is whether I've obtained the year correctly. By using the method described in this PR with Godot v3.2.3.stable.official on Linux I receive following copyright information:
```
The FreeType Project

Files:
    ./thirdparty/freetype/
(c) 1996-2020, David Turner, Robert Wilhelm, and Werner Lemberg.
License: FTL
```

Although in file `thirdparty/freetype/FTL.txt` on v3.2 branch ([FTL.txt](https://github.com/godotengine/godot/blob/3.2/thirdparty/freetype/FTL.TXT)) has this information:
```
                    Copyright 1996-2002, 2006 by
          David Turner, Robert Wilhelm, and Werner Lemberg
```

I would appreciate a clarification on which one is the right one.