### PR TITLE
Fixed grammar in "Awaiting for signals" end note

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1771,8 +1771,8 @@ This also means that returning a signal from a function that isn't a coroutine w
         await get_signal()
         print("Button was pressed")
 
-.. note:: Unlike ``yield`` in previous Godot versions, you cannot obtain the function state object. This is in the spirit of
-          type-safety, because a function cannot say that it returns an ``int`` but actually return a function state object
+.. note:: Unlike ``yield`` in previous Godot versions, you cannot obtain the function state object. This is done to ensure type safety.
+A function cannot say that it returns an ``int`` while it actually returns a function state object
           during runtime.
 
 .. _doc_gdscript_onready_annotation:

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1771,8 +1771,8 @@ This also means that returning a signal from a function that isn't a coroutine w
         await get_signal()
         print("Button was pressed")
 
-.. note:: Unlike ``yield`` in previous Godot versions, you cannot obtain the function state object. This in spirit of
-          type-safety, because a function cannot say that returns an ``int`` but actually give a function state object
+.. note:: Unlike ``yield`` in previous Godot versions, you cannot obtain the function state object. This is in the spirit of
+          type-safety, because a function cannot say that it returns an ``int`` but actually return a function state object
           during runtime.
 
 .. _doc_gdscript_onready_annotation:

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1771,8 +1771,9 @@ This also means that returning a signal from a function that isn't a coroutine w
         await get_signal()
         print("Button was pressed")
 
-.. note:: Unlike ``yield`` in previous Godot versions, you cannot obtain the function state object. This is done to ensure type safety.
-A function cannot say that it returns an ``int`` while it actually returns a function state object
+.. note:: Unlike ``yield`` in previous Godot versions, you cannot obtain the function state object.
+          This is done to ensure type safety.
+          With this type safety in place, a function cannot say that it returns an ``int`` while it actually returns a function state object
           during runtime.
 
 .. _doc_gdscript_onready_annotation:


### PR DESCRIPTION
Added a few words to the note at the end of the "Awaiting for signals" section for proper grammar. Also changed "give" to "return" in the same note, so that it's more concise and consistent. This is also my first PR, so I hope I did it right!

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
