### PR TITLE
Swap `extends` line with `class_name` to follow GDScript style guide

### DIFF
--- a/tutorials/best_practices/scenes_versus_scripts.rst
+++ b/tutorials/best_practices/scenes_versus_scripts.rst
@@ -209,8 +209,9 @@ In the end, the best approach is to consider the following:
     .. code-tab:: gdscript GDScript
 
       # game.gd
-      extends Reference
       class_name Game # extends Reference, so it won't show up in the node creation dialog
+      extends Reference
+
       const MyScene = preload("my_scene.tscn")
 
       # main.gd


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
According to [GDScript style guide (Code Order)](https://docs.godotengine.org/en/latest/tutorials/scripting/gdscript/gdscript_styleguide.html#code-order), `class_name` should come before `extends`.
This pull request fixes this order in one of the tutorials.