### PR TITLE
docs: glue generation, change wrong paths

### DIFF
--- a/development/compiling/compiling_with_mono.rst
+++ b/development/compiling/compiling_with_mono.rst
@@ -69,7 +69,7 @@ This path must be ``modules/mono/glue`` in the Godot directory::
     <godot_binary> --generate-mono-glue modules/mono/glue
 
 This command will tell Godot to generate the file ``modules/mono/glue/mono_glue.gen.cpp``
-and the C# solution for the Godot API at ``modules/mono/glue/Managed/Generated``.
+and the C# solution for the Godot API at ``modules/mono/glue/GodotSharp/GodotSharp/Generated``, as well as the C# solution for the Godot Editor API at ``modules/mono/glue/GodotSharp/GodotSharpEditor/Generated``.
 Once these files are generated, you can build Godot for all the desired targets
 without having to repeat this process.
 


### PR DESCRIPTION
I found that the path in the documentation wasn't update and confused me as a first time user, trying to generate the glue and not founding the named solution.

I am not sure if "C# solution for GoDot Editor API" is correctly coined?