### PR TITLE
Fix and expand user data path information

### DIFF
--- a/tutorials/io/data_paths.rst
+++ b/tutorials/io/data_paths.rst
@@ -66,25 +66,25 @@ Editor data paths
 The editor uses different paths for user data, user settings, and cache,
 depending on the platform. By default, these paths are:
 
-+------------------------------+----------------------------------------------------------------+
-| Type                         | Location                                                       |
-+==============================+================================================================+
-| User data                    | - Windows: ``%APPDATA%\Godot\app_userdata\[project_name]``     |
-|                              | - macOS: ``~/Library/Application Support/Godot/[project_name]``|
-|                              | - Linux: ``~/.local/share/godot/[project_name]``               |
-+------------------------------+----------------------------------------------------------------+
-| User data                    | - Windows: ``%APPDATA%\[project_name]``                        |
-| (when ``use_custom_user_dir``| - macOS: ``~/Library/Application Support/[project_name]``      |
-| project setting is true)     | - Linux: ``~/.local/share/[project_name]``                     |
-+------------------------------+----------------------------------------------------------------+
-| User settings                | - Windows: ``%APPDATA%\Godot\``                                |
-|                              | - macOS: ``~/Library/Application Support/Godot/``              |
-|                              | - Linux: ``~/.config/godot/``                                  |
-+------------------------------+----------------------------------------------------------------+
-| Cache                        | - Windows: ``%TEMP%\Godot\``                                   |
-|                              | - macOS: ``~/Library/Caches/Godot/``                           |
-|                              | - Linux: ``~/.cache/godot/``                                   |
-+------------------------------+----------------------------------------------------------------+
++-------------------------------+----------------------------------------------------------------+
+| Type                          | Location                                                       |
++===============================+================================================================+
+| User data                     | - Windows: ``%APPDATA%\Godot\app_userdata\[project_name]``     |
+|                               | - macOS: ``~/Library/Application Support/Godot/[project_name]``|
+|                               | - Linux: ``~/.local/share/godot/[project_name]``               |
++-------------------------------+----------------------------------------------------------------+
+| User data                     | - Windows: ``%APPDATA%\[project_name]``                        |
+| (when ``use_custom_user_dir`` | - macOS: ``~/Library/Application Support/[project_name]``      |
+| project setting is ``true``)  | - Linux: ``~/.local/share/[project_name]``                     |
++-------------------------------+----------------------------------------------------------------+
+| User settings                 | - Windows: ``%APPDATA%\Godot\``                                |
+|                               | - macOS: ``~/Library/Application Support/Godot/``              |
+|                               | - Linux: ``~/.config/godot/``                                  |
++-------------------------------+----------------------------------------------------------------+
+| Cache                         | - Windows: ``%TEMP%\Godot\``                                   |
+|                               | - macOS: ``~/Library/Caches/Godot/``                           |
+|                               | - Linux: ``~/.cache/godot/``                                   |
++-------------------------------+----------------------------------------------------------------+
 
 - **User data** contains export templates and project-specific data.
 - **User settings** contains editor settings, text editor themes, script

--- a/tutorials/io/data_paths.rst
+++ b/tutorials/io/data_paths.rst
@@ -37,10 +37,11 @@ when the game is running, the project's file system will likely be read-only.
 
 The ``user://`` prefix points to a different directory on the user's device. On
 mobile and consoles, this path is unique to the project. On desktop, the engine
