### PR TITLE
fix vs code configuration build tasks.json

### DIFF
--- a/development/cpp/configuring_an_ide/visual_studio_code.rst
+++ b/development/cpp/configuring_an_ide/visual_studio_code.rst
@@ -41,7 +41,8 @@ Importing the project
       "type": "shell",
       "command": "scons",
       "args": [
-        "-j $(nproc)"
+        "-j",
+        "$(nproc)"
       ],
       "problemMatcher": "$msCompile"
     }


### PR DESCRIPTION
With recent versions of vs code (from version 1.66), build arguments must be
split to be resolved.
