### PR TITLE
Add Xbox Series X/S support by Pineapple Works

### DIFF
--- a/tutorials/platform/consoles.rst
+++ b/tutorials/platform/consoles.rst
@@ -66,7 +66,7 @@ Following is the list of providers:
 - `Lone Wolf Technology <http://www.lonewolftechnology.com/>`_ offers
   Switch and PS4 porting and publishing of Godot games.
 - `Pineapple Works <https://pineapple.works/>`_ offers
-  Switch and Xbox One porting and publishing of Godot games.
+  Switch, Xbox One and Xbox Series X/S porting and publishing of Godot games.
 
 If your company offers porting and/or publishing services for Godot games,
 feel free to


### PR DESCRIPTION
Recently we've completed work on a native Xbox GDK port of Godot Engine 3.x so it would be great to reflect that in the docs by extending Pineapple Works' console support to the current-gen Xbox Series X/S consoles.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
