### PR TITLE
Add section about the RESET animation in Introduction to the animation features

### DIFF
--- a/tutorials/animation/introduction.rst
+++ b/tutorials/animation/introduction.rst
@@ -321,13 +321,27 @@ You can tweak your animations this way until the movement "looks right."
 .. |Play from beginning| image:: img/animation_play_from_beginning.png
 .. |Add Animation| image:: img/animation_add.png
 
-Using reset tracks
+Using RESET tracks
 ------------------
 
-You can set up a special *RESET* animation to contain the "default pose". Add an animation called "RESET", and add tracks for each property that you want to reset. The only keyframe should be at time 0, and give it the desired default value for each track.
+You can set up a special *RESET* animation to contain the "default pose".
+This is used to ensure that the default pose is restored when you save
+the scene and open it again in the editor.
 
-If "reset on save" is set to `true`, the scene will be saved with the effects of the reset animation applied (as if it had been seeked to time 0). This only affects the saved file - the property tracks in the editor stay where they were.
+For existing tracks, you can add an animation called "RESET" (case-sensitive),
+then add tracks for each property that you want to reset. The only keyframe should be at time 0, and give it the desired default value for each track.
 
-If you want to reset the tracks in the editor, choose *apply reset* from the *Animation Properties* dropdown.
+If AnimationPlayer's **Reset On Save** property is set to ``true``,
+the scene will be saved with the effects of the reset animation applied
+(as if it had been seeked to time ``0.0``).
+This only affects the saved file – the property tracks in the editor stay
+where they were.
 
-When adding tracks on other animations, if you have *Create Reset Track(s)* checked and there's no reset animation, one will be automatically created.
+If you want to reset the tracks in the editor, select the AnimationPlayer node,
+open the **Animation** bottom panel then choose **Apply Reset** in the
+animation editor's **Animation** dropdown menu.
+
+When adding tracks on new animations, the editor will ask you to automatically
+create a RESET track when using the keyframe icon next to a property in the inspector.
+This does not apply on tracks created with Godot versions prior to 3.4,
+as the animation reset track feature was added in 3.4.

--- a/tutorials/animation/introduction.rst
+++ b/tutorials/animation/introduction.rst
@@ -329,7 +329,9 @@ This is used to ensure that the default pose is restored when you save
 the scene and open it again in the editor.
 
 For existing tracks, you can add an animation called "RESET" (case-sensitive),
-then add tracks for each property that you want to reset. The only keyframe should be at time 0, and give it the desired default value for each track.
+then add tracks for each property that you want to reset.
+The only keyframe should be at time 0, and give it the desired default value
+for each track.
 
 If AnimationPlayer's **Reset On Save** property is set to ``true``,
 the scene will be saved with the effects of the reset animation applied

--- a/tutorials/animation/introduction.rst
+++ b/tutorials/animation/introduction.rst
@@ -320,3 +320,14 @@ You can tweak your animations this way until the movement "looks right."
 
 .. |Play from beginning| image:: img/animation_play_from_beginning.png
 .. |Add Animation| image:: img/animation_add.png
+
+Using reset tracks
+------------------
+
+You can set up a special *RESET* animation to contain the "default pose". Add an animation called "RESET", and add tracks for each property that you want to reset. The only keyframe should be at time 0, and give it the desired default value for each track.
+
+If "reset on save" is set to `true`, the scene will be saved with the effects of the reset animation applied (as if it had been seeked to time 0). This only affects the saved file - the property tracks in the editor stay where they were.
+
+If you want to reset the tracks in the editor, choose *apply reset* from the *Animation Properties* dropdown.
+
+When adding tracks on other animations, if you have *Create Reset Track(s)* checked and there's no reset animation, one will be automatically created.


### PR DESCRIPTION
This adds a short section covering the new RESET animation and the behaviour of reset-on-save. Most of the text is taken from https://github.com/godotengine/godot/pull/4311

This closes #5438 