### PR TITLE
Update mentions of "editor_hint"

### DIFF
--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -50,7 +50,7 @@ For example, if you want to execute some code only in the editor, use:
 
  .. code-tab:: csharp
 
-    if (Engine.EditorHint)
+    if (Engine.IsEditorHint())
     {
         // Code to execute when in editor.
     }
@@ -66,7 +66,7 @@ same statement:
 
  .. code-tab:: csharp
 
-    if (!Engine.EditorHint)
+    if (!Engine.IsEditorHint())
     {
         // Code to execute when in game.
     }
@@ -92,12 +92,12 @@ Here is how a ``_process()`` function might look for you:
 
     public override void _Process(float delta)
     {
-        if (Engine.EditorHint)
+        if (Engine.IsEditorHint())
         {
             // Code to execute in editor.
         }
 
-        if (!Engine.EditorHint)
+        if (!Engine.IsEditorHint())
         {
             // Code to execute in game.
         }
@@ -165,7 +165,7 @@ look like this:
 
     public override void _Process(float delta)
     {
-        if (Engine.EditorHint)
+        if (Engine.IsEditorHint())
         {
             RotationDegrees += 180 * delta;
         }

--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -38,14 +38,14 @@ How to use it
 
 To turn a script into a tool, add the keyword ``@tool`` at the top of your code.
 
-To check if you are currently in the editor, use: ``Engine.editor_hint``.
+To check if you are currently in the editor, use: ``Engine.is_editor_hint()``.
 
 For example, if you want to execute some code only in the editor, use:
 
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    if Engine.editor_hint:
+    if Engine.is_editor_hint():
         # Code to execute when in editor.
 
  .. code-tab:: csharp
@@ -61,7 +61,7 @@ same statement:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    if not Engine.editor_hint:
+    if not Engine.is_editor_hint():
         # Code to execute when in game.
 
  .. code-tab:: csharp
@@ -80,10 +80,10 @@ Here is how a ``_process()`` function might look for you:
  .. code-tab:: gdscript GDScript
 
     func _process(delta):
-        if Engine.editor_hint:
+        if Engine.is_editor_hint():
             # Code to execute in editor.
 
-        if not Engine.editor_hint:
+        if not Engine.is_editor_hint():
             # Code to execute in game.
 
         # Code to execute both in editor and in game.
@@ -156,7 +156,7 @@ look like this:
  .. code-tab:: gdscript GDScript
 
     func _process(delta):
-        if Engine.editor_hint:
+        if Engine.is_editor_hint():
             rotation_degrees += 180 * delta
         else:
             rotation_degrees -= 180 * delta


### PR DESCRIPTION
At some point it seems like `Engine.editor_hint` was removed in favor of `Engine.is_editor_hint`. You can see this in the [latest Engine class reference](https://docs.godotengine.org/en/latest/classes/class_engine.html). This change updates references to `editor_hint` in `running_code_in_the_editor.rst`.

This only updates the gdscript examples. The C# code has references to `Engine.EditorHint` that may need to be updated as well, but I don't have a Mono build I can check against.