### PR TITLE
Clarify what selecting the XR runtime does

### DIFF
--- a/tutorials/vr/openxr/runtime_selection.rst
+++ b/tutorials/vr/openxr/runtime_selection.rst
@@ -22,8 +22,9 @@ but Godot uses OpenGL ES 3.0 or 2.0.
 
 .. note::
 
-    Selecting a runtime in this dropdown only applies to your local session. 
-    It does **not** change the runtime used by other applications. 
+    Selecting a runtime in this dropdown only applies to running the game
+    from the editor. It does **not** change the runtime used by other
+    applications. Exported projects will use the computers current runtime.
     Also, if you are deploying to an external device, this setting has no effect.
 
 As OpenXR doesn't have a mechanism for registering runtimes that we can query,


### PR DESCRIPTION
clarifies that choosing the runtime in the editor only applies to running a project from the editor, and exported projects will use the computers current OpenXR runtime.