### PR TITLE
classref: Sync with godotengine/godot#54991 to dehardcode docs URL

### DIFF
--- a/classes/class_@gdscript.rst
+++ b/classes/class_@gdscript.rst
@@ -19,7 +19,7 @@ List of core built-in GDScript functions. Math functions and other utilities. Ev
 Tutorials
 ---------
 
-- :doc:`../tutorials/math/random_number_generation`
+- :doc:`Random number generation <../tutorials/math/random_number_generation>`
 
 Methods
 -------

--- a/classes/class_aabb.rst
+++ b/classes/class_aabb.rst
@@ -23,11 +23,11 @@ It uses floating-point coordinates. The 2D counterpart to ``AABB`` is :ref:`Rect
 Tutorials
 ---------
 
-- :doc:`../tutorials/math/index`
+- :doc:`Math documentation index <../tutorials/math/index>`
 
-- :doc:`../tutorials/math/vector_math`
+- :doc:`Vector math <../tutorials/math/vector_math>`
 
-- :doc:`../tutorials/math/vectors_advanced`
+- :doc:`Advanced vector math <../tutorials/math/vectors_advanced>`
 
 Properties
 ----------

--- a/classes/class_animatedsprite2d.rst
+++ b/classes/class_animatedsprite2d.rst
@@ -23,7 +23,7 @@ Animations are created using a :ref:`SpriteFrames<class_SpriteFrames>` resource,
 Tutorials
 ---------
 
-- :doc:`../tutorials/2d/2d_sprite_animation`
+- :doc:`2D Sprite animation <../tutorials/2d/2d_sprite_animation>`
 
 - `2D Dodge The Creeps Demo <https://godotengine.org/asset-library/asset/515>`__
 

--- a/classes/class_animatedsprite3d.rst
+++ b/classes/class_animatedsprite3d.rst
@@ -21,7 +21,7 @@ Animations are created using a :ref:`SpriteFrames<class_SpriteFrames>` resource,
 Tutorials
 ---------
 
-- :doc:`../tutorials/2d/2d_sprite_animation`
+- :doc:`2D Sprite animation (also applies to 3D) <../tutorials/2d/2d_sprite_animation>`
 
 Properties
 ----------

--- a/classes/class_animation.rst
+++ b/classes/class_animation.rst
@@ -48,7 +48,7 @@ Animations are just data containers, and must be added to nodes such as an :ref:
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/index`
+- :doc:`Animation documentation index <../tutorials/animation/index>`
 
 Properties
 ----------

--- a/classes/class_animationnode.rst
+++ b/classes/class_animationnode.rst
@@ -25,7 +25,7 @@ Inherit this when creating nodes mainly for use in :ref:`AnimationNodeBlendTree<
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/animation_tree`
+- :doc:`AnimationTree <../tutorials/animation/animation_tree>`
 
 Properties
 ----------

--- a/classes/class_animationnodeadd2.rst
+++ b/classes/class_animationnodeadd2.rst
@@ -21,7 +21,7 @@ A resource to add to an :ref:`AnimationNodeBlendTree<class_AnimationNodeBlendTre
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/animation_tree`
+- :doc:`AnimationTree <../tutorials/animation/animation_tree>`
 
 Properties
 ----------

--- a/classes/class_animationnodeadd3.rst
+++ b/classes/class_animationnodeadd3.rst
@@ -29,7 +29,7 @@ This node has three inputs:
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/animation_tree`
+- :doc:`AnimationTree <../tutorials/animation/animation_tree>`
 
 - `Third Person Shooter Demo <https://godotengine.org/asset-library/asset/678>`__
 

--- a/classes/class_animationnodeanimation.rst
+++ b/classes/class_animationnodeanimation.rst
@@ -21,7 +21,7 @@ A resource to add to an :ref:`AnimationNodeBlendTree<class_AnimationNodeBlendTre
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/animation_tree`
+- :doc:`AnimationTree <../tutorials/animation/animation_tree>`
 
 - `3D Platformer Demo <https://godotengine.org/asset-library/asset/125>`__
 

--- a/classes/class_animationnodeblend2.rst
+++ b/classes/class_animationnodeblend2.rst
@@ -21,7 +21,7 @@ A resource to add to an :ref:`AnimationNodeBlendTree<class_AnimationNodeBlendTre
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/animation_tree`
+- :doc:`AnimationTree <../tutorials/animation/animation_tree>`
 
 - `3D Platformer Demo <https://godotengine.org/asset-library/asset/125>`__
 

--- a/classes/class_animationnodeblend3.rst
+++ b/classes/class_animationnodeblend3.rst
@@ -29,7 +29,7 @@ This node has three inputs:
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/animation_tree`
+- :doc:`AnimationTree <../tutorials/animation/animation_tree>`
 
 Properties
 ----------

--- a/classes/class_animationnodeblendspace1d.rst
+++ b/classes/class_animationnodeblendspace1d.rst
@@ -27,7 +27,7 @@ You can set the extents of the axis using the :ref:`min_space<class_AnimationNod
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/animation_tree`
+- :doc:`AnimationTree <../tutorials/animation/animation_tree>`
 
 Properties
 ----------

--- a/classes/class_animationnodeblendspace2d.rst
+++ b/classes/class_animationnodeblendspace2d.rst
@@ -25,7 +25,7 @@ You can add vertices to the blend space with :ref:`add_blend_point<class_Animati
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/animation_tree`
+- :doc:`AnimationTree <../tutorials/animation/animation_tree>`
 
 - `Third Person Shooter Demo <https://godotengine.org/asset-library/asset/678>`__
 

--- a/classes/class_animationnodeblendtree.rst
+++ b/classes/class_animationnodeblendtree.rst
@@ -21,7 +21,7 @@ This node may contain a sub-tree of any other blend type nodes, such as mix, ble
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/animation_tree`
+- :doc:`AnimationTree <../tutorials/animation/animation_tree>`
 
 Properties
 ----------

--- a/classes/class_animationnodeoneshot.rst
+++ b/classes/class_animationnodeoneshot.rst
@@ -21,7 +21,7 @@ A resource to add to an :ref:`AnimationNodeBlendTree<class_AnimationNodeBlendTre
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/animation_tree`
+- :doc:`AnimationTree <../tutorials/animation/animation_tree>`
 
 - `Third Person Shooter Demo <https://godotengine.org/asset-library/asset/678>`__
 

--- a/classes/class_animationnodeoutput.rst
+++ b/classes/class_animationnodeoutput.rst
@@ -16,7 +16,7 @@ Generic output node to be added to :ref:`AnimationNodeBlendTree<class_AnimationN
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/animation_tree`
+- :doc:`AnimationTree <../tutorials/animation/animation_tree>`
 
 - `3D Platformer Demo <https://godotengine.org/asset-library/asset/125>`__
 

--- a/classes/class_animationnodestatemachine.rst
+++ b/classes/class_animationnodestatemachine.rst
@@ -38,7 +38,7 @@ Contains multiple nodes representing animation states, connected in a graph. Nod
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/animation_tree`
+- :doc:`AnimationTree <../tutorials/animation/animation_tree>`
 
 Methods
 -------

--- a/classes/class_animationnodestatemachineplayback.rst
+++ b/classes/class_animationnodestatemachineplayback.rst
@@ -38,7 +38,7 @@ Allows control of :ref:`AnimationTree<class_AnimationTree>` state machines creat
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/animation_tree`
+- :doc:`AnimationTree <../tutorials/animation/animation_tree>`
 
 Properties
 ----------

--- a/classes/class_animationnodestatemachinetransition.rst
+++ b/classes/class_animationnodestatemachinetransition.rst
@@ -16,7 +16,7 @@ AnimationNodeStateMachineTransition
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/animation_tree`
+- :doc:`AnimationTree <../tutorials/animation/animation_tree>`
 
 Properties
 ----------
@@ -78,7 +78,7 @@ Property Descriptions
 | *Getter*  | get_advance_condition()      |
 +-----------+------------------------------+
 
-Turn on auto advance when this condition is set. The provided name will become a boolean parameter on the :ref:`AnimationTree<class_AnimationTree>` that can be controlled from code (see `https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html#controlling-from-code <https://docs.godotengine.org/en/latest/tutorials/animation/animation_tree.html#controlling-from-code>`__). For example, if :ref:`AnimationTree.tree_root<class_AnimationTree_property_tree_root>` is an :ref:`AnimationNodeStateMachine<class_AnimationNodeStateMachine>` and :ref:`advance_condition<class_AnimationNodeStateMachineTransition_property_advance_condition>` is set to ``"idle"``:
+Turn on auto advance when this condition is set. The provided name will become a boolean parameter on the :ref:`AnimationTree<class_AnimationTree>` that can be controlled from code (see `#controlling-from-code <../tutorials/animation/animation_tree.html#controlling-from-code>`__ in :doc:`../tutorials/animation/animation_tree`). For example, if :ref:`AnimationTree.tree_root<class_AnimationTree_property_tree_root>` is an :ref:`AnimationNodeStateMachine<class_AnimationNodeStateMachine>` and :ref:`advance_condition<class_AnimationNodeStateMachineTransition_property_advance_condition>` is set to ``"idle"``:
 
 
 .. tabs::

--- a/classes/class_animationnodetimescale.rst
+++ b/classes/class_animationnodetimescale.rst
@@ -21,7 +21,7 @@ Allows scaling the speed of the animation (or reversing it) in any children node
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/animation_tree`
+- :doc:`AnimationTree <../tutorials/animation/animation_tree>`
 
 - `3D Platformer Demo <https://godotengine.org/asset-library/asset/125>`__
 

--- a/classes/class_animationnodetimeseek.rst
+++ b/classes/class_animationnodetimeseek.rst
@@ -46,7 +46,7 @@ This node can be used to cause a seek command to happen to any sub-children of t
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/animation_tree`
+- :doc:`AnimationTree <../tutorials/animation/animation_tree>`
 
 .. |virtual| replace:: :abbr:`virtual (This method should typically be overridden by the user to have any effect.)`
 .. |const| replace:: :abbr:`const (This method has no side effects. It doesn't modify any of the instance's member variables.)`

--- a/classes/class_animationnodetransition.rst
+++ b/classes/class_animationnodetransition.rst
@@ -21,7 +21,7 @@ Simple state machine for cases which don't require a more advanced :ref:`Animati
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/animation_tree`
+- :doc:`AnimationTree <../tutorials/animation/animation_tree>`
 
 - `3D Platformer Demo <https://godotengine.org/asset-library/asset/125>`__
 

--- a/classes/class_animationplayer.rst
+++ b/classes/class_animationplayer.rst
@@ -25,9 +25,9 @@ Updating the target properties of animations occurs at process time.
 Tutorials
 ---------
 
-- :doc:`../tutorials/2d/2d_sprite_animation`
+- :doc:`2D Sprite animation <../tutorials/2d/2d_sprite_animation>`
 
-- :doc:`../tutorials/animation/index`
+- :doc:`Animation documentation index <../tutorials/animation/index>`
 
 - `Third Person Shooter Demo <https://godotengine.org/asset-library/asset/678>`__
 

--- a/classes/class_animationtree.rst
+++ b/classes/class_animationtree.rst
@@ -23,7 +23,7 @@ A node to be used for advanced animation transitions in an :ref:`AnimationPlayer
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/animation_tree`
+- :doc:`Using AnimationTree <../tutorials/animation/animation_tree>`
 
 - `Third Person Shooter Demo <https://godotengine.org/asset-library/asset/678>`__
 

--- a/classes/class_area2d.rst
+++ b/classes/class_area2d.rst
@@ -21,7 +21,7 @@ Description
 Tutorials
 ---------
 
-- :doc:`../tutorials/physics/using_area_2d`
+- :doc:`Using Area2D <../tutorials/physics/using_area_2d>`
 
 - `2D Dodge The Creeps Demo <https://godotengine.org/asset-library/asset/515>`__
 

--- a/classes/class_arraymesh.rst
+++ b/classes/class_arraymesh.rst
@@ -70,7 +70,7 @@ See also :ref:`ImmediateMesh<class_ImmediateMesh>`, :ref:`MeshDataTool<class_Mes
 Tutorials
 ---------
 
-- :doc:`../tutorials/3d/procedural_geometry/arraymesh`
+- :doc:`Procedural geometry using the ArrayMesh <../tutorials/3d/procedural_geometry/arraymesh>`
 
 Properties
 ----------

--- a/classes/class_audioeffectdistortion.rst
+++ b/classes/class_audioeffectdistortion.rst
@@ -25,7 +25,7 @@ By distorting the waveform the frequency content change, which will often make t
 Tutorials
 ---------
 
-- :doc:`../tutorials/audio/audio_buses`
+- :doc:`Audio buses <../tutorials/audio/audio_buses>`
 
 Properties
 ----------

--- a/classes/class_audioeffectfilter.rst
+++ b/classes/class_audioeffectfilter.rst
@@ -23,7 +23,7 @@ Allows frequencies other than the :ref:`cutoff_hz<class_AudioEffectFilter_proper
 Tutorials
 ---------
 
-- :doc:`../tutorials/audio/audio_buses`
+- :doc:`Audio buses <../tutorials/audio/audio_buses>`
 
 Properties
 ----------

