### PR TITLE
Cross-reference compiling and exporting pages, rename OSX/Mac to macOS

### DIFF
--- a/development/compiling/compiling_for_android.rst
+++ b/development/compiling/compiling_for_android.rst
@@ -5,6 +5,11 @@ Compiling for Android
 
 .. highlight:: shell
 
+.. seealso::
+
+    This page describes how to compile Android export template binaries from source.
+    If you're looking to export your project to Android instead, read :ref:`doc_exporting_for_android`.
+
 Note
 ----
 

--- a/development/compiling/compiling_for_ios.rst
+++ b/development/compiling/compiling_for_ios.rst
@@ -5,6 +5,11 @@ Compiling for iOS
 
 .. highlight:: shell
 
+.. seealso::
+
+    This page describes how to compile iOS export template binaries from source.
+    If you're looking to export your project to iOS instead, read :ref:`doc_exporting_for_ios`.
+
 Requirements
 ------------
 

--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -5,6 +5,11 @@ Compiling for Linux, \*BSD
 
 .. highlight:: shell
 
+.. seealso::
+
+    This page describes how to compile Linux editor and export template binaries from source.
+    If you're looking to export your project to Linux instead, read :ref:`doc_exporting_for_linux`.
+
 Requirements
 ------------
 

--- a/development/compiling/compiling_for_macos.rst
+++ b/development/compiling/compiling_for_macos.rst
@@ -5,6 +5,11 @@ Compiling for macOS
 
 .. highlight:: shell
 
+.. note::
+
+    This page describes how to compile macOS editor and export template binaries from source.
+    If you're looking to export your project to macOS instead, read :ref:`doc_exporting_for_macos`.
+
 Requirements
 ------------
 

--- a/development/compiling/compiling_for_uwp.rst
+++ b/development/compiling/compiling_for_uwp.rst
@@ -5,6 +5,11 @@ Compiling for Universal Windows Platform
 
 .. highlight:: shell
 
+.. seealso::
+
+    This page describes how to compile UWP export template binaries from source.
+    If you're looking to export your project to UWP instead, read :ref:`doc_exporting_for_uwp`.
+
 Requirements
 ------------
 

--- a/development/compiling/compiling_for_web.rst
+++ b/development/compiling/compiling_for_web.rst
@@ -3,6 +3,11 @@
 Compiling for the Web
 =====================
 
+.. seealso::
+
+    This page describes how to compile HTML5 editor and export template binaries from source.
+    If you're looking to export your project to HTML5 instead, read :ref:`doc_exporting_for_web`.
+
 .. highlight:: shell
 
 Requirements

--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -5,6 +5,11 @@ Compiling for Windows
 
 .. highlight:: shell
 
+.. seealso::
+
+    This page describes how to compile Windows editor and export template binaries from source.
+    If you're looking to export your project to Windows instead, read :ref:`doc_exporting_for_windows`.
+
 Requirements
 ------------
 

--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -3,6 +3,13 @@
 Exporting for Android
 =====================
 
+
+.. seealso::
+
+    This page describes how to export a Godot project to Android.
+    If you're looking to compile export template binaries from source instead,
+    read :ref:`doc_compiling_for_android`.
+
 Exporting for Android has fewer requirements than compiling Godot for Android.
 The following steps detail what is needed to set up the Android SDK and the engine.
 

--- a/tutorials/export/exporting_for_ios.rst
+++ b/tutorials/export/exporting_for_ios.rst
@@ -3,6 +3,12 @@
 Exporting for iOS
 =================
 
+.. seealso::
+
+    This page describes how to export a Godot project to iOS.
+    If you're looking to compile export template binaries from source instead,
+    read :ref:`doc_compiling_for_ios`.
+
 These are the steps to load a Godot project in Xcode. This allows you to
 build and deploy to an iOS device, build a release for the App Store, and
 do everything else you can normally do with Xcode.

--- a/tutorials/export/exporting_for_linux.rst
+++ b/tutorials/export/exporting_for_linux.rst
@@ -3,6 +3,12 @@
 Exporting for Linux
 ===================
 
+.. seealso::
+
+    This page describes how to export a Godot project to Linux.
+    If you're looking to compile editor or export template binaries from source instead,
+    read :ref:`doc_compiling_for_linuxbsd`.
+
 The simplest way to distribute a game for PC is to copy the executable
 (``godot``), compress the folder and send it to someone else. However, this is
 often not desired.

