### PR TITLE
Fix player and mob scene being reversed in Your first game

### DIFF
--- a/getting_started/first_3d_game/09.adding_animations.rst
+++ b/getting_started/first_3d_game/09.adding_animations.rst
@@ -245,10 +245,10 @@ node structure, you can copy them to different scenes.
 For example, both the *Mob* and the *Player* scenes have a *Pivot* and a
 *Character* node, so we can reuse animations between them.
 
-Open the *Player* scene, select the animation player node and open the float animation.
-Next, click on *Animation -> Copy*. Then Open ``Mob.tscn`` and open its animation
-player (Add an AnimationPlayer child node to Mob it if not already done). Click *Animation -> Paste*. 
-That's it; all monsters will now play the float animation.
+Open the *Player* scene, select the animation player node and open the "float" animation.
+Next, click on **Animation > Copy**. Then open ``Mob.tscn`` and open its animation
+player (add an AnimationPlayer child node to Mob it not already done).
+Click **Animation > Paste**. That's it; all monsters will now play the float animation.
 
 We can change the playback speed based on the creature's ``random_speed``. Open
 the *Mob*'s script and at the end of the ``initialize()`` function, add the

--- a/getting_started/first_3d_game/09.adding_animations.rst
+++ b/getting_started/first_3d_game/09.adding_animations.rst
@@ -245,10 +245,10 @@ node structure, you can copy them to different scenes.
 For example, both the *Mob* and the *Player* scenes have a *Pivot* and a
 *Character* node, so we can reuse animations between them.
 
-Open the *Mob* scene, select the animation player node and open the float animation.
-Next, click on *Animation -> Copy*. Then Open ``Player.tscn`` and open its animation
-player. Click *Animation -> Paste*. That's it; all monsters will now play the float
-animation.
+Open the *Player* scene, select the animation player node and open the float animation.
+Next, click on *Animation -> Copy*. Then Open ``Mob.tscn`` and open its animation
+player (Add an AnimationPlayer child node to Mob it if not already done). Click *Animation -> Paste*. 
+That's it; all monsters will now play the float animation.
 
 We can change the playback speed based on the creature's ``random_speed``. Open
 the *Mob*'s script and at the end of the ``initialize()`` function, add the


### PR DESCRIPTION
Corrected the description of copying animation from Player scene to mob scene which incorrectly mentioned the source and target scenes

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
