### PR TITLE
Minor addition to help out new users

### DIFF
--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -19,7 +19,7 @@ For compiling under Windows, the following is required:
   **Important:** When using MinGW to compile the ``master`` branch, you need GCC 9 or later. Because
   MinGW has not officially released GCC 9 yet, you can get an alternate installer from
   `here <https://jmeubank.github.io/tdm-gcc/articles/2020-03/9.2.0-release>`_.
-- `Python 3.5+ <https://www.python.org/downloads/windows/>`_.
+- `Python 3.5+ <https://www.python.org/downloads/windows/>`_ (see below).
 - `SCons 3.0 <https://www.scons.org/>`_ build system. If using Visual Studio 2019,
   you need at least SCons 3.1.1.
 


### PR DESCRIPTION
  While building the source code on windows. I saw the requirements and proceeded to download what i needed first. it worked out fine but for python, I forgot to  "enable the option to add Python to the PATH in the Python installer" and I then had to redownload it again. I would assume this would happen with many. So I added a "(see below)" to kind of notify that there was information regarding the installation before proceeding to do so.

p.s- thought of explicitly adding "enable the option to add Python to the PATH in the Python installer" there but thought it would be a bit too redundant because it was already mentioned below.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
