### PR TITLE
Update "PhysicsBody2D" to "CollisionObject2D"

### DIFF
--- a/getting_started/first_2d_game/04.creating_the_enemy.rst
+++ b/getting_started/first_2d_game/04.creating_the_enemy.rst
@@ -26,7 +26,7 @@ the Player scene.
 
 In the :ref:`RigidBody2D <class_RigidBody2D>` properties, set ``Gravity Scale``
 to ``0``, so the mob will not fall downward. In addition, under the
-``PhysicsBody2D`` section, click the ``Mask`` property and uncheck the first
+``CollisionObject2D`` section, click the ``Mask`` property and uncheck the first
 box. This will ensure the mobs do not collide with each other.
 
 .. image:: img/set_collision_mask.png


### PR DESCRIPTION
In godot 3.4 it doesn't have a section called "PhysicsBody2D"
![image](https://user-images.githubusercontent.com/1515020/146413567-8a21331c-715b-406a-af48-da90c1de2c27.png)

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
