### PR TITLE
State Machine travel teleports in the absence of any transition betwe…

### DIFF
--- a/tutorials/animation/animation_tree.rst
+++ b/tutorials/animation/animation_tree.rst
@@ -259,7 +259,7 @@ State machine travel
 --------------------
 
 One of the nice features in Godot's ``StateMachine`` implementation is the ability to travel. The graph can be instructed to go from the
-current state to another one, while visiting all the intermediate ones. This is done via the A\* algorithm.
+current state to another one, while visiting all the intermediate ones. This is done via the A\* algorithm.In the absence of any transition between the current state and the destination state, the graph teleports to the destination state. 
 
 To use the travel ability, you should first retrieve the :ref:`AnimationNodeStateMachinePlayback <class_AnimationNodeStateMachinePlayback>`
 object from the ``AnimationTree`` node (it is exported as a property).


### PR DESCRIPTION
…en the states

Added a line explaining that the State Machine travel function teleports to a destination node in absence of any transition between the current and destination node.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
