### PR TITLE
Compiling: Reference `doc_getting_source` in all platform-specific pages

### DIFF
--- a/development/compiling/compiling_for_android.rst
+++ b/development/compiling/compiling_for_android.rst
@@ -35,7 +35,10 @@ For compiling under Windows, Linux or macOS, the following is required:
 
    -  You can download a build from `ojdkbuild <https://github.com/ojdkbuild/ojdkbuild>`_.
 
-.. seealso:: For a general overview of SCons usage for Godot, see
+.. seealso:: To get the Godot source code for compiling, see
+             :ref:`doc_getting_source`.
+
+             For a general overview of SCons usage for Godot, see
              :ref:`doc_introduction_to_the_buildsystem`.
 
 .. _doc_android_setting_up_the_buildsystem:

--- a/development/compiling/compiling_for_ios.rst
+++ b/development/compiling/compiling_for_ios.rst
@@ -18,7 +18,10 @@ If you are building the ``master`` branch:
 -  Download and follow README instructions to build a static ``.a`` library
    from the `MoltenVK SDK <https://github.com/KhronosGroup/MoltenVK#fetching-moltenvk-source-code>`__.
 
-.. seealso:: For a general overview of SCons usage for Godot, see
+.. seealso:: To get the Godot source code for compiling, see
+             :ref:`doc_getting_source`.
+
+             For a general overview of SCons usage for Godot, see
              :ref:`doc_introduction_to_the_buildsystem`.
 
 Compiling

--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -25,7 +25,10 @@ required:
 -  PulseAudio development libraries.
 -  *Optional* - libudev (build with ``udev=yes``).
 
-.. seealso:: For a general overview of SCons usage for Godot, see
+.. seealso:: To get the Godot source code for compiling, see
+             :ref:`doc_getting_source`.
+
+             For a general overview of SCons usage for Godot, see
              :ref:`doc_introduction_to_the_buildsystem`.
 
 Distro-specific one-liners

--- a/development/compiling/compiling_for_macos.rst
+++ b/development/compiling/compiling_for_macos.rst
@@ -36,7 +36,10 @@ For compiling under macOS, the following is required:
 
               sudo port install scons
 
-.. seealso:: For a general overview of SCons usage for Godot, see
+.. seealso:: To get the Godot source code for compiling, see
+             :ref:`doc_getting_source`.
+
+             For a general overview of SCons usage for Godot, see
              :ref:`doc_introduction_to_the_buildsystem`.
 
 Compiling

--- a/development/compiling/compiling_for_uwp.rst
+++ b/development/compiling/compiling_for_uwp.rst
@@ -26,7 +26,10 @@ Requirements
           This page will eventually be updated in the future to reflect
           the new build instructions.
 
-.. seealso:: For a general overview of SCons usage for Godot, see
+.. seealso:: To get the Godot source code for compiling, see
+             :ref:`doc_getting_source`.
+
+             For a general overview of SCons usage for Godot, see
              :ref:`doc_introduction_to_the_buildsystem`.
 
 Compiling

--- a/development/compiling/compiling_for_web.rst
+++ b/development/compiling/compiling_for_web.rst
@@ -14,7 +14,10 @@ To compile export templates for the Web, the following is required:
 -  `Python 3.5+ <https://www.python.org/>`__.
 -  `SCons 3.0+ <https://www.scons.org>`__ build system.
 
-.. seealso:: For a general overview of SCons usage for Godot, see
+.. seealso:: To get the Godot source code for compiling, see
+             :ref:`doc_getting_source`.
+
+             For a general overview of SCons usage for Godot, see
              :ref:`doc_introduction_to_the_buildsystem`.
 
 Building export templates

--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -37,7 +37,10 @@ For compiling under Windows, the following is required:
           For each MSYS2 MinGW subsystem, you should then run
           `pip3 install scons` in its shell.
 
-.. seealso:: For a general overview of SCons usage for Godot, see
+.. seealso:: To get the Godot source code for compiling, see
+             :ref:`doc_getting_source`.
+
+             For a general overview of SCons usage for Godot, see
              :ref:`doc_introduction_to_the_buildsystem`.
 
 Setting up Python
@@ -88,8 +91,7 @@ a **Repair** option, which won't let you install C++ tools.
 Downloading Godot's source
 --------------------------
 
-Godot's source code is `hosted on GitHub <https://github.com/godotengine/godot>`_.
-Downloading it (cloning) using `Git <https://git-scm.com/>`_ is recommended.
+Refer to :ref:`doc_getting_source` for detailed instructions.
 
 The tutorial will assume from now on that you placed the source code in
 ``C:\godot``.


### PR DESCRIPTION
Supersedes #5663.