### PR TITLE
Remove references to 'godot-headers' from gdnative cpp example

### DIFF
--- a/tutorials/scripting/gdnative/gdnative_cpp_example.rst
+++ b/tutorials/scripting/gdnative/gdnative_cpp_example.rst
@@ -172,7 +172,7 @@ we'll save it as ``main.tscn``. We'll come back to that later.
 Back in the top-level GDNative module folder, we're also going to create a
 subfolder called ``src`` in which we'll place our source files.
 
-You should now have ``demo``, ``godot-cpp``, ``godot-headers``, and ``src``
+You should now have ``demo``, ``godot-cpp``, and ``src``
 directories in your GDNative module.
 
 In the ``src`` folder, we'll start with creating our header file for the
@@ -397,7 +397,7 @@ build files in a subsequent tutorial.
     refer to the ``SConstruct`` file in the Godot 3.0 documentation.
 
 Once you've downloaded the ``SConstruct`` file, place it in your GDNative module
-folder besides ``godot-cpp``, ``godot-headers`` and ``demo``, then run:
+folder besides ``godot-cpp``, ``src`` and ``demo``, then run:
 
 .. code-block:: none
 


### PR DESCRIPTION
As I understand, this folder is not needed anymore as gdnative-cpp now contains the headers as a submodule.