### PR TITLE
[Net] Change server in the websocket demo.

### DIFF
--- a/tutorials/networking/websocket.rst
+++ b/tutorials/networking/websocket.rst
@@ -37,7 +37,7 @@ This example will show you how to create a WebSocket connection to a remote serv
     extends Node
 
     # The URL we will connect to
-    export var websocket_url = "ws://echo.websocket.org"
+    export var websocket_url = "wss://libwebsockets.org"
 
     # Our WebSocketClient instance
     var _client = WebSocketClient.new()
@@ -53,7 +53,7 @@ This example will show you how to create a WebSocket connection to a remote serv
         _client.data_received.connect(_on_data)
 
         # Initiate connection to the given URL.
-        var err = _client.connect_to_url(websocket_url)
+        var err = _client.connect_to_url(websocket_url, ["lws-mirror-protocol"])
         if err != OK:
             print("Unable to connect")
             set_process(false)


### PR DESCRIPTION
The old server (echo.websocket.org) is no longer active.
The new server (libwebsockets.org) is the demo server of another popular
websocket library (LWS) which we also previously used.

Closes #5460
