### PR TITLE
Update class_label.rst for property visible_characters

### DIFF
--- a/classes/class_label.rst
+++ b/classes/class_label.rst
@@ -442,7 +442,7 @@ Controls the text's vertical align. Supports top, center, bottom, and fill. Set 
 | *Getter*  | get_visible_characters()      |
 +-----------+-------------------------------+
 
-Restricts the number of characters to display. Set to -1 to disable.
+Restricts the number of visible characters to display. Whitespace characters are not counted. Set to -1 to disable.
 
 Method Descriptions
 -------------------


### PR DESCRIPTION
Clarify that space characters do not count toward the visible count.  This makes sense but it's not obvious.  In general programming, a space character is never ignored in a string, and a user might easily assume at first (as I did) that the string "Hello World! the musical" with visible_characters set to 12 would produce "Hello World!" when in fact it would produce "Hello World! t".

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