--- a/tutorials/export/exporting_for_macos.rst
+++ b/tutorials/export/exporting_for_macos.rst
@@ -1,7 +1,13 @@
-.. _doc_exporting_for_mac:
+.. _doc_exporting_for_macos:
 
 Exporting for macOS
 ===================
+
+.. seealso::
+
+    This page describes how to export a Godot project to macOS.
+    If you're looking to compile editor or export template binaries from source instead,
+    read :ref:`doc_compiling_for_macos`.
 
 macOS apps are exported as an ``.app`` bundle, a folder with a specific structure which stores the executable, libraries and all the project files.
 This bundle is packed in a ZIP archive or DMG disk image (only supported when exporting for macOS).
@@ -14,12 +20,12 @@ Requirements
 
 .. warning::
 
-    Projects exported without code signing and notarization will be blocked by Gatekeeper if they are downloaded from unknown sources, see the :ref:`Running Godot apps on macOS <doc_running_on_mac>` page for more info.
+    Projects exported without code signing and notarization will be blocked by Gatekeeper if they are downloaded from unknown sources, see the :ref:`Running Godot apps on macOS <doc_running_on_macos>` page for more information.
 
 Code signing and notarization
 -----------------------------
 
-By default, macOS will run only applications that are signed and notarized, if you use any other signing configuration see :ref:`Running Godot apps on macOS <doc_running_on_mac>` for workarounds.
+By default, macOS will run only applications that are signed and notarized, if you use any other signing configuration see :ref:`Running Godot apps on macOS <doc_running_on_macos>` for workarounds.
 
 To notarize an app you mast have a valid `Apple Developer ID Certificate <https://developer.apple.com/>`__.
 

--- a/tutorials/export/exporting_for_uwp.rst
+++ b/tutorials/export/exporting_for_uwp.rst
@@ -3,6 +3,12 @@
 Exporting for Universal Windows Platform
 ========================================
 
+.. seealso::
+
+    This page describes how to export a Godot project to UWP.
+    If you're looking to compile export template binaries from source instead,
+    read :ref:`doc_compiling_for_uwp`.
+
 There's no extra requirement to export an ``.appx`` package that can be
 installed as a Windows App or submitted to the Windows Store. Exporting UWP
 packages also works from any platform, not only from Windows.

--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -3,6 +3,12 @@
 Exporting for the Web
 =====================
 
+.. seealso::
+
+    This page describes how to export a Godot project to HTML5.
+    If you're looking to compile editor or export template binaries from source instead,
+    read :ref:`doc_compiling_for_web`.
+
 HTML5 export allows publishing games made in Godot Engine to the browser.
 This requires support for `WebAssembly
 <https://webassembly.org/>`__ and `WebGL <https://www.khronos.org/webgl/>`__

--- a/tutorials/export/exporting_for_windows.rst
+++ b/tutorials/export/exporting_for_windows.rst
@@ -3,6 +3,12 @@
 Exporting for Windows
 =====================
 
+.. seealso::
+
+    This page describes how to export a Godot project to Windows.
+    If you're looking to compile editor or export template binaries from source instead,
+    read :ref:`doc_compiling_for_windows`.
+
 The simplest way to distribute a game for PC is to copy the executable
 (``godot.exe``), compress the folder and send it to someone else. However, this
 is often not desired.

--- a/tutorials/export/index.rst
+++ b/tutorials/export/index.rst
@@ -9,8 +9,8 @@ Export
    exporting_pcks
    feature_tags
    exporting_for_linux
-   exporting_for_mac
-   running_on_mac
+   exporting_for_macos
+   running_on_macos
    exporting_for_windows
    changing_application_icon_for_windows
    exporting_for_uwp

--- a/tutorials/export/running_on_macos.rst
+++ b/tutorials/export/running_on_macos.rst
@@ -1,7 +1,12 @@
-.. _doc_running_on_mac:
+.. _doc_running_on_macos:
 
 Running Godot apps on macOS
 ===========================
+
+.. seealso::
+
+    This page covers running Godot projects on macOS.
+    If you haven't exported your project yet, read :ref:`doc_exporting_for_macos` first.
 
 By default, macOS will run only applications that are signed and notarized.
 


### PR DESCRIPTION
This was requested on Reddit: https://www.reddit.com/r/godot/comments/r0fort/compiling_godot_on_pinebook_pro_with_manjaro/hlszzq3/?context=3

There's a lot of confusion between compiling Godot and exporting projects.

This aims to resolve part of the confusion by cross-linking other pages for each platform.

This will need a different PR for `3.4`, since we want to avoid breaking URLs there.