### PR TITLE
Improve explenation for Trigger and Capture update modes

### DIFF
--- a/tutorials/animation/introduction.rst
+++ b/tutorials/animation/introduction.rst
@@ -231,13 +231,13 @@ mode, track interpolation, and loop mode.
 The update mode of a track tells Godot when to update the property
 values. This can be:
 
--  Continuous: Update the property on each frame
--  Discrete: Only update the property on keyframes
--  Trigger: Only update the property on keyframes or triggers.
+-  **Continuous:** Update the property on each frame
+-  **Discrete:** Only update the property on keyframes
+-  **Trigger:** Only update the property on keyframes or triggers.
    Triggers are a type of keyframe used by the
    ``current_animation`` property of a :ref:`class_AnimationPlayer`,
    and Animation Playback tracks.
--  Capture: if the first keyframe's time is greater than ``0.0``, the
+-  **Capture:** if the first keyframe's time is greater than ``0.0``, the
    current value of the property will be remembered and
    will be blended with the first animation key. For example, you
    could use the Capture mode to move a node that's located anywhere

--- a/tutorials/animation/introduction.rst
+++ b/tutorials/animation/introduction.rst
@@ -233,9 +233,14 @@ values. This can be:
 
 -  Continuous: Update the property on each frame
 -  Discrete: Only update the property on keyframes
--  Trigger: Only update the property on keyframes or triggers
--  Capture: Remember the current value of the property, and blend it with the
-   first animation key
+-  Trigger: Only update the property on keyframes or triggers.
+   Triggers are a type of keyframe used by the
+   ``current_animation`` property of a :ref:`class_AnimationPlayer`,
+   and Animation Playback tracks.
+-  Capture: if the first keyframes time is greater than 0 the
+   current value of the property will be remembered, and it
+   will blend with the first animation key. For example, you
+   could move a node that's anywhere to a specific location.
 
 .. figure:: img/animation_track_rate.png
    :alt: Track mode

--- a/tutorials/animation/introduction.rst
+++ b/tutorials/animation/introduction.rst
@@ -237,10 +237,11 @@ values. This can be:
    Triggers are a type of keyframe used by the
    ``current_animation`` property of a :ref:`class_AnimationPlayer`,
    and Animation Playback tracks.
--  Capture: if the first keyframes time is greater than 0 the
-   current value of the property will be remembered, and it
-   will blend with the first animation key. For example, you
-   could move a node that's anywhere to a specific location.
+-  Capture: if the first keyframe's time is greater than ``0.0``, the
+   current value of the property will be remembered and
+   will be blended with the first animation key. For example, you
+   could use the Capture mode to move a node that's located anywhere
+   to a specific location.
 
 .. figure:: img/animation_track_rate.png
    :alt: Track mode


### PR DESCRIPTION
Gives a clearer explanation for how Capture works and a possible use case, explains what exactly a trigger is and when it's used. Closes #5127.