### PR TITLE
Use a note for FreeType year advice in Complying with licenses

### DIFF
--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -115,6 +115,7 @@ Godot license:
     Portions of this software are copyright © <year> The FreeType Project (www.freetype.org).  All rights reserved.
 
 .. note::
+
     <year> should correspond to the value from the FreeType version used 
     in your build. This information can be found in the editor by opening
     the **Help > About** dialog and going to the **Third-party Licenses**

--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -114,9 +114,11 @@ Godot license:
 
     Portions of this software are copyright © <year> The FreeType Project (www.freetype.org).  All rights reserved.
 
-Note that <year> should correspond to the value from the FreeType version
-used in your build. This information can be found in the editor by opening
-the **Help > About** dialog and going to the **Third-party Licenses** tab.
+.. note::
+    <year> should correspond to the value from the FreeType version used 
+    in your build. This information can be found in the editor by opening
+    the **Help > About** dialog and going to the **Third-party Licenses**
+    tab.
 
 ENet
 ^^^^


### PR DESCRIPTION
Just for making it look like an actual note.
