### PR TITLE
class_String_method_rsplit correction

### DIFF
--- a/classes/class_string.rst
+++ b/classes/class_string.rst
@@ -910,8 +910,8 @@ Example:
     var some_string = "One,Two,Three,Four"
     var some_array = some_string.rsplit(",", true, 1)
     print(some_array.size()) # Prints 2
-    print(some_array[0]) # Prints "Four"
-    print(some_array[1]) # Prints "Three,Two,One"
+    print(some_array[0]) # Prints "One,Two,Three"
+    print(some_array[1]) # Prints "Four"
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
In the GDScript example it says it prints the following:
"2"
"Four"
"Three,Two,One"
Which confused me first and isn't true either.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
