### PR TITLE
Fix section header markup

### DIFF
--- a/tutorials/performance/index.rst
+++ b/tutorials/performance/index.rst
@@ -88,7 +88,7 @@ GPU
    optimizing_3d_performance
 
 Multi-threading
---
+---------------
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
The "Multi-threading" [here](https://docs.godotengine.org/en/stable/tutorials/performance/index.html) is not recognized as a section header due to RST syntax restrictions. The underline has to be at least as long as the text.