### PR TITLE
Fix another typo in Using the SurfaceTool

### DIFF
--- a/tutorials/3d/procedural_geometry/surfacetool.rst
+++ b/tutorials/3d/procedural_geometry/surfacetool.rst
@@ -22,7 +22,7 @@ Attributes are added before each vertex is added:
     st.add_normal() # Normal never added to a vertex.
 
 When finished generating your geometry with the :ref:`SurfaceTool <class_surfacetool>`
-call ``commit()`` to finished generating the mesh. If an :ref:`ArrayMesh <class_ArrayMesh>` is passed
+call ``commit()`` to finish generating the mesh. If an :ref:`ArrayMesh <class_ArrayMesh>` is passed
 to ``commit()`` then it appends a new surface to the end of the ArrayMesh. While if nothing is passed
 in, ``commit()`` returns an ArrayMesh.
 


### PR DESCRIPTION
### 3D » Procedural geometry » Using the SurfaceTool

"call commit() to **finished** generating the mesh"
should be:
"call commit() to **finish** generating the mesh"

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
