### PR TITLE
How to change windows icon with no external tools

### DIFF
--- a/tutorials/export/changing_application_icon_for_windows.rst
+++ b/tutorials/export/changing_application_icon_for_windows.rst
@@ -61,7 +61,7 @@ use the ``Icon`` setting.
 Changing the file icon
 ----------------------
 
-In Godot 3.5 and Godot 4.0, you can change the file icon without
+In Godot 3.5 and later, you can change the file icon without
 external tools using `godoticon <https://github.com/pkowal1982/godoticon>`__.
 Changing the file icon this way should work for executables containing
 an embedded PCK.

--- a/tutorials/export/changing_application_icon_for_windows.rst
+++ b/tutorials/export/changing_application_icon_for_windows.rst
@@ -61,13 +61,10 @@ use the ``Icon`` setting.
 Changing the file icon
 ----------------------
 
-For Godot 3.5 beta 3+ and Godot 4 alpha 5+ you can change file icon with no
-external tools, just running two GDScript files from console. Files and detailed
-description can be found here:
-
-`Windows icon replacement scripts <https://github.com/pkowal1982/godoticon>`__
-
-Changing icon this way should work for executables containing embedded PCK.
+In Godot 3.5 and Godot 4.0, you can change the file icon without
+external tools using `godoticon <https://github.com/pkowal1982/godoticon>`__.
+Changing the file icon this way should work for executables containing
+an embedded PCK.
 
 .. warning::
 

--- a/tutorials/export/changing_application_icon_for_windows.rst
+++ b/tutorials/export/changing_application_icon_for_windows.rst
@@ -61,6 +61,14 @@ use the ``Icon`` setting.
 Changing the file icon
 ----------------------
 
+For Godot 3.5 beta 3+ and Godot 4 alpha 5+ you can change file icon with no
+external tools, just running two GDScript files from console. Files and detailed
+description can be found here:
+
+`Windows icon replacement scripts <https://github.com/pkowal1982/godoticon>`__
+
+Changing icon this way should work for executables containing embedded PCK.
+
 .. warning::
 
     There are `known issues <https://github.com/godotengine/godot/issues/33466>`__


### PR DESCRIPTION
Latest versions of Godot incorporate fixed icon size which can be replaced with no external tools.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
