### PR TITLE
Remove broken link to opengameart

### DIFF
--- a/tutorials/2d/2d_sprite_animation.rst
+++ b/tutorials/2d/2d_sprite_animation.rst
@@ -16,8 +16,7 @@ animate a collection of individual images. Then we will animate a sprite sheet u
 with :ref:`AnimationPlayer <class_AnimationPlayer>` and the *Animation*
 property of :ref:`Sprite2D <class_Sprite2D>`.
 
-.. note:: Art for the following examples by https://opengameart.org/users/ansimuz and by
-                                           https://opengameart.org/users/tgfcoder
+.. note:: Art for the following examples by https://opengameart.org/users/ansimuz and tgfcoder.
 
 Individual images with AnimatedSprite2D
 ---------------------------------------


### PR DESCRIPTION
Closes #5258. The person who made the art has since deleted their open game art account. I don't know what license the original art was released as, but as we're still giving credit we should be complying with it whatever it was.