### PR TITLE
Fix toctree expand icon colors and margins in the theme

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -917,21 +917,24 @@ kbd.compound > .kbd,
     border: none;
 }
 
-.wy-side-nav-search, .wy-menu-vertical a, .wy-menu-vertical a span.toctree-expand,
-.wy-menu-vertical li.toctree-l2 a span.toctree-expand {
+.wy-side-nav-search, .wy-menu-vertical a, .wy-menu-vertical a button.toctree-expand,
+.wy-menu-vertical li.toctree-l1 a button.toctree-expand,
+.wy-menu-vertical li.toctree-l2 a button.toctree-expand {
     color: var(--navbar-level-3-color);
     opacity: 0.9;
     margin-right: 8px;
 }
 
-.wy-side-nav-search, .wy-menu-vertical a, .wy-menu-vertical a:hover span.toctree-expand,
-.wy-menu-vertical li.toctree-l2 a:hover span.toctree-expand {
+.wy-side-nav-search, .wy-menu-vertical a, .wy-menu-vertical a:hover button.toctree-expand,
+.wy-menu-vertical li.toctree-l1 a:hover button.toctree-expand,
+.wy-menu-vertical li.toctree-l2 a:hover button.toctree-expand {
     color: var(--navbar-level-2-color);
     opacity: 1;
 }
 
-.wy-side-nav-search, .wy-menu-vertical a, .wy-menu-vertical a:active span.toctree-expand,
-.wy-menu-vertical li.toctree-l2 a:active span.toctree-expand {
+.wy-side-nav-search, .wy-menu-vertical a, .wy-menu-vertical a:active button.toctree-expand,
+.wy-menu-vertical li.toctree-l1 a:active button.toctree-expand,
+.wy-menu-vertical li.toctree-l2 a:active button.toctree-expand {
     color: var(--navbar-level-1-color);
     opacity: 1;
 }


### PR DESCRIPTION
This also applies the color and margin changes to expanded top-level sections.

This closes https://github.com/godotengine/godot-docs/issues/5676.

## Preview

### Light theme (Chromium 96)

![2022-03-14_19 57 54](https://user-images.githubusercontent.com/180032/158242267-d7ae4627-949b-4db4-b8bd-7dff57ba80c2.png)

### Dark theme (Firefox 98)

![2022-03-14_19 57 29](https://user-images.githubusercontent.com/180032/158242262-85fca332-da60-488d-a08e-46a658e1be2e.png)