### PR TITLE
Remove redundant line in Version control systems

### DIFF
--- a/tutorials/best_practices/version_control_systems.rst
+++ b/tutorials/best_practices/version_control_systems.rst
@@ -18,8 +18,7 @@ Official Git plugin
 
 Using Git from inside the editor is supported with an official plugin.
 You can find the latest releases
-`here <https://github.com/godotengine/godot-git-plugin/releases>`__
-(it is not available in the asset library). Documentation on how to use the Git
+`here <https://github.com/godotengine/godot-git-plugin/releases>`__. Documentation on how to use the Git
 plugin can be found
 `here <https://github.com/godotengine/godot-git-plugin/wiki>`__.
 


### PR DESCRIPTION
Line 22: (it is not available in the asset library) is no longer relevant as Godot Git Plugin is now available in Asset Library.


