### PR TITLE
Add a link to the notifications page from the Object class page

### DIFF
--- a/development/cpp/object_class.rst
+++ b/development/cpp/object_class.rst
@@ -237,6 +237,13 @@ Adding signals to a class is done in ``_bind_methods``, using the
 
     ADD_SIGNAL(MethodInfo("been_killed"))
 
+Notifications
+-------------
+
+All objects in godot have a :ref:`_notification <class_Object_method__notification>`
+method that allows it to respond to engine level callbacks that may relate to it.
+More information can be found on :ref:`this page <doc_doc_godot_notifications>`.
+
 References
 ----------
 

--- a/development/cpp/object_class.rst
+++ b/development/cpp/object_class.rst
@@ -240,9 +240,9 @@ Adding signals to a class is done in ``_bind_methods``, using the
 Notifications
 -------------
 
-All objects in godot have a :ref:`_notification <class_Object_method__notification>`
+All objects in Godot have a :ref:`_notification <class_Object_method__notification>`
 method that allows it to respond to engine level callbacks that may relate to it.
-More information can be found on :ref:`this page <doc_doc_godot_notifications>`.
+More information can be found on the :ref:`doc_godot_notifications` page.
 
 References
 ----------


### PR DESCRIPTION
Adds a link to the notifications page from the object class page in the development section of the docs. Closes #5346.