### PR TITLE
Update IRC links to point to Godot Contributors Chat

### DIFF
--- a/community/contributing/pr_workflow.rst
+++ b/community/contributing/pr_workflow.rst
@@ -365,7 +365,7 @@ that will let you issue a pull request on the ``godotengine/godot`` upstream
 repository. It should show you your two commits, and state "Able to merge".
 If not (e.g. it has way more commits, or says there are merge conflicts),
 don't create the PR, something went wrong. Go to the 
-`Contributors Chat <https://chat.godotengine.org/>`_ and ask for support :)
+`Godot Contributors Chat <https://chat.godotengine.org/>`_ and ask for support :)
 
 Use an explicit title for the PR and put the necessary details in the comment
 area. You can drag and drop screenshots, GIFs or zipped projects if relevant,

--- a/community/contributing/pr_workflow.rst
+++ b/community/contributing/pr_workflow.rst
@@ -364,7 +364,8 @@ On that line, there is a "Pull request" link. Clicking it will open a form
 that will let you issue a pull request on the ``godotengine/godot`` upstream
 repository. It should show you your two commits, and state "Able to merge".
 If not (e.g. it has way more commits, or says there are merge conflicts),
-don't create the PR, something went wrong. Go to IRC and ask for support :)
+don't create the PR, something went wrong. Go to the 
+`Contributors Chat <https://chat.godotengine.org/>`_ and ask for support :)
 
 Use an explicit title for the PR and put the necessary details in the comment
 area. You can drag and drop screenshots, GIFs or zipped projects if relevant,

--- a/community/contributing/updating_the_class_reference.rst
+++ b/community/contributing/updating_the_class_reference.rst
@@ -119,7 +119,7 @@ Another option is to delete the branch you're working on, synchronize the master
     git pull --rebase upstream master
     git checkout -b your-new-branch-name
 
-If you're feeling lost by now, come to our `Contributors Chat <https://chat.godotengine.org/>`_ and ask for help. Experienced Git users will give you a hand.
+If you're feeling lost by now, come to our `Godot Contributors Chat <https://chat.godotengine.org/>`_ and ask for help. Experienced Git users will give you a hand.
 
 Updating the documentation template
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -310,7 +310,7 @@ I don't know what this method does!
 
 No problem. Leave it behind, and list the methods you skipped when you request a pull of your changes. Another writer will take care of it.
 
-You can still have a look at the methods' implementation in Godot's source code on GitHub. Also, if you have doubts, feel free to ask on the `Q&A website <https://godotengine.org/qa/>`__ and on the `Contributors Chat <https://chat.godotengine.org/>`__.
+You can still have a look at the methods' implementation in Godot's source code on GitHub. Also, if you have doubts, feel free to ask on the `Q&A website <https://godotengine.org/qa/>`__ and on the `Godot Contributors Chat <https://chat.godotengine.org/>`__.
 
 
 Localization

--- a/community/contributing/updating_the_class_reference.rst
+++ b/community/contributing/updating_the_class_reference.rst
@@ -119,7 +119,7 @@ Another option is to delete the branch you're working on, synchronize the master
     git pull --rebase upstream master
     git checkout -b your-new-branch-name
 
-If you're feeling lost by now, come to our `IRC channels <https://webchat.freenode.net/?channels=#godotengine>`_ and ask for help. Experienced Git users will give you a hand.
+If you're feeling lost by now, come to our `Contributors Chat <https://chat.godotengine.org/>`_ and ask for help. Experienced Git users will give you a hand.
 
 Updating the documentation template
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -310,7 +310,7 @@ I don't know what this method does!
 
 No problem. Leave it behind, and list the methods you skipped when you request a pull of your changes. Another writer will take care of it.
 
-You can still have a look at the methods' implementation in Godot's source code on GitHub. Also, if you have doubts, feel free to ask on the `Q&A website <https://godotengine.org/qa/>`__ and on IRC (freenode, #godotengine).
+You can still have a look at the methods' implementation in Godot's source code on GitHub. Also, if you have doubts, feel free to ask on the `Q&A website <https://godotengine.org/qa/>`__ and on the `Contributors Chat <https://chat.godotengine.org/>`__.
 
 
 Localization


### PR DESCRIPTION
Replace links to IRC with links to Contributor's Chat in contributing docs for 3.3 (to match 3.4 and above).

Or would link to Libera.Chat be better to match #5547?