### PR TITLE
Rename "compiling_for_osx.rst" to "compiling_for_macos.rst"

### DIFF
--- a/development/compiling/compiling_for_macos.rst
+++ b/development/compiling/compiling_for_macos.rst
@@ -1,4 +1,4 @@
-.. _doc_compiling_for_osx:
+.. _doc_compiling_for_macos:
 
 Compiling for macOS
 ===================

--- a/development/compiling/index.rst
+++ b/development/compiling/index.rst
@@ -9,7 +9,7 @@ Compiling
    introduction_to_the_buildsystem
    compiling_for_windows
    compiling_for_linuxbsd
-   compiling_for_osx
+   compiling_for_macos
    compiling_for_android
    compiling_for_ios
    cross-compiling_for_ios_on_linux

--- a/development/compiling/introduction_to_the_buildsystem.rst
+++ b/development/compiling/introduction_to_the_buildsystem.rst
@@ -41,7 +41,7 @@ Setup
 
 Please refer to the documentation for :ref:`doc_compiling_for_android`,
 :ref:`doc_compiling_for_ios`,  :ref:`doc_compiling_for_linuxbsd`,
-:ref:`doc_compiling_for_osx`, :ref:`doc_compiling_for_uwp`,
+:ref:`doc_compiling_for_macos`, :ref:`doc_compiling_for_uwp`,
 :ref:`doc_compiling_for_web`, and :ref:`doc_compiling_for_windows`.
 
 Note that for **Windows/Visual Studio**, you need to use ``x86_x64 Cross Tools

--- a/tutorials/export/exporting_for_dedicated_servers.rst
+++ b/tutorials/export/exporting_for_dedicated_servers.rst
@@ -12,7 +12,7 @@ Platform support
 - **Linux:** `Download an official Linux server binary <https://godotengine.org/download/server>`__.
   To compile a server binary from source, follow instructions in
   :ref:`doc_compiling_for_linuxbsd`.
-- **macOS:** :ref:`Compile a server binary from source for macOS <doc_compiling_for_osx>`.
+- **macOS:** :ref:`Compile a server binary from source for macOS <doc_compiling_for_macos>`.
 - **Windows:** There is no dedicated server build for Windows yet. As an alternative,
   you can use the ``--no-window`` command-line argument to prevent Godot from
   spawning a window. Note that even with the ``--no-window`` command-line argument,


### PR DESCRIPTION
The title and contents of the article have already been renamed, the only thing left is the file name.