### PR TITLE
Link to transparency sorting limitations page in Spatial shaders

### DIFF
--- a/tutorials/3d/3d_rendering_limitations.rst
+++ b/tutorials/3d/3d_rendering_limitations.rst
@@ -76,6 +76,8 @@ Depending on the scene and viewing conditions, you may also be able to move the
 Z-fighting objects further apart without the difference being visible to the
 player.
 
+.. _doc_3d_rendering_limitations_transparency_sorting:
+
 Transparency sorting
 --------------------
 

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -369,5 +369,5 @@ If you want the lights to add together, add the light contribution to ``DIFFUSE_
 
     Shaders going through the transparent pipeline when ``ALPHA`` is written to
     may exhibit transparency sorting issues. Read the
-    :ref:`section transparency sorting in the 3D rendering limitations page <doc_3d_rendering_limitations_transparency_sorting>`
+    :ref:`transparency sorting section in the 3D rendering limitations page <doc_3d_rendering_limitations_transparency_sorting>`
     for more information and ways to avoid issues.

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -278,7 +278,7 @@ these properties, and if you don't write to them, Godot will optimize away the c
 
     Shaders going through the transparent pipeline when ``ALPHA`` is written to
     may exhibit transparency sorting issues. Read the
-    :ref:`section transparency sorting in the 3D rendering limitations page <doc_3d_rendering_limitations_transparency_sorting>`
+    :ref:`transparency sorting section in the 3D rendering limitations page <doc_3d_rendering_limitations_transparency_sorting>`
     for more information and ways to avoid issues.
 
 Light built-ins

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -274,6 +274,13 @@ these properties, and if you don't write to them, Godot will optimize away the c
 | in vec2 **POINT_COORD**           | Point Coordinate for drawing points with POINT_SIZE.                                             |
 +-----------------------------------+--------------------------------------------------------------------------------------------------+
 
+.. note::
+
+    Shaders going through the transparent pipeline when ``ALPHA`` is written to
+    may exhibit transparency sorting issues. Read the
+    :ref:`section transparency sorting in the 3D rendering limitations page <doc_3d_rendering_limitations_transparency_sorting>`
+    for more information and ways to avoid issues.
+
 Light built-ins
 ^^^^^^^^^^^^^^^
 
@@ -357,3 +364,10 @@ If you want the lights to add together, add the light contribution to ``DIFFUSE_
 +-----------------------------------+-----------------------------------------------------+
 | out vec3 **SPECULAR_LIGHT**       | Specular light result.                              |
 +-----------------------------------+-----------------------------------------------------+
+
+.. note::
+
+    Shaders going through the transparent pipeline when ``ALPHA`` is written to
+    may exhibit transparency sorting issues. Read the
+    :ref:`section transparency sorting in the 3D rendering limitations page <doc_3d_rendering_limitations_transparency_sorting>`
+    for more information and ways to avoid issues.


### PR DESCRIPTION
`3.4` version of https://github.com/godotengine/godot-docs/pull/5740.

This closes https://github.com/godotengine/godot-docs/issues/4417.