### PR TITLE
Fix wrong description about the warning icon

### DIFF
--- a/tutorials/2d/particle_systems_2d.rst
+++ b/tutorials/2d/particle_systems_2d.rst
@@ -34,7 +34,7 @@ inspector, and selecting "Convert to CPUParticles2D" in the "Particles" menu of 
 
 The rest of this tutorial is going to use the Particles2D node. First, add a Particles2D
 node to your scene. After creating that node you will notice that only a white dot was created,
-and that there is a warning icon next to your Particles2D node in the inspector. This
+and that there is a warning icon next to your Particles2D node in the scene dock. This
 is because the node needs a ParticlesMaterial to function.
 
 ParticlesMaterial


### PR DESCRIPTION
Warning icons appear in the scene dock, not inspector.

Should I create a separate PR for the 3.4 branch?