### PR TITLE
Link to transparency sorting limitations page in Spatial shaders

### DIFF
--- a/tutorials/3d/3d_rendering_limitations.rst
+++ b/tutorials/3d/3d_rendering_limitations.rst
@@ -76,6 +76,8 @@ Depending on the scene and viewing conditions, you may also be able to move the
 Z-fighting objects further apart without the difference being visible to the
 player.
 
+.. _doc_3d_rendering_limitations_transparency_sorting:
+
 Transparency sorting
 --------------------
 

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -435,5 +435,5 @@ If you want the lights to add together, add the light contribution to ``DIFFUSE_
 
     Shaders going through the transparent pipeline when ``ALPHA`` is written to
     may exhibit transparency sorting issues. Read the
-    :ref:`section transparency sorting in the 3D rendering limitations page <doc_3d_rendering_limitations_transparency_sorting>`
+    :ref:`transparency sorting section in the 3D rendering limitations page <doc_3d_rendering_limitations_transparency_sorting>`
     for more information and ways to avoid issues.

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -340,6 +340,13 @@ these properties, and if you don't write to them, Godot will optimize away the c
 | out vec4 **IRRADIANCE**                | If written to, blends environment map IRRADIANCE with IRRADIANCE.rgb based on IRRADIANCE.a.      |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
 
+.. note::
+
+    Shaders going through the transparent pipeline when ``ALPHA`` is written to
+    may exhibit transparency sorting issues. Read the
+    :ref:`section transparency sorting in the 3D rendering limitations page <doc_3d_rendering_limitations_transparency_sorting>`
+    for more information and ways to avoid issues.
+
 Light built-ins
 ^^^^^^^^^^^^^^^
 
@@ -423,3 +430,10 @@ If you want the lights to add together, add the light contribution to ``DIFFUSE_
 | out float **ALPHA**               | Alpha (0..1); if written to, the material will go  |
 |                                   | to the transparent pipeline.                       |
 +-----------------------------------+----------------------------------------------------+
+
+.. note::
+
+    Shaders going through the transparent pipeline when ``ALPHA`` is written to
+    may exhibit transparency sorting issues. Read the
+    :ref:`section transparency sorting in the 3D rendering limitations page <doc_3d_rendering_limitations_transparency_sorting>`
+    for more information and ways to avoid issues.

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -344,7 +344,7 @@ these properties, and if you don't write to them, Godot will optimize away the c
 
     Shaders going through the transparent pipeline when ``ALPHA`` is written to
     may exhibit transparency sorting issues. Read the
-    :ref:`section transparency sorting in the 3D rendering limitations page <doc_3d_rendering_limitations_transparency_sorting>`
+    :ref:`transparency sorting section in the 3D rendering limitations page <doc_3d_rendering_limitations_transparency_sorting>`
     for more information and ways to avoid issues.
 
 Light built-ins


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot-docs/pull/5741.

This closes https://github.com/godotengine/godot-docs/issues/4417.