-stores user files in ``~/.local/share/godot/app_userdata/Name`` on
-Linux, ``~/Library/Application Support/Godot/app_userdata/Name`` on macOS (since Catalina) and ``%APPDATA%/Name`` on Windows. ``Name`` is based on the application
-name defined in the Project Settings, but you can override it on a per-platform
-basis using :ref:`feature tags <doc_feature_tags>`.
+stores user files in ``~/.local/share/godot/app_userdata/[project_name]`` on
+Linux, ``~/Library/Application Support/Godot/app_userdata/[project_name]`` on
+macOS (since Catalina) and ``%APPDATA%\Godot\app_userdata\[project_name]`` on Windows.
+``[project_name]`` is based on the application name defined in the Project Settings, but
+you can override it on a per-platform basis using :ref:`feature tags <doc_feature_tags>`.
 
 On HTML5 exports, ``user://`` will refer to a virtual filesystem stored on the
 device via IndexedDB. (Interaction with the main filesystem can still be performed
@@ -65,21 +66,25 @@ Editor data paths
 The editor uses different paths for user data, user settings, and cache,
 depending on the platform. By default, these paths are:
 
-+---------------+---------------------------------------------------+
-| Type          | Location                                          |
-+===============+===================================================+
-| User data     | - Windows: ``%APPDATA%\Godot\``                   |
-|               | - macOS: ``~/Library/Application Support/Godot/`` |
-|               | - Linux: ``~/.local/share/godot/``                |
-+---------------+---------------------------------------------------+
-| User settings | - Windows: ``%APPDATA%\Godot\``                   |
-|               | - macOS: ``~/Library/Application Support/Godot/`` |
-|               | - Linux: ``~/.config/godot/``                     |
-+---------------+---------------------------------------------------+
-| Cache         | - Windows: ``%TEMP%\Godot\``                      |
-|               | - macOS: ``~/Library/Caches/Godot/``              |
-|               | - Linux: ``~/.cache/godot/``                      |
-+---------------+---------------------------------------------------+
++------------------------------+----------------------------------------------------------------+
+| Type                         | Location                                                       |
++==============================+================================================================+
+| User data                    | - Windows: ``%APPDATA%\Godot\app_userdata\[project_name]``     |
+|                              | - macOS: ``~/Library/Application Support/Godot/[project_name]``|
+|                              | - Linux: ``~/.local/share/godot/[project_name]``               |
++------------------------------+----------------------------------------------------------------+
+| User Data                    | - Windows: ``%APPDATA%\[project_name]``                        |
+| (when ``use_custom_user_dir``| - macOS: ``~/Library/Application Support/[project_name]``      |
+| project setting is true)     | - Linux: ``~/.local/share/[project_name]``                     |
++------------------------------+----------------------------------------------------------------+
+| User settings                | - Windows: ``%APPDATA%\Godot\``                                |
+|                              | - macOS: ``~/Library/Application Support/Godot/``              |
+|                              | - Linux: ``~/.config/godot/``                                  |
++------------------------------+----------------------------------------------------------------+
+| Cache                        | - Windows: ``%TEMP%\Godot\``                                   |
+|                              | - macOS: ``~/Library/Caches/Godot/``                           |
+|                              | - Linux: ``~/.cache/godot/``                                   |
++------------------------------+----------------------------------------------------------------+
 
 - **User data** contains export templates and project-specific data.
 - **User settings** contains editor settings, text editor themes, script

--- a/tutorials/io/data_paths.rst
+++ b/tutorials/io/data_paths.rst
@@ -73,7 +73,7 @@ depending on the platform. By default, these paths are:
 |                              | - macOS: ``~/Library/Application Support/Godot/[project_name]``|
 |                              | - Linux: ``~/.local/share/godot/[project_name]``               |
 +------------------------------+----------------------------------------------------------------+
-| User Data                    | - Windows: ``%APPDATA%\[project_name]``                        |
+| User data                    | - Windows: ``%APPDATA%\[project_name]``                        |
 | (when ``use_custom_user_dir``| - macOS: ``~/Library/Application Support/[project_name]``      |
 | project setting is true)     | - Linux: ``~/.local/share/[project_name]``                     |
 +------------------------------+----------------------------------------------------------------+


### PR DESCRIPTION
Fixes the user data location for windows. Also adds information on the data path when the `use_custom_user_dir` project setting is true. Closes #5462 
