### PR TITLE
Fix shortcut info on signals page

### DIFF
--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -190,7 +190,7 @@ Let's use a different node here. Godot has a :ref:`Timer <class_Timer>` node
 that's useful to implement skill cooldown times, weapon reloading, and more.
 
 Head back to the 2D workspace. You can either click the "2D" text at the top of
-the window or press :kbd:`Ctrl + F2` (:kbd:`Alt + 2` on macOS).
+the window or press :kbd:`Ctrl + F1` (:kbd:`Alt + 1` on macOS).
 
 In the Scene dock, right-click on the Sprite2D node and add a new node. Search for
 Timer and add the corresponding node. Your scene should now look like this.


### PR DESCRIPTION
Ctrl + F1 and alt +1 are used to switch to the 2D window, not Ctrl + F2 and alt + 2. Closes #5595