### PR TITLE
Fix the syntax for the Android permission requirement on network tutorials

### DIFF
--- a/tutorials/networking/high_level_multiplayer.rst
+++ b/tutorials/networking/high_level_multiplayer.rst
@@ -145,7 +145,7 @@ Terminating the networking feature:
 
 .. warning::
 
-    When exporting to Android, make sure to enable the [code]INTERNET[/code]
+    When exporting to Android, make sure to enable the ``INTERNET``
     permission in the Android export preset before exporting the project or
     using one-click deploy. Otherwise, network communication of any kind will be
     blocked by Android.

--- a/tutorials/networking/http_client_class.rst
+++ b/tutorials/networking/http_client_class.rst
@@ -9,7 +9,7 @@ which has a tutorial available :ref:`here <doc_http_request_class>`.
 
 .. warning::
 
-    When exporting to Android, make sure to enable the [code]INTERNET[/code]
+    When exporting to Android, make sure to enable the ``INTERNET``
     permission in the Android export preset before exporting the project or
     using one-click deploy. Otherwise, network communication of any kind will be
     blocked by Android.

--- a/tutorials/networking/http_request_class.rst
+++ b/tutorials/networking/http_request_class.rst
@@ -10,7 +10,7 @@ For the sake of this example, we will create a simple UI with a button, that whe
 
 .. warning::
 
-    When exporting to Android, make sure to enable the [code]INTERNET[/code]
+    When exporting to Android, make sure to enable the ``INTERNET``
     permission in the Android export preset before exporting the project or
     using one-click deploy. Otherwise, network communication of any kind will be
     blocked by Android.

--- a/tutorials/networking/webrtc.rst
+++ b/tutorials/networking/webrtc.rst
@@ -39,7 +39,7 @@ WebRTC is implemented in Godot via two main classes :ref:`WebRTCPeerConnection <
 
 .. warning::
 
-    When exporting to Android, make sure to enable the [code]INTERNET[/code]
+    When exporting to Android, make sure to enable the ``INTERNET``
     permission in the Android export preset before exporting the project or
     using one-click deploy. Otherwise, network communication of any kind will be
     blocked by Android.

--- a/tutorials/networking/websocket.rst
+++ b/tutorials/networking/websocket.rst
@@ -22,7 +22,7 @@ WebSocket is implemented in Godot via three main classes :ref:`WebSocketClient <
 
 .. warning::
 
-    When exporting to Android, make sure to enable the [code]INTERNET[/code]
+    When exporting to Android, make sure to enable the ``INTERNET``
     permission in the Android export preset before exporting the project or
     using one-click deploy. Otherwise, network communication of any kind will be
     blocked by Android.


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->

The Android permission requirement warning had [code]INTERNET[/code] rather than ``INTERNET``, so that has been adjusted. 