### PR TITLE
Change link on the first script page

### DIFF
--- a/getting_started/introduction/introduction_to_godot.rst
+++ b/getting_started/introduction/introduction_to_godot.rst
@@ -95,6 +95,8 @@ completely free and open-source.
              see :ref:`GDNative third-party bindings
              <doc_what_is_gdnative_third_party_bindings>`.
 
+.. doc_learning_programming
+
 What do I need to know to use Godot?
 ------------------------------------
 

--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -3,8 +3,8 @@
 
     - Giving a *short* and sweet hands-on intro to GDScript. The page should
       focus on working in the code editor.
-    - We assume the reader has programming foundations, as explained in
-    getting_started/introduction.
+    - We assume the reader has programming foundations. If you do not consider
+      taking the course we recommend in the :ref:`introduction to Godot page <doc_learning_programming>`.
 
     Techniques:
 

--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -3,7 +3,7 @@
 
     - Giving a *short* and sweet hands-on intro to GDScript. The page should
       focus on working in the code editor.
-    - We assume the reader has programming foundations. If you do not consider
+    - We assume the reader has programming foundations. If you don't, consider
       taking the course we recommend in the :ref:`introduction to Godot page <doc_learning_programming>`.
 
     Techniques:


### PR DESCRIPTION
Instead of pointing to the introduction index page it points to the "What do I need to know to use Godot?" section of the introduction page. I've also rephrased it to be a bit more helpful. Closes #5675.
