### PR TITLE
Sphinx: Update to 4.4.0, drop incompatible readthedocs-sphinx-search

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -61,9 +61,6 @@ ogp_site_name = "Godot Engine documentation"
 if not os.getenv("SPHINX_NO_GDSCRIPT"):
     extensions.append("gdscript")
 
-if not os.getenv("SPHINX_NO_SEARCH"):
-    extensions.append("sphinx_search.extension")
-
 if not os.getenv("SPHINX_NO_DESCRIPTIONS"):
     extensions.append("godot_descriptions")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,19 +2,15 @@
 
 # Sync with readthedocs:
 # https://github.com/readthedocs/readthedocs.org/blob/master/requirements/pip.txt
-# Stuck on <4 until we can update sphinx-tabs (see below).
-sphinx==3.5.4  # pyup: <4
+# https://github.com/readthedocs/readthedocs.org/blob/master/requirements/docs.txt
+sphinx==4.4.0
 sphinx_rtd_theme==1.0.0
 
 # Code tabs extension for GDScript/C#
-# Stay on 1.3.0 until https://github.com/readthedocs/readthedocs-sphinx-search/issues/82 is fixed.
-sphinx-tabs==1.3.0  # pyup: ignore
+sphinx-tabs==3.2.0
 
 # Custom 404 error page (more useful than the default)
 sphinx-notfound-page==0.8
 
 # Adds Open Graph tags in the HTML `<head>` tag
-sphinxext-opengraph==0.6.1
-
-# Full-page search UI for RTD: https://readthedocs-sphinx-search.readthedocs.io
-readthedocs-sphinx-search==0.1.1
+sphinxext-opengraph==0.6.2


### PR DESCRIPTION
The readthedocs-sphinx-search extension is not actively maintained upstream,
and they pin some extremely old versions of Sphinx components which are not
compatible with what we need to use.

It was already dropped in the master branch, this syncs the requirements.txt
from master with 3.4.

Fixes #5650