### PR TITLE
Correct VisibleOnScreenNotifier2D and RigidDynamicBody2D refs in Your First 2D Game tutorial

### DIFF
--- a/getting_started/first_2d_game/04.creating_the_enemy.rst
+++ b/getting_started/first_2d_game/04.creating_the_enemy.rst
@@ -15,16 +15,16 @@ Node setup
 
 Click Scene -> New Scene and add the following nodes:
 
-- :ref:`RigidBody2D <class_RigidBody2D>` (named ``Mob``)
+- :ref:`RigidDynamicBody2D <class_RigidDynamicBody2D>` (named ``Mob``)
 
    - :ref:`AnimatedSprite2D <class_AnimatedSprite2D>`
    - :ref:`CollisionShape2D <class_CollisionShape2D>`
-   - :ref:`VisibilityNotifier2D <class_VisibilityNotifier2D>`
+   - :ref:`VisibleOnScreenNotifier2D <class_VisibleOnScreenNotifier2D>`
 
 Don't forget to set the children so they can't be selected, like you did with
 the Player scene.
 
-In the :ref:`RigidBody2D <class_RigidBody2D>` properties, set ``Gravity Scale``
+In the :ref:`RigidDynamicBody2D <class_RigidDynamicBody2D>` properties, set ``Gravity Scale``
 to ``0``, so the mob will not fall downward. In addition, under the
 :ref:`CollisionObject2D <class_CollisionObject2D>` section, click the ``Mask`` property and uncheck the first
 box. This will ensure the mobs do not collide with each other.
@@ -61,11 +61,11 @@ Add a script to the ``Mob`` like this:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    extends RigidBody2D
+    extends RigidDynamicBody2D
 
  .. code-tab:: csharp
 
-    public class Mob : RigidBody2D
+    public class Mob : RigidDynamicBody2D
     {
         // Don't forget to rebuild the project.
     }
@@ -82,17 +82,17 @@ Add a script to the ``Mob`` like this:
 
     #include <AnimatedSprite2D.hpp>
     #include <Godot.hpp>
-    #include <RigidBody2D.hpp>
+    #include <RigidDynamicBody2D.hpp>
 
-    class Mob : public godot::RigidBody2D {
-        GODOT_CLASS(Mob, godot::RigidBody2D)
+    class Mob : public godot::RigidDynamicBody2D {
+        GODOT_CLASS(Mob, godot::RigidDynamicBody2D)
 
         godot::AnimatedSprite2D *_animated_sprite;
 
     public:
         void _init() {}
         void _ready();
-        void _on_VisibilityNotifier2D_screen_exited();
+        void _on_VisibleOnScreenNotifier2D_screen_exited();
 
         static void _register_methods();
     };
@@ -150,18 +150,18 @@ selects a random integer between ``0`` and ``n-1``.
             use ``randomize()`` in our ``Main`` scene, so we won't need it here.
 
 The last piece is to make the mobs delete themselves when they leave the screen.
-Connect the ``screen_exited()`` signal of the ``VisibilityNotifier2D`` node and
+Connect the ``screen_exited()`` signal of the ``VisibleOnScreenNotifier2D`` node and
 add this code:
 
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    func _on_VisibilityNotifier2D_screen_exited():
+    func _on_visible_on_screen_notifier_2d_screen_exited():
         queue_free()
 
  .. code-tab:: csharp
 
-    public void OnVisibilityNotifier2DScreenExited()
+    public void OnVisibleOnScreenNotifier2DScreenExited()
     {
         QueueFree();
     }
@@ -169,7 +169,7 @@ add this code:
  .. code-tab:: cpp
 
     // This code goes in `mob.cpp`.
-    void Mob::_on_VisibilityNotifier2D_screen_exited() {
+    void Mob::_on_VisibleOnScreenNotifier2D_screen_exited() {
         queue_free();
     }
 


### PR DESCRIPTION
Changed the VisibilityNotifier2D class references to the renamed VisibleOnScreenNotifier2D class, and the RigidBody2D class reference to the renamed RigidDynamicBody2D class.

Addresses some of what's mentioned in issue #5498  

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
