### PR TITLE
Removing additional newline in shaders intro

### DIFF
--- a/tutorials/shaders/introduction_to_shaders.rst
+++ b/tutorials/shaders/introduction_to_shaders.rst
@@ -133,7 +133,6 @@ Fragment processor
 ^^^^^^^^^^^^^^^^^^
 
 The ``fragment()`` processing function is used to set up the Godot material
-
 parameters per pixel. This code runs on every visible pixel the object or
 primitive draws. It is only available in ``spatial`` and ``canvas_item`` shaders.
 


### PR DESCRIPTION
This newline creates unwanted paragraph; it affects `stable` branch (already fixed on latest).

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
