### PR TITLE
Clarify the location of binaries to copy in Compiling for Linux/*BSD

### DIFF
--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -202,7 +202,8 @@ following parameters:
 Note that cross-compiling for the opposite bits (64/32) as your host
 platform is not always straight-forward and might need a chroot environment.
 
-To create standard export templates, the resulting files must be copied to:
+To create standard export templates, the resulting files in the ``bin/`` folder
+must be copied to:
 
 ::
 


### PR DESCRIPTION
This was requested on Reddit: https://www.reddit.com/r/godot/comments/r0fort/compiling_godot_on_pinebook_pro_with_manjaro/hlszzq3/?context=3