### PR TITLE
Remove outdated vertex attributes link

### DIFF
--- a/tutorials/shaders/converting_glsl_to_godot_shaders.rst
+++ b/tutorials/shaders/converting_glsl_to_godot_shaders.rst
@@ -35,8 +35,8 @@ Vertex attributes
 In GLSL, you can pass in per-vertex information using attributes and have the
 flexibility to pass in as much or as little as you want. In Godot, you have a
 set number of input attributes, including ``VERTEX`` (position), ``COLOR``,
-``UV``, ``UV2``, ``NORMAL``. For a complete list, see the :ref:`Shading language
-reference <doc_shading_language>`.
+``UV``, ``UV2``, ``NORMAL``. Each shaders' page in the shader reference section
+of the documentation comes with a complete list of its vertex attributes.
 
 gl_Position
 ^^^^^^^^^^^


### PR DESCRIPTION
Vertex attributes are no longer listed on the shading language page, each shader has its vertex attributes listed on its own page. Closes #5050. This page has a different name for the 3.x branch of the docs, should I open a separate PR or can this be cherry picked?