### PR TITLE
Mention that Godot OpenXR doesn't work with Microsoft MR runtime

### DIFF
--- a/tutorials/vr/openxr/runtime_selection.rst
+++ b/tutorials/vr/openxr/runtime_selection.rst
@@ -4,7 +4,7 @@ Switching runtimes
 ==================
 
 In OpenXR, it is standard for each runtime to implement a mechanism to make it
-the current runtime.  In Steam, the Oculus application or Windows MR portal,
+the current runtime. In Steam, the Oculus application or Windows MR portal,
 there will be an option to switch to their runtime as the current OpenXR runtime.
 
 Generally speaking, end users will have a preferred runtime due to not having a reason
@@ -15,6 +15,9 @@ To make this easy, Godot provides a dropdown in the top-right corner which can
 switch the runtime Godot will use when testing:
 
 .. image:: img/switch_runtime.png
+
+The OpenXR plugin will not work with the Microsoft MR runtime. That runtime only supports
+OpenXR applications that use DirectX, and Godot uses OpenGL 3 and 2. 
 
 .. note::
 

--- a/tutorials/vr/openxr/runtime_selection.rst
+++ b/tutorials/vr/openxr/runtime_selection.rst
@@ -16,8 +16,9 @@ switch the runtime Godot will use when testing:
 
 .. image:: img/switch_runtime.png
 
-The OpenXR plugin will not work with the Microsoft MR runtime. That runtime only supports
-OpenXR applications that use DirectX, and Godot uses OpenGL 3 and 2. 
+The OpenXR plugin will **not** work with the Microsoft MR runtime.
+That runtime only supports OpenXR applications that use DirectX,
+but Godot uses OpenGL ES 3.0 or 2.0.
 
 .. note::
 


### PR DESCRIPTION
VR games made with the OpenXR plugin do not work with the Microsoft MR runtime, as it only supports projects made using DirectX, see https://github.com/GodotVR/godot_openxr/issues/51. This is only for the 3.4 branch as there's no documentation in master yet. I also removed an extra space in a paragraph.
