### PR TITLE
Document that autoloads must not be freed to avoid crashes

### DIFF
--- a/tutorials/scripting/singletons_autoload.rst
+++ b/tutorials/scripting/singletons_autoload.rst
@@ -99,6 +99,11 @@ you'll see the autoloaded nodes appear:
 
 .. image:: img/autoload_runtime.png
 
+.. warning::
+
+    Autoloads must **not** be removed using ``free()`` or ``queue_free()`` at
+    runtime, or the engine will crash.
+
 Custom scene switcher
 ---------------------
 


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/36310.

We may also want to add a check in debug builds when freeing a node. It would check whether it's an autoload, and if so, print a warning message and prevent freeing the node to avoid a crash.