### PR TITLE
Clarify singleton read order

### DIFF
--- a/tutorials/scripting/singletons_autoload.rst
+++ b/tutorials/scripting/singletons_autoload.rst
@@ -62,8 +62,8 @@ menu and switch to the **AutoLoad** tab.
 Here you can add any number of scenes or scripts. Each entry in the list
 requires a name, which is assigned as the node's ``name`` property. The order of
 the entries as they are added to the global scene tree can be manipulated using
-the up/down arrow keys. Like regular scenes the engine will read these nodes
-in top to bottom order.
+the up/down arrow keys. Like regular scenes, the engine will read these nodes
+in top-to-bottom order.
 
 .. image:: img/autoload_example.png
 

--- a/tutorials/scripting/singletons_autoload.rst
+++ b/tutorials/scripting/singletons_autoload.rst
@@ -62,7 +62,8 @@ menu and switch to the **AutoLoad** tab.
 Here you can add any number of scenes or scripts. Each entry in the list
 requires a name, which is assigned as the node's ``name`` property. The order of
 the entries as they are added to the global scene tree can be manipulated using
-the up/down arrow keys.
+the up/down arrow keys. Like regular scenes the engine will read these nodes
+in top to bottom order.
 
 .. image:: img/autoload_example.png
 


### PR DESCRIPTION
Clarifies that like regular scenes singletons are read in top to bottom order. Closes #4495. The other half of that issue was fixed by #5449.