### PR TITLE
Rename references to Node3D back to Spatial

### DIFF
--- a/community/contributing/class_reference_writing_guidelines.rst
+++ b/community/contributing/class_reference_writing_guidelines.rst
@@ -129,7 +129,7 @@ the text. Here's the list of available tags:
 +----------------------------+--------------------------------------+-----------------------------------+---------------------------------------------------+
 | [method methodname]        | Link to a method in this class       | Call [method hide].               | Call :ref:`hide <class_Spatial_method_hide>`.     |
 +----------------------------+--------------------------------------+-----------------------------------+---------------------------------------------------+
-| [method Class.methodname]  | Link to another class's method       | Call [method Node3D.hide].        | Call :ref:`hide <class_Spatial_method_hide>`.     |
+| [method Class.methodname]  | Link to another class's method       | Call [method Spatial.hide].       | Call :ref:`hide <class_Spatial_method_hide>`.     |
 +----------------------------+--------------------------------------+-----------------------------------+---------------------------------------------------+
 | [member membername]        | Link to a member in this class       | Get [member scale].               | Get :ref:`scale <class_Node2D_property_scale>`.   |
 +----------------------------+--------------------------------------+-----------------------------------+---------------------------------------------------+

--- a/tutorials/3d/3d_rendering_limitations.rst
+++ b/tutorials/3d/3d_rendering_limitations.rst
@@ -80,7 +80,7 @@ Transparency sorting
 --------------------
 
 In Godot, transparent materials are drawn after opaque materials. Transparent
-objects are sorted back to front before being drawn based on the Node3D's
+objects are sorted back to front before being drawn based on the Spatial's
 position, not the vertex position in world space. Due to this, overlapping
 objects may often be sorted out of order. To fix improperly sorted objects, tweak
 the material's :ref:`Render Priority <class_Material_property_render_priority>`

--- a/tutorials/animation/introduction.rst
+++ b/tutorials/animation/introduction.rst
@@ -115,7 +115,7 @@ its child. We will animate the sprite to move between two points on the screen.
 
 .. warning::
 
-   AnimationPlayer inherits from Node instead of Node2D or Node3D, which means
+   AnimationPlayer inherits from Node instead of Node2D or Spatial, which means
    that the child nodes will not inherit the transform from the parent nodes
    due to a bare Node being present in the hierarchy.
 


### PR DESCRIPTION
Spatial was only renamed to Node3D in Godot 4.0, not Godot 3.x.