### PR TITLE
Update project_manager.rst

### DIFF
--- a/tutorials/editor/project_manager.rst
+++ b/tutorials/editor/project_manager.rst
@@ -6,7 +6,11 @@ Using the Project manager
 When you launch Godot, the first window you see is the Project Manager. It lets
 you create, remove, import, or play game projects.
 
+You can also reach that screen from within Godot by selecting menu entry Project-->Quit to Project List
+
 .. image:: img/editor_ui_intro_project_manager_01.png
+
+Note : In more recent versions of Godot, the "Tempates" tab has been renamed "Asset Library Projects".
 
 In the window's top-right corner, a drop-down menu allows you to change the
 editor's language.


### PR DESCRIPTION
- Clarified that the "Project manager" is sometimes called "Projects list"
- Pointed out that the screenshot is obsolete and that the "Templates" tab has a new name.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
