### PR TITLE
Clarify the name of the menu action to add a node in Signals

### DIFF
--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -192,7 +192,7 @@ that's useful to implement skill cooldown times, weapon reloading, and more.
 Head back to the 2D workspace. You can either click the "2D" text at the top of
 the window or press :kbd:`Ctrl + F1` (:kbd:`Alt + 1` on macOS).
 
-In the Scene dock, right-click on the Sprite2D node and add a new node. Search for
+In the Scene dock, right-click on the Sprite2D node and add a new child node. Search for
 Timer and add the corresponding node. Your scene should now look like this.
 
 .. image:: img/signals_15_scene_tree.png


### PR DESCRIPTION
In the right-click context menu, it's labeled Add Child Node, not just Add Node or Add New Node.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
