### PR TITLE
Get rid of openssl warning during PCK encryption setup

### DIFF
--- a/development/compiling/compiling_with_script_encryption_key.rst
+++ b/development/compiling/compiling_with_script_encryption_key.rst
@@ -25,15 +25,13 @@ Step by step
 
    ::
 
-       openssl enc -aes-256-cbc -k secret -P -md sha1 > godot.gdkey
+       openssl rand -hex 32 > godot.gdkey
 
-   This should output the following to ``godot.gdkey`` file:
+   The output in ``godot.gdkey`` should be similar to:
 
    ::
 
-       salt=5786FE8B91CA048A
-       key=D2F90FCC4FCA64B8990F916EF5A73230C1841601D1EA06B2380EC0F530E4EF85
-       iv =047C353AEC9E6C211515E3341BF9C61B
+       aeb1bc56aaf580cc31784e9c41551e9ed976ecba10d315db591e749f3f64890f
 
    You can generate the key without redirecting the output to a file, but
    that way you can minimize the risk of exposing the key.


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
Tested with openssl v1.1.1k , v1.1.1m, and v3.0.1 and godotengine/godot@b9a2569be6fcd1127454127d989b504334d2dac8.

resolves #5567
