### PR TITLE
Small typo fix what_are_shaders.rst

### DIFF
--- a/tutorials/shading/your_first_shader/what_are_shaders.rst
+++ b/tutorials/shading/your_first_shader/what_are_shaders.rst
@@ -29,7 +29,7 @@ rendering because they are optimized for running thousands of instructions in pa
 The output of the shader is typically the colored pixels of the object drawn to the viewport. But some
 shaders allow for specialized outputs (this is especially true for APIs like Vulkan). Shaders operate
 inside the shader pipeline. The standard process is the vertex -> fragment shader pipeline. The vertex
-shader is used to decided where each vertex (point in a 3D model, or corner of a Sprite) goes and the
+shader is used to decide where each vertex (point in a 3D model, or corner of a Sprite) goes and the
 fragment shader decides what color individual pixels receive.
 
 Suppose you want to update all the pixels in a texture to a given color, on the CPU you would write:


### PR DESCRIPTION
"The vertex shader is used to __decided__ where each vertex..." -> "The vertex shader is used to __decide__ where each vertex..."

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
