### PR TITLE
Fix 2D optimization section in the Performance toctree

### DIFF
--- a/tutorials/performance/index.rst
+++ b/tutorials/performance/index.rst
@@ -73,9 +73,6 @@ GPU
    :maxdepth: 1
    :name: toc-learn-features-2d-optimization
 
-   optimizing_3d_performance
-   vertex_animation/index
-
    batching
 
 3D
@@ -86,6 +83,7 @@ GPU
    :name: toc-learn-features-3d-optimization
 
    optimizing_3d_performance
+   vertex_animation/index
 
 Multi-threading
 ---------------


### PR DESCRIPTION
This closes https://github.com/godotengine/godot-docs/issues/5733.

**Note:** It's already correct on `master`, so this fix is only needed for `3.4`.