### PR TITLE
Make the Vulkan SDK note more prominent in Compiling for macOS

### DIFF
--- a/development/compiling/compiling_for_macos.rst
+++ b/development/compiling/compiling_for_macos.rst
@@ -15,10 +15,12 @@ For compiling under macOS, the following is required:
 - `Xcode <https://apps.apple.com/us/app/xcode/id497799835>`_
   (or the more lightweight Command Line Tools for Xcode).
 
-.. important::
+.. warning::
 
     If you are building the ``master`` branch, download and install the
-    `Vulkan SDK for macOS <https://vulkan.lunarg.com/sdk/home>`__.
+    `Vulkan SDK for macOS <https://vulkan.lunarg.com/sdk/home>`__. This
+    is **required** to compile Godot 4.x, as MoltenVK is used to translate Vulkan
+    to Metal (macOS doesn't support Vulkan out of the box).
 
 .. note:: If you have `Homebrew <https://brew.sh/>`_ installed, you can easily
           install SCons using the following command::


### PR DESCRIPTION
`important` in Sphinx is green, but `warning` is yellow, so it's more noticeable.


<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->