### PR TITLE
Add openssl and freetype dependencies to Fedora (3.4)

### DIFF
--- a/development/compiling/compiling_for_x11.rst
+++ b/development/compiling/compiling_for_x11.rst
@@ -51,7 +51,7 @@ Distro-specific one-liners
 |                  |                                                                                                           |
 |                  |     sudo dnf install scons pkgconfig libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel \    |
 |                  |         libXi-devel mesa-libGL-devel mesa-libGLU-devel alsa-lib-devel pulseaudio-libs-devel \             |
-|                  |         libudev-devel yasm gcc-c++ libstdc++-static libatomic-static                                      |
+|                  |         libudev-devel yasm gcc-c++ libstdc++-static libatomic-static openssl-devel freetype-devel         |
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **FreeBSD**      | ::                                                                                                        |
 |                  |                                                                                                           |


### PR DESCRIPTION
I am not able to compile godot without `openssl-devel` and `freetype-devel`. This might apply to other distros as well, but I have no way to check.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
