### PR TITLE
Fix typo in GDNative C++ example

### DIFF
--- a/tutorials/scripting/gdnative/gdnative_cpp_example.rst
+++ b/tutorials/scripting/gdnative/gdnative_cpp_example.rst
@@ -256,7 +256,7 @@ it. However, we do not have to tell Godot about our constructor, destructor and
 The other method of note is our ``_process`` function, which keeps track
 of how much time has passed and calculates a new position for our sprite using a
 sine and cosine function. What stands out is calling
-``owner->set_position`` to call one of the build in methods of our Sprite2D. This
+``owner->set_position`` to call one of the built-in methods of our Sprite2D. This
 is because our class is a container class; ``owner`` points to the actual Sprite2D
 node our script relates to.
 


### PR DESCRIPTION
Changed: "build in" to "built-in"

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
