### PR TITLE
3d game tutorial: fix asset url version

### DIFF
--- a/getting_started/first_3d_game/01.game_setup.rst
+++ b/getting_started/first_3d_game/01.game_setup.rst
@@ -9,7 +9,7 @@ importing the start assets and setting up the game scene.
 We've prepared a Godot project with the 3D models and sounds we'll use for this
 tutorial, linked in the index page. If you haven't done so yet, you can download
 the archive here: `Squash the Creeps assets
-<https://github.com/GDQuest/godot-3d-dodge-the-creeps/releases/tag/1.0.0>`__.
+<https://github.com/GDQuest/godot-3d-dodge-the-creeps/releases/tag/1.1.0>`__.
 
 Once you downloaded it, extract the .zip archive on your computer. Open the
 Godot project manager and click the *Import* button.


### PR DESCRIPTION
On the tutorial index the version is already 1.1.0 since commit
a187b111714565cc7a23e97f8209e0f52f17e725. However the reference on the
second page was forgotten. This patch corrects that.