### PR TITLE
Fix a typo in Using the MeshDataTool

### DIFF
--- a/tutorials/3d/procedural_geometry/meshdatatool.rst
+++ b/tutorials/3d/procedural_geometry/meshdatatool.rst
@@ -33,7 +33,7 @@ An edge is a connection between any two vertices. Each edge in the edge array co
 the two vertices it is composed of, and up to two faces that it is contained within.
 
 A face is a triangle made up of three vertices and three corresponding edges. Each face in the face array contains
-a reference to the three triangles and three edges it is composed of.
+a reference to the three vertices and three edges it is composed of.
 
 The vertex array contains edges, faces, normals, color, tangent, uv, uv2, bones, and weight information connected
 with each vertex.


### PR DESCRIPTION
### 3D » Procedural geometry » Using the MeshDataTool

"Each face in the face array contains a reference to the three **triangles** and three edges it is composed of."
should be:
"Each face in the face array contains a reference to the three **vertices** and three edges it is composed of."

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
