### PR TITLE
Mention that Godot uses Mikktspace in List of features

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -484,6 +484,8 @@ Import
    - Wavefront OBJ (static scenes only, can be loaded directly as a mesh).
 
 - Support for loading glTF 2.0 scenes at run-time, including from an exported project.
+- 3D meshes use `Mikktspace <http://www.mikktspace.com/>`__ to generate tangents
+  on import, which ensures consistency with other 3D applications such as Blender.
 
 Input
 ^^^^^

--- a/tutorials/assets_pipeline/importing_scenes.rst
+++ b/tutorials/assets_pipeline/importing_scenes.rst
@@ -251,8 +251,8 @@ Ensure Tangents
 
 If textures with normal mapping are to be used, meshes need to have tangent arrays.
 This option ensures that these are generated if not present in the source scene.
-Godot uses Mikktspace for this, but it's always better to have them generated in
-the exporter.
+Godot uses `Mikktspace <http://www.mikktspace.com/>`__ for this,
+but it's always better to have them generated in the exporter.
 
 Storage
 ^^^^^^^


### PR DESCRIPTION
This is also mentioned in Importing scenes, but it makes sense to mention it in List of features as this is an expected feature of most 3D engines nowadays.


<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->