### PR TITLE
Fix matrix member to column-major access in Shading language

### DIFF
--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -114,7 +114,7 @@ Individual scalar members of vector types are accessed via the "x", "y", "z" and
 "w" members. Alternatively, using "r", "g", "b" and "a" also works and is
 equivalent. Use whatever fits best for your needs.
 
-For matrices, use the ``m[row][column]`` indexing syntax to access each scalar,
+For matrices, use the ``m[column][row]`` indexing syntax to access each scalar,
 or ``m[idx]`` to access a vector by row index. For example, for accessing the y
 position of an object in a mat4 you use ``m[3][1]``.
 


### PR DESCRIPTION
GLSL and Godot matrices are column major:

```
m[column][row]

m[0][0] m[1][0] m[2][0] m[3][0]
m[0][1] m[1][1] m[2][1] m[3][1]
m[0][2] m[1][2] m[2][2] m[3][2]
m[0][3] m[1][3] m[2][3] m[3][3]
```

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