--- a/classes/class_audioeffecthighshelffilter.rst
+++ b/classes/class_audioeffecthighshelffilter.rst
@@ -16,7 +16,7 @@ Reduces all frequencies above the :ref:`AudioEffectFilter.cutoff_hz<class_AudioE
 Tutorials
 ---------
 
-- :doc:`../tutorials/audio/audio_buses`
+- :doc:`Audio buses <../tutorials/audio/audio_buses>`
 
 .. |virtual| replace:: :abbr:`virtual (This method should typically be overridden by the user to have any effect.)`
 .. |const| replace:: :abbr:`const (This method has no side effects. It doesn't modify any of the instance's member variables.)`

--- a/classes/class_audioeffectlowshelffilter.rst
+++ b/classes/class_audioeffectlowshelffilter.rst
@@ -16,7 +16,7 @@ Reduces all frequencies below the :ref:`AudioEffectFilter.cutoff_hz<class_AudioE
 Tutorials
 ---------
 
-- :doc:`../tutorials/audio/audio_buses`
+- :doc:`Audio buses <../tutorials/audio/audio_buses>`
 
 .. |virtual| replace:: :abbr:`virtual (This method should typically be overridden by the user to have any effect.)`
 .. |const| replace:: :abbr:`const (This method has no side effects. It doesn't modify any of the instance's member variables.)`

--- a/classes/class_audioeffectrecord.rst
+++ b/classes/class_audioeffectrecord.rst
@@ -21,7 +21,7 @@ Allows the user to record sound from a microphone. It sets and gets the format i
 Tutorials
 ---------
 
-- :doc:`../tutorials/audio/recording_with_microphone`
+- :doc:`Recording with microphone <../tutorials/audio/recording_with_microphone>`
 
 - `Audio Mic Record Demo <https://godotengine.org/asset-library/asset/527>`__
 

--- a/classes/class_audioserver.rst
+++ b/classes/class_audioserver.rst
@@ -21,7 +21,7 @@ Description
 Tutorials
 ---------
 
-- :doc:`../tutorials/audio/audio_buses`
+- :doc:`Audio buses <../tutorials/audio/audio_buses>`
 
 - `Audio Device Changer Demo <https://godotengine.org/asset-library/asset/525>`__
 

--- a/classes/class_audiostream.rst
+++ b/classes/class_audiostream.rst
@@ -23,7 +23,7 @@ Base class for audio streams. Audio streams are used for sound effects and music
 Tutorials
 ---------
 
-- :doc:`../tutorials/audio/audio_streams`
+- :doc:`Audio streams <../tutorials/audio/audio_streams>`
 
 - `Audio Generator Demo <https://godotengine.org/asset-library/asset/526>`__
 

--- a/classes/class_audiostreamplayer.rst
+++ b/classes/class_audiostreamplayer.rst
@@ -23,7 +23,7 @@ To play audio positionally, use :ref:`AudioStreamPlayer2D<class_AudioStreamPlaye
 Tutorials
 ---------
 
-- :doc:`../tutorials/audio/audio_streams`
+- :doc:`Audio streams <../tutorials/audio/audio_streams>`
 
 - `2D Dodge The Creeps Demo <https://godotengine.org/asset-library/asset/515>`__
 

--- a/classes/class_audiostreamplayer2d.rst
+++ b/classes/class_audiostreamplayer2d.rst
@@ -25,7 +25,7 @@ See also :ref:`AudioStreamPlayer<class_AudioStreamPlayer>` to play a sound non-p
 Tutorials
 ---------
 
-- :doc:`../tutorials/audio/audio_streams`
+- :doc:`Audio streams <../tutorials/audio/audio_streams>`
 
 Properties
 ----------

--- a/classes/class_audiostreamplayer3d.rst
+++ b/classes/class_audiostreamplayer3d.rst
@@ -27,7 +27,7 @@ See also :ref:`AudioStreamPlayer<class_AudioStreamPlayer>` to play a sound non-p
 Tutorials
 ---------
 
-- :doc:`../tutorials/audio/audio_streams`
+- :doc:`Audio streams <../tutorials/audio/audio_streams>`
 
 Properties
 ----------

--- a/classes/class_basematerial3d.rst
+++ b/classes/class_basematerial3d.rst
@@ -23,7 +23,7 @@ This provides a default material with a wide variety of rendering features and p
 Tutorials
 ---------
 
-- :doc:`../tutorials/3d/standard_material_3d`
+- :doc:`Standard Material 3D <../tutorials/3d/standard_material_3d>`
 
 Properties
 ----------

--- a/classes/class_basis.rst
+++ b/classes/class_basis.rst
@@ -25,11 +25,11 @@ For more information, read the "Matrices and transforms" documentation article.
 Tutorials
 ---------
 
-- :doc:`../tutorials/math/index`
+- :doc:`Math documentation index <../tutorials/math/index>`
 
-- :doc:`../tutorials/math/matrices_and_transforms`
+- :doc:`Matrices and transforms <../tutorials/math/matrices_and_transforms>`
 
-- :doc:`../tutorials/3d/using_transforms`
+- :doc:`Using 3D transforms <../tutorials/3d/using_transforms>`
 
 - `Matrix Transform Demo <https://godotengine.org/asset-library/asset/584>`__
 

--- a/classes/class_canvasitem.rst
+++ b/classes/class_canvasitem.rst
@@ -33,9 +33,9 @@ Ultimately, a transform notification can be requested, which will notify the nod
 Tutorials
 ---------
 
-- :doc:`../tutorials/2d/2d_transforms`
+- :doc:`Viewport and canvas transforms <../tutorials/2d/2d_transforms>`
 
-- :doc:`../tutorials/2d/custom_drawing_in_2d`
+- :doc:`Custom drawing in 2D <../tutorials/2d/custom_drawing_in_2d>`
 
 - `Audio Spectrum Demo <https://godotengine.org/asset-library/asset/528>`__
 

--- a/classes/class_canvaslayer.rst
+++ b/classes/class_canvaslayer.rst
@@ -23,9 +23,9 @@ Canvas drawing layer. :ref:`CanvasItem<class_CanvasItem>` nodes that are direct 
 Tutorials
 ---------
 
-- :doc:`../tutorials/2d/2d_transforms`
+- :doc:`Viewport and canvas transforms <../tutorials/2d/2d_transforms>`
 
-- :doc:`../tutorials/2d/canvas_layers`
+- :doc:`Canvas layers <../tutorials/2d/canvas_layers>`
 
 - `2D Dodge The Creeps Demo <https://godotengine.org/asset-library/asset/515>`__
 

--- a/classes/class_characterbody2d.rst
+++ b/classes/class_characterbody2d.rst
@@ -25,9 +25,9 @@ Character bodies are special types of bodies that are meant to be user-controlle
 Tutorials
 ---------
 
-- :doc:`../tutorials/physics/kinematic_character_2d`
+- :doc:`Kinematic character (2D) <../tutorials/physics/kinematic_character_2d>`
 
-- :doc:`../tutorials/physics/using_kinematic_body_2d`
+- :doc:`Using KinematicBody2D <../tutorials/physics/using_kinematic_body_2d>`
 
 - `2D Kinematic Character Demo <https://godotengine.org/asset-library/asset/113>`__
 

--- a/classes/class_characterbody3d.rst
+++ b/classes/class_characterbody3d.rst
@@ -25,7 +25,7 @@ Character bodies are special types of bodies that are meant to be user-controlle
 Tutorials
 ---------
 
-- :doc:`../tutorials/physics/kinematic_character_2d`
+- :doc:`Kinematic character (2D) <../tutorials/physics/kinematic_character_2d>`
 
 - `3D Kinematic Character Demo <https://godotengine.org/asset-library/asset/126>`__
 

--- a/classes/class_charfxtransform.rst
+++ b/classes/class_charfxtransform.rst
@@ -21,7 +21,7 @@ By setting various properties on this object, you can control how individual cha
 Tutorials
 ---------
 
-- :doc:`../tutorials/ui/bbcode_in_richtextlabel`
+- :doc:`BBCode in RichTextLabel <../tutorials/ui/bbcode_in_richtextlabel>`
 
 - `RichTextEffect test project (third-party) <https://github.com/Eoin-ONeill-Yokai/Godot-Rich-Text-Effect-Test-Project>`__
 

--- a/classes/class_collisionobject2d.rst
+++ b/classes/class_collisionobject2d.rst
@@ -169,7 +169,7 @@ Property Descriptions
 
 The physics layers this CollisionObject2D is in. Collision objects can exist in one or more of 32 different layers. See also :ref:`collision_mask<class_CollisionObject2D_property_collision_mask>`.
 
-**Note:** Object A can detect a contact with object B only if object B is in any of the layers that object A scans. See `Collision layers and masks <https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
+**Note:** Object A can detect a contact with object B only if object B is in any of the layers that object A scans. See `Collision layers and masks <../tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
 
 ----
 
@@ -187,7 +187,7 @@ The physics layers this CollisionObject2D is in. Collision objects can exist in 
 
 The physics layers this CollisionObject2D scans. Collision objects can scan one or more of 32 different layers. See also :ref:`collision_layer<class_CollisionObject2D_property_collision_layer>`.
 
-**Note:** Object A can detect a contact with object B only if object B is in any of the layers that object A scans. See `Collision layers and masks <https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
+**Note:** Object A can detect a contact with object B only if object B is in any of the layers that object A scans. See `Collision layers and masks <../tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
 
 ----
 

--- a/classes/class_collisionobject3d.rst
+++ b/classes/class_collisionobject3d.rst
@@ -147,7 +147,7 @@ Property Descriptions
 
 The physics layers this CollisionObject3D **is in**. Collision objects can exist in one or more of 32 different layers. See also :ref:`collision_mask<class_CollisionObject3D_property_collision_mask>`.
 
-**Note:** Object A can detect a contact with object B only if object B is in any of the layers that object A scans. See `Collision layers and masks <https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
+**Note:** Object A can detect a contact with object B only if object B is in any of the layers that object A scans. See `Collision layers and masks <../tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
 
 ----
 
@@ -165,7 +165,7 @@ The physics layers this CollisionObject3D **is in**. Collision objects can exist
 
 The physics layers this CollisionObject3D **scans**. Collision objects can scan one or more of 32 different layers. See also :ref:`collision_layer<class_CollisionObject3D_property_collision_layer>`.
 
-**Note:** Object A can detect a contact with object B only if object B is in any of the layers that object A scans. See `Collision layers and masks <https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
+**Note:** Object A can detect a contact with object B only if object B is in any of the layers that object A scans. See `Collision layers and masks <../tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
 
 ----
 

--- a/classes/class_collisionshape2d.rst
+++ b/classes/class_collisionshape2d.rst
@@ -21,7 +21,7 @@ Editor facility for creating and editing collision shapes in 2D space. You can u
 Tutorials
 ---------
 
-- :doc:`../tutorials/physics/physics_introduction`
+- :doc:`Physics introduction <../tutorials/physics/physics_introduction>`
 
 - `2D Dodge The Creeps Demo <https://godotengine.org/asset-library/asset/515>`__
 

--- a/classes/class_collisionshape3d.rst
+++ b/classes/class_collisionshape3d.rst
@@ -21,7 +21,7 @@ Editor facility for creating and editing collision shapes in 3D space. You can u
 Tutorials
 ---------
 
-- :doc:`../tutorials/physics/physics_introduction`
+- :doc:`Physics introduction <../tutorials/physics/physics_introduction>`
 
 - `3D Kinematic Character Demo <https://godotengine.org/asset-library/asset/126>`__
 

--- a/classes/class_control.rst
+++ b/classes/class_control.rst
@@ -41,11 +41,11 @@ Sets :ref:`mouse_filter<class_Control_property_mouse_filter>` to :ref:`MOUSE_FIL
 Tutorials
 ---------
 
-- :doc:`../tutorials/ui/index`
+- :doc:`GUI documentation index <../tutorials/ui/index>`
 
-- :doc:`../tutorials/2d/custom_drawing_in_2d`
+- :doc:`Custom drawing in 2D <../tutorials/2d/custom_drawing_in_2d>`
 
-- :doc:`../tutorials/ui/control_node_gallery`
+- :doc:`Control node gallery <../tutorials/ui/control_node_gallery>`
 
 - `All GUI Demos <https://github.com/godotengine/godot-demo-projects/tree/master/gui>`__
 
@@ -1238,7 +1238,7 @@ The node's rotation around its pivot, in radians. See :ref:`rect_pivot_offset<cl
 
 The node's scale, relative to its :ref:`rect_size<class_Control_property_rect_size>`. Change this property to scale the node around its :ref:`rect_pivot_offset<class_Control_property_rect_pivot_offset>`. The Control's :ref:`hint_tooltip<class_Control_property_hint_tooltip>` will also scale according to this value.
 
