### PR TITLE
Add missing closing quotation marks in GDScript format strings

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_format_string.rst
+++ b/tutorials/scripting/gdscript/gdscript_format_string.rst
@@ -11,7 +11,7 @@ placeholder character-sequences. These placeholders can then easily be replaced
 by parameters handed to the format string.
 
 As an example, with ``%s`` as a placeholder, the format string ``"Hello %s, how
-are you?`` can easily be changed to ``"Hello World, how are you?"``. Notice
+are you?"`` can easily be changed to ``"Hello World, how are you?"``. Notice
 the placeholder is in the middle of the string; modifying it without format
 strings could be cumbersome.
 


### PR DESCRIPTION
An example code snippet was missing closing quotation marks.