### PR TITLE
conf.py: Add support for loading localized class reference

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -269,6 +269,19 @@ def godot_get_image_filename_for_language(filename, env):
 
 sphinx.util.i18n.get_image_filename_for_language = godot_get_image_filename_for_language
 
+# Similar story for the localized class reference, it's out of tree and there doesn't
+# seem to be an easy way for us to tweak the toctree to take this into account.
+# So we're deleting the existing class reference and adding a symlink instead...
+if is_i18n and os.path.exists("../classes/" + language):
+    import shutil
+
+    if os.path.islink("classes"):  # Previously made symlink.
+        os.unlink("classes")
+    else:
+        shutil.rmtree("classes")
+
+    os.symlink("../classes/" + language, "classes")
+
 # Couldn't find a way to retrieve variables nor do advanced string
 # concat from reST, so had to hardcode this in the "epilog" added to
 # all pages. This is used in index.rst to display the Weblate badge.


### PR DESCRIPTION
It will look up a potential `classes/<lang>` folder in the parent repository
of https://github.com/godotengine/godot-docs-l10n and use it if provided.

This folder includes a pre-translated copy of the class reference XML, read
to be used by Sphinx. This turned out to be a simpler approach than generating
PO files for class reference strings in reStructured Text format, given that
their source format is XML and the conversion on a per `msgid` basis would be
quite tricky.

This approach is very hacky, as Sphinx doesn't seem to support any kind of
conditional statements in its `toctree` directives, so we have to outright
replace the content at build time. This should typically only be done on RTD
so it shouldn't end up polluting the Git history.

![image](https://user-images.githubusercontent.com/4701338/146948995-2976b116-ec2b-41f7-8876-483f31aa6aa6.png)
