### PR TITLE
Mention that the WOFF2 font format is now supported

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -97,7 +97,7 @@ Vulkan renderer.
 
    - Bitmap fonts can be exported using tools like BMFont.
    - Dynamic fonts support monochrome fonts as well as colored fonts (e.g. for emoji).
-     Supported formats are TTF, OTF and WOFF1.
+     Supported formats are TTF, OTF, WOFF1 and WOFF2.
    - Dynamic fonts support optional font outlines with adjustable width and color.
    - Dynamic fonts support variable fonts and OpenType features.
    - Dynamic fonts support oversampling to keep fonts sharp at higher resolutions.

--- a/tutorials/ui/gui_using_fonts.rst
+++ b/tutorials/ui/gui_using_fonts.rst
@@ -31,6 +31,7 @@ Dynamic Font supports the following formats:
 - TrueType (``.ttf``)
 - OpenType (``.otf``)
 - Web Open Font Format 1 (``.woff``)
+- Web Open Font Format 2 (``.woff2``, since Godot 4.0)
 
 If you are using one of these select **New Dynamic Font**.
 Click on it to open its settings in the inspector. From here
@@ -48,7 +49,7 @@ In addition, the font data has antialiasing and hinting settings you
 can see if you click on it. If you want to adjust either of these
 you need to make the font data resource unique, then save it to a
 ``.tres`` file. Adjusting the font file will not work because ``.ttf``/
-``.otf``/ ``.woff`` files can't contain metadata about antialiasing
+``.otf``/``.woff``/``.woff2`` files can't contain metadata about antialiasing
 or hinting.
 
 If you want to use the same font again but with different settings,


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/59275.