### PR TITLE
Initial test of new shader function style

### DIFF
--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -818,314 +818,924 @@ Uniforms can also be assigned default values:
 Built-in variables
 ------------------
 
-A large number of built-in variables are available, like ``UV``, ``COLOR`` and ``VERTEX``. What variables are available depends on the type of shader (``spatial``, ``canvas_item`` or ``particle``) and the function used (``vertex``, ``fragment`` or ``light``).
-For a list of the built-in variables that are available, please see the corresponding pages:
+A large number of built-in variables are available, like ``UV``, ``COLOR`` and
+``VERTEX``. What variables are available depends on the type of shader
+(``spatial``, ``canvas_item``, ``particle``, ``sky``, or ``fog``) and the
+function used (``vertex``, ``fragment``, ``light``, ``start``, ``process,
+``sky``, or ``fog``). For a list of the built-in variables that are available,
+please see the corresponding pages:
 
 - :ref:`Spatial shaders <doc_spatial_shader>`
 - :ref:`Canvas item shaders <doc_canvas_item_shader>`
 - :ref:`Particle shaders <doc_particle_shader>`
+- :ref:`Sky shaders <doc_sky_shader>`
+- :ref:`Fog shaders <doc_fog_shader>`
 
 Built-in functions
 ------------------
 
-A large number of built-in functions are supported, conforming to GLSL ES 3.0.
-When vec_type (float), vec_int_type, vec_uint_type, vec_bool_type nomenclature
-is used, it can be scalar or vector.
+Godot supports a large number of built-in functions, conforming roughly to the
+GLSL 4.00 specification.
 
