### PR TITLE
Fix incorrect export template path in Compiling for macOS

### DIFF
--- a/development/compiling/compiling_for_macos.rst
+++ b/development/compiling/compiling_for_macos.rst
@@ -139,7 +139,7 @@ with the following commands (assuming a universal build, otherwise replace the
     mkdir -p osx_template.app/Contents/MacOS
     cp bin/godot.osx.opt.universal osx_template.app/Contents/MacOS/godot_osx_release.64
     cp bin/godot.osx.opt.debug.universal osx_template.app/Contents/MacOS/godot_osx_debug.64
-    chmod +x Godot.app/Contents/MacOS/godot_osx*
+    chmod +x osx_template.app/Contents/MacOS/godot_osx*
 
 .. note::
 


### PR DESCRIPTION
I saw that the given path was wrong

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
