### PR TITLE
Fix capitalization of macOS

### DIFF
--- a/community/contributing/building_the_manual.rst
+++ b/community/contributing/building_the_manual.rst
@@ -35,7 +35,7 @@ folder of this repository with the following command:
 
 .. code:: sh
 
-    # On Linux and MacOS
+    # On Linux and macOS
     make html
 
     # On Windows, you need to execute the ``make.bat`` file instead.

--- a/getting_started/first_3d_game/01.game_setup.rst
+++ b/getting_started/first_3d_game/01.game_setup.rst
@@ -41,11 +41,11 @@ Setting up the playable area
 We're going to create our main scene with a plain *Node* as its root. In the
 *Scene* dock, click the *Add Node* button represented by a "+" icon in the
 top-left and double-click on *Node*. Name the node "Main". Alternatively, to add
-a node to the scene, you can press :kbd:`Ctrl + a` (or :kbd:`Cmd + a` on MacOS).
+a node to the scene, you can press :kbd:`Ctrl + a` (or :kbd:`Cmd + a` on macOS).
 
 |image5|
 
-Save the scene as ``Main.tscn`` by pressing :kbd:`Ctrl + s` (:kbd:`Cmd + s` on MacOS).
+Save the scene as ``Main.tscn`` by pressing :kbd:`Ctrl + s` (:kbd:`Cmd + s` on macOS).
 
 We'll start by adding a floor that'll prevent the characters from falling. To
 create static colliders like the floor, walls, or ceilings, you can use
@@ -105,7 +105,7 @@ You should see a wide grey slab that covers the grid and blue and red axes in
 the viewport.
 
 We're going to move the ground down so we can see the floor grid. Select the
-*Ground* node, hold the :kbd:`Ctrl` key down to turn on grid snapping (:kbd:`Cmd` on MacOS),
+*Ground* node, hold the :kbd:`Ctrl` key down to turn on grid snapping (:kbd:`Cmd` on macOS),
 and click and drag down on the Y axis. It's the green arrow in the move gizmo.
 
 |image13|

--- a/getting_started/first_3d_game/03.player_movement_code.rst
+++ b/getting_started/first_3d_game/03.player_movement_code.rst
@@ -361,7 +361,7 @@ Let's first split the 3D view to be able to freely navigate the scene and see
 what the camera sees.
 
 In the toolbar right above the viewport, click on *View*, then *2 Viewports*.
-You can also press :kbd:`Ctrl + 2` (:kbd:`Cmd + 2` on MacOS).
+You can also press :kbd:`Ctrl + 2` (:kbd:`Cmd + 2` on macOS).
 
 |image5|
 

--- a/getting_started/first_3d_game/05.spawning_mobs.rst
+++ b/getting_started/first_3d_game/05.spawning_mobs.rst
@@ -35,7 +35,7 @@ a path, we won't see it from the camera preview.
 
 To find the view's limits, we can use some placeholder meshes. Your viewport
 should still be split into two parts, with the camera preview at the bottom. If
-that isn't the case, press :kbd:`Ctrl + 2` (:kbd:`Cmd + 2` on MacOS) to split the view into two.
+that isn't the case, press :kbd:`Ctrl + 2` (:kbd:`Cmd + 2` on macOS) to split the view into two.
 Select the *Camera* node and click the *Preview* checkbox in the bottom
 viewport.
 
@@ -76,7 +76,7 @@ corner.
 |image9|
 
 We're going to create copies of the mesh and place them around the game area.
-Press :kbd:`Ctrl + D` (:kbd:`Cmd + D` on MacOS) to duplicate the node. You can also right-click
+Press :kbd:`Ctrl + D` (:kbd:`Cmd + D` on macOS) to duplicate the node. You can also right-click
 the node in the *Scene* dock and select *Duplicate*. Move the copy down along
 the blue Z axis until it's right outside the camera's preview.
 


### PR DESCRIPTION
The operating system is named "macOS" with a lowercase m.

[macOS - Wikipedia](https://en.wikipedia.org/wiki/MacOS)
[Trademark List - Apple](https://www.apple.com/legal/intellectual-property/trademark/appletmlist.html)