### PR TITLE
Update information regarding VCS-ignorable directories

### DIFF
--- a/tutorials/best_practices/version_control_systems.rst
+++ b/tutorials/best_practices/version_control_systems.rst
@@ -25,7 +25,7 @@ plugin can be found
 Files to exclude from VCS
 -------------------------
 
-There are some folders Godot creates which you should have your VCS ignore:
+There are some files and folders Godot automatically creates. You should add them to your VCS ignore:
 
 - ``.godot/``: This folder stores various project cache data. ``.godot/imported/`` stores
   all the files the engine imports automatically based on your source assets and their

--- a/tutorials/best_practices/version_control_systems.rst
+++ b/tutorials/best_practices/version_control_systems.rst
@@ -25,10 +25,12 @@ plugin can be found
 Files to exclude from VCS
 -------------------------
 
-There are some folders Godot creates you should have your VCS ignore:
+There are some folders Godot creates which you should have your VCS ignore:
 
-- ``.import/``: This folder stores all the files it imports automatically based on
-  your source assets and their import flags.
+- ``.godot/``: This folder stores various project cache data. ``.godot/imported/`` stores
+  all the files the engine imports automatically based on your source assets and their
+  import flags. ``.godot/editor/`` holds data regarding the editor state, such as currently
+  opened script files, and recently used nodes.
 - ``*.translation``: These files are binary imported translations generated from CSV files.
 - ``export_presets.cfg``: This file contains all the export presets for the
   project, including sensitive information such as Android keystore credentials.


### PR DESCRIPTION
since the `.import/` folder was reworked into being `.godot/imported/`, this updates the docs to reflect that.
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
