### PR TITLE
Add missing `onready` for NodePath usage in GDScript exports

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_exports.rst
+++ b/tutorials/scripting/gdscript/gdscript_exports.rst
@@ -121,7 +121,7 @@ Examples
     export(NodePath) var node_path
     # Do take note that the node itself isn't being exported -
     # there is one more step to call the true node:
-    var node = get_node(node_path)
+    onready var node = get_node(node_path)
 
     # Resources
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/36719038/158705487-859bb415-445b-4d7b-bbfb-b14dacc8fd40.png)

attempting to initialize a variable using get_node() without onready will lead to a compiler error.


<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
