### PR TITLE
Mention that FBX support is partial in List of features

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -404,7 +404,7 @@ Import
    - glTF 2.0 *(recommended)*.
    - `ESCN <https://github.com/godotengine/godot-blender-exporter>`__
      (direct export from Blender).
-   - FBX.
+   - FBX (static meshes only).
    - Collada (.dae).
    - Wavefront OBJ (static scenes only, can be loaded directly as a mesh).
 


### PR DESCRIPTION
Support for animated FBX scenes is techically present, but it's usually too broken to be usable in production (as evidenced by GitHub issues).

For reference, this partial support is already mentioned [on the FAQ](https://github.com/Calinou/godot-docs/blob/6c3a8035c87e86a603cf4974db853651691c8ce1/about/faq.rst#L163).