-**Note:** This property is mainly intended to be used for animation purposes. Text inside the Control will look pixelated or blurry when the Control is scaled. To support multiple resolutions in your project, use an appropriate viewport stretch mode as described in the `documentation <https://docs.godotengine.org/en/latest/tutorials/viewports/multiple_resolutions.html>`__ instead of scaling Controls individually.
+**Note:** This property is mainly intended to be used for animation purposes. Text inside the Control will look pixelated or blurry when the Control is scaled. To support multiple resolutions in your project, use an appropriate viewport stretch mode as described in the :doc:`documentation <../tutorials/viewports/multiple_resolutions>` instead of scaling Controls individually.
 
 **Note:** If the Control node is a child of a :ref:`Container<class_Container>` node, the scale will be reset to ``Vector2(1, 1)`` when the scene is instantiated. To set the Control's scale when it's instantiated, wait for one frame using ``await get_tree().process_frame`` then set its :ref:`rect_scale<class_Control_property_rect_scale>` property.
 

--- a/classes/class_cpuparticles2d.rst
+++ b/classes/class_cpuparticles2d.rst
@@ -23,7 +23,7 @@ See also :ref:`GPUParticles2D<class_GPUParticles2D>`, which provides the same fu
 Tutorials
 ---------
 
-- :doc:`../tutorials/2d/particle_systems_2d`
+- :doc:`Particle systems (2D) <../tutorials/2d/particle_systems_2d>`
 
 Properties
 ----------

--- a/classes/class_csgshape3d.rst
+++ b/classes/class_csgshape3d.rst
@@ -108,7 +108,7 @@ The physics layers this area is in.
 
 Collidable objects can exist in any of 32 different layers. These layers work like a tagging system, and are not visual. A collidable can use these layers to select with which objects it can collide, using the collision_mask property.
 
-A contact is detected if object A is in any of the layers that object B scans, or object B is in any layer scanned by object A. See `Collision layers and masks <https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
+A contact is detected if object A is in any of the layers that object B scans, or object B is in any layer scanned by object A. See `Collision layers and masks <../tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
 
 ----
 
@@ -124,7 +124,7 @@ A contact is detected if object A is in any of the layers that object B scans, o
 | *Getter*  | get_collision_mask()      |
 +-----------+---------------------------+
 
-The physics layers this CSG shape scans for collisions. See `Collision layers and masks <https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
+The physics layers this CSG shape scans for collisions. See `Collision layers and masks <../tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
 
 ----
 

--- a/classes/class_csharpscript.rst
+++ b/classes/class_csharpscript.rst
@@ -23,7 +23,7 @@ See also :ref:`GodotSharp<class_GodotSharp>`.
 Tutorials
 ---------
 
-- :doc:`../tutorials/scripting/c_sharp/index`
+- :doc:`C# documentation index <../tutorials/scripting/c_sharp/index>`
 
 Methods
 -------

--- a/classes/class_dictionary.rst
+++ b/classes/class_dictionary.rst
@@ -236,7 +236,7 @@ You need to first calculate the dictionary's hash with :ref:`hash<class_Dictiona
 Tutorials
 ---------
 
-- `#dictionary <../tutorials/scripting/gdscript/gdscript_basics.html#dictionary>`_ in :doc:`../tutorials/scripting/gdscript/gdscript_basics`
+- `GDScript basics: Dictionary <../tutorials/scripting/gdscript/gdscript_basics.html#dictionary>`__
 
 - `3D Voxel Demo <https://godotengine.org/asset-library/asset/676>`__
 

--- a/classes/class_directionallight3d.rst
+++ b/classes/class_directionallight3d.rst
@@ -21,7 +21,7 @@ A directional light is a type of :ref:`Light3D<class_Light3D>` node that models 
 Tutorials
 ---------
 
-- :doc:`../tutorials/3d/lights_and_shadows`
+- :doc:`Lights and shadows <../tutorials/3d/lights_and_shadows>`
 
 Properties
 ----------

--- a/classes/class_directory.rst
+++ b/classes/class_directory.rst
@@ -76,7 +76,7 @@ Here is an example on how to iterate through the files of a directory:
 Tutorials
 ---------
 
-- :doc:`../tutorials/scripting/filesystem`
+- :doc:`File system <../tutorials/scripting/filesystem>`
 
 Methods
 -------

--- a/classes/class_displayserver.rst
+++ b/classes/class_displayserver.rst
@@ -475,7 +475,7 @@ enum **WindowMode**:
 
 - **WINDOW_MODE_FULLSCREEN** = **3** --- Fullscreen window mode. Note that this is not *exclusive* fullscreen. On Windows and Linux, a borderless window is used to emulate fullscreen. On macOS, a new desktop is used to display the running project.
 
-Regardless of the platform, enabling fullscreen will change the window size to match the monitor's size. Therefore, make sure your project supports `multiple resolutions <https://docs.godotengine.org/en/latest/tutorials/rendering/multiple_resolutions.html>`__ when enabling fullscreen mode.
+Regardless of the platform, enabling fullscreen will change the window size to match the monitor's size. Therefore, make sure your project supports :doc:`multiple resolutions <../tutorials/rendering/multiple_resolutions>` when enabling fullscreen mode.
 
 ----
 

--- a/classes/class_editorimportplugin.rst
+++ b/classes/class_editorimportplugin.rst
@@ -133,7 +133,7 @@ To use ``EditorImportPlugin``, register it using the :ref:`EditorPlugin.add_impo
 Tutorials
 ---------
 
-- :doc:`../tutorials/plugins/editor/import_plugins`
+- :doc:`Import plugins <../tutorials/plugins/editor/import_plugins>`
 
 Methods
 -------

--- a/classes/class_editorinspectorplugin.rst
+++ b/classes/class_editorinspectorplugin.rst
@@ -33,7 +33,7 @@ To use ``EditorInspectorPlugin``, register it using the :ref:`EditorPlugin.add_i
 Tutorials
 ---------
 
-- :doc:`../tutorials/plugins/editor/inspector_plugins`
+- :doc:`Inspector plugins <../tutorials/plugins/editor/inspector_plugins>`
 
 Methods
 -------

--- a/classes/class_editornode3dgizmoplugin.rst
+++ b/classes/class_editornode3dgizmoplugin.rst
@@ -23,7 +23,7 @@ To use ``EditorNode3DGizmoPlugin``, register it using the :ref:`EditorPlugin.add
 Tutorials
 ---------
 
-- :doc:`../tutorials/plugins/editor/spatial_gizmos`
+- :doc:`Spatial gizmo plugins <../tutorials/plugins/editor/spatial_gizmos>`
 
 Methods
 -------

--- a/classes/class_editorplugin.rst
+++ b/classes/class_editorplugin.rst
@@ -21,7 +21,7 @@ Plugins are used by the editor to extend functionality. The most common types of
 Tutorials
 ---------
 
-- :doc:`../tutorials/plugins/editor/index`
+- :doc:`Editor plugins documentation index <../tutorials/plugins/editor/index>`
 
 Methods
 -------

--- a/classes/class_editorscenepostimport.rst
+++ b/classes/class_editorscenepostimport.rst
@@ -72,7 +72,7 @@ The :ref:`_post_import<class_EditorScenePostImport_method__post_import>` callbac
 Tutorials
 ---------
 
-- `#custom-script <../tutorials/assets_pipeline/importing_scenes.html#custom-script>`_ in :doc:`../tutorials/assets_pipeline/importing_scenes`
+- `Importing 3D scenes: Custom script <../tutorials/assets_pipeline/importing_scenes.html#custom-script>`__
 
 Methods
 -------

--- a/classes/class_enetmultiplayerpeer.rst
+++ b/classes/class_enetmultiplayerpeer.rst
@@ -23,7 +23,7 @@ A MultiplayerPeer implementation that should be passed to :ref:`MultiplayerAPI.m
 Tutorials
 ---------
 
-- :doc:`../tutorials/networking/high_level_multiplayer`
+- :doc:`High-level multiplayer <../tutorials/networking/high_level_multiplayer>`
 
 - `API documentation on the ENet website <http://enet.bespin.org/usergroup0.html>`__
 

--- a/classes/class_engine.rst
+++ b/classes/class_engine.rst
@@ -370,7 +370,7 @@ Returns ``true`` if the script is currently running inside the editor, ``false``
     else:
         simulate_physics()
 
-See `Running code in the editor <https://docs.godotengine.org/en/latest/tutorials/plugins/running_code_in_the_editor.html>`__ in the documentation for more information.
+See :doc:`Running code in the editor <../tutorials/plugins/running_code_in_the_editor>` in the documentation for more information.
 
 **Note:** To detect whether the script is run from an editor *build* (e.g. when pressing :kbd:`F5`), use :ref:`OS.has_feature<class_OS_method_has_feature>` with the ``"editor"`` argument instead. ``OS.has_feature("editor")`` will evaluate to ``true`` both when the code is running in the editor and when running the project from the editor, but it will evaluate to ``false`` when the code is run from an exported project.
 

