### PR TITLE
requirements: Update to Sphinx 4.4.0, RTD theme 1.0.0, notfound 0.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,15 +3,14 @@
 # Sync with readthedocs:
 # https://github.com/readthedocs/readthedocs.org/blob/master/requirements/pip.txt
 # https://github.com/readthedocs/readthedocs.org/blob/master/requirements/docs.txt
-sphinx==4.0.2
-sphinx_rtd_theme==0.5.2
-docutils<0.18
+sphinx==4.4.0
+sphinx_rtd_theme==1.0.0
 
 # Code tabs extension for GDScript/C#
 sphinx-tabs==3.2.0
 
 # Custom 404 error page (more useful than the default)
-sphinx-notfound-page==0.7.1
+sphinx-notfound-page==0.8
 
 # Adds Open Graph tags in the HTML `<head>` tag
 sphinxext-opengraph==0.6.1


### PR DESCRIPTION
Needed to support Python 3.10.

We're then in sync with https://github.com/readthedocs/readthedocs.org/blob/master/requirements/docs.txt