### PR TITLE
Update connecting signal code for Godot 4

### DIFF
--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -241,12 +241,12 @@ We can now connect the Timer to the Sprite2D in the ``_ready()`` function.
 
     func _ready():
         var timer = get_node("Timer")
-        timer.connect("timeout", self, "_on_Timer_timeout")
+        timer.timeout.connect(_on_Timer_timeout)
 
 The line reads like so: we connect the Timer's "timeout" signal to the node to
-which the script is attached (``self``). When the Timer emits "timeout", we want
-to call the function "_on_Timer_timeout", that we need to define. Let's add it
-at the bottom of our script and use it to toggle our sprite's visibility.
+which the script is attached. When the Timer emits "timeout", we want to call
+the function "_on_Timer_timeout", that we need to define. Let's add it at the
+bottom of our script and use it to toggle our sprite's visibility.
 
 .. tabs::
  .. code-tab:: gdscript GDScript

--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -244,8 +244,8 @@ We can now connect the Timer to the Sprite2D in the ``_ready()`` function.
         timer.timeout.connect(_on_Timer_timeout)
 
 The line reads like so: we connect the Timer's "timeout" signal to the node to
-which the script is attached. When the Timer emits "timeout", we want to call
-the function "_on_Timer_timeout", that we need to define. Let's add it at the
+which the script is attached. When the Timer emits ``timeout``, we want to call
+the function ``_on_Timer_timeout()``, that we need to define. Let's add it at the
 bottom of our script and use it to toggle our sprite's visibility.
 
 .. tabs::


### PR DESCRIPTION
Updates the example of connecting a signal via code in the step by step section for Godot 4. Closes #5577.