### PR TITLE
fix 'making_plugin' tutorial code snippet

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -177,10 +177,10 @@ clicked. For that, we'll need a script that extends from
     {
         public override void _EnterTree()
         {
-            Connect("pressed", clicked);
+            Connect("pressed", Clicked);
         }
 
-        public void clicked()
+        public void Clicked()
         {
             GD.Print("You clicked me!");
         }

--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -161,7 +161,7 @@ clicked. For that, we'll need a script that extends from
 
 
     func _enter_tree():
-        connect("pressed", clicked)
+        pressed.connect(clicked)
 
 
     func clicked():

--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -161,7 +161,7 @@ clicked. For that, we'll need a script that extends from
 
 
     func _enter_tree():
-        connect("pressed", self, "clicked")
+        connect("pressed", clicked)
 
 
     func clicked():
@@ -177,7 +177,7 @@ clicked. For that, we'll need a script that extends from
     {
         public override void _EnterTree()
         {
-            Connect("pressed", this, "clicked");
+            Connect("pressed", clicked);
         }
 
         public void clicked()


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->

On version: v4.0.alpha1.official [31a7ddbf8]


Following the guide Making Plugins from 'latest' cause: https://docs.godotengine.org/en/latest/tutorials/plugins/editor/making_plugins.html
![image](https://user-images.githubusercontent.com/1633368/152658048-d9f3a23d-c809-4d27-85ef-e1de55f3f430.png)

```
Line 6:Invalid argument for "connect()" function: argument 2 should be Callable but is res://addons/sentry/my_button.gd
Line 6:Invalid argument for "connect()" function: argument 3 should be Array but is String.
```

It seems the new API takes a callback directly.

Related to: https://github.com/godotengine/godot-docs/issues/5577