### PR TITLE
Remove deprecated Discord link on homepage

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -57,8 +57,7 @@ the top-level ``index.html`` in a web browser.
           <https://github.com/godotengine/godot-docs/issues>`_,
           help us `translate the documentation
           <https://hosted.weblate.org/engage/godot-engine/>`_ into your
-          language, or talk to us on either the ``#documentation``
-          channel on `Discord <https://discord.gg/zH7NUgz>`_, or the
+          language, or talk to us on the
           ``#documentation`` channel on the `Godot Contributors Chat
           <https://chat.godotengine.org/>`_!
 


### PR DESCRIPTION
`#documentation` channel was removed from the Godot Discord in favor of preferring the rocketchat
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
