### PR TITLE
Update plugin tutorial to use @tool

### DIFF
--- a/tutorials/plugins/editor/import_plugins.rst
+++ b/tutorials/plugins/editor/import_plugins.rst
@@ -48,7 +48,7 @@ when needed:
 ::
 
     # material_import.gd
-    tool
+    @tool
     extends EditorPlugin
 
 
@@ -90,7 +90,7 @@ Let's begin to code our plugin, one method at time:
 ::
 
     # import_plugin.gd
-    tool
+    @tool
     extends EditorImportPlugin
 
 
@@ -179,7 +179,7 @@ good practice to use an enum so you can refer to them using names.
 
 ::
 
-    tool
+    @tool
     extends EditorImportPlugin
 
 

--- a/tutorials/plugins/editor/inspector_plugins.rst
+++ b/tutorials/plugins/editor/inspector_plugins.rst
@@ -45,7 +45,7 @@ you should remove the instance you have added by calling
   .. code-tab:: gdscript GDScript
 
     # plugin.gd
-    tool
+    @tool
     extends EditorPlugin
 
     var plugin

--- a/tutorials/plugins/editor/making_main_screen_plugins.rst
+++ b/tutorials/plugins/editor/making_main_screen_plugins.rst
@@ -28,7 +28,7 @@ Add five extra methods such that the script looks like this:
 
 ::
 
-    tool
+    @tool
     extends EditorPlugin
 
 
@@ -77,7 +77,7 @@ Add a script to the button like this:
 
 ::
 
-    tool
+    @tool
     extends Button
 
 
@@ -98,7 +98,7 @@ Here is the full plugin script:
 
 ::
 
-    tool
+    @tool
     extends EditorPlugin
 
 

--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -69,13 +69,13 @@ The script file
 
 Upon creation of the plugin, the dialog will automatically open the
 EditorPlugin script for you. The script has two requirements that you cannot
-change: it must be a ``tool`` script, or else it will not load properly in the
+change: it must be a ``@tool`` script, or else it will not load properly in the
 editor, and it must inherit from :ref:`class_EditorPlugin`.
 
 .. warning::
 
     In addition to the EditorPlugin script, any other GDScript that your plugin uses
-    must *also* be a tool. Any GDScript without ``tool`` imported into the editor
+    must *also* be a tool. Any GDScript without ``@tool`` imported into the editor
     will act like an empty file!
 
 It's important to deal with initialization and clean-up of resources.
@@ -89,7 +89,7 @@ like this:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    tool
+    @tool
     extends EditorPlugin
 
 
@@ -146,7 +146,7 @@ To create a new node type, you can use the function
 :ref:`class_EditorPlugin` class. This function can add new types to the editor
 (nodes or resources). However, before you can create the type, you need a script
 that will act as the logic for the type. While that script doesn't have to use
-the ``tool`` keyword, it can be added so the script runs in the editor.
+the ``@tool`` keyword, it can be added so the script runs in the editor.
 
 For this tutorial, we'll create a button that prints a message when
 clicked. For that, we'll need a script that extends from
@@ -156,7 +156,7 @@ clicked. For that, we'll need a script that extends from
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    tool
+    @tool
     extends Button
 
 
@@ -200,7 +200,7 @@ dialog. For that, change the ``custom_node.gd`` script to the following:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    tool
+    @tool
     extends EditorPlugin
 
 
@@ -316,7 +316,7 @@ The script could look like this:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    tool
+    @tool
     extends EditorPlugin
 
 

--- a/tutorials/plugins/editor/spatial_gizmos.rst
+++ b/tutorials/plugins/editor/spatial_gizmos.rst
@@ -39,7 +39,7 @@ This would be a basic setup:
 ::
 
     # MyCustomEditorPlugin.gd
-    tool
+    @tool
     extends EditorPlugin
 
 

--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -3,10 +3,10 @@
 Running code in the editor
 ==========================
 
-What is ``tool``?
+What is ``@tool``?
 -----------------
 
-``tool`` is a powerful line of code that, when added at the top of your script,
+``@tool`` is a powerful line of code that, when added at the top of your script,
 makes it execute in the editor. You can also decide which parts of the script
 execute in the editor, which in game, and which in both.
 
@@ -25,10 +25,10 @@ use cases:
 
 .. DANGER::
 
-    ``tool`` scripts run inside the editor, and let you access the scene tree
+    ``@tool`` scripts run inside the editor, and let you access the scene tree
     of the currently edited scene. This is a powerful feature which also comes
     with caveats, as the editor does not include protections for potential
-    misuse of ``tool`` scripts.
+    misuse of ``@tool`` scripts.
     Be **extremely** cautious when manipulating the scene tree, especially via
     :ref:`Node.queue_free<class_Node_method_queue_free>`, as it can cause
     crashes if you free a node while the editor runs logic involving it.
@@ -36,7 +36,7 @@ use cases:
 How to use it
 -------------
 
-To turn a script into a tool, add the keyword ``tool`` at the top of your code.
+To turn a script into a tool, add the keyword ``@tool`` at the top of your code.
 
 To check if you are currently in the editor, use: ``Engine.editor_hint``.
 
@@ -120,7 +120,7 @@ and open a script, and change it to this:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    tool
+    @tool
     extends Sprite2D
 
     func _process(delta):
@@ -188,7 +188,7 @@ Add and export a variable speed to the script. The function set_speed after
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    tool
+    @tool
     extends Sprite2D
 
 
@@ -295,7 +295,7 @@ You can instantiate packed scenes normally and add them to the scene currently
 opened in the editor. Be sure to set the scene root as the owner of all the
 nodes created this way or the nodes won't be visible in the editor.
 
-If you are using ``tool``:
+If you are using ``@tool``:
 
 .. tabs::
  .. code-tab:: gdscript GDScript
@@ -339,7 +339,7 @@ If you are using :ref:`EditorScript<class_EditorScript>`:
 
 .. warning::
 
-    Using ``tool`` improperly can yield many errors. It is advised to first
-    write the code how you want it, and only then add the ``tool`` keyword to
+    Using ``@tool`` improperly can yield many errors. It is advised to first
+    write the code how you want it, and only then add the ``@tool`` keyword to
     the top. Also, make sure to separate code that runs in-editor from code that
     runs in-game. This way, you can find bugs more easily.


### PR DESCRIPTION
Replaces instances of tool with @tool in plugin tutorial. This includes GDScript code examples, while C# examples have been left with `[Tool]`.
