### PR TITLE
Fix typo: "intantiated" -> "instantiated"

### DIFF
--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -224,7 +224,7 @@ We need to do two operations to connect the nodes via code:
           method of the node you want to listen to. In this case, we want to
           listen to the Timer's "timeout" signal.
 
-We want to connect the signal when the scene is intantiated, and we can do that
+We want to connect the signal when the scene is instantiated, and we can do that
 using the :ref:`Node._ready() <class_Node_method__ready>` built-in function,
 which is called automatically by the engine when a node is fully instantiated.
 


### PR DESCRIPTION
There is 1 instance of the word "intantiated" - this PR will correct the spelling of this word.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