-.. note:: For a list of the functions that are not available in the GLES2
+When vec_type, ivec_type, uvec_type, or bvec_type nomenclature is used, the type
+can be scalar or vector. For example vec_type can be float, vec2, vec3, or vec4.
+
+.. note:: For a list of the functions that are not available in the OpenGL
           backend, please see the :ref:`Differences between GLES2 and GLES3 doc
           <doc_gles2_gles3_differences>`.
 
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| Function                                                                  | Description / Return value                                          |
-+===========================================================================+=====================================================================+
-| vec_type **radians** (vec_type degrees)                                   | Convert degrees to radians.                                         |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **degrees** (vec_type radians)                                   | Convert radians to degrees.                                         |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **sin** (vec_type x)                                             | Sine.                                                               |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **cos** (vec_type x)                                             | Cosine.                                                             |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **tan** (vec_type x)                                             | Tangent.                                                            |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **asin** (vec_type x)                                            | Arcsine.                                                            |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **acos** (vec_type x)                                            | Arccosine.                                                          |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **atan** (vec_type y_over_x)                                     | Arctangent.                                                         |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **atan** (vec_type y, vec_type x)                                | Arctangent.                                                         |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **sinh** (vec_type x)                                            | Hyperbolic sine.                                                    |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **cosh** (vec_type x)                                            | Hyperbolic cosine.                                                  |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **tanh** (vec_type x)                                            | Hyperbolic tangent.                                                 |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **asinh** (vec_type x)                                           | Inverse hyperbolic sine.                                            |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **acosh** (vec_type x)                                           | Inverse hyperbolic cosine.                                          |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **atanh** (vec_type x)                                           | Inverse hyperbolic tangent.                                         |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **pow** (vec_type x, vec_type y)                                 | Power (undefined if ``x`` < 0 or if ``x`` == 0 and ``y`` <= 0).     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **exp** (vec_type x)                                             | Base-e exponential.                                                 |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **exp2** (vec_type x)                                            | Base-2 exponential.                                                 |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **log** (vec_type x)                                             | Natural logarithm.                                                  |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **log2** (vec_type x)                                            | Base-2 logarithm.                                                   |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **sqrt** (vec_type x)                                            | Square root.                                                        |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **inversesqrt** (vec_type x)                                     | Inverse square root.                                                |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **abs** (vec_type x)                                             | Absolute value (returns positive value if negative).                |
-|                                                                           |                                                                     |
-| ivec_type **abs** (ivec_type x)                                           |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **sign** (vec_type x)                                            | Sign (returns ``1.0`` if positive, ``-1.0`` if negative,            |
-|                                                                           | ``0.0`` if zero).                                                   |
-| ivec_type **sign** (ivec_type x)                                          |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **floor** (vec_type x)                                           | Round to the integer below.                                         |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **round** (vec_type x)                                           | Round to the nearest integer.                                       |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **roundEven** (vec_type x)                                       | Round to the nearest even integer.                                  |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **trunc** (vec_type x)                                           | Truncation.                                                         |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **ceil** (vec_type x)                                            | Round to the integer above.                                         |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **fract** (vec_type x)                                           | Fractional (returns ``x - floor(x)``).                              |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **mod** (vec_type x, vec_type y)                                 | Modulo (division remainder).                                        |
-|                                                                           |                                                                     |
-| vec_type **mod** (vec_type x, float y)                                    |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **modf** (vec_type x, out vec_type i)                            | Fractional of ``x``, with ``i`` as integer part.                    |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type  **min** (vec_type a, vec_type b)                                | Lowest value between ``a`` and ``b``.                               |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type  **max** (vec_type a, vec_type b)                                | Highest value between ``a`` and ``b``.                              |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **clamp** (vec_type x, vec_type min, vec_type max)               | Clamp ``x`` between ``min`` and ``max`` (inclusive).                |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| float **mix** (float a, float b, float c)                                 | Linear interpolate between ``a`` and ``b`` by ``c``.                |
-|                                                                           |                                                                     |
-| vec_type **mix** (vec_type a, vec_type b, float c)                        |                                                                     |
-|                                                                           |                                                                     |
-| vec_type **mix** (vec_type a, vec_type b, bvec_type c)                    |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **fma** (vec_type a, vec_type b, vec_type c)                     | Performs a fused multiply-add operation: ``(a * b + c)``            |
-|                                                                           | (faster than doing it manually).                                    |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **step** (vec_type a, vec_type b)                                | ``b[i] < a[i] ? 0.0 : 1.0``.                                        |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **step** (float a, vec_type b)                                   | ``b[i] < a ? 0.0 : 1.0``.                                           |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **smoothstep** (vec_type a, vec_type b, vec_type c)              | Hermite interpolate between ``a`` and ``b`` by ``c``.               |
-|                                                                           |                                                                     |
-| vec_type **smoothstep** (float a, float b, vec_type c)                    |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| bvec_type **isnan** (vec_type x)                                          | Returns ``true`` if scalar or vector component is ``NaN``.          |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| bvec_type **isinf** (vec_type x)                                          | Returns ``true`` if scalar or vector component is ``INF``.          |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| ivec_type **floatBitsToInt** (vec_type x)                                 | Float->Int bit copying, no conversion.                              |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| uvec_type **floatBitsToUint** (vec_type x)                                | Float->UInt bit copying, no conversion.                             |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **intBitsToFloat** (ivec_type x)                                 | Int->Float bit copying, no conversion.                              |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **uintBitsToFloat** (uvec_type x)                                | UInt->Float bit copying, no conversion.                             |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| float **length** (vec_type x)                                             | Vector length.                                                      |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| float **distance** (vec_type a, vec_type b)                               | Distance between vectors i.e ``length(a - b)``.                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| float **dot** (vec_type a, vec_type b)                                    | Dot product.                                                        |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec3 **cross** (vec3 a, vec3 b)                                           | Cross product.                                                      |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **normalize** (vec_type x)                                       | Normalize to unit length.                                           |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec3 **reflect** (vec3 I, vec3 N)                                         | Reflect.                                                            |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec3 **refract** (vec3 I, vec3 N, float eta)                              | Refract.                                                            |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **faceforward** (vec_type N, vec_type I, vec_type Nref)          | If ``dot(Nref, I)`` < 0, return N, otherwise –N.                    |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| mat_type **matrixCompMult** (mat_type x, mat_type y)                      | Matrix component multiplication.                                    |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| mat_type **outerProduct** (vec_type column, vec_type row)                 | Matrix outer product.                                               |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| mat_type **transpose** (mat_type m)                                       | Transpose matrix.                                                   |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| float **determinant** (mat_type m)                                        | Matrix determinant.                                                 |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| mat_type **inverse** (mat_type m)                                         | Inverse matrix.                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| bvec_type **lessThan** (vec_type x, vec_type y)                           | Bool vector comparison on < int/uint/float vectors.                 |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| bvec_type **greaterThan** (vec_type x, vec_type y)                        | Bool vector comparison on > int/uint/float vectors.                 |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| bvec_type **lessThanEqual** (vec_type x, vec_type y)                      | Bool vector comparison on <= int/uint/float vectors.                |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| bvec_type **greaterThanEqual** (vec_type x, vec_type y)                   | Bool vector comparison on >= int/uint/float vectors.                |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| bvec_type **equal** (vec_type x, vec_type y)                              | Bool vector comparison on == int/uint/float vectors.                |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| bvec_type **notEqual** (vec_type x, vec_type y)                           | Bool vector comparison on != int/uint/float vectors.                |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| bool **any** (bvec_type x)                                                | ``true`` if any component is ``true``, ``false`` otherwise.         |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| bool **all** (bvec_type x)                                                | ``true`` if all components are ``true``, ``false`` otherwise.       |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| bvec_type **not** (bvec_type x)                                           | Invert boolean vector.                                              |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| ivec2 **textureSize** (gsampler2D s, int lod)                             | Get the size of a texture.                                          |
-|                                                                           |                                                                     |
-| ivec3 **textureSize** (gsampler2DArray s, int lod)                        |                                                                     |
-|                                                                           |                                                                     |
-| ivec3 **textureSize** (gsampler3D s, int lod)                             |                                                                     |
-|                                                                           |                                                                     |
-| ivec2 **textureSize** (samplerCube s, int lod)                            |                                                                     |
-|                                                                           |                                                                     |
-| ivec2 **textureSize** (samplerCubeArray s, int lod)                       |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| gvec4_type **texture** (gsampler2D s, vec2 p [, float bias])              | Perform a texture read.                                             |
-|                                                                           |                                                                     |
-| gvec4_type **texture** (gsampler2DArray s, vec3 p [, float bias])         |                                                                     |
-|                                                                           |                                                                     |
-| gvec4_type **texture** (gsampler3D s, vec3 p [, float bias])              |                                                                     |
-|                                                                           |                                                                     |
-| vec4 **texture** (samplerCube s, vec3 p [, float bias])                   |                                                                     |
-|                                                                           |                                                                     |
-| vec4 **texture** (samplerCubeArray s, vec4 p [, float bias])              |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| gvec4_type **textureProj** (gsampler2D s, vec3 p [, float bias])          | Perform a texture read with projection.                             |
-|                                                                           |                                                                     |
-| gvec4_type **textureProj** (gsampler2D s, vec4 p [, float bias])          |                                                                     |
-|                                                                           |                                                                     |
-| gvec4_type **textureProj** (gsampler3D s, vec4 p [, float bias])          |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| gvec4_type **textureLod** (gsampler2D s, vec2 p, float lod)               | Perform a texture read at custom mipmap.                            |
-|                                                                           |                                                                     |
-| gvec4_type **textureLod** (gsampler2DArray s, vec3 p, float lod)          |                                                                     |
-|                                                                           |                                                                     |
-| gvec4_type **textureLod** (gsampler3D s, vec3 p, float lod)               |                                                                     |
-|                                                                           |                                                                     |
-| vec4 **textureLod** (samplerCube s, vec3 p, float lod)                    |                                                                     |
-|                                                                           |                                                                     |
-| vec4 **textureLod** (samplerCubeArray s, vec4 p, float lod)               |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| gvec4_type **textureProjLod** (gsampler2D s, vec3 p, float lod)           | Performs a texture read with projection/LOD.                        |
-|                                                                           |                                                                     |
-| gvec4_type **textureProjLod** (gsampler2D s, vec4 p, float lod)           |                                                                     |
-|                                                                           |                                                                     |
-| gvec4_type **textureProjLod** (gsampler3D s, vec4 p, float lod)           |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| gvec4_type **textureGrad** (gsampler2D s, vec2 p, vec2 dPdx,              | Performs a texture read with explicit gradients.                    |
-| vec2 dPdy)                                                                |                                                                     |
-|                                                                           |                                                                     |
-| gvec4_type **textureGrad** (gsampler2DArray s, vec3 p, vec2 dPdx,         |                                                                     |
-| vec2 dPdy)                                                                |                                                                     |
-|                                                                           |                                                                     |
-| gvec4_type **textureGrad** (gsampler3D s, vec3 p, vec2 dPdx,              |                                                                     |
-| vec2 dPdy)                                                                |                                                                     |
-|                                                                           |                                                                     |
-| vec4 **textureGrad** (samplerCube s, vec3 p, vec3 dPdx, vec3 dPdy)        |                                                                     |
-|                                                                           |                                                                     |
-| vec4 **textureGrad** (samplerCubeArray s, vec3 p, vec3 dPdx,              |                                                                     |
-| vec3 dPdy)                                                                |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| gvec4_type **texelFetch** (gsampler2D s, ivec2 p, int lod)                | Fetches a single texel using integer coordinates.                   |
-|                                                                           |                                                                     |
-| gvec4_type **texelFetch** (gsampler2DArray s, ivec3 p, int lod)           |                                                                     |
-|                                                                           |                                                                     |
-| gvec4_type **texelFetch** (gsampler3D s, ivec3 p, int lod)                |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| gvec4_type **textureGather** (gsampler2D s, vec2 p [, int comps])         | Gathers four texels from a texture.                                 |
-|                                                                           | Use ``comps`` within range of 0..3 to                               |
-| gvec4_type **textureGather** (gsampler2DArray s, vec3 p [, int comps])    | define which component (x, y, z, w) is returned.                    |
-|                                                                           | If ``comps`` is not provided: 0 (or x-component) is used.           |
-| vec4 **textureGather** (samplerCube s, vec3 p [, int comps])              |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **dFdx** (vec_type p)                                            | Derivative in ``x`` using local differencing.                       |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **dFdy** (vec_type p)                                            | Derivative in ``y`` using local differencing.                       |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **fwidth** (vec_type p)                                          | Sum of absolute derivative in ``x`` and ``y``.                      |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| uint **packHalf2x16** (vec2 v)                                            | Convert two 32-bit floating-point numbers into 16-bit               |
-|                                                                           | and pack them into a 32-bit unsigned integer and vice-versa.        |
-| vec2 **unpackHalf2x16** (uint v)                                          |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| uint **packUnorm2x16** (vec2 v)                                           | Convert two 32-bit floating-point numbers (clamped                  |
-|                                                                           | within 0..1 range) into 16-bit and pack them                        |
-| vec2 **unpackUnorm2x16** (uint v)                                         | into a 32-bit unsigned integer and vice-versa.                      |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| uint **packSnorm2x16** (vec2 v)                                           | Convert two 32-bit floating-point numbers (clamped                  |
-|                                                                           | within -1..1 range) into 16-bit and pack them                       |
-| vec2 **unpackSnorm2x16** (uint v)                                         | into a 32-bit unsigned integer and vice-versa.                      |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| uint **packUnorm4x8** (vec4 v)                                            | Convert four 32-bit floating-point numbers (clamped                 |
-|                                                                           | within 0..1 range) into 8-bit and pack them                         |
-| vec4 **unpackUnorm4x8** (uint v)                                          | into a 32-bit unsigned integer and vice-versa.                      |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| uint **packSnorm4x8** (vec4 v)                                            | Convert four 32-bit floating-point numbers (clamped                 |
-|                                                                           | within -1..1 range) into 8-bit and pack them                        |
-| vec4 **unpackSnorm4x8** (uint v)                                          | into a 32-bit unsigned integer and vice-versa.                      |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| ivec_type **bitfieldExtract** (ivec_type value, int offset, int bits)     | Extracts a range of bits from an integer.                           |
-|                                                                           |                                                                     |
-| uvec_type **bitfieldExtract** (uvec_type value, int offset, int bits)     |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| ivec_type **bitfieldInsert** (ivec_type base, ivec_type insert,           | Insert a range of bits into an integer.                             |
-| int offset, int bits)                                                     |                                                                     |
-|                                                                           |                                                                     |
-| uvec_type **bitfieldInsert** (uvec_type base, uvec_type insert,           |                                                                     |
-| int offset, int bits)                                                     |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| ivec_type **bitfieldReverse** (ivec_type value)                           | Reverse the order of bits in an integer.                            |
-|                                                                           |                                                                     |
-| uvec_type **bitfieldReverse** (uvec_type value)                           |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| ivec_type **bitCount** (ivec_type value)                                  | Counts the number of 1 bits in an integer.                          |
-|                                                                           |                                                                     |
-| uvec_type **bitCount** (uvec_type value)                                  |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| ivec_type **findLSB** (ivec_type value)                                   | Find the index of the least significant bit set to 1 in an integer. |
-|                                                                           |                                                                     |
-| uvec_type **findLSB** (uvec_type value)                                   |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| ivec_type **findMSB** (ivec_type value)                                   | Find the index of the most significant bit set to 1 in an integer.  |
-|                                                                           |                                                                     |
-| uvec_type **findMSB** (uvec_type value)                                   |                                                                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| void **imulExtended** (ivec_type x, ivec_type y, out ivec_type msb,       | Adds two 32-bit numbers and produce a 64-bit result.                |
-| out ivec_type lsb)                                                        | ``x`` - the first number.                                           |
-|                                                                           | ``y`` - the second number.                                          |
-| void **umulExtended** (uvec_type x, uvec_type y, out uvec_type msb,       | ``msb`` - will contain the most significant bits.                   |
-| out uvec_type lsb)                                                        | ``lsb`` - will contain the least significant bits.                  |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| uvec_type **uaddCarry** (uvec_type x, uvec_type y, out uvec_type carry)   | Adds two unsigned integers and generates carry.                     |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| uvec_type **usubBorrow** (uvec_type x, uvec_type y, out uvec_type borrow) | Subtracts two unsigned integers and generates borrow.               |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **ldexp** (vec_type x, out ivec_type exp)                        | Assemble a floating-point number from a value and exponent.         |
-|                                                                           |                                                                     |
-|                                                                           | If this product is too large to be represented in the               |
-|                                                                           | floating-point type the result is undefined.                        |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
-| vec_type **frexp** (vec_type x, out ivec_type exp)                        | Splits a floating-point number(``x``) into significand              |
-|                                                                           | (in the range of [0.5, 1.0]) and an integral exponent.              |
-|                                                                           |                                                                     |
-|                                                                           | For ``x`` equals zero the significand and exponent are both zero.   |
-|                                                                           | For ``x`` of infinity or NaN, the results are undefined.            |
-+---------------------------------------------------------------------------+---------------------------------------------------------------------+
++-------------+---------------------------------------------------------------------------------------------------------+
+| Return Type |                                                Function                                                 |
++=============+=========================================================================================================+
+| vec_type    | :js:attr:`radians <radians>` (vec_type degrees)                                                         |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`degrees <degrees>` (vec_type radians)                                                         |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`sin <sin>` (vec_type x)                                                                       |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`cos <cos>` (vec_type x)                                                                       |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`tan <tan>` (vec_type x)                                                                       |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`asin <asin>` (vec_type x)                                                                     |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`acos <acos>` (vec_type x)                                                                     |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`atan <atan>` (vec_type y_over_x)                                                              |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`atan <atan>` (vec_type y, vec_type x)                                                         |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`sinh <sinh>` (vec_type x)                                                                     |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`cosh <cosh>` (vec_type x)                                                                     |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`tanh <tanh>` (vec_type x)                                                                     |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`asinh <asinh>` (vec_type x)                                                                   |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`acosh <acosh>` (vec_type x)                                                                   |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`atanh <atanh>` (vec_type x)                                                                   |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`pow <pow>` (vec_type x, vec_type y)                                                           |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`exp <exp>` (vec_type x)                                                                       |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`exp2 <exp2>` (vec_type x)                                                                     |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`log <log>` (vec_type x)                                                                       |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`log2 <log2>` (vec_type x)                                                                     |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`sqrt <sqrt>` (vec_type x)                                                                     |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`inversesqrt <inversesqrt>` (vec_type x)                                                       |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`abs <abs>` (vec_type x)                                                                       |
+|             |                                                                                                         |
+| ivec_type   | :js:attr:`abs <abs>` (ivec_type x)                                                                      |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`sign <sign>` (vec_type x)                                                                     |
+|             |                                                                                                         |
+| ivec_type   | :js:attr:`sign <sign>` (ivec_type x)                                                                    |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`floor <floor>` (vec_type x)                                                                   |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`round <round>` (vec_type x)                                                                   |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`roundEven <roundEven>` (vec_type x)                                                           |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`trunc <trunc>` (vec_type x)                                                                   |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`ceil <ceil>` (vec_type x)                                                                     |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`fract <fract>` (vec_type x)                                                                   |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`mod <mod>` (vec_type x, vec_type y)                                                           |
+|             |                                                                                                         |
+| vec_type    | :js:attr:`mod <mod>` (vec_type x, float y)                                                              |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`modf <modf>` (vec_type x, out vec_type i)                                                     |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`min <min>` (vec_type a, vec_type b)                                                           |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`max <max>` (vec_type a, vec_type b)                                                           |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`clamp <clamp>` (vec_type x, vec_type min, vec_type max)                                       |
++-------------+---------------------------------------------------------------------------------------------------------+
+| float       | :js:attr:`mix <mix>` (float a, float b, float c)                                                        |
+|             |                                                                                                         |
+| vec_type    | :js:attr:`mix <mix>` (vec_type a, vec_type b, float c)                                                  |
+|             |                                                                                                         |
+| vec_type    | :js:attr:`mix <mix>` (vec_type a, vec_type b, bvec_type c)                                              |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`fma <fma>` (vec_type a, vec_type b, vec_type c)                                               |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`step <step>` (vec_type a, vec_type b)                                                         |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`step <step>` (float a, vec_type b)                                                            |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`smoothstep <smoothstep>` (vec_type a, vec_type b, vec_type c)                                 |
+|             |                                                                                                         |
+| vec_type    | :js:attr:`smoothstep <smoothstep>` (float a, float b, vec_type c)                                       |
++-------------+---------------------------------------------------------------------------------------------------------+
+| bvec_type   | :js:attr:`isnan <isnan>` (vec_type x)                                                                   |
++-------------+---------------------------------------------------------------------------------------------------------+
+| bvec_type   | :js:attr:`isinf <isinf>` (vec_type x)                                                                   |
++-------------+---------------------------------------------------------------------------------------------------------+
+| ivec_type   | :js:attr:`floatBitsToInt <floatBitsToInt>` (vec_type x)                                                 |
++-------------+---------------------------------------------------------------------------------------------------------+
+| uvec_type   | :js:attr:`floatBitsToUint <floatBitsToUint>` (vec_type x)                                               |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`intBitsToFloat <intBitsToFloat>` (ivec_type x)                                                |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`uintBitsToFloat <uintBitsToFloat>` (uvec_type x)                                              |
++-------------+---------------------------------------------------------------------------------------------------------+
+| float       | :js:attr:`length <length>` (vec_type x)                                                                 |
++-------------+---------------------------------------------------------------------------------------------------------+
+| float       | :js:attr:`distance <distance>` (vec_type a, vec_type b)                                                 |
++-------------+---------------------------------------------------------------------------------------------------------+
+| float       | :js:attr:`dot <dot>` (vec_type a, vec_type b)                                                           |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec3        | :js:attr:`cross <cross>` (vec3 a, vec3 b)                                                               |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`normalize <normalize>` (vec_type x)                                                           |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec3        | :js:attr:`reflect <reflect>` (vec3 I, vec3 N)                                                           |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec3        | :js:attr:`refract <refract>` (vec3 I, vec3 N, float eta)                                                |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`faceforward <faceforward>` (vec_type N, vec_type I, vec_type Nref)                            |
++-------------+---------------------------------------------------------------------------------------------------------+
+| mat_type    | :js:attr:`matrixCompMult <matrixCompMult>` (mat_type x, mat_type y)                                     |
++-------------+---------------------------------------------------------------------------------------------------------+
+| mat_type    | :js:attr:`outerProduct <outerProduct>` (vec_type column, vec_type row)                                  |
++-------------+---------------------------------------------------------------------------------------------------------+
+| mat_type    | :js:attr:`transpose <transpose>` (mat_type m)                                                           |
++-------------+---------------------------------------------------------------------------------------------------------+
+| float       | :js:attr:`determinant <determinant>` (mat_type m)                                                       |
++-------------+---------------------------------------------------------------------------------------------------------+
+| mat_type    | :js:attr:`inverse <inverse>` (mat_type m)                                                               |
++-------------+---------------------------------------------------------------------------------------------------------+
+| bvec_type   | :js:attr:`lessThan <lessThan>` (vec_type x, vec_type y)                                                 |
++-------------+---------------------------------------------------------------------------------------------------------+
+| bvec_type   | :js:attr:`greaterThan <greaterThan>` (vec_type x, vec_type y)                                           |
++-------------+---------------------------------------------------------------------------------------------------------+
+| bvec_type   | :js:attr:`lessThanEqual <lessThanEqual>` (vec_type x, vec_type y)                                       |
++-------------+---------------------------------------------------------------------------------------------------------+
+| bvec_type   | :js:attr:`greaterThanEqual <greaterThanEqual>` (vec_type x, vec_type y)                                 |
++-------------+---------------------------------------------------------------------------------------------------------+
+| bvec_type   | :js:attr:`equal <equal>` (vec_type x, vec_type y)                                                       |
++-------------+---------------------------------------------------------------------------------------------------------+
+| bvec_type   | :js:attr:`notEqual <notEqual>` (vec_type x, vec_type y)                                                 |
++-------------+---------------------------------------------------------------------------------------------------------+
+| bool        | :js:attr:`any <any>` (bvec_type x)                                                                      |
++-------------+---------------------------------------------------------------------------------------------------------+
+| bool        | :js:attr:`all <all>` (bvec_type x)                                                                      |
++-------------+---------------------------------------------------------------------------------------------------------+
+| bvec_type   | :js:attr:`not <not>` (bvec_type x)                                                                      |
++-------------+---------------------------------------------------------------------------------------------------------+
+| ivec2       | :js:attr:`textureSize <textureSize>` (gsampler2D s, int lod)                                            |
+|             |                                                                                                         |
+| ivec3       | :js:attr:`textureSize <textureSize>` (gsampler2DArray s, int lod)                                       |
+|             |                                                                                                         |
+| ivec3       | :js:attr:`textureSize <textureSize>` (gsampler3D s, int lod)                                            |
+|             |                                                                                                         |
+| ivec2       | :js:attr:`textureSize <textureSize>` (samplerCube s, int lod)                                           |
+|             |                                                                                                         |
+| ivec2       | :js:attr:`textureSize <textureSize>` (samplerCubeArray s, int lod)                                      |
++-------------+---------------------------------------------------------------------------------------------------------+
+| gvec4_type  | :js:attr:`texture <texture>` (gsampler2D s, vec2 p [, float bias])                                      |
+|             |                                                                                                         |
+| gvec4_type  | :js:attr:`texture <texture>` (gsampler2DArray s, vec3 p [, float bias])                                 |
+|             |                                                                                                         |
+| gvec4_type  | :js:attr:`texture <texture>` (gsampler3D s, vec3 p [, float bias])                                      |
+|             |                                                                                                         |
+| vec4        | :js:attr:`texture <texture>` (samplerCube s, vec3 p [, float bias])                                     |
+|             |                                                                                                         |
+| vec4        | :js:attr:`texture <texture>` (samplerCubeArray s, vec4 p [, float bias])                                |
++-------------+---------------------------------------------------------------------------------------------------------+
+| gvec4_type  | :js:attr:`textureProj <textureProj>` (gsampler2D s, vec3 p [, float bias])                              |
+|             |                                                                                                         |
+| gvec4_type  | :js:attr:`textureProj <textureProj>` (gsampler2D s, vec4 p [, float bias])                              |
+|             |                                                                                                         |
+| gvec4_type  | :js:attr:`textureProj <textureProj>` (gsampler3D s, vec4 p [, float bias])                              |
++-------------+---------------------------------------------------------------------------------------------------------+
+| gvec4_type  | :js:attr:`textureLod <textureLod>` (gsampler2D s, vec2 p, float lod)                                    |
+|             |                                                                                                         |
+| gvec4_type  | :js:attr:`textureLod <textureLod>` (gsampler2DArray s, vec3 p, float lod)                               |
+|             |                                                                                                         |
+| gvec4_type  | :js:attr:`textureLod <textureLod>` (gsampler3D s, vec3 p, float lod)                                    |
+|             |                                                                                                         |
+| vec4        | :js:attr:`textureLod <textureLod>` (samplerCube s, vec3 p, float lod)                                   |
+|             |                                                                                                         |
+| vec4        | :js:attr:`textureLod <textureLod>` (samplerCubeArray s, vec4 p, float lod)                              |
++-------------+---------------------------------------------------------------------------------------------------------+
+| gvec4_type  | :js:attr:`textureProjLod <textureProjLod>` (gsampler2D s, vec3 p, float lod)                            |
+|             |                                                                                                         |
+| gvec4_type  | :js:attr:`textureProjLod <textureProjLod>` (gsampler2D s, vec4 p, float lod)                            |
+|             |                                                                                                         |
+| gvec4_type  | :js:attr:`textureProjLod <textureProjLod>` (gsampler3D s, vec4 p, float lod)                            |
++-------------+---------------------------------------------------------------------------------------------------------+
+| gvec4_type  | :js:attr:`textureGrad <textureGrad>` (gsampler2D s, vec2 p, vec2 dPdx, vec2 dPdy)                       |
+|             |                                                                                                         |
+| gvec4_type  | :js:attr:`textureGrad <textureGrad>` (gsampler2DArray s, vec3 p, vec2 dPdx, vec2 dPdy)                  |
+|             |                                                                                                         |
+| gvec4_type  | :js:attr:`textureGrad <textureGrad>` (gsampler3D s, vec3 p, vec2 dPdx, vec2 dPdy)                       |
+|             |                                                                                                         |
+| vec4        | :js:attr:`textureGrad <textureGrad>` (samplerCube s, vec3 p, vec3 dPdx, vec3 dPdy)                      |
+|             |                                                                                                         |
+| vec4        | :js:attr:`textureGrad <textureGrad>` (samplerCubeArray s, vec3 p, vec3 dPdx, vec3 dPdy)                 |
++-------------+---------------------------------------------------------------------------------------------------------+
+| gvec4_type  | :js:attr:`texelFetch <texelFetch>` (gsampler2D s, ivec2 p, int lod)                                     |
+|             |                                                                                                         |
+| gvec4_type  | :js:attr:`texelFetch <texelFetch>` (gsampler2DArray s, ivec3 p, int lod)                                |
+|             |                                                                                                         |
+| gvec4_type  | :js:attr:`texelFetch <texelFetch>` (gsampler3D s, ivec3 p, int lod)                                     |
++-------------+---------------------------------------------------------------------------------------------------------+
+| gvec4_type  | :js:attr:`textureGather <textureGather>` (gsampler2D s, vec2 p [, int comps])                           |
+|             |                                                                                                         |
+| gvec4_type  | :js:attr:`textureGather <textureGather>` (gsampler2DArray s, vec3 p [, int comps])                      |
+|             |                                                                                                         |
+| vec4        | :js:attr:`textureGather <textureGather>` (samplerCube s, vec3 p [, int comps])                          |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`dFdx <dFdx>` (vec_type p)                                                                     |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`dFdy <dFdy>` (vec_type p)                                                                     |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`fwidth <fwidth>` (vec_type p)                                                                 |
++-------------+---------------------------------------------------------------------------------------------------------+
+| uint        | :js:attr:`packHalf2x16 <packHalf2x16>` (vec2 v)                                                         |
+|             |                                                                                                         |
+| vec2        | :js:attr:`unpackHalf2x16 <unpackHalf2x16>` (uint v)                                                     |
++-------------+---------------------------------------------------------------------------------------------------------+
+| uint        | :js:attr:`packUnorm2x16 <packUnorm2x16>` (vec2 v)                                                       |
+|             |                                                                                                         |
+| vec2        | :js:attr:`unpackUnorm2x16 <unpackUnorm2x16>` (uint v)                                                   |
++-------------+---------------------------------------------------------------------------------------------------------+
+| uint        | :js:attr:`packSnorm2x16 <packSnorm2x16>` (vec2 v)                                                       |
+|             |                                                                                                         |
+| vec2        | :js:attr:`unpackSnorm2x16 <unpackSnorm2x16>` (uint v)                                                   |
++-------------+---------------------------------------------------------------------------------------------------------+
+| uint        | :js:attr:`packUnorm4x8 <packUnorm4x8>` (vec4 v)                                                         |
+|             |                                                                                                         |
+| vec4        | :js:attr:`unpackUnorm4x8 <unpackUnorm4x8>` (uint v)                                                     |
++-------------+---------------------------------------------------------------------------------------------------------+
+| uint        | :js:attr:`packSnorm4x8 <packSnorm4x8>` (vec4 v)                                                         |
+|             |                                                                                                         |
+| vec4        | :js:attr:`unpackSnorm4x8 <unpackSnorm4x8>` (uint v)                                                     |
++-------------+---------------------------------------------------------------------------------------------------------+
+| ivec_type   | :js:attr:`bitfieldExtract <bitfieldExtract>` (ivec_type value, int offset, int bits)                    |
+|             |                                                                                                         |
+| uvec_type   | :js:attr:`bitfieldExtract <bitfieldExtract>` (uvec_type value, int offset, int bits)                    |
++-------------+---------------------------------------------------------------------------------------------------------+
+| ivec_type   | :js:attr:`bitfieldInsert <bitfieldInsert>` (ivec_type base, ivec_type insert, int offset, int bits)     |
+|             |                                                                                                         |
+| uvec_type   | :js:attr:`bitfieldInsert <bitfieldInsert>` (uvec_type base, uvec_type insert, int offset, int bits)     |
++-------------+---------------------------------------------------------------------------------------------------------+
+| ivec_type   | :js:attr:`bitfieldReverse <bitfieldReverse>` (ivec_type value)                                          |
+|             |                                                                                                         |
+| uvec_type   | :js:attr:`bitfieldReverse <bitfieldReverse>` (uvec_type value)                                          |
++-------------+---------------------------------------------------------------------------------------------------------+
+| ivec_type   | :js:attr:`bitCount <bitCount>` (ivec_type value)                                                        |
+|             |                                                                                                         |
+| uvec_type   | :js:attr:`bitCount <bitCount>` (uvec_type value)                                                        |
++-------------+---------------------------------------------------------------------------------------------------------+
+| ivec_type   | :js:attr:`findLSB <findLSB>` (ivec_type value)                                                          |
+|             |                                                                                                         |
+| uvec_type   | :js:attr:`findLSB <findLSB>` (uvec_type value)                                                          |
++-------------+---------------------------------------------------------------------------------------------------------+
+| ivec_type   | :js:attr:`findMSB <findMSB>` (ivec_type value)                                                          |
+|             |                                                                                                         |
+| uvec_type   | :js:attr:`findMSB <findMSB>` (uvec_type value)                                                          |
++-------------+---------------------------------------------------------------------------------------------------------+
+| void        | :js:attr:`imulExtended <imulExtended>` (ivec_type x, ivec_type y, out ivec_type msb, out ivec_type lsb) |
+|             |                                                                                                         |
+| void        | :js:attr:`umulExtended <umulExtended>` (uvec_type x, uvec_type y, out uvec_type msb, out uvec_type lsb) |
++-------------+---------------------------------------------------------------------------------------------------------+
+| uvec_type   | :js:attr:`uaddCarry <uaddCarry>` (uvec_type x, uvec_type y, out uvec_type carry)                        |
++-------------+---------------------------------------------------------------------------------------------------------+
+| uvec_type   | :js:attr:`usubBorrow <usubBorrow>` (uvec_type x, uvec_type y, out uvec_type borrow)                     |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`ldexp <ldexp>` (vec_type x, out ivec_type exp)                                                |
++-------------+---------------------------------------------------------------------------------------------------------+
+| vec_type    | :js:attr:`frexp <frexp>` (vec_type x, out ivec_type exp)                                                |
++-------------+---------------------------------------------------------------------------------------------------------+
+
+.. js:function:: radians( vec_type degrees )
+
+    ``radians`` converts a quantity specified in degrees into radians.
+
+    `GLSL documentation <https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/radians.xhtml>`_
+
+    :param vec_type degrees:
+        Specify the quantity, in degrees, to be converted to radians.
+
+    :return:
+        The return value is ``(π * degrees) / 180``.
+
+    :rtype: vec_type
+
+.. js:function:: degrees (vec_type radians)    
+
+    ``degrees`` converts a quantity specified in radians into degrees.
+
+    `GLSL documentation <https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/degrees.xhtml>`_.
+
+    :param vec_type radians:
+        Specify the quantity, in radians, to be converted to degrees.
+
+    :return:
+        The return value is ``(radians * 180) / π``.
+
+    :rtype: vec_type
+
+.. js:function:: sin (vec_type angle)
+
+    `GLSL documentation <https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/sin.xhtml>`_.
+
+    :param vec_type angle:
+        The quantity, in radians, of which to return the sine
+
+    :return:
+        The return value is the trigonometric sine of ``angle``.
+
+    :rtype: vec_type
+
+.. js:function:: cos (vec_type angle)
+
+    `GLSL documentation <https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/cos.xhtml>`_.
+
+    :param vec_type angle:
+        The quantity, in radians, of which to return the cosine.
+
+    :return:
+        The return value is the trigonometric cosine of ``angle``.
+
+    :rtype: vec_type
+
+.. js:function:: tan (vec_type angle)
+
+    `GLSL documentation <https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/tan.xhtml>`_.
+
+    :param vec_type angle:
+        The quantity, in radians, of which to return the tangent.
+
+    :return:
+        The return value is the trigonometric tangent of ``angle``.
+
+    :rtype: vec_type
+
+.. js:function:: asin (vec_type x)
+
+    Calculates the angle whose sine is ``x``.
+    The result is undefined if ``x < -1`` or ``x > 1``.
+
+    `GLSL documentation <https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/asin.xhtml>`_.
+
+    :param vec_type x:
+        The value whose arccosine to return.
+    :return:
+        The return value is the angle whose trigonometric sine is ``x`` and is 
+        in the range ``[-π/2, π/2]``.
+
+    :rtype: vec_type
+
+.. js:function:: acos (vec_type x)
+
+    Calculates the angle whose cosine is ``x``.
+    The result is undefined if ``x < -1`` or ``x > 1``.
+
+    `GLSL documentation <https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/acos.xhtml>`_.
+
+    :param vec_type x:
+        The value whose arccosine to return.
+
+    :return:
+        The return value is the angle whose trigonometric cosine is ``x`` and
+        is in the range ``[0, π]``.
+
+    :rtype: vec_type
+
+.. js:function:: atan (vec_type y_over_x)
+
+    Calculate the arctangent given a tangent value of ``y/x``. Note: becuase of
+    the sign ambiguity, the function cannot determine with certainty in which
+    quadrant the angle falls only by its tangent value. If you need to know the
+    quadrant, use the other overload of ``atan``.
+
+    `GLSL documentation <https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/atan.xhtml>`_.
+
+    :param vec_type y_over_x:
+        The fraction whose arctangent to return.
+
+    :return:
+        The return value is the trigonometric arc-tangent of ``y_over_x`` and is
+        in the range ``[−π/2, π/2]``.
+
+    :rtype: vec_type
+
+.. js:function:: atan (vec_type y, vec_type x)
+
+    Calculate the arctangent given a numerator and denominator. The signs of
+    ``y`` and ``x`` are used to determine the quadrant that the angle lies in.
+    The result is undefined if ``x == 0``.
+    
+    `GLSL documentation <https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/atan.xhtml>`_.
+
+    :param vec_type y:
+        The numerator of the fraction whose arctangent to return.
+
+    :param vec_type x:
+        The denominator of the fraction whose arctangent to return.
+
+    :return:
+        The return value is the trigonometric arc-tangent of ``y/x`` and is in
+        the range ``[−π, π]``.
+
+    :rtype: vec_type
+
+.. js:function:: sinh (vec_type x)
+
+    Calculates the hyperbolic sine using ``(e^x - e^-x)/2``.
+    `GLSL documentation <https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/sinh.xhtml>`_.
+
+    :param vec_type x:
+        The value whose hyperbolic sine to return.
+
+    :return:
+        The return value is the hyperbolic sine of ``x``.
+
+    :rtype: vec_type
+
+.. js:function:: cosh (vec_type x)
+
+    Calculates the hyperbolic cosine using ``(e^x + e^-x)/2``.
+    `GLSL documentation <https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/cosh.xhtml>`_.
+
+    :param vec_type x:
+        The value whose hyperbolic cosine to return.
+
+    :return:
+        The return value is the hyperbolic cosine of ``x``.
+
+    :rtype: vec_type
+
+.. js:function:: tanh (vec_type x)
+
+    Calculates the hyperbolic tangent using ``sinh(x)/cosh(x)``.
+    `GLSL documentation <https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/tanh.xhtml>`_.
+
+    :param vec_type x:
+        The value whose hyperbolic tangent to return.
+
+    :return:
+        The return value is the hyperbolic tangent of ``x``.
+
+    :rtype: vec_type
+
+.. js:function:: asinh (vec_type x)
+
+    Calculates the arc hyperbolic sine of a value.
+
+    `GLSL documentation <https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/asinh.xhtml>`_.
+
+    :param vec_type x:
+        The value whose arc hyperbolic sine to return.
+
+    :return:
+        The return value is the arc hyperbolic sine of ``x`` which is the
+        inverse of sinh.
+
+    :rtype: vec_type
+
+.. js:function:: acosh (vec_type x)
+
+    Calculates the arc hyperbolic cosine of a value.
+    The result is undefined if ``x < 1``.
+
+    `GLSL documentation <https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/acos.xhtml>`_.
+
+    :param vec_type x:
+        The value whose arc hyperbolic cosine to return.
+
+    :return:
+        The return value is the arc hyperbolic cosine of ``x`` which is the
+        inverse of cosh.
+
+    :rtype: vec_type
+
+.. js:function:: atanh (vec_type x)
+
+    Calculate the arctangent given a tangent value of ``y/x``. Note: becuase of
+    the sign ambiguity, the function cannot determine with certainty in which
+    quadrant the angle falls only by its tangent value. If you need to know the
+    quadrant, use the other overload of ``atan``.
+
+    The result is undefined if ``x < -1`` or ``x > 1``.
+
+    `GLSL documentation <https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/atan.xhtml>`_.
+
+    :param vec_type y_over_x:
+        The fraction whose arc hyperbolic tangent to return.
+
+    :return:
+        The return value is the arc hyperbolic tangent of ``x`` which is the
+        inverse of tanh.
+
+    :rtype: vec_type
+
+.. js:function:: pow (vec_type x, vec_type y)
+
+    Raises ``x`` to the power of ``y``.
+
+    The result is undefined if ``x < 0`` or  if ``x == 0`` and ``y <= 0``.
+
+    `GLSL documentation <https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/pow.xhtml>`_.
+
+    :param vec_type x:
+        The value to be raised to the power ``y``.
+
+    :param vec_type y:
+        The power to which ``x`` will be raised.
+
+    :return:
+        Returns the value of ``x`` raised to the ``y`` power.
+
+    :rtype: vec_type
+
+.. js:function:: exp (vec_type x)
+
+
+    `GLSL documentation <>`_.
+
+      :param vec_type radians:
+
+      :return:
+The return value is 
+
+      :rtype: vec_type
+
+.. js:function:: exp2 (vec_type x)
+
+    `GLSL documentation <>`_.
+
+      :param vec_type radians:
+
+      :return:
+The return value is 
+
+      :rtype: vec_type
+
+.. js:function:: log (vec_type x)
+
+    `GLSL documentation <>`_.
+
+      :param vec_type radians:
+
+      :return:
+The return value is 
+
+      :rtype: vec_type
+
+.. js:function:: log2 (vec_type x)
+
+    `GLSL documentation <>`_.
+
+      :param vec_type radians:
+
+      :return:
+The return value is 
+
+      :rtype: vec_type
+
+.. js:function:: sqrt (vec_type x)
+
+    `GLSL documentation <>`_.
+
+      :param vec_type radians:
+
+      :return:
+The return value is 
+
+      :rtype: vec_type
+
+.. js:function:: inversesqrt (vec_type x)
+
+    `GLSL documentation <>`_.
+
+      :param vec_type radians:
+
+      :return:
+The return value is 
+
+      :rtype: vec_type
+
+.. js:function:: abs (vec_type x)
+
+    `GLSL documentation <>`_.
+ 
+      :param vec_type radians:
+
+      :return:
+The return value is 
+
+      :rtype: vec_type
+
+.. js:function:: abs (ivec_type x)
+
+    `GLSL documentation <>`_.
+
+      :param ivec_type x:
+
+      :return:
+The return value is 
+
+      :rtype: ivec_type
+
+.. js:function:: sign (vec_type x)
+
+    `GLSL documentation <>`_.
+
+      :param vec_type radians:
+
+      :return:
+The return value is 
+
+      :rtype: vec_type
+
+.. js:function:: sign (ivec_type x)
+
+    `GLSL documentation <>`_.
+
+      :param ivec_type x:
+
+      :return:
+The return value is 
+
+      :rtype: ivec_type
+
+.. js:function:: floor (vec_type x)
+
+    `GLSL documentation <>`_.
+
+      :param vec_type radians:
+
+      :return:
+The return value is 
+
+      :rtype: vec_type
+
+.. js:function:: round (vec_type x)
+
+    `GLSL documentation <>`_.
+
+      :param vec_type radians:
+
+      :return:
+The return value is 
+
+      :rtype: vec_type
+
+.. js:function:: roundEven (vec_type x)
+
+    `GLSL documentation <>`_.
+
+      :param vec_type radians:
+
+      :return:
+The return value is 
+
+      :rtype: vec_type
+
+.. js:function:: trunc (vec_type x)
+
+    `GLSL documentation <>`_.
+
+      :param vec_type radians:
+
+      :return:
+The return value is 
+
+      :rtype: vec_type
+
+.. js:function:: ceil (vec_type x)
+
+    `GLSL documentation <>`_.
+
+      :param vec_type radians:
+
+      :return:
+The return value is 
+
+      :rtype: vec_type
+
+.. js:function:: fract (vec_type x)
+
+    `GLSL documentation <>`_.
+
+      :param vec_type radians:
+
+      :return:
+The return value is 
+
+      :rtype: vec_type
+
+.. js:function:: mod (vec_type x, vec_type y)
+
+.. js:function:: mod (vec_type x, float y)
+
+.. js:function:: modf (vec_type x, out vec_type i)
+
+.. js:function:: min (vec_type a, vec_type b)
+
+.. js:function:: max (vec_type a, vec_type b)
+
+.. js:function:: clamp (vec_type x, vec_type min, vec_type max)
+
+.. js:function:: mix (float a, float b, float c)
+
+.. js:function:: mix (vec_type a, vec_type b, float c)
+
+.. js:function:: mix (vec_type a, vec_type b, bvec_type c)
+
+.. js:function:: fma (vec_type a, vec_type b, vec_type c)
+
+.. js:function:: step (vec_type a, vec_type b)
+
+.. js:function:: step (float a, vec_type b) 
+
+.. js:function:: smoothstep (vec_type a, vec_type b, vec_type c)
+
+.. js:function:: smoothstep (float a, float b, vec_type c)
+
+.. js:function:: isnan (vec_type x)
+
+.. js:function:: isinf (vec_type x)
+
+.. js:function:: floatBitsToInt (vec_type x)
+
+.. js:function:: floatBitsToUint (vec_type x)
+
+.. js:function:: intBitsToFloat (ivec_type x)
+
+.. js:function:: uintBitsToFloat (uvec_type x)
+
+.. js:function:: length (vec_type x)
+
+.. js:function:: distance (vec_type a, vec_type b)
+
+.. js:function:: dot (vec_type a, vec_type b)
+
+.. js:function:: cross (vec3 a, vec3 b)
+
+.. js:function:: normalize (vec_type x)
+
+.. js:function:: reflect (vec3 I, vec3 N)
+
+.. js:function:: refract (vec3 I, vec3 N, float eta)
+
+.. js:function:: faceforward (vec_type N, vec_type I, vec_type Nref)
+
+.. js:function:: matrixCompMult (mat_type x, mat_type y)
+
+.. js:function:: outerProduct (vec_type column, vec_type row)
+
+.. js:function:: transpose (mat_type m)
+
+.. js:function:: determinant (mat_type m)
+
+.. js:function:: inverse (mat_type m)
+
+.. js:function:: lessThan (vec_type x, vec_type y)
+
+.. js:function:: greaterThan (vec_type x, vec_type y)
+
+.. js:function:: lessThanEqual (vec_type x, vec_type y)
+
+.. js:function:: greaterThanEqual (vec_type x, vec_type y)
+
+.. js:function:: equal (vec_type x, vec_type y)
+
+.. js:function:: notEqual (vec_type x, vec_type y)
+
+.. js:function:: any (bvec_type x)
+
+.. js:function:: all (bvec_type x)
+
+.. js:function:: not (bvec_type x)
+
+    ``degrees`` converts a quantity specified in radians into degrees.
+    `GLSL documentation <https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/degrees.xhtml>`_
+
+      :param bvec_type x:
+Specify the quantity, in radians, to be converted to degrees.
+
+      :return:
+The return value is ``(radians * 180) / π``.
+
+      :rtype: bool
+
+.. js:function:: textureSize (gsampler2D s, int lod)
+.. js:function:: textureSize (gsampler2DArray s, int lod)
+.. js:function:: textureSize (gsampler3D s, int lod)
+.. js:function:: textureSize (samplerCube s, int lod)
+.. js:function:: textureSize (samplerCubeArray s, int lod)
+
+    ``degrees`` converts a quantity specified in radians into degrees.
+    `GLSL documentation <https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/degrees.xhtml>`_
+
+      :param sampler_type s:
+Specify the quantity, in radians, to be converted to degrees.
+
+      :param int lod:
+Specify the quantity, in radians, to be converted to degrees.
+
+      :return:
+The return value is ``(radians * 180) / π``.
+
+      :rtype: vec_type
+
+.. js:function:: texture (gsampler2D s, vec2 p [, float bias])
+.. js:function:: texture (gsampler2DArray s, vec3 p [, float bias])
+.. js:function:: texture (gsampler3D s, vec3 p [, float bias])
+.. js:function:: texture (samplerCube s, vec3 p [, float bias])
+.. js:function:: texture (samplerCubeArray s, vec4 p [, float bias])
+
+.. js:function:: textureProj (gsampler2D s, vec3 p [, float bias])
+.. js:function:: textureProj (gsampler2D s, vec4 p [, float bias])
+.. js:function:: textureProj (gsampler3D s, vec4 p [, float bias])
+
+.. js:function:: textureLod (gsampler2D s, vec2 p, float lod)
+.. js:function:: textureLod (gsampler2DArray s, vec3 p, float lod)
+.. js:function:: textureLod (gsampler3D s, vec3 p, float lod)
+.. js:function:: textureLod (samplerCube s, vec3 p, float lod)
+.. js:function:: textureLod (samplerCubeArray s, vec4 p, float lod)
+
+.. js:function:: textureProjLod (gsampler2D s, vec3 p, float lod)
+.. js:function:: textureProjLod (gsampler2D s, vec4 p, float lod)
+.. js:function:: textureProjLod (gsampler3D s, vec4 p, float lod)
+
+.. js:function:: textureGrad (gsampler2D s, vec2 p, vec2 dPdx, vec2 dPdy)
+.. js:function:: textureGrad (gsampler2DArray s, vec3 p, vec2 dPdx, vec2 dPdy)
+.. js:function:: textureGrad (gsampler3D s, vec3 p, vec2 dPdx, vec2 dPdy)
+.. js:function:: textureGrad <textureGrad>` (samplerCube s, vec3 p, vec3 dPdx, vec3 dPdy)
+.. js:function:: textureGrad <textureGrad>` (samplerCubeArray s, vec3 p, vec3 dPdx, vec3 dPdy)
+
+.. js:function:: texelFetch <texelFetch>` (gsampler2D s, ivec2 p, int lod)
+.. js:function:: texelFetch <texelFetch>` (gsampler2DArray s, ivec3 p, int lod)
+.. js:function:: texelFetch <texelFetch>` (gsampler3D s, ivec3 p, int lod)
+
+.. js:function:: textureGather <textureGather>` (gsampler2D s, vec2 p [, int comps])
+.. js:function:: textureGather <textureGather>` (gsampler2DArray s, vec3 p [, int comps])
+.. js:function:: textureGather <textureGather>` (samplerCube s, vec3 p [, int comps])
+
+.. js:function:: dFdx (vec_type p)
+
+.. js:function:: dFdy (vec_type p)
+
+.. js:function:: fwidth (vec_type p)
+
+.. js:function:: packHalf2x16 (vec2 v)
+.. js:function:: unpackHalf2x16 (uint v)
+
+.. js:function:: packUnorm2x16 (vec2 v)
+.. js:function:: unpackUnorm2x16 (uint v)
+
+.. js:function:: packSnorm2x16 (vec2 v)
+.. js:function:: unpackSnorm2x16 (uint v)
+
+.. js:function:: packUnorm4x8 (vec4 v)
+.. js:function:: unpackUnorm4x8 (uint v)
+
+.. js:function:: packSnorm4x8 (vec4 v)
+.. js:function:: unpackSnorm4x8 (uint v)
+
+.. js:function:: bitfieldExtract (ivec_type value, int offset, int bits)
+.. js:function:: bitfieldExtract (uvec_type value, int offset, int bits)
+
+.. js:function:: bitfieldInsert (ivec_type base, ivec_type insert, int offset, int bits)     
+.. js:function:: bitfieldInsert (uvec_type base, uvec_type insert, int offset, int bits)     
+
+.. js:function:: bitfieldReverse (ivec_type value)
+.. js:function:: bitfieldReverse (uvec_type value)
+
+.. js:function:: bitCount (ivec_type value)
+.. js:function:: bitCount (uvec_type value)
+
+.. js:function:: findLSB (ivec_type value)
+.. js:function:: findLSB (uvec_type value)
+
+.. js:function:: findMSB (ivec_type value)
+.. js:function:: findMSB (uvec_type value)
+
+.. js:function:: imulExtended (ivec_type x, ivec_type y, out ivec_type msb, out ivec_type lsb) 
+.. js:function:: umulExtended (uvec_type x, uvec_type y, out uvec_type msb, out uvec_type lsb) 
+
+.. js:function:: uaddCarry (uvec_type x, uvec_type y, out uvec_type carry)
+
+.. js:function:: usubBorrow (uvec_type x, uvec_type y, out uvec_type borrow)
+
+.. js:function:: ldexp (vec_type x, out ivec_type exp)
+
+.. js:function:: frexp (vec_type x, out ivec_type exp)


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot-docs/issues/5594

I am looking for feedback on a new style for the shader builtin functions. Previously the descriptions were presented in a table format that made them hard to edit and hard to read. 

The new format uses the jsdoc formatting used [here](https://docs.godotengine.org/en/3.4/tutorials/platform/html5_shell_classref.html)

_Old Format_
![Screenshot (2)](https://user-images.githubusercontent.com/16521339/161478681-3ec8846b-4de6-45f2-9d3b-9507e7e8eb28.png)
/tutorials/platform/html5_shell_classref.html)

_New Format_
![Screenshot (1)](https://user-images.githubusercontent.com/16521339/161477514-0792f191-b1d7-4ef7-b3de-a47528359d07.png)

