### PR TITLE
Fix "inspecter" to "inspector"

### DIFF
--- a/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
@@ -174,7 +174,7 @@ shader, outside the ``vertex()`` function.
   uniform sampler2D noise;
 
 This will allow you to send a noise texture to the shader. Now look in the
-inspecter under your material. You should see a section called "Shader Params".
+inspector under your material. You should see a section called "Shader Params".
 If you open it up, you'll see a section called "noise".
 
 Click beside it where it says "[empty]" and select "New NoiseTexture". Then in


### PR DESCRIPTION
This changes "inspecter" to "inspector" in the "your first 3d shader" tutorial.