### PR TITLE
Document class reference XML linting with Visual Studio Code

### DIFF
--- a/community/contributing/class_reference_writing_guidelines.rst
+++ b/community/contributing/class_reference_writing_guidelines.rst
@@ -114,6 +114,12 @@ We recommend using a code editor that supports XML files like Vim, Atom, Visual 
 Notepad++, or another to comfortably edit the file. You can also use their
 search feature to find classes and properties quickly.
 
+.. tip::
+
+    If you use Visual Studio Code, you can install the
+    `vscode-xml extension <https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml>`__
+    to get linting for class reference XML files.
+
 .. _doc_class_reference_writing_guidelines_bbcode:
 
 Improve formatting with BBCode style tags

--- a/development/cpp/configuring_an_ide/visual_studio_code.rst
+++ b/development/cpp/configuring_an_ide/visual_studio_code.rst
@@ -161,10 +161,15 @@ To run and debug the project you need to create a new configuration in the ``lau
 
     If you encounter issues with lldb, you may consider using gdb (see the LinuxBSD_gdb configuration).
 
-    Do note that lldb may work better with llvm-based builds. See :ref:`doc_compiling_for_linuxbsd` for further information.
+    Do note that lldb may work better with LLVM-based builds. See :ref:`doc_compiling_for_linuxbsd` for further information.
 
 The name under ``program`` depends on your build configuration,
 e.g. ``godot.linuxbsd.tools.64`` for 64-bit LinuxBSD platform with ``tools`` enabled.
 
 If you run into any issues, ask for help in one of
 `Godot's community channels <https://godotengine.org/community>`__.
+
+.. tip::
+
+    To get linting on class reference XML files, install the
+    `vscode-xml extension <https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml>`__.


### PR DESCRIPTION
Now that https://github.com/godotengine/godot/pull/35679 was merged, it can be put to good use by installing the appropriate extension in VS Code.