### PR TITLE
Minor accuracy update to ViewportContainer's description

### DIFF
--- a/classes/class_subviewportcontainer.rst
+++ b/classes/class_subviewportcontainer.rst
@@ -16,7 +16,7 @@ Control for holding :ref:`SubViewport<class_SubViewport>`\ s.
 Description
 -----------
 
-A :ref:`Container<class_Container>` node that holds a :ref:`SubViewport<class_SubViewport>`, automatically setting its size.
+A :ref:`Container<class_Container>` node that holds a :ref:`SubViewport<class_SubViewport>`. It can be used to automatically manage the size of its contained :ref:`SubViewport<class_SubViewport>`\ s.
 
 \ **Note:** Changing a SubViewportContainer's :ref:`Control.rect_scale<class_Control_property_rect_scale>` will cause its contents to appear distorted. To change its visual size without causing distortion, adjust the node's margins instead (if it's not already in a container).
 


### PR DESCRIPTION
The original description of this class implies that Viewport scaling occurs automatically. However, `ViewportContainer.stretch` by default is `false`, which means the description of the class is misleading. I should know, it took me way too long to realize why my `ViewportContainer`s weren't behaving as described.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
