### PR TITLE
Update `NORMALMAP` builtin name in Your first 3D shader

### DIFF
--- a/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
@@ -320,7 +320,7 @@ explained in more detail in the next part of this tutorial.
 
 When we have normals that correspond to a specific vertex we set ``NORMAL``, but
 if you have a normalmap that comes from a texture, set the normal using
-``NORMALMAP``. This way Godot will handle the wrapping the texture around the
+``NORMAL_MAP``. This way Godot will handle the wrapping the texture around the
 mesh automatically.
 
 Lastly, in order to ensure that we are reading from the same places on the noise
@@ -347,7 +347,7 @@ And now we can access ``tex_position`` from the ``fragment()`` function.
 .. code-block:: glsl
 
   void fragment() {
-    NORMALMAP = texture(normalmap, tex_position).xyz;
+    NORMAL_MAP = texture(normalmap, tex_position).xyz;
   }
 
 With the normals in place the light now reacts to the height of the mesh
@@ -379,7 +379,7 @@ Godot handles most of the difficult stuff for you.
   }
 
   void fragment() {
-    NORMALMAP = texture(normalmap, tex_position).xyz;
+    NORMAL_MAP = texture(normalmap, tex_position).xyz;
   }
 
 That is everything for this part. Hopefully, you now understand the basics of


### PR DESCRIPTION
updating NORMALMAP to NORMAL_MAP to match Godot 4.0 definition

I tried following the tutorial in Godot 4.0 alpha, and I got an error on this line as NORMALMAP was not recognized. 
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
