### PR TITLE
Update Harvard CS50 link to latest version

### DIFF
--- a/getting_started/introduction/introduction_to_godot.rst
+++ b/getting_started/introduction/introduction_to_godot.rst
@@ -125,4 +125,4 @@ In the next part, you will get an overview of the engine's essential concepts.
 .. _Emacs: https://github.com/godotengine/emacs-gdscript-mode
 .. _April 2020 desktop and console showcase: https://youtu.be/UEDEIksGEjQ
 .. _April 2020 mobile showcase: https://youtu.be/AIapugketbs
-.. _CS50 open courseware: https://cs50.harvard.edu/x/2020/
+.. _CS50 open courseware: https://cs50.harvard.edu/x


### PR DESCRIPTION
CS50 link was to the 2020 course. I have replaced the link to a generic link that will redirect to the most up to date version of the course.

A header on the site for the 2020 link reads:
This is CS50x 2020, an older version of the course. See cs50.harvard.edu/x for the latest!

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
