### PR TITLE
Document how export filters work

### DIFF
--- a/tutorials/export/exporting_projects.rst
+++ b/tutorials/export/exporting_projects.rst
@@ -103,8 +103,8 @@ option in the editor:
 
 .. _doc_exporting_projects_export_mode:
 
-Export mode
-~~~~~~~~~~~
+Resource options
+~~~~~~~~~~~~~~~~
 
 When exporting, Godot makes a list of all the files to export and then
 creates the package. There are 3 different modes for exporting:
@@ -127,6 +127,11 @@ select every scene or resource you want to export.
     Files and folders whose name begin with a period will never be included in
     the exported project. This is done to prevent version control folders like
     ``.git`` from being included in the exported PCK file.
+
+Below the list of resources are two filters that can be setup. The first allows
+non resource files such as ``.txt``,``.json`` and ``.csv`` to be exported with
+the project. The second filter can be used to exclude every file of a certain
+type without manually deselecting every one. For example, ``.png`` files.
 
 Exporting from the command line
 -------------------------------


### PR DESCRIPTION
Documents how export filters work, and that one needs to be set to allow non resource files to be exported. I would argue this fixes #5272. That issue is about two things people don't know, one is not to access res:// directly. Step by step explains that this shouldn't be done, the [file class reference page](https://docs.godotengine.org/en/latest/classes/class_file.html) explains that this shouldn't be done. I don't think a FAQ section is going to stop anyone. The second issue was that non resource files aren't exported by default, that information wasn't documented anywhere, but now it is. If there's other frequently asked questions that should be documented I'll gladly do it. But I don't think it's necessary after this PR.