### PR TITLE
Updated tools to @tools

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -89,7 +89,7 @@ like this:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    tool
+    @tool
     extends EditorPlugin
 
 
@@ -156,7 +156,7 @@ clicked. For that, we'll need a script that extends from
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    tool
+    @tool
     extends Button
 
 
@@ -200,7 +200,7 @@ dialog. For that, change the ``custom_node.gd`` script to the following:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    tool
+    @tool
     extends EditorPlugin
 
 
@@ -316,7 +316,7 @@ The script could look like this:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    tool
+    @tool
     extends EditorPlugin
 
 


### PR DESCRIPTION
Godot 4.0 complains that tools is an "Unexpected Identifier" so you need to put an @ in front of it, for example @export

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
