### PR TITLE
Update theme overrides section for Godot 3.4 in Score and replay

### DIFF
--- a/getting_started/first_3d_game/08.score_and_replay.rst
+++ b/getting_started/first_3d_game/08.score_and_replay.rst
@@ -24,7 +24,7 @@ In the *Inspector*, set the *Label*'s *Text* to a placeholder like "Score: 0".
 Also, the text is white by default, like our game's background. We need to
 change its color to see it at runtime.
 
-Scroll down to *Custom Colors* and click the black box next to *Font Color* to
+Scroll down to *Theme Overrides*, and expand *Colors* and click the black box next to *Font Color* to
 tint the text.
 
 |image2|


### PR DESCRIPTION
Looks like this has changed in 3.4.3?  I'm new to this, and wasn't sure how to go about changing the image, which should also be done...

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
