### PR TITLE
Update task.json creation instructions

### DIFF
--- a/development/cpp/configuring_an_ide/visual_studio_code.rst
+++ b/development/cpp/configuring_an_ide/visual_studio_code.rst
@@ -27,6 +27,8 @@ Importing the project
 
 .. figure:: img/vscode_create_tasksjson_others.png
    :align: center
+ 
+- If there is no such option as **Create tasks.json file from template** available, either delete the file if it already exists in your folder or create a ``.vscode/tasks.json`` file manually. See `Tasks in Visual Studio Code <https://code.visualstudio.com/docs/editor/tasks#_custom-tasks>`_ for more details on tasks.
 
 - Within the ``tasks.json`` file find the ``"tasks"`` array and add a new section to it:
 


### PR DESCRIPTION
The PR aims to fix the problem that there is no ''Create tasks.json file from template'' option shown and I had to check stack overflow to conclude that just pressing enter after configure task will create a task.json file. Also, just pressing F1 instead of ctrl+shift+p launches the configure task option.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
