### PR TITLE
Fix incorrect explanation of successful evaluation in Evaluating expressions

### DIFF
--- a/tutorials/scripting/evaluating_expressions.rst
+++ b/tutorials/scripting/evaluating_expressions.rst
@@ -107,11 +107,11 @@ instance such as ``self``, another script instance or even a singleton::
         var expression = Expression.new()
         expression.parse("double(10)")
 
-        # This won't work, since we're not passing the current script as the base instance.
+        # This won't work since we're not passing the current script as the base instance.
         var result = expression.execute([], null)
         print(result)  # null
 
-        # This will work won't work, since we're not passing the current script
+        # This will work since we're passing the current script (i.e. self)
         # as the base instance.
         result = expression.execute([], self)
         print(result)  # 20


### PR DESCRIPTION
Fixed incorrect explanation of successful evaluation for a given example

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