--- a/classes/class_environment.rst
+++ b/classes/class_environment.rst
@@ -29,9 +29,9 @@ Resource for environment nodes (like :ref:`WorldEnvironment<class_WorldEnvironme
 Tutorials
 ---------
 
-- :doc:`../tutorials/3d/environment_and_post_processing`
+- :doc:`Environment and post-processing <../tutorials/3d/environment_and_post_processing>`
 
-- :doc:`../tutorials/3d/high_dynamic_range`
+- :doc:`Light transport in game engines <../tutorials/3d/high_dynamic_range>`
 
 - `3D Material Testers Demo <https://godotengine.org/asset-library/asset/123>`__
 

--- a/classes/class_file.rst
+++ b/classes/class_file.rst
@@ -59,7 +59,7 @@ Here's a sample on how to write and read from a file:
 
 
 
-In the example above, the file will be saved in the user data folder as specified in the `Data paths <https://docs.godotengine.org/en/latest/tutorials/io/data_paths.html>`__ documentation.
+In the example above, the file will be saved in the user data folder as specified in the :doc:`Data paths <../tutorials/io/data_paths>` documentation.
 
 **Note:** To access project resources once exported, it is recommended to use :ref:`ResourceLoader<class_ResourceLoader>` instead of the ``File`` API, as some files are converted to engine-specific formats and their original source files might not be present in the exported PCK package.
 
@@ -68,7 +68,7 @@ In the example above, the file will be saved in the user data folder as specifie
 Tutorials
 ---------
 
-- :doc:`../tutorials/scripting/filesystem`
+- :doc:`File system <../tutorials/scripting/filesystem>`
 
 - `3D Voxel Demo <https://godotengine.org/asset-library/asset/676>`__
 

--- a/classes/class_gdnativelibrary.rst
+++ b/classes/class_gdnativelibrary.rst
@@ -21,9 +21,9 @@ A GDNative library can implement :ref:`NativeScript<class_NativeScript>`\ s, glo
 Tutorials
 ---------
 
-- :doc:`../tutorials/scripting/gdnative/gdnative_c_example`
+- :doc:`GDNative C example <../tutorials/scripting/gdnative/gdnative_c_example>`
 
-- :doc:`../tutorials/scripting/gdnative/gdnative_cpp_example`
+- :doc:`GDNative C++ example <../tutorials/scripting/gdnative/gdnative_cpp_example>`
 
 Properties
 ----------

--- a/classes/class_gdscript.rst
+++ b/classes/class_gdscript.rst
@@ -23,7 +23,7 @@ A script implemented in the GDScript programming language. The script extends th
 Tutorials
 ---------
 
-- :doc:`../tutorials/scripting/gdscript/index`
+- :doc:`GDScript documentation index <../tutorials/scripting/gdscript/index>`
 
 Methods
 -------

--- a/classes/class_gpuparticles2d.rst
+++ b/classes/class_gpuparticles2d.rst
@@ -23,7 +23,7 @@ Use the ``process_material`` property to add a :ref:`ParticlesMaterial<class_Par
 Tutorials
 ---------
 
-- :doc:`../tutorials/2d/particle_systems_2d`
+- :doc:`Particle systems (2D) <../tutorials/2d/particle_systems_2d>`
 
 - `2D Dodge The Creeps Demo <https://godotengine.org/asset-library/asset/515>`__
 

--- a/classes/class_gpuparticles3d.rst
+++ b/classes/class_gpuparticles3d.rst
@@ -23,7 +23,7 @@ Use the ``process_material`` property to add a :ref:`ParticlesMaterial<class_Par
 Tutorials
 ---------
 
-- :doc:`../tutorials/performance/vertex_animation/controlling_thousands_of_fish`
+- :doc:`Controlling thousands of fish with Particles <../tutorials/performance/vertex_animation/controlling_thousands_of_fish>`
 
 - `Third Person Shooter Demo <https://godotengine.org/asset-library/asset/678>`__
 

--- a/classes/class_gridmap.rst
+++ b/classes/class_gridmap.rst
@@ -29,7 +29,7 @@ Internally, a GridMap is split into a sparse collection of octants for efficient
 Tutorials
 ---------
 
-- :doc:`../tutorials/3d/using_gridmaps`
+- :doc:`Using gridmaps <../tutorials/3d/using_gridmaps>`
 
 - `3D Platformer Demo <https://godotengine.org/asset-library/asset/125>`__
 
@@ -268,7 +268,7 @@ GridMaps act as static bodies, meaning they aren't affected by gravity or other 
 | *Getter*  | get_collision_mask()      |
 +-----------+---------------------------+
 
-The physics layers this GridMap detects collisions in. See `Collision layers and masks <https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
+The physics layers this GridMap detects collisions in. See `Collision layers and masks <../tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
 
 ----
 

--- a/classes/class_httpclient.rst
+++ b/classes/class_httpclient.rst
@@ -37,9 +37,9 @@ For more information on HTTP, see https://developer.mozilla.org/en-US/docs/Web/H
 Tutorials
 ---------
 
-- :doc:`../tutorials/networking/http_client_class`
+- :doc:`HTTP client class <../tutorials/networking/http_client_class>`
 
-- :doc:`../tutorials/networking/ssl_certificates`
+- :doc:`SSL certificates <../tutorials/networking/ssl_certificates>`
 
 Properties
 ----------

--- a/classes/class_httprequest.rst
+++ b/classes/class_httprequest.rst
@@ -183,9 +183,9 @@ Can be used to make HTTP requests, i.e. download or upload files or web content 
 Tutorials
 ---------
 
-- :doc:`../tutorials/networking/http_request_class`
+- :doc:`Making HTTP requests <../tutorials/networking/http_request_class>`
 
-- :doc:`../tutorials/networking/ssl_certificates`
+- :doc:`SSL certificates <../tutorials/networking/ssl_certificates>`
 
 Properties
 ----------

--- a/classes/class_image.rst
+++ b/classes/class_image.rst
@@ -25,7 +25,7 @@ An ``Image`` cannot be assigned to a ``texture`` property of an object directly 
 Tutorials
 ---------
 
-- :doc:`../tutorials/assets_pipeline/importing_images`
+- :doc:`Importing images <../tutorials/assets_pipeline/importing_images>`
 
 Properties
 ----------
@@ -783,7 +783,7 @@ Returns ``true`` if all the image's pixels have an alpha value of 0. Returns ``f
 
 - :ref:`Error<enum_@GlobalScope_Error>` **load** **(** :ref:`String<class_String>` path **)**
 
-Loads an image from file ``path``. See `Supported image formats <https://docs.godotengine.org/en/latest/getting_started/workflow/assets/importing_images.html#supported-image-formats>`__ for a list of supported image formats and limitations.
+Loads an image from file ``path``. See `Supported image formats <../getting_started/workflow/assets/importing_images.html#supported-image-formats>`__ for a list of supported image formats and limitations.
 
 **Warning:** This method should only be used in the editor or in cases when you need to load external images at run-time, such as images located at the ``user://`` directory, and may not work in exported projects.
 

--- a/classes/class_imagetexture.rst
+++ b/classes/class_imagetexture.rst
@@ -51,7 +51,7 @@ An ``ImageTexture`` is not meant to be operated from within the editor interface
 Tutorials
 ---------
 
-- :doc:`../tutorials/assets_pipeline/importing_images`
+- :doc:`Importing images <../tutorials/assets_pipeline/importing_images>`
 
 Methods
 -------

--- a/classes/class_input.rst
+++ b/classes/class_input.rst
@@ -21,7 +21,7 @@ A singleton that deals with inputs. This includes key presses, mouse buttons and
 Tutorials
 ---------
 
-- :doc:`../tutorials/inputs/index`
+- :doc:`Inputs documentation index <../tutorials/inputs/index>`
 
 - `2D Dodge The Creeps Demo <https://godotengine.org/asset-library/asset/515>`__
 

--- a/classes/class_inputevent.rst
+++ b/classes/class_inputevent.rst
@@ -23,9 +23,9 @@ Base class of all sort of input event. See :ref:`Node._input<class_Node_method__
 Tutorials
 ---------
 
-- :doc:`../tutorials/inputs/inputevent`
+- :doc:`InputEvent <../tutorials/inputs/inputevent>`
 
-- :doc:`../tutorials/2d/2d_transforms`
+- :doc:`Viewport and canvas transforms <../tutorials/2d/2d_transforms>`
 
 - `2D Dodge The Creeps Demo <https://godotengine.org/asset-library/asset/515>`__
 

--- a/classes/class_inputeventaction.rst
+++ b/classes/class_inputeventaction.rst
@@ -21,7 +21,7 @@ Contains a generic action which can be targeted from several types of inputs. Ac
 Tutorials
 ---------
 
-- `#actions <../tutorials/inputs/inputevent.html#actions>`_ in :doc:`../tutorials/inputs/inputevent`
+- `InputEvent: Actions <../tutorials/inputs/inputevent.html#actions>`__
 
 - `2D Dodge The Creeps Demo <https://godotengine.org/asset-library/asset/515>`__
 

--- a/classes/class_inputeventjoypadbutton.rst
+++ b/classes/class_inputeventjoypadbutton.rst
@@ -21,7 +21,7 @@ Input event type for gamepad buttons. For gamepad analog sticks and joysticks, s
 Tutorials
 ---------
 
-- :doc:`../tutorials/inputs/inputevent`
+- :doc:`InputEvent <../tutorials/inputs/inputevent>`
 
 Properties
 ----------

--- a/classes/class_inputeventjoypadmotion.rst
+++ b/classes/class_inputeventjoypadmotion.rst
@@ -21,7 +21,7 @@ Stores information about joystick motions. One ``InputEventJoypadMotion`` repres
 Tutorials
 ---------
 
-- :doc:`../tutorials/inputs/inputevent`
+- :doc:`InputEvent <../tutorials/inputs/inputevent>`
 
 Properties
 ----------

--- a/classes/class_inputeventkey.rst
+++ b/classes/class_inputeventkey.rst
@@ -21,7 +21,7 @@ Stores key presses on the keyboard. Supports key presses, key releases and :ref:
 Tutorials
 ---------
 
-- :doc:`../tutorials/inputs/inputevent`
+- :doc:`InputEvent <../tutorials/inputs/inputevent>`
 
 Properties
 ----------

--- a/classes/class_inputeventmouse.rst
+++ b/classes/class_inputeventmouse.rst
@@ -23,7 +23,7 @@ Stores general mouse events information.
 Tutorials
 ---------
 
-- :doc:`../tutorials/inputs/inputevent`
+- :doc:`InputEvent <../tutorials/inputs/inputevent>`
 
 Properties
 ----------

--- a/classes/class_inputeventmousebutton.rst
+++ b/classes/class_inputeventmousebutton.rst
@@ -21,7 +21,7 @@ Contains mouse click information. See :ref:`Node._input<class_Node_method__input
 Tutorials
 ---------
 
-- :doc:`../tutorials/inputs/mouse_and_input_coordinates`
+- :doc:`Mouse and input coordinates <../tutorials/inputs/mouse_and_input_coordinates>`
 
 Properties
 ----------

--- a/classes/class_inputeventmousemotion.rst
+++ b/classes/class_inputeventmousemotion.rst
@@ -23,7 +23,7 @@ Contains mouse and pen motion information. Supports relative, absolute positions
 Tutorials
 ---------
 
-- :doc:`../tutorials/inputs/mouse_and_input_coordinates`
+- :doc:`Mouse and input coordinates <../tutorials/inputs/mouse_and_input_coordinates>`
 
 - `3D Voxel Demo <https://godotengine.org/asset-library/asset/676>`__
 

--- a/classes/class_inputeventscreendrag.rst
+++ b/classes/class_inputeventscreendrag.rst
@@ -21,7 +21,7 @@ Contains screen drag information. See :ref:`Node._input<class_Node_method__input
 Tutorials
 ---------
 
-- :doc:`../tutorials/inputs/inputevent`
+- :doc:`InputEvent <../tutorials/inputs/inputevent>`
 
 Properties
 ----------

--- a/classes/class_inputeventscreentouch.rst
+++ b/classes/class_inputeventscreentouch.rst
@@ -23,7 +23,7 @@ Stores multi-touch press/release information. Supports touch press, touch releas
 Tutorials
 ---------
 
-- :doc:`../tutorials/inputs/inputevent`
+- :doc:`InputEvent <../tutorials/inputs/inputevent>`
 
 Properties
 ----------

--- a/classes/class_inputeventwithmodifiers.rst
+++ b/classes/class_inputeventwithmodifiers.rst
@@ -23,7 +23,7 @@ Contains keys events information with modifiers support like :kbd:`Shift` or :kb
 Tutorials
 ---------
 
-- :doc:`../tutorials/inputs/inputevent`
+- :doc:`InputEvent <../tutorials/inputs/inputevent>`
 
 Properties
 ----------

--- a/classes/class_inputmap.rst
+++ b/classes/class_inputmap.rst
@@ -21,7 +21,7 @@ Manages all :ref:`InputEventAction<class_InputEventAction>` which can be created
 Tutorials
 ---------
 
-- `#inputmap <../tutorials/inputs/inputevent.html#inputmap>`_ in :doc:`../tutorials/inputs/inputevent`
+- `InputEvent: InputMap <../tutorials/inputs/inputevent.html#inputmap>`__
 
 Methods
 -------

--- a/classes/class_javascript.rst
+++ b/classes/class_javascript.rst
@@ -18,12 +18,12 @@ Description
 
 The JavaScript singleton is implemented only in the HTML5 export. It's used to access the browser's JavaScript context. This allows interaction with embedding pages or calling third-party JavaScript APIs.
 
-**Note:** This singleton can be disabled at build-time to improve security. By default, the JavaScript singleton is enabled. Official export templates also have the JavaScript singleton enabled. See `Compiling for the Web <https://docs.godotengine.org/en/latest/development/compiling/compiling_for_web.html>`__ in the documentation for more information.
+**Note:** This singleton can be disabled at build-time to improve security. By default, the JavaScript singleton is enabled. Official export templates also have the JavaScript singleton enabled. See :doc:`Compiling for the Web <../development/compiling/compiling_for_web>` in the documentation for more information.
 
 Tutorials
 ---------
 
-- `#calling-javascript-from-script <../tutorials/export/exporting_for_web.html#calling-javascript-from-script>`_ in :doc:`../tutorials/export/exporting_for_web`
+- `Exporting for the Web: Calling JavaScript from script <../tutorials/export/exporting_for_web.html#calling-javascript-from-script>`__
 
 Methods
 -------

--- a/classes/class_jnisingleton.rst
+++ b/classes/class_jnisingleton.rst
@@ -21,7 +21,7 @@ The JNISingleton is implemented only in the Android export. It's used to call me
 Tutorials
 ---------
 
-- `#doc-android-plugin <../tutorials/platform/android/android_plugin.html#doc-android-plugin>`_ in :doc:`../tutorials/platform/android/android_plugin`
+- `Creating Android plugins <../tutorials/platform/android/android_plugin.html#doc-android-plugin>`__
 
 .. |virtual| replace:: :abbr:`virtual (This method should typically be overridden by the user to have any effect.)`
 .. |const| replace:: :abbr:`const (This method has no side effects. It doesn't modify any of the instance's member variables.)`

--- a/classes/class_light2d.rst
+++ b/classes/class_light2d.rst
@@ -25,7 +25,7 @@ Casts light in a 2D environment. Light is defined by a (usually grayscale) textu
 Tutorials
 ---------
 
-- :doc:`../tutorials/2d/2d_lights_and_shadows`
+- :doc:`2D lights and shadows <../tutorials/2d/2d_lights_and_shadows>`
 
 Properties
 ----------

--- a/classes/class_light3d.rst
+++ b/classes/class_light3d.rst
@@ -23,7 +23,7 @@ Light3D is the *abstract* base class for light nodes. As it can't be instantiate
 Tutorials
 ---------
 
-- :doc:`../tutorials/3d/lights_and_shadows`
+- :doc:`3D lights and shadows <../tutorials/3d/lights_and_shadows>`
 
 - `Third Person Shooter Demo <https://godotengine.org/asset-library/asset/678>`__
 

--- a/classes/class_lightoccluder2d.rst
+++ b/classes/class_lightoccluder2d.rst
@@ -21,7 +21,7 @@ Occludes light cast by a Light2D, casting shadows. The LightOccluder2D must be p
 Tutorials
 ---------
 
-- :doc:`../tutorials/2d/2d_lights_and_shadows`
+- :doc:`2D lights and shadows <../tutorials/2d/2d_lights_and_shadows>`
 
 Properties
 ----------

--- a/classes/class_meshinstance2d.rst
+++ b/classes/class_meshinstance2d.rst
@@ -21,7 +21,7 @@ Node used for displaying a :ref:`Mesh<class_Mesh>` in 2D. Can be constructed fro
 Tutorials
 ---------
 
-- :doc:`../tutorials/2d/2d_meshes`
+- :doc:`2D meshes <../tutorials/2d/2d_meshes>`
 
 Properties
 ----------

--- a/classes/class_multimesh.rst
+++ b/classes/class_multimesh.rst
@@ -27,9 +27,9 @@ Since instances may have any behavior, the AABB used for visibility must be prov
 Tutorials
 ---------
 
-- :doc:`../tutorials/performance/vertex_animation/animating_thousands_of_fish`
+- :doc:`Animating thousands of fish with MultiMeshInstance <../tutorials/performance/vertex_animation/animating_thousands_of_fish>`
 
-- :doc:`../tutorials/performance/using_multimesh`
+- :doc:`Optimization using MultiMeshes <../tutorials/performance/using_multimesh>`
 
 Properties
 ----------

--- a/classes/class_multimeshinstance3d.rst
+++ b/classes/class_multimeshinstance3d.rst
@@ -23,11 +23,11 @@ This is useful to optimize the rendering of a high amount of instances of a give
 Tutorials
 ---------
 
-- :doc:`../tutorials/performance/vertex_animation/animating_thousands_of_fish`
+- :doc:`Animating thousands of fish with MultiMeshInstance <../tutorials/performance/vertex_animation/animating_thousands_of_fish>`
 
-- :doc:`../tutorials/3d/using_multi_mesh_instance`
+- :doc:`Using MultiMeshInstance <../tutorials/3d/using_multi_mesh_instance>`
 
-- :doc:`../tutorials/performance/using_multimesh`
+- :doc:`Optimization using MultiMeshes <../tutorials/performance/using_multimesh>`
 
 Properties
 ----------

--- a/classes/class_multiplayerpeer.rst
+++ b/classes/class_multiplayerpeer.rst
@@ -27,7 +27,7 @@ Manages the connection to multiplayer peers. Assigns unique IDs to each client c
 Tutorials
 ---------
 
-- :doc:`../tutorials/networking/high_level_multiplayer`
+- :doc:`High-level multiplayer <../tutorials/networking/high_level_multiplayer>`
 
 - `WebRTC Signaling Demo <https://godotengine.org/asset-library/asset/537>`__
 

--- a/classes/class_mutex.rst
+++ b/classes/class_mutex.rst
@@ -21,7 +21,7 @@ A synchronization mutex (mutual exclusion). This is used to synchronize multiple
 Tutorials
 ---------
 
-- :doc:`../tutorials/performance/using_multiple_threads`
+- :doc:`Using multiple threads <../tutorials/performance/using_multiple_threads>`
 
 Methods
 -------

--- a/classes/class_node.rst
+++ b/classes/class_node.rst
@@ -43,7 +43,7 @@ Finally, when a node is freed with :ref:`Object.free<class_Object_method_free>` 
 Tutorials
 ---------
 
-- `Nodes and scenes <https://docs.godotengine.org/en/latest/getting_started/step_by_step/nodes_and_scenes.htmltml>`__
+- :doc:`Nodes and scenes <../getting_started/step_by_step/nodes_and_scenes>`
 
 - `All Demos <https://github.com/godotengine/godot-demo-projects/>`__
 

--- a/classes/class_node2d.rst
+++ b/classes/class_node2d.rst
@@ -23,7 +23,7 @@ A 2D game object, with a transform (position, rotation, and scale). All 2D nodes
 Tutorials
 ---------
 
-- :doc:`../tutorials/2d/custom_drawing_in_2d`
+- :doc:`Custom drawing in 2D <../tutorials/2d/custom_drawing_in_2d>`
 
 - `All 2D Demos <https://github.com/godotengine/godot-demo-projects/tree/master/2d>`__
 

--- a/classes/class_node3d.rst
+++ b/classes/class_node3d.rst
@@ -27,7 +27,7 @@ Affine operations (rotate, scale, translate) happen in parent's local coordinate
 Tutorials
 ---------
 
-- :doc:`../tutorials/3d/introduction_to_3d`
+- :doc:`Introduction to 3D <../tutorials/3d/introduction_to_3d>`
 
 - `All 3D Demos <https://github.com/godotengine/godot-demo-projects/tree/master/3d>`__
 

--- a/classes/class_object.rst
+++ b/classes/class_object.rst
@@ -56,7 +56,7 @@ Objects also receive notifications. Notifications are a simple way to notify the
 Tutorials
 ---------
 
-- :doc:`../tutorials/best_practices/node_alternatives`
+- :doc:`When and how to avoid using nodes for everything <../tutorials/best_practices/node_alternatives>`
 
 Methods
 -------
@@ -871,7 +871,7 @@ Translates a message using translation catalogs configured in the Project Settin
 
 Only works if message translation is enabled (which it is by default), otherwise it returns the ``message`` unchanged. See :ref:`set_message_translation<class_Object_method_set_message_translation>`.
 
-See `Internationalizing games <https://docs.godotengine.org/en/latest/tutorials/i18n/internationalizing_games.html>`__ for examples of the usage of this method.
+See :doc:`Internationalizing games <../tutorials/i18n/internationalizing_games>` for examples of the usage of this method.
 
 ----
 
@@ -887,7 +887,7 @@ The number ``n`` is the number or quantity of the plural object. It will be used
 
 **Note:** Negative and floating-point values usually represent physical entities for which singular and plural don't clearly apply. In such cases, use :ref:`tr<class_Object_method_tr>`.
 
-See `Localization using gettext <https://docs.godotengine.org/en/latest/tutorials/i18n/localization_using_gettext.html>`__ for examples of the usage of this method.
+See :doc:`Localization using gettext <../tutorials/i18n/localization_using_gettext>` for examples of the usage of this method.
 
 .. |virtual| replace:: :abbr:`virtual (This method should typically be overridden by the user to have any effect.)`
 .. |const| replace:: :abbr:`const (This method has no side effects. It doesn't modify any of the instance's member variables.)`

--- a/classes/class_omnilight3d.rst
+++ b/classes/class_omnilight3d.rst
@@ -21,7 +21,7 @@ An Omnidirectional light is a type of :ref:`Light3D<class_Light3D>` that emits l
 Tutorials
 ---------
 
-- :doc:`../tutorials/3d/lights_and_shadows`
+- :doc:`3D lights and shadows <../tutorials/3d/lights_and_shadows>`
 
 Properties
 ----------

--- a/classes/class_os.rst
+++ b/classes/class_os.rst
@@ -491,7 +491,7 @@ Returns the keycode of the given string (e.g. "Escape").
 
 - :ref:`String<class_String>` **get_cache_dir** **(** **)** |const|
 
-Returns the *global* cache data directory according to the operating system's standards. On desktop platforms, this path can be overridden by setting the ``XDG_CACHE_HOME`` environment variable before starting the project. See `File paths in Godot projects <https://docs.godotengine.org/en/latest/tutorials/io/data_paths.html>`__ in the documentation for more information. See also :ref:`get_config_dir<class_OS_method_get_config_dir>` and :ref:`get_data_dir<class_OS_method_get_data_dir>`.
+Returns the *global* cache data directory according to the operating system's standards. On desktop platforms, this path can be overridden by setting the ``XDG_CACHE_HOME`` environment variable before starting the project. See :doc:`File paths in Godot projects <../tutorials/io/data_paths>` in the documentation for more information. See also :ref:`get_config_dir<class_OS_method_get_config_dir>` and :ref:`get_data_dir<class_OS_method_get_data_dir>`.
 
 Not to be confused with :ref:`get_user_data_dir<class_OS_method_get_user_data_dir>`, which returns the *project-specific* user data path.
 
@@ -542,7 +542,7 @@ Here's a minimal example on how to parse command-line arguments into a dictionar
 
 - :ref:`String<class_String>` **get_config_dir** **(** **)** |const|
 
-Returns the *global* user configuration directory according to the operating system's standards. On desktop platforms, this path can be overridden by setting the ``XDG_CONFIG_HOME`` environment variable before starting the project. See `File paths in Godot projects <https://docs.godotengine.org/en/latest/tutorials/io/data_paths.html>`__ in the documentation for more information. See also :ref:`get_cache_dir<class_OS_method_get_cache_dir>` and :ref:`get_data_dir<class_OS_method_get_data_dir>`.
+Returns the *global* user configuration directory according to the operating system's standards. On desktop platforms, this path can be overridden by setting the ``XDG_CONFIG_HOME`` environment variable before starting the project. See :doc:`File paths in Godot projects <../tutorials/io/data_paths>` in the documentation for more information. See also :ref:`get_cache_dir<class_OS_method_get_cache_dir>` and :ref:`get_data_dir<class_OS_method_get_data_dir>`.
 
 Not to be confused with :ref:`get_user_data_dir<class_OS_method_get_user_data_dir>`, which returns the *project-specific* user data path.
 
@@ -564,7 +564,7 @@ The returned array will be empty if the system MIDI driver has not previously be
 
 - :ref:`String<class_String>` **get_data_dir** **(** **)** |const|
 
-Returns the *global* user data directory according to the operating system's standards. On desktop platforms, this path can be overridden by setting the ``XDG_DATA_HOME`` environment variable before starting the project. See `File paths in Godot projects <https://docs.godotengine.org/en/latest/tutorials/io/data_paths.html>`__ in the documentation for more information. See also :ref:`get_cache_dir<class_OS_method_get_cache_dir>` and :ref:`get_config_dir<class_OS_method_get_config_dir>`.
+Returns the *global* user data directory according to the operating system's standards. On desktop platforms, this path can be overridden by setting the ``XDG_DATA_HOME`` environment variable before starting the project. See :doc:`File paths in Godot projects <../tutorials/io/data_paths>` in the documentation for more information. See also :ref:`get_cache_dir<class_OS_method_get_cache_dir>` and :ref:`get_config_dir<class_OS_method_get_config_dir>`.
 
 Not to be confused with :ref:`get_user_data_dir<class_OS_method_get_user_data_dir>`, which returns the *project-specific* user data path.
 
@@ -756,7 +756,7 @@ Returns ``true`` if the environment variable with the name ``variable`` exists.
 
 - :ref:`bool<class_bool>` **has_feature** **(** :ref:`String<class_String>` tag_name **)** |const|
 
-Returns ``true`` if the feature for the given feature tag is supported in the currently running instance, depending on the platform, build, etc. Can be used to check whether you're currently running a debug build, on a certain platform or arch, etc. Refer to the `Feature Tags <https://docs.godotengine.org/en/latest/getting_started/workflow/export/feature_tags.html>`__ documentation for more details.
+Returns ``true`` if the feature for the given feature tag is supported in the currently running instance, depending on the platform, build, etc. Can be used to check whether you're currently running a debug build, on a certain platform or arch, etc. Refer to the :doc:`Feature Tags <../getting_started/workflow/export/feature_tags>` documentation for more details.
 
 **Note:** Tag names are case-sensitive.
 
@@ -906,7 +906,7 @@ Requests the OS to open a resource with the most appropriate program. For exampl
 
 - ``OS.shell_open("https://godotengine.org")`` opens the default web browser on the official Godot website.
 
-- ``OS.shell_open("mailto:example@example.com")`` opens the default email client with the "To" field set to ``example@example.com``. See `Customizing ``mailto:`` Links <https://blog.escapecreative.com/customizing-mailto-links/>`__ for a list of fields that can be added.
+- ``OS.shell_open("mailto:example@example.com")`` opens the default email client with the "To" field set to ``example@example.com``. See `Customizing [code]mailto:[/code] Links <https://blog.escapecreative.com/customizing-mailto-links/>`__ for a list of fields that can be added.
 
 Use :ref:`ProjectSettings.globalize_path<class_ProjectSettings_method_globalize_path>` to convert a ``res://`` or ``user://`` path into a system path for use with this method.
 

--- a/classes/class_physicsbody2d.rst
+++ b/classes/class_physicsbody2d.rst
@@ -23,7 +23,7 @@ PhysicsBody2D is an abstract base class for implementing a physics body. All \*B
 Tutorials
 ---------
 
-- :doc:`../tutorials/physics/physics_introduction`
+- :doc:`Physics introduction <../tutorials/physics/physics_introduction>`
 
 Properties
 ----------

--- a/classes/class_physicsbody3d.rst
+++ b/classes/class_physicsbody3d.rst
@@ -23,7 +23,7 @@ PhysicsBody3D is an abstract base class for implementing a physics body. All \*B
 Tutorials
 ---------
 
-- :doc:`../tutorials/physics/physics_introduction`
+- :doc:`Physics introduction <../tutorials/physics/physics_introduction>`
 
 Properties
 ----------

--- a/classes/class_physicsdirectbodystate2d.rst
+++ b/classes/class_physicsdirectbodystate2d.rst
@@ -21,9 +21,9 @@ Provides direct access to a physics body in the :ref:`PhysicsServer2D<class_Phys
 Tutorials
 ---------
 
-- :doc:`../tutorials/physics/physics_introduction`
+- :doc:`Physics introduction <../tutorials/physics/physics_introduction>`
 
-- :doc:`../tutorials/physics/ray-casting`
+- :doc:`Ray-casting <../tutorials/physics/ray-casting>`
 
 Properties
 ----------

--- a/classes/class_physicsdirectbodystate3d.rst
+++ b/classes/class_physicsdirectbodystate3d.rst
@@ -21,9 +21,9 @@ Provides direct access to a physics body in the :ref:`PhysicsServer3D<class_Phys
 Tutorials
 ---------
 
-- :doc:`../tutorials/physics/physics_introduction`
+- :doc:`Physics introduction <../tutorials/physics/physics_introduction>`
 
-- :doc:`../tutorials/physics/ray-casting`
+- :doc:`Ray-casting <../tutorials/physics/ray-casting>`
 
 Properties
 ----------

--- a/classes/class_physicsdirectspacestate2d.rst
+++ b/classes/class_physicsdirectspacestate2d.rst
@@ -21,9 +21,9 @@ Direct access object to a space in the :ref:`PhysicsServer2D<class_PhysicsServer
 Tutorials
 ---------
 
-- :doc:`../tutorials/physics/physics_introduction`
+- :doc:`Physics introduction <../tutorials/physics/physics_introduction>`
 
-- :doc:`../tutorials/physics/ray-casting`
+- :doc:`Ray-casting <../tutorials/physics/ray-casting>`
 
 Methods
 -------

--- a/classes/class_physicsdirectspacestate3d.rst
+++ b/classes/class_physicsdirectspacestate3d.rst
@@ -21,9 +21,9 @@ Direct access object to a space in the :ref:`PhysicsServer3D<class_PhysicsServer
 Tutorials
 ---------
 
-- :doc:`../tutorials/physics/physics_introduction`
+- :doc:`Physics introduction <../tutorials/physics/physics_introduction>`
 
-- :doc:`../tutorials/physics/ray-casting`
+- :doc:`Ray-casting <../tutorials/physics/ray-casting>`
 
 Methods
 -------

--- a/classes/class_physicspointqueryparameters2d.rst
+++ b/classes/class_physicspointqueryparameters2d.rst
@@ -98,7 +98,7 @@ If ``true``, the query will take :ref:`PhysicsBody2D<class_PhysicsBody2D>`\ s in
 | *Getter*  | get_collision_mask()      |
 +-----------+---------------------------+
 
-The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See `Collision layers and masks <https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
+The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See `Collision layers and masks <../tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
 
 ----
 

--- a/classes/class_physicspointqueryparameters3d.rst
+++ b/classes/class_physicspointqueryparameters3d.rst
@@ -80,7 +80,7 @@ If ``true``, the query will take :ref:`PhysicsBody3D<class_PhysicsBody3D>`\ s in
 | *Getter*  | get_collision_mask()      |
 +-----------+---------------------------+
 
-The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See `Collision layers and masks <https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
+The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See `Collision layers and masks <../tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
 
 ----
 

--- a/classes/class_physicsrayqueryparameters2d.rst
+++ b/classes/class_physicsrayqueryparameters2d.rst
@@ -84,7 +84,7 @@ If ``true``, the query will take :ref:`PhysicsBody2D<class_PhysicsBody2D>`\ s in
 | *Getter*  | get_collision_mask()      |
 +-----------+---------------------------+
 
-The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See `Collision layers and masks <https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
+The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See `Collision layers and masks <../tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
 
 ----
 

--- a/classes/class_physicsrayqueryparameters3d.rst
+++ b/classes/class_physicsrayqueryparameters3d.rst
@@ -86,7 +86,7 @@ If ``true``, the query will take :ref:`PhysicsBody3D<class_PhysicsBody3D>`\ s in
 | *Getter*  | get_collision_mask()      |
 +-----------+---------------------------+
 
-The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See `Collision layers and masks <https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
+The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See `Collision layers and masks <../tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
 
 ----
 

--- a/classes/class_physicsshapequeryparameters2d.rst
+++ b/classes/class_physicsshapequeryparameters2d.rst
@@ -88,7 +88,7 @@ If ``true``, the query will take :ref:`PhysicsBody2D<class_PhysicsBody2D>`\ s in
 | *Getter*  | get_collision_mask()      |
 +-----------+---------------------------+
 
-The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See `Collision layers and masks <https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
+The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See `Collision layers and masks <../tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
 
 ----
 

--- a/classes/class_physicsshapequeryparameters3d.rst
+++ b/classes/class_physicsshapequeryparameters3d.rst
@@ -88,7 +88,7 @@ If ``true``, the query will take :ref:`PhysicsBody3D<class_PhysicsBody3D>`\ s in
 | *Getter*  | get_collision_mask()      |
 +-----------+---------------------------+
 
-The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See `Collision layers and masks <https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
+The physics layers the query will detect (as a bitmask). By default, all collision layers are detected. See `Collision layers and masks <../tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
 
 ----
 

--- a/classes/class_plane.rst
+++ b/classes/class_plane.rst
@@ -19,7 +19,7 @@ Plane represents a normalized plane equation. Basically, "normal" is the normal 
 Tutorials
 ---------
 
-- :doc:`../tutorials/math/index`
+- :doc:`Math documentation index <../tutorials/math/index>`
 
 Properties
 ----------

--- a/classes/class_projectsettings.rst
+++ b/classes/class_projectsettings.rst
@@ -20,9 +20,9 @@ Contains global variables accessible from everywhere. Use :ref:`get_setting<clas
 
 When naming a Project Settings property, use the full path to the setting including the category. For example, ``"application/config/name"`` for the project name. Category and property names can be viewed in the Project Settings dialog.
 
-**Feature tags:** Project settings can be overridden for specific platforms and configurations (debug, release, ...) using `feature tags <https://docs.godotengine.org/en/latest/tutorials/export/feature_tags.html>`__.
+**Feature tags:** Project settings can be overridden for specific platforms and configurations (debug, release, ...) using :doc:`feature tags <../tutorials/export/feature_tags>`.
 
-**Overriding:** Any project setting can be overridden by creating a file named ``override.cfg`` in the project's root directory. This can also be used in exported projects by placing this file in the same directory as the project binary. Overriding will still take the base project settings' `feature tags <https://docs.godotengine.org/en/latest/tutorials/export/feature_tags.html>`__ in account. Therefore, make sure to *also* override the setting with the desired feature tags if you want them to override base project settings on all platforms and configurations.
+**Overriding:** Any project setting can be overridden by creating a file named ``override.cfg`` in the project's root directory. This can also be used in exported projects by placing this file in the same directory as the project binary. Overriding will still take the base project settings' :doc:`feature tags <../tutorials/export/feature_tags>` in account. Therefore, make sure to *also* override the setting with the desired feature tags if you want them to override base project settings on all platforms and configurations.
 
 Tutorials
 ---------
@@ -1296,7 +1296,7 @@ Icon set in ``.icns`` format used on macOS to set the game's icon. This is done 
 
 The project's name. It is used both by the Project Manager and by exporters. The project name can be translated by translating its value in localization files. The window title will be set to match the project name automatically on startup.
 
-**Note:** Changing this value will also change the user data folder's path if :ref:`application/config/use_custom_user_dir<class_ProjectSettings_property_application/config/use_custom_user_dir>` is ``false``. After renaming the project, you will no longer be able to access existing data in ``user://`` unless you rename the old folder to match the new project name. See `Data paths <https://docs.godotengine.org/en/latest/tutorials/io/data_paths.html>`__ in the documentation for more information.
+**Note:** Changing this value will also change the user data folder's path if :ref:`application/config/use_custom_user_dir<class_ProjectSettings_property_application/config/use_custom_user_dir>` is ``false``. After renaming the project, you will no longer be able to access existing data in ``user://`` unless you rename the old folder to match the new project name. See :doc:`Data paths <../tutorials/io/data_paths>` in the documentation for more information.
 
 ----
 
@@ -2378,7 +2378,7 @@ Forces the main window to be borderless.
 
 Sets the main window to full screen when the project starts. Note that this is not *exclusive* fullscreen. On Windows and Linux, a borderless window is used to emulate fullscreen. On macOS, a new desktop is used to display the running project.
 
-Regardless of the platform, enabling fullscreen will change the window size to match the monitor's size. Therefore, make sure your project supports `multiple resolutions <https://docs.godotengine.org/en/latest/tutorials/rendering/multiple_resolutions.html>`__ when enabling fullscreen mode.
+Regardless of the platform, enabling fullscreen will change the window size to match the monitor's size. Therefore, make sure your project supports :doc:`multiple resolutions <../tutorials/rendering/multiple_resolutions>` when enabling fullscreen mode.
 
 **Note:** This setting is ignored on iOS, Android, and HTML5.
 
@@ -7590,7 +7590,7 @@ Returns the value of a setting.
 
 - :ref:`String<class_String>` **globalize_path** **(** :ref:`String<class_String>` path **)** |const|
 
-Returns the absolute, native OS path corresponding to the localized ``path`` (starting with ``res://`` or ``user://``). The returned path will vary depending on the operating system and user preferences. See `File paths in Godot projects <https://docs.godotengine.org/en/latest/tutorials/io/data_paths.html>`__ to see what those paths convert to. See also :ref:`localize_path<class_ProjectSettings_method_localize_path>`.
+Returns the absolute, native OS path corresponding to the localized ``path`` (starting with ``res://`` or ``user://``). The returned path will vary depending on the operating system and user preferences. See :doc:`File paths in Godot projects <../tutorials/io/data_paths>` to see what those paths convert to. See also :ref:`localize_path<class_ProjectSettings_method_localize_path>`.
 
 **Note:** :ref:`globalize_path<class_ProjectSettings_method_globalize_path>` with ``res://`` will not work in an exported project. Instead, prepend the executable's base directory to the path when running from an exported project:
 

--- a/classes/class_quaternion.rst
+++ b/classes/class_quaternion.rst
@@ -23,7 +23,7 @@ Due to its compactness and the way it is stored in memory, certain operations (o
 Tutorials
 ---------
 
-- `#interpolating-with-quaternions <../tutorials/3d/using_transforms.html#interpolating-with-quaternions>`_ in :doc:`../tutorials/3d/using_transforms`
+- `Using 3D transforms <../tutorials/3d/using_transforms.html#interpolating-with-quaternions>`__
 
 - `Third Person Shooter Demo <https://godotengine.org/asset-library/asset/678>`__
 

--- a/classes/class_randomnumbergenerator.rst
+++ b/classes/class_randomnumbergenerator.rst
@@ -34,7 +34,7 @@ To generate a random float number (within a given range) based on a time-dependa
 Tutorials
 ---------
 
-- :doc:`../tutorials/math/random_number_generation`
+- :doc:`Random number generation <../tutorials/math/random_number_generation>`
 
 Properties
 ----------

--- a/classes/class_raycast2d.rst
+++ b/classes/class_raycast2d.rst
@@ -29,7 +29,7 @@ RayCast2D calculates intersection every physics frame (see :ref:`Node<class_Node
 Tutorials
 ---------
 
-- :doc:`../tutorials/physics/ray-casting`
+- :doc:`Ray-casting <../tutorials/physics/ray-casting>`
 
 Properties
 ----------
@@ -128,7 +128,7 @@ If ``true``, collision with :ref:`PhysicsBody2D<class_PhysicsBody2D>`\ s will be
 | *Getter*  | get_collision_mask()      |
 +-----------+---------------------------+
 
-The ray's collision mask. Only objects in at least one collision layer enabled in the mask will be detected. See `Collision layers and masks <https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
+The ray's collision mask. Only objects in at least one collision layer enabled in the mask will be detected. See `Collision layers and masks <../tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
 
 ----
 

--- a/classes/class_raycast3d.rst
+++ b/classes/class_raycast3d.rst
@@ -29,7 +29,7 @@ RayCast3D calculates intersection every physics frame (see :ref:`Node<class_Node
 Tutorials
 ---------
 
-- :doc:`../tutorials/physics/ray-casting`
+- :doc:`Ray-casting <../tutorials/physics/ray-casting>`
 
 - `3D Voxel Demo <https://godotengine.org/asset-library/asset/676>`__
 
@@ -134,7 +134,7 @@ If ``true``, collision with :ref:`PhysicsBody3D<class_PhysicsBody3D>`\ s will be
 | *Getter*  | get_collision_mask()      |
 +-----------+---------------------------+
 
-The ray's collision mask. Only objects in at least one collision layer enabled in the mask will be detected. See `Collision layers and masks <https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
+The ray's collision mask. Only objects in at least one collision layer enabled in the mask will be detected. See `Collision layers and masks <../tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
 
 ----
 

--- a/classes/class_rect2.rst
+++ b/classes/class_rect2.rst
@@ -23,11 +23,11 @@ The 3D counterpart to ``Rect2`` is :ref:`AABB<class_AABB>`.
 Tutorials
 ---------
 
-- :doc:`../tutorials/math/index`
+- :doc:`Math documentation index <../tutorials/math/index>`
 
-- :doc:`../tutorials/math/vector_math`
+- :doc:`Vector math <../tutorials/math/vector_math>`
 
-- :doc:`../tutorials/math/vectors_advanced`
+- :doc:`Advanced vector math <../tutorials/math/vectors_advanced>`
 
 Properties
 ----------

--- a/classes/class_rect2i.rst
+++ b/classes/class_rect2i.rst
@@ -21,9 +21,9 @@ It uses integer coordinates. If you need floating-point coordinates, use :ref:`R
 Tutorials
 ---------
 
-- :doc:`../tutorials/math/index`
+- :doc:`Math documentation index <../tutorials/math/index>`
 
-- :doc:`../tutorials/math/vector_math`
+- :doc:`Vector math <../tutorials/math/vector_math>`
 
 Properties
 ----------

--- a/classes/class_refcounted.rst
+++ b/classes/class_refcounted.rst
@@ -29,7 +29,7 @@ In the vast majority of use cases, instantiating and using ``RefCounted``-derive
 Tutorials
 ---------
 
-- :doc:`../tutorials/best_practices/node_alternatives`
+- :doc:`When and how to avoid using nodes for everything <../tutorials/best_practices/node_alternatives>`
 
 Methods
 -------

--- a/classes/class_reflectionprobe.rst
+++ b/classes/class_reflectionprobe.rst
@@ -23,7 +23,7 @@ The ``ReflectionProbe`` is used to create high-quality reflections at the cost o
 Tutorials
 ---------
 
-- :doc:`../tutorials/3d/reflection_probes`
+- :doc:`Reflection probes <../tutorials/3d/reflection_probes>`
 
 Properties
 ----------

--- a/classes/class_renderingserver.rst
+++ b/classes/class_renderingserver.rst
@@ -37,7 +37,7 @@ In 2D, all visible objects are some form of canvas item. In order to be visible,
 Tutorials
 ---------
 
-- :doc:`../tutorials/performance/using_servers`
+- :doc:`Optimization using Servers <../tutorials/performance/using_servers>`
 
 Properties
 ----------

--- a/classes/class_resource.rst
+++ b/classes/class_resource.rst
@@ -25,9 +25,9 @@ Resource is the base class for all Godot-specific resource types, serving primar
 Tutorials
 ---------
 
-- :doc:`../tutorials/scripting/resources`
+- :doc:`Resources <../tutorials/scripting/resources>`
 
-- :doc:`../tutorials/best_practices/node_alternatives`
+- :doc:`When and how to avoid using nodes for everything <../tutorials/best_practices/node_alternatives>`
 
 Properties
 ----------

--- a/classes/class_resourceimporter.rst
+++ b/classes/class_resourceimporter.rst
@@ -23,7 +23,7 @@ This is the base class for the resource importers implemented in core. To implem
 Tutorials
 ---------
 
-- :doc:`../tutorials/plugins/editor/import_plugins`
+- :doc:`Import plugins <../tutorials/plugins/editor/import_plugins>`
 
 Enumerations
 ------------

--- a/classes/class_richtexteffect.rst
+++ b/classes/class_richtexteffect.rst
@@ -40,7 +40,7 @@ A custom effect for use with :ref:`RichTextLabel<class_RichTextLabel>`.
 Tutorials
 ---------
 
-- :doc:`../tutorials/ui/bbcode_in_richtextlabel`
+- :doc:`BBCode in RichTextLabel <../tutorials/ui/bbcode_in_richtextlabel>`
 
 - `RichTextEffect test project (third-party) <https://github.com/Eoin-ONeill-Yokai/Godot-Rich-Text-Effect-Test-Project>`__
 

--- a/classes/class_richtextlabel.rst
+++ b/classes/class_richtextlabel.rst
@@ -29,7 +29,7 @@ Rich text can contain custom text, fonts, images and some basic formatting. The 
 Tutorials
 ---------
 
-- :doc:`../tutorials/ui/bbcode_in_richtextlabel`
+- :doc:`BBCode in RichTextLabel <../tutorials/ui/bbcode_in_richtextlabel>`
 
 - `GUI Rich Text/BBcode Demo <https://godotengine.org/asset-library/asset/132>`__
 

--- a/classes/class_rigiddynamicbody3d.rst
+++ b/classes/class_rigiddynamicbody3d.rst
@@ -29,7 +29,7 @@ If you need to override the default physics behavior, you can write a custom for
 Tutorials
 ---------
 
-- :doc:`../tutorials/physics/physics_introduction`
+- :doc:`Physics introduction <../tutorials/physics/physics_introduction>`
 
 - `3D Truck Town Demo <https://godotengine.org/asset-library/asset/524>`__
 

--- a/classes/class_rootmotionview.rst
+++ b/classes/class_rootmotionview.rst
@@ -23,7 +23,7 @@ Description
 Tutorials
 ---------
 
-- `#root-motion <../tutorials/animation/animation_tree.html#root-motion>`_ in :doc:`../tutorials/animation/animation_tree`
+- `Using AnimationTree - Root motion <../tutorials/animation/animation_tree.html#root-motion>`__
 
 Properties
 ----------

--- a/classes/class_scenetree.rst
+++ b/classes/class_scenetree.rst
@@ -25,9 +25,9 @@ You can also use the ``SceneTree`` to organize your nodes into groups: every nod
 Tutorials
 ---------
 
-- :doc:`../tutorials/scripting/scene_tree`
+- :doc:`SceneTree <../tutorials/scripting/scene_tree>`
 
-- :doc:`../tutorials/rendering/multiple_resolutions`
+- :doc:`Multiple resolutions <../tutorials/rendering/multiple_resolutions>`
 
 Properties
 ----------

--- a/classes/class_script.rst
+++ b/classes/class_script.rst
@@ -25,7 +25,7 @@ The ``new`` method of a script subclass creates a new instance. :ref:`Object.set
 Tutorials
 ---------
 
-- :doc:`../tutorials/scripting/index`
+- :doc:`Scripting documentation index <../tutorials/scripting/index>`
 
 Properties
 ----------

--- a/classes/class_semaphore.rst
+++ b/classes/class_semaphore.rst
@@ -21,7 +21,7 @@ A synchronization semaphore which can be used to synchronize multiple :ref:`Thre
 Tutorials
 ---------
 
-- :doc:`../tutorials/performance/using_multiple_threads`
+- :doc:`Using multiple threads <../tutorials/performance/using_multiple_threads>`
 
 Methods
 -------

--- a/classes/class_shader.rst
+++ b/classes/class_shader.rst
@@ -23,7 +23,7 @@ This class allows you to define a custom shader program that can be used by a :r
 Tutorials
 ---------
 
-- :doc:`../tutorials/shaders/index`
+- :doc:`Shaders documentation index <../tutorials/shaders/index>`
 
 Properties
 ----------

--- a/classes/class_shadermaterial.rst
+++ b/classes/class_shadermaterial.rst
@@ -21,7 +21,7 @@ A material that uses a custom :ref:`Shader<class_Shader>` program to render eith
 Tutorials
 ---------
 
-- :doc:`../tutorials/shaders/index`
+- :doc:`Shaders documentation index <../tutorials/shaders/index>`
 
 Properties
 ----------

--- a/classes/class_shape2d.rst
+++ b/classes/class_shape2d.rst
@@ -23,7 +23,7 @@ Base class for all 2D shapes. All 2D shape types inherit from this.
 Tutorials
 ---------
 
-- :doc:`../tutorials/physics/physics_introduction`
+- :doc:`Physics introduction <../tutorials/physics/physics_introduction>`
 
 Properties
 ----------

--- a/classes/class_shape3d.rst
+++ b/classes/class_shape3d.rst
@@ -23,7 +23,7 @@ Base class for all 3D shape resources. Nodes that inherit from this can be used 
 Tutorials
 ---------
 
-- :doc:`../tutorials/physics/physics_introduction`
+- :doc:`Physics introduction <../tutorials/physics/physics_introduction>`
 
 Properties
 ----------

--- a/classes/class_skeleton2d.rst
+++ b/classes/class_skeleton2d.rst
@@ -23,7 +23,7 @@ To setup different types of inverse kinematics for the given Skeleton2D, a :ref:
 Tutorials
 ---------
 
-- :doc:`../tutorials/animation/2d_skeletons`
+- :doc:`2D skeletons <../tutorials/animation/2d_skeletons>`
 
 Methods
 -------

--- a/classes/class_softdynamicbody3d.rst
+++ b/classes/class_softdynamicbody3d.rst
@@ -21,7 +21,7 @@ A deformable physics body. Used to create elastic or deformable objects such as 
 Tutorials
 ---------
 
-- :doc:`../tutorials/physics/soft_body`
+- :doc:`SoftBody <../tutorials/physics/soft_body>`
 
 Properties
 ----------
@@ -111,7 +111,7 @@ Property Descriptions
 
 The physics layers this SoftDynamicBody3D **is in**. Collision objects can exist in one or more of 32 different layers. See also :ref:`collision_mask<class_SoftDynamicBody3D_property_collision_mask>`.
 
-**Note:** Object A can detect a contact with object B only if object B is in any of the layers that object A scans. See `Collision layers and masks <https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
+**Note:** Object A can detect a contact with object B only if object B is in any of the layers that object A scans. See `Collision layers and masks <../tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
 
 ----
 
@@ -129,7 +129,7 @@ The physics layers this SoftDynamicBody3D **is in**. Collision objects can exist
 
 The physics layers this SoftDynamicBody3D **scans**. Collision objects can scan one or more of 32 different layers. See also :ref:`collision_layer<class_SoftDynamicBody3D_property_collision_layer>`.
 
-**Note:** Object A can detect a contact with object B only if object B is in any of the layers that object A scans. See `Collision layers and masks <https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
+**Note:** Object A can detect a contact with object B only if object B is in any of the layers that object A scans. See `Collision layers and masks <../tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
 
 ----
 

--- a/classes/class_spotlight3d.rst
+++ b/classes/class_spotlight3d.rst
@@ -21,7 +21,7 @@ A Spotlight is a type of :ref:`Light3D<class_Light3D>` node that emits lights in
 Tutorials
 ---------
 
-- :doc:`../tutorials/3d/lights_and_shadows`
+- :doc:`3D lights and shadows <../tutorials/3d/lights_and_shadows>`
 
 - `Third Person Shooter Demo <https://godotengine.org/asset-library/asset/678>`__
 

--- a/classes/class_springarm3d.rst
+++ b/classes/class_springarm3d.rst
@@ -65,7 +65,7 @@ Property Descriptions
 | *Getter*  | get_collision_mask()      |
 +-----------+---------------------------+
 
-The layers against which the collision check shall be done. See `Collision layers and masks <https://docs.godotengine.org/en/latest/tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
+The layers against which the collision check shall be done. See `Collision layers and masks <../tutorials/physics/physics_introduction.html#collision-layers-and-masks>`__ in the documentation for more information.
 
 ----
 

--- a/classes/class_standardmaterial3d.rst
+++ b/classes/class_standardmaterial3d.rst
@@ -16,7 +16,7 @@ StandardMaterial3D
 Tutorials
 ---------
 
-- :doc:`../tutorials/3d/standard_material_3d`
+- :doc:`Standard Material 3D <../tutorials/3d/standard_material_3d>`
 
 .. |virtual| replace:: :abbr:`virtual (This method should typically be overridden by the user to have any effect.)`
 .. |const| replace:: :abbr:`const (This method has no side effects. It doesn't modify any of the instance's member variables.)`

--- a/classes/class_streampeerssl.rst
+++ b/classes/class_streampeerssl.rst
@@ -23,7 +23,7 @@ SSL stream peer. This object can be used to connect to an SSL server or accept a
 Tutorials
 ---------
 
-- :doc:`../tutorials/networking/ssl_certificates`
+- :doc:`SSL certificates <../tutorials/networking/ssl_certificates>`
 
 Properties
 ----------

--- a/classes/class_string.rst
+++ b/classes/class_string.rst
@@ -19,7 +19,7 @@ This is the built-in string class (and the one used by GDScript). It supports Un
 Tutorials
 ---------
 
-- :doc:`../tutorials/scripting/gdscript/gdscript_format_string`
+- :doc:`GDScript format strings <../tutorials/scripting/gdscript/gdscript_format_string>`
 
 Constructors
 ------------

--- a/classes/class_subviewport.rst
+++ b/classes/class_subviewport.rst
@@ -16,9 +16,9 @@ Creates a sub-view into the screen.
 Tutorials
 ---------
 
-- :doc:`../tutorials/rendering/viewports`
+- :doc:`Using Viewports <../tutorials/rendering/viewports>`
 
-- :doc:`../tutorials/2d/2d_transforms`
+- :doc:`Viewport and canvas transforms <../tutorials/2d/2d_transforms>`
 
 - `GUI in 3D Demo <https://godotengine.org/asset-library/asset/127>`__
 

--- a/classes/class_theme.rst
+++ b/classes/class_theme.rst
@@ -23,7 +23,7 @@ Theme resources can alternatively be loaded by writing them in a ``.theme`` file
 Tutorials
 ---------
 
-- :doc:`../tutorials/ui/gui_skinning`
+- :doc:`GUI skinning <../tutorials/ui/gui_skinning>`
 
 Properties
 ----------

--- a/classes/class_thread.rst
+++ b/classes/class_thread.rst
@@ -23,9 +23,9 @@ A unit of execution in a process. Can run methods on :ref:`Object<class_Object>`
 Tutorials
 ---------
 
-- :doc:`../tutorials/performance/using_multiple_threads`
+- :doc:`Using multiple threads <../tutorials/performance/using_multiple_threads>`
 
-- :doc:`../tutorials/performance/thread_safe_apis`
+- :doc:`Thread-safe APIs <../tutorials/performance/thread_safe_apis>`
 
 - `3D Voxel Demo <https://godotengine.org/asset-library/asset/676>`__
 

--- a/classes/class_tilemap.rst
+++ b/classes/class_tilemap.rst
@@ -21,7 +21,7 @@ Node for 2D tile-based maps. Tilemaps use a :ref:`TileSet<class_TileSet>` which 
 Tutorials
 ---------
 
-- :doc:`../tutorials/2d/using_tilemaps`
+- :doc:`Using Tilemaps <../tutorials/2d/using_tilemaps>`
 
 - `2D Platformer Demo <https://godotengine.org/asset-library/asset/120>`__
 

--- a/classes/class_tileset.rst
+++ b/classes/class_tileset.rst
@@ -33,7 +33,7 @@ See the functions to add new layers for more information.
 Tutorials
 ---------
 
-- :doc:`../tutorials/2d/using_tilemaps`
+- :doc:`Using Tilemaps <../tutorials/2d/using_tilemaps>`
 
 - `2D Platformer Demo <https://godotengine.org/asset-library/asset/120>`__
 

--- a/classes/class_transform2d.rst
+++ b/classes/class_transform2d.rst
@@ -21,9 +21,9 @@ For more information, read the "Matrices and transforms" documentation article.
 Tutorials
 ---------
 
-- :doc:`../tutorials/math/index`
+- :doc:`Math documentation index <../tutorials/math/index>`
 
-- :doc:`../tutorials/math/matrices_and_transforms`
+- :doc:`Matrices and transforms <../tutorials/math/matrices_and_transforms>`
 
 - `Matrix Transform Demo <https://godotengine.org/asset-library/asset/584>`__
 

--- a/classes/class_transform3d.rst
+++ b/classes/class_transform3d.rst
@@ -21,11 +21,11 @@ For more information, read the "Matrices and transforms" documentation article.
 Tutorials
 ---------
 
-- :doc:`../tutorials/math/index`
+- :doc:`Math documentation index <../tutorials/math/index>`
 
-- :doc:`../tutorials/math/matrices_and_transforms`
+- :doc:`Matrices and transforms <../tutorials/math/matrices_and_transforms>`
 
-- :doc:`../tutorials/3d/using_transforms`
+- :doc:`Using 3D transforms <../tutorials/3d/using_transforms>`
 
 - `Matrix Transform Demo <https://godotengine.org/asset-library/asset/584>`__
 

--- a/classes/class_translation.rst
+++ b/classes/class_translation.rst
@@ -23,9 +23,9 @@ Translations are resources that can be loaded and unloaded on demand. They map a
 Tutorials
 ---------
 
-- :doc:`../tutorials/i18n/internationalizing_games`
+- :doc:`Internationalizing games <../tutorials/i18n/internationalizing_games>`
 
-- :doc:`../tutorials/i18n/locales`
+- :doc:`Locales <../tutorials/i18n/locales>`
 
 Properties
 ----------

--- a/classes/class_translationserver.rst
+++ b/classes/class_translationserver.rst
@@ -21,9 +21,9 @@ Server that manages all translations. Translations can be set to it and removed 
 Tutorials
 ---------
 
-- :doc:`../tutorials/i18n/internationalizing_games`
+- :doc:`Internationalizing games <../tutorials/i18n/internationalizing_games>`
 
-- :doc:`../tutorials/i18n/locales`
+- :doc:`Locales <../tutorials/i18n/locales>`
 
 Properties
 ----------

--- a/classes/class_variant.rst
+++ b/classes/class_variant.rst
@@ -115,7 +115,7 @@ Modifications to a container will modify all references to it. A :ref:`Mutex<cla
 Tutorials
 ---------
 
-- :doc:`../development/cpp/variant_class`
+- :doc:`Variant class <../development/cpp/variant_class>`
 
 .. |virtual| replace:: :abbr:`virtual (This method should typically be overridden by the user to have any effect.)`
 .. |const| replace:: :abbr:`const (This method has no side effects. It doesn't modify any of the instance's member variables.)`

--- a/classes/class_vector2.rst
+++ b/classes/class_vector2.rst
@@ -23,11 +23,11 @@ It uses floating-point coordinates. See :ref:`Vector2i<class_Vector2i>` for its 
 Tutorials
 ---------
 
-- :doc:`../tutorials/math/index`
+- :doc:`Math documentation index <../tutorials/math/index>`
 
-- :doc:`../tutorials/math/vector_math`
+- :doc:`Vector math <../tutorials/math/vector_math>`
 
-- :doc:`../tutorials/math/vectors_advanced`
+- :doc:`Advanced vector math <../tutorials/math/vectors_advanced>`
 
 - `3Blue1Brown Essence of Linear Algebra <https://www.youtube.com/playlist?list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab>`__
 

--- a/classes/class_vector2i.rst
+++ b/classes/class_vector2i.rst
@@ -23,9 +23,9 @@ It uses integer coordinates and is therefore preferable to :ref:`Vector2<class_V
 Tutorials
 ---------
 
-- :doc:`../tutorials/math/index`
+- :doc:`Math documentation index <../tutorials/math/index>`
 
-- :doc:`../tutorials/math/vector_math`
+- :doc:`Vector math <../tutorials/math/vector_math>`
 
 - `3Blue1Brown Essence of Linear Algebra <https://www.youtube.com/playlist?list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab>`__
 

--- a/classes/class_vector3.rst
+++ b/classes/class_vector3.rst
@@ -23,11 +23,11 @@ It uses floating-point coordinates. See :ref:`Vector3i<class_Vector3i>` for its 
 Tutorials
 ---------
 
-- :doc:`../tutorials/math/index`
+- :doc:`Math documentation index <../tutorials/math/index>`
 
-- :doc:`../tutorials/math/vector_math`
+- :doc:`Vector math <../tutorials/math/vector_math>`
 
-- :doc:`../tutorials/math/vectors_advanced`
+- :doc:`Advanced vector math <../tutorials/math/vectors_advanced>`
 
 - `3Blue1Brown Essence of Linear Algebra <https://www.youtube.com/playlist?list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab>`__
 

--- a/classes/class_vector3i.rst
+++ b/classes/class_vector3i.rst
@@ -23,9 +23,9 @@ It uses integer coordinates and is therefore preferable to :ref:`Vector3<class_V
 Tutorials
 ---------
 
-- :doc:`../tutorials/math/index`
+- :doc:`Math documentation index <../tutorials/math/index>`
 
-- :doc:`../tutorials/math/vector_math`
+- :doc:`Vector math <../tutorials/math/vector_math>`
 
 - `3Blue1Brown Essence of Linear Algebra <https://www.youtube.com/playlist?list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab>`__
 

--- a/classes/class_viewport.rst
+++ b/classes/class_viewport.rst
@@ -33,9 +33,9 @@ Finally, viewports can also behave as render targets, in which case they will no
 Tutorials
 ---------
 
-- :doc:`../tutorials/rendering/viewports`
+- :doc:`Using Viewports <../tutorials/rendering/viewports>`
 
-- :doc:`../tutorials/2d/2d_transforms`
+- :doc:`Viewport and canvas transforms <../tutorials/2d/2d_transforms>`
 
 - `GUI in 3D Demo <https://godotengine.org/asset-library/asset/127>`__
 

--- a/classes/class_visualscript.rst
+++ b/classes/class_visualscript.rst
@@ -25,7 +25,7 @@ You are most likely to use this class via the Visual Script editor or when writi
 Tutorials
 ---------
 
-- :doc:`../tutorials/scripting/visual_script/index`
+- :doc:`VisualScript documentation index <../tutorials/scripting/visual_script/index>`
 
 Methods
 -------

--- a/classes/class_visualshadernode.rst
+++ b/classes/class_visualshadernode.rst
@@ -23,7 +23,7 @@ Visual shader graphs consist of various nodes. Each node in the graph is a separ
 Tutorials
 ---------
 
-- :doc:`../tutorials/shaders/visual_shaders`
+- :doc:`VisualShaders <../tutorials/shaders/visual_shaders>`
 
 Properties
 ----------

--- a/classes/class_visualshadernodecustom.rst
+++ b/classes/class_visualshadernodecustom.rst
@@ -29,7 +29,7 @@ In order for the node to be registered as an editor addon, you must use the ``@t
 Tutorials
 ---------
 
-- :doc:`../tutorials/plugins/editor/visual_shader_plugins`
+- :doc:`Visual Shader plugins <../tutorials/plugins/editor/visual_shader_plugins>`
 
 Methods
 -------

--- a/classes/class_visualshadernodeinput.rst
+++ b/classes/class_visualshadernodeinput.rst
@@ -21,7 +21,7 @@ Gives access to input variables (built-ins) available for the shader. See the sh
 Tutorials
 ---------
 
-- :doc:`../tutorials/shaders/shader_reference/index`
+- :doc:`Shading reference index <../tutorials/shaders/shader_reference/index>`
 
 Properties
 ----------

--- a/classes/class_voxelgi.rst
+++ b/classes/class_voxelgi.rst
@@ -27,7 +27,7 @@ Description
 Tutorials
 ---------
 
-- :doc:`../tutorials/3d/gi_probes`
+- :doc:`GI probes <../tutorials/3d/gi_probes>`
 
 - `Third Person Shooter Demo <https://godotengine.org/asset-library/asset/678>`__
 

--- a/classes/class_window.rst
+++ b/classes/class_window.rst
@@ -271,7 +271,7 @@ enum **Mode**:
 
 - **MODE_FULLSCREEN** = **3** --- Fullscreen window mode. Note that this is not *exclusive* fullscreen. On Windows and Linux, a borderless window is used to emulate fullscreen. On macOS, a new desktop is used to display the running project.
 
-Regardless of the platform, enabling fullscreen will change the window size to match the monitor's size. Therefore, make sure your project supports `multiple resolutions <https://docs.godotengine.org/en/latest/tutorials/rendering/multiple_resolutions.html>`__ when enabling fullscreen mode.
+Regardless of the platform, enabling fullscreen will change the window size to match the monitor's size. Therefore, make sure your project supports :doc:`multiple resolutions <../tutorials/rendering/multiple_resolutions>` when enabling fullscreen mode.
 
 ----
 

--- a/classes/class_world2d.rst
+++ b/classes/class_world2d.rst
@@ -21,7 +21,7 @@ Class that has everything pertaining to a 2D world. A physics space, a visual sc
 Tutorials
 ---------
 
-- :doc:`../tutorials/physics/ray-casting`
+- :doc:`Ray-casting <../tutorials/physics/ray-casting>`
 
 Properties
 ----------

--- a/classes/class_world3d.rst
+++ b/classes/class_world3d.rst
@@ -21,7 +21,7 @@ Class that has everything pertaining to a world. A physics space, a visual scena
 Tutorials
 ---------
 
-- :doc:`../tutorials/physics/ray-casting`
+- :doc:`Ray-casting <../tutorials/physics/ray-casting>`
 
 Properties
 ----------

--- a/classes/class_worldenvironment.rst
+++ b/classes/class_worldenvironment.rst
@@ -25,7 +25,7 @@ The ``WorldEnvironment`` allows the user to specify default lighting parameters 
 Tutorials
 ---------
 
-- :doc:`../tutorials/3d/environment_and_post_processing`
+- :doc:`Environment and post-processing <../tutorials/3d/environment_and_post_processing>`
 
 - `3D Material Testers Demo <https://godotengine.org/asset-library/asset/123>`__
 

--- a/classes/class_xrcamera3d.rst
+++ b/classes/class_xrcamera3d.rst
@@ -23,7 +23,7 @@ The position and orientation of this node is automatically updated by the XR Ser
 Tutorials
 ---------
 
-- :doc:`../tutorials/vr/index`
+- :doc:`VR documentation index <../tutorials/vr/index>`
 
 .. |virtual| replace:: :abbr:`virtual (This method should typically be overridden by the user to have any effect.)`
 .. |const| replace:: :abbr:`const (This method has no side effects. It doesn't modify any of the instance's member variables.)`

--- a/classes/class_xrcontroller3d.rst
+++ b/classes/class_xrcontroller3d.rst
@@ -27,7 +27,7 @@ As many XR runtimes now use a configurable action map all inputs are named.
 Tutorials
 ---------
 
-- :doc:`../tutorials/vr/index`
+- :doc:`VR documentation index <../tutorials/vr/index>`
 
 Properties
 ----------

--- a/classes/class_xrinterface.rst
+++ b/classes/class_xrinterface.rst
@@ -25,7 +25,7 @@ Interfaces should be written in such a way that simply enabling them will give u
 Tutorials
 ---------
 
-- :doc:`../tutorials/vr/index`
+- :doc:`VR documentation index <../tutorials/vr/index>`
 
 Properties
 ----------

--- a/classes/class_xrorigin3d.rst
+++ b/classes/class_xrorigin3d.rst
@@ -27,7 +27,7 @@ For example, if your character is driving a car, the XROrigin3D node should be a
 Tutorials
 ---------
 
-- :doc:`../tutorials/vr/index`
+- :doc:`VR documentation index <../tutorials/vr/index>`
 
 Properties
 ----------

--- a/classes/class_xrpositionaltracker.rst
+++ b/classes/class_xrpositionaltracker.rst
@@ -25,7 +25,7 @@ The :ref:`XRController3D<class_XRController3D>` and :ref:`XRAnchor3D<class_XRAnc
 Tutorials
 ---------
 
-- :doc:`../tutorials/vr/index`
+- :doc:`VR documentation index <../tutorials/vr/index>`
 
 Properties
 ----------

--- a/classes/class_xrserver.rst
+++ b/classes/class_xrserver.rst
@@ -21,7 +21,7 @@ The AR/VR server is the heart of our Advanced and Virtual Reality solution and h
 Tutorials
 ---------
 
-- :doc:`../tutorials/vr/index`
+- :doc:`VR documentation index <../tutorials/vr/index>`
 
 Properties
 ----------


### PR DESCRIPTION
Prior to this PR I pushed 30193215cfb4a9325c5a1b67d5b51abf5056be8c to sync the classref from before godotengine/godot#54991, so we can easily review the changes.