### PR TITLE
State the implementation of HTML5 export for `user://` path in Data Paths

### DIFF
--- a/tutorials/io/data_paths.rst
+++ b/tutorials/io/data_paths.rst
@@ -42,6 +42,10 @@ Linux, ``~/Library/Application Support/Godot/app_userdata/Name`` on macOS (since
 name defined in the Project Settings, but you can override it on a per-platform
 basis using :ref:`feature tags <doc_feature_tags>`.
 
+On HTML5 exports, ``user://`` will refer to a virtual filesystem stored on the
+device via IndexedDB. (Interaction with the main filesystem can still be performed
+through the :ref:`JavaScript <class_JavaScript>` singleton.)
+
 Converting paths to absolute paths or "local" paths
 ---------------------------------------------------
 


### PR DESCRIPTION
resolves #4613

(The information is correct right? https://github.com/godotengine/godot-proposals/issues/2207 states that `indexedDB` is what is used)

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
