### PR TITLE
Fix formatting on AUTHORS.md file

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,40 +14,40 @@ name is available.
 
 (in alphabetical order, with over 10 commits excluding merges)
 
-Aaron Franke (aaronfranke)
-Andrew Conrad (her001)
-Andrii Doroshenko (Xrayez)
-Arman (puchik)
-Bastiaan Olij (BastiaanOlij)
-bitbutter
-Camille Mohr-Daurat (pouleyKetchoupp)
-Chris Bradfield (cbscribe)
-Clay John (clayjohn)
-corrigentia
-Fabio Alessandrelli (Faless)
-FeralBytes
-Frido (mega-bit)
-George Marques (vnen)
-Gerrit Großkopf (Grosskopf)
-Griatch
-Haoyu Qiu (timothyqiu)
-Hugo Locurcio (Calinou)
-Ignacio Roldán Etcheverry (neikeq)
-Jérôme Gully (Nutriz)
-Juan Linietsky (reduz)
-Julian Murgia (StraToN)
-Kelly Thomas (KellyThomas)
-Leon Krause (leonkrause)
-Matthew (skyace65)
-Max Hilbrunner (mhilbrunner)
-Michael Alexsander (YeldhamDev)
-Nathan Lovato (NathanLovato)
-Paul Joannon (paulloz)
-Poommetee Ketson (Naryosha)
-Rémi Verschelde (akien-mga)
-Tomasz Chabora (KoBeWi)
-TwistedTwigleg
-Will Nations (willnationsdev)
-Yuri Roubinsky (Chaosus)
-Yuri Sizov (pycbouh)
-ZX-WT
+    Aaron Franke (aaronfranke)
+    Andrew Conrad (her001)
+    Andrii Doroshenko (Xrayez)
+    Arman (puchik)
+    Bastiaan Olij (BastiaanOlij)
+    bitbutter
+    Camille Mohr-Daurat (pouleyKetchoupp)
+    Chris Bradfield (cbscribe)
+    Clay John (clayjohn)
+    corrigentia
+    Fabio Alessandrelli (Faless)
+    FeralBytes
+    Frido (mega-bit)
+    George Marques (vnen)
+    Gerrit Großkopf (Grosskopf)
+    Griatch
+    Haoyu Qiu (timothyqiu)
+    Hugo Locurcio (Calinou)
+    Ignacio Roldán Etcheverry (neikeq)
+    Jérôme Gully (Nutriz)
+    Juan Linietsky (reduz)
+    Julian Murgia (StraToN)
+    Kelly Thomas (KellyThomas)
+    Leon Krause (leonkrause)
+    Matthew (skyace65)
+    Max Hilbrunner (mhilbrunner)
+    Michael Alexsander (YeldhamDev)
+    Nathan Lovato (NathanLovato)
+    Paul Joannon (paulloz)
+    Poommetee Ketson (Naryosha)
+    Rémi Verschelde (akien-mga)
+    Tomasz Chabora (KoBeWi)
+    TwistedTwigleg
+    Will Nations (willnationsdev)
+    Yuri Roubinsky (Chaosus)
+    Yuri Sizov (pycbouh)
+    ZX-WT


### PR DESCRIPTION
Each contributor is now listed on a separate line in the github mardown rendering.
And it is more consistent with the authors file in the main engine repo.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
Before: ![image](https://user-images.githubusercontent.com/60046681/141032554-fceb8e25-8279-4f5a-9412-19a469a869ca.png)

After: 
![image](https://user-images.githubusercontent.com/60046681/141032648-6a59b0be-325e-497c-9522-97e90a47958f.png)
