### PR TITLE
Fix typo in verb conjugation

### DIFF
--- a/community/contributing/best_practices_for_engine_contributors.rst
+++ b/community/contributing/best_practices_for_engine_contributors.rst
@@ -16,7 +16,7 @@ Language
 --------
 
 The scope of this document is to be a list of best practices for contributors to
-follow, as well as to creating a language they can use to refer to common
+follow, as well as to create a language they can use to refer to common
 situations that arise in the process of submitting their contributions.
 
 While some may find it useful to extend this to general software development,


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->

This PR fixes a small typo in the conjugation of a verb. I spotted the typo while reading up on how to contribute to the code of the engine!

Hope this helps.
