### PR TITLE
Add @ to onready annotated variables in examples

### DIFF
--- a/tutorials/best_practices/godot_interfaces.rst
+++ b/tutorials/best_practices/godot_interfaces.rst
@@ -140,12 +140,12 @@ Nodes likewise have an alternative access point: the SceneTree.
         print($Child)
 
     # Fastest. Doesn't break if node moves later.
-    # Note that `onready` keyword is GDScript only.
+    # Note that `@onready` annotation is GDScript only.
     # Other languages must do...
     #     var child
     #     func _ready():
     #         child = get_node("Child")
-    onready var child = $Child
+    @onready var child = $Child
     func lookup_and_cache_for_future_access():
         print(child)
 
@@ -469,7 +469,7 @@ accesses:
     # parent.gd
     extends Node
 
-    onready var child = $Child
+    @onready var child = $Child
 
     func _ready():
         child.fn = funcref(self, "print_me")

--- a/tutorials/scripting/gdnative/gdnative_c_example.rst
+++ b/tutorials/scripting/gdnative/gdnative_c_example.rst
@@ -543,7 +543,7 @@ Now we can implement our ``main.gd`` code:
     extends Control
 
     # load the Simple library
-    onready var data = preload("res://bin/simple.gdns").new()
+    @onready var data = preload("res://bin/simple.gdns").new()
 
     func _on_Button_pressed():
         $Label.text = "Data = " + data.get_data()

--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -38,8 +38,8 @@ Here is a complete class example based on these guidelines:
     export var initial_state = NodePath()
     var is_active = true setget set_is_active
 
-    onready var _state = get_node(initial_state) setget set_state
-    onready var _state_name = _state.name
+    @onready var _state = get_node(initial_state) setget set_state
+    @onready var _state_name = _state.name
 
 
     func _init():
@@ -772,8 +772,8 @@ variables, in that order.
 
    var _speed = 300.0
 
-   onready var sword = get_node("Sword")
-   onready var gun = get_node("Gun")
+   @onready var sword = get_node("Sword")
+   @onready var gun = get_node("Gun")
 
 
 .. note::
@@ -887,7 +887,7 @@ should set the type explicitly.
 
 ::
 
-   onready var health_bar: ProgressBar = get_node("UI/LifeBar")
+   @onready var health_bar: ProgressBar = get_node("UI/LifeBar")
 
 Alternatively, you can use the ``as`` keyword to cast the return type, and
 that type will be used to infer the type of the var.
@@ -896,7 +896,7 @@ that type will be used to infer the type of the var.
 
 ::
 
-   onready var health_bar := get_node("UI/LifeBar") as ProgressBar
+   @onready var health_bar := get_node("UI/LifeBar") as ProgressBar
    # health_bar will be typed as ProgressBar
 
 This option is also considered more :ref:`type-safe<doc_gdscript_static_typing_safe_lines>` than the first.
@@ -909,4 +909,4 @@ This option is also considered more :ref:`type-safe<doc_gdscript_static_typing_s
 
    # The compiler can't infer the exact type and will use Node
    # instead of ProgressBar.
-   onready var health_bar := get_node("UI/LifeBar")
+   @onready var health_bar := get_node("UI/LifeBar")

--- a/tutorials/scripting/nodes_and_scene_instances.rst
+++ b/tutorials/scripting/nodes_and_scene_instances.rst
@@ -97,20 +97,20 @@ Syntactic sugar
 ~~~~~~~~~~~~~~~
 
 You can use two shorthands to shorten your code in GDScript. Firstly, putting the
-``onready`` keyword before a member variable makes it initialize right before
+``@onready`` annotation before a member variable makes it initialize right before
 the ``_ready()`` callback.
 
 .. code-block:: gdscript
 
-    onready var sprite2d = get_node("Sprite2D")
+    @onready var sprite2d = get_node("Sprite2D")
 
 There is also a short notation for ``get_node()``: the dollar sign, "$". You
 place it before the name or path of the node you want to get.
 
 .. code-block:: gdscript
 
-    onready var sprite2d = $Sprite2D
-    onready var tween = $ShieldBar/Tween
+    @onready var sprite2d = $Sprite2D
+    @onready var tween = $ShieldBar/Tween
 
 Creating nodes
 --------------


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
Update examples to use `@onready` annotation instead of the old `onready` keyword.