### PR TITLE
Open editor with a script

### DIFF
--- a/tutorials/editor/external_editor.rst
+++ b/tutorials/editor/external_editor.rst
@@ -57,3 +57,130 @@ We have official plugins for the following code editors:
 
 - `Visual Studio Code <https://github.com/godotengine/godot-vscode-plugin>`_
 - `Emacs <https://github.com/godotengine/emacs-gdscript-mode>`_
+
+Open editor with a script
+-------------------------
+
+For advanced behavior a script can be used to open the
+external editor. The location of the script should be in a global directory.
+
+For Unix the script with a `Shebang <https://en.wikipedia.org/wiki/Shebang_(Unix)>`__
+replaces the executable path. For Windows the script interpreter replaces the executable path
+and additionally the command-line flags contain the location of the script.
+
+The following example opens a Visual Studio Code workspace if available.
+
+.. tabs::
+ .. code-tab:: python
+
+    #!/usr/bin/env python3
+
+    # Use vsCode as External Editor for Godot
+    #
+    # Settings to edit ( <...> must be replaced )
+    #  - Unix
+    #    - Exec Path  : <location-of-this-file> 
+    #    - Exec FLags : {project} {file} {line} {col}
+    #  - Windows
+    #    - Exec Path  : <python-executable>
+    #    - Exec Flags : <location-of-this-file> {project} {file} {line} {col}
+
+    import os
+    import shutil
+    import sys
+
+    # remove script location from args
+    args = sys.argv[1:]
+
+    # find vsCode workspace in project directory
+    path = args[0]
+    for filename in os.listdir(path):
+        if filename.endswith(".code-workspace"):
+            path = path + "/" + filename
+            break
+
+    # change this process to an instance of vsCode
+    code = shutil.which("code")
+    os.execl(code, "\""+code+"\"", "-g", path, args[1]+":"+args[2]+":"+args[3])
+
+ .. code-tab:: javascript Javascript (Node)
+
+    #!/usr/bin/env node
+
+    /**
+    * Use vsCode as External Editor for Godot
+    * 
+    * Settings to edit( <...> must be replaced )
+    * - Unix
+    *   - Exec Path: <location-of-this-file>
+    *   - Exec FLags : {project} {file} {line} {col}
+    * - Windows
+    *   - Exec Path  : <node-executable>
+    *   - Exec Flags : <location-of-this-file> {project} {file} {line} {col}
+    */
+
+    const cp = require('child_process')
+    const fs = require("fs")
+
+    //remove node and script location from args
+    const args = process.argv.splice(2)
+
+    //find vsCode workspace in project directory
+    let path = args[0]
+    const files = fs.readdirSync(path)
+    for (let i = 0; i < files.length; i++) {
+        const file = files[i]
+        if (file.endsWith(".code-workspace")) {
+            path = path + "/" + file
+        }
+    }
+
+    //start vsCode in separate process
+    cp.exec("code -g " + path + " " + args[1] + ":" + args[2] + ":" + args[3])
+
+
+ .. code-tab:: typescript Typescript (Deno)
+
+    #!/usr/bin/env -S deno run --allow-read --allow-run
+
+    /**
+    * Use vsCode as External Editor for Godot
+    * 
+    * Settings to edit( <...> must be replaced )
+    * - Unix
+    *   - Exec Path: <location-of-this-file>
+    *   - Exec FLags : {project} {file} {line} {col}
+    * - Windows
+    *   - Exec Path  : <deno-executable>
+    *   - Exec Flags : run --allow-read --allow-run <location-of-this-file>
+    *                               {project} {file} {line} {col}
+    */
+
+    const args = Deno.args
+
+    //find vsCode workspace in project directory
+    let path = args[0]
+    for await (const entry of Deno.readDir(path)) {
+        if (entry.isFile && entry.name.endsWith(".code-workspace")) {
+            path = path + "/" + entry.name
+        }
+    }
+
+    //get correct vsCode name
+    let code: string
+    switch (Deno.build.os) {
+        case "windows":
+            code = "code.cmd";
+            break;
+        case "linux":
+        case "darwin":
+            code = "code"
+            break;
+    }
+
+    //start vsCode in separate process
+    await Deno.run({
+        cmd: [code, path, "-g", args[1] + ":" + args[2] + ":" + args[3]],
+    }).status()
+
+::


### PR DESCRIPTION
[Closed Related Proposal #4476](https://github.com/godotengine/godot-proposals/issues/4476)

Use a scripting language to start the external editor (or anything else).

The script (and shebang behavior) is not tested on linux and macOS.