### PR TITLE
Player and Mob scene are reversed

### DIFF
--- a/getting_started/first_3d_game/09.adding_animations.rst
+++ b/getting_started/first_3d_game/09.adding_animations.rst
@@ -245,8 +245,8 @@ node structure, you can copy them to different scenes.
 For example, both the *Mob* and the *Player* scenes have a *Pivot* and a
 *Character* node, so we can reuse animations between them.
 
-Open the *Mob* scene, select the animation player node and open the float animation.
-Next, click on *Animation -> Copy*. Then Open ``Player.tscn`` and open its animation
+Open the ``Player.tscn`` scene, select the *AnimationPlayer* node and open the float animation.
+Next, click on *Animation -> Copy*. Then Open ``Mob.tscn``, add *AnimationPlayer* node as child of the *Mob* node and open its animation
 player. Click *Animation -> Paste*. That's it; all monsters will now play the float
 animation.
 


### PR DESCRIPTION
Hi, Line 248 to 250, the named "Mob.tscn" and "Player.tscn" scene are reversed. The animation data must be copied from the "Player" scene. Also in the Mob scene a new AnimationPlayer node must be created to paste it.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
