### PR TITLE
specify correct emscripten version for godot 3.4

### DIFF
--- a/development/compiling/compiling_for_web.rst
+++ b/development/compiling/compiling_for_web.rst
@@ -8,9 +8,9 @@ Compiling for the Web
 Requirements
 ------------
 
-To compile export templates for the Web, the following is required:
+To compile Godot 3.4 export templates for the Web, the following is required:
 
--  `Emscripten 1.39.9+ <https://emscripten.org>`__.
+-  `Emscripten 2.0.17+ <https://emscripten.org>`__.
 -  `Python 3.5+ <https://www.python.org/>`__.
 -  `SCons 3.0+ <https://www.scons.org>`__ build system.
 


### PR DESCRIPTION
we need https://github.com/emscripten-core/emscripten/pull/13776 available

i hope this is the right branch to put this to. i assume it also applies to godot 4.

it would be nice if scons would be able to check the emscripten version and complain when it is too low, that would have saved me some time searching for my problem.