### PR TITLE
Give example of one liner for natural sort

### DIFF
--- a/classes/class_array.rst
+++ b/classes/class_array.rst
@@ -692,6 +692,8 @@ Sorts the array.
  .. code-tab:: csharp
 
     // There is no sort support for Godot.Collections.Array
+ 
+For natural sorting the same array you can use ``strings.sort_custom(func(a,b): return a.naturalnocasecmp_to(b) < 0)``
 
 
 


### PR DESCRIPTION
The documentation for the `sort` method warns the user that it doesn't do natural sort but fails to provide a solution when it's just a one liner thanks to `String.naturalnocasecmp_to()` and lambda support

This suggests exactly the same algorithm as used by the filesystem dock for file sorting.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
