### PR TITLE
Define DCCs during its first use in Introduction to 3D

### DIFF
--- a/tutorials/3d/introduction_to_3d.rst
+++ b/tutorials/3d/introduction_to_3d.rst
@@ -40,9 +40,9 @@ scale.
 
 Unlike 2D, where loading image content and drawing is straightforward,
 3D is a little more difficult. The content needs to be created with
-special 3D tools (usually referred to as DCCs) and exported to an
-exchange file format in order to be imported in Godot (3D formats are
-not as standardized as images).
+special 3D tools (usually referred to as Digital Content Creation tools, or
+DCCs) and exported to an exchange file format in order to be imported in
+Godot (3D formats are not as standardized as images).
 
 DCC-created models
 ------------------

--- a/tutorials/3d/introduction_to_3d.rst
+++ b/tutorials/3d/introduction_to_3d.rst
@@ -41,8 +41,8 @@ scale.
 Unlike 2D, where loading image content and drawing is straightforward,
 3D is a little more difficult. The content needs to be created with
 special 3D tools (usually referred to as Digital Content Creation tools, or
-DCCs) and exported to an exchange file format in order to be imported in
-Godot (3D formats are not as standardized as images).
+DCCs) and exported to an exchange file format to be imported in
+Godot. This is required since 3D formats are not as standardized as images.
 
 DCC-created models
 ------------------


### PR DESCRIPTION
When we first introduce an acronym it's important to provide its expanded form or it can be really confusing to somebody who has never heard the term. This is especially important when we then go on to use the acronym several times in the document.
