### PR TITLE
Fix references to window size project settings in Multiple resolutions

### DIFF
--- a/tutorials/rendering/multiple_resolutions.rst
+++ b/tutorials/rendering/multiple_resolutions.rst
@@ -135,8 +135,8 @@ demonstrate the effect of different stretch modes. A single sprite, also
 
    .. image:: img/stretch_disabled_expand.gif
 
--  **Stretch Mode = 2D**: In this mode, the size specified in
-   display/width and display/height in the project settings is
+-  **Stretch Mode = 2D**: In this mode, the base size specified in
+   width and height in the project settings is
    stretched to cover the whole screen (taking the **Stretch Aspect**
    setting into account). This means that everything is rendered
    directly at the target resolution. 3D is largely unaffected,


### PR DESCRIPTION
Changes done in Multiple Resolutions -> Stretch Settings -> Stretch Mode -> Stretch Mode = 2D, section of the documentation.

The first line refers to base width and height as - ```display/width``` and ```display/height```. So basically, it's trying to refer to them by an address. But when tested with the following Godot releases -
- Godot v3.4.1
- Godot v3.4.2

<br>

The address was this instead -

- ```display/window/size/width```
![width](https://user-images.githubusercontent.com/87367130/147469618-5a64a9b3-babd-4027-be6e-3a918342c64b.png)

<br>

- ```display/window/size/height```
![height](https://user-images.githubusercontent.com/87367130/147469635-24b07b8c-bace-4c3e-9086-195a05c1a076.png)

<br>

So the address needs to be corrected. But since the corrected one is quite long, I instead renamed it from -
- ```the size specified in display/width and display/height``` -> to -> ```the base size specified in width and height```

So we are no longer using the obsolete address, and I think it's much easier to understand now.