### PR TITLE
Documents ARRAY_BONES and ARRAY_WEIGHTS

### DIFF
--- a/tutorials/3d/procedural_geometry/arraymesh.rst
+++ b/tutorials/3d/procedural_geometry/arraymesh.rst
@@ -24,8 +24,8 @@ PackedInt32Array, etc.) for each type of information.
 - ``ARRAY_COLOR`` = 3 | PackedColorArray
 - ``ARRAY_TEX_UV`` = 4 | PackedVector2Array or PackedVector3Array
 - ``ARRAY_TEX_UV2`` = 5 | PackedVector2Array or PackedVector3Array
-- ``ARRAY_BONES`` = 6 | PackedFloat32Array of groups of 4 floats or PackedInt32Array of groups of 4 ints
-- ``ARRAY_WEIGHTS`` = 7 | PackedFloat32Array of groups of 4 floats
+- ``ARRAY_BONES`` = 6 | PackedFloat32Array of groups of 4 floats or PackedInt32Array of groups of 4 ints. Each group lists indexes of 4 bones that affects a given vertex.
+- ``ARRAY_WEIGHTS`` = 7 | PackedFloat32Array of groups of 4 floats. Each float lists the amount of weight an determined bone on ``ARRAY_BONES`` has on a given vertex.
 - ``ARRAY_INDEX`` = 8 | PackedInt32Array
 
 The Array of vertices is always required. All the others are optional and will only be used if included.


### PR DESCRIPTION
This PR gives a little more details on how ARRAY_BONES and ARRAY_WEIGHTS are used on an ArrayMesh. This is based on @pycbouh 's explanation in #5434, and fixes that issue.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->

*Bugsquad edit: Fixes https://github.com/godotengine/godot-docs/issues/5434*
