### PR TITLE
Remove mentions of PVRTC texture compression in the documentation

### DIFF
--- a/tutorials/assets_pipeline/importing_images.rst
+++ b/tutorials/assets_pipeline/importing_images.rst
@@ -83,7 +83,7 @@ advantages and disadvantages (|good| = best, |bad| = worst):
 +----------------+------------------------+-------------------------------+----------------------+------------------------------------------------------+
 |                | Uncompressed           | Compress Lossless             | Compress Lossy       | Compress VRAM                                        |
 +================+========================+===============================+======================+======================================================+
-| Description    | Stored as raw pixels   | Stored as Lossless WebP / PNG | Stored as Lossy WebP | Stored as S3TC/BC or PVRTC/ETC depending on platform |
+| Description    | Stored as raw pixels   | Stored as Lossless WebP / PNG | Stored as Lossy WebP | Stored as S3TC, BPTC or ETC2 depending on platform   |
 +----------------+------------------------+-------------------------------+----------------------+------------------------------------------------------+
 | Size on Disk   | |bad| Large            | |regular| Small               | |good| Very Small    | |regular| Small                                      |
 +----------------+------------------------+-------------------------------+----------------------+------------------------------------------------------+

--- a/tutorials/export/exporting_projects.rst
+++ b/tutorials/export/exporting_projects.rst
@@ -51,8 +51,7 @@ There is also another problem with this approach: different devices
 prefer some data in different formats to run. The main example of this
 is texture compression. All PC hardware uses S3TC (BC) compression and
 that has been standardized for more than a decade, but mobile devices
-use different formats for texture compression, such as PVRTC (iOS) or
-ETC (Android).
+use different formats for texture compression, such as ETC1 and ETC2.
 
 Export menu
 -----------

--- a/tutorials/export/feature_tags.rst
+++ b/tutorials/export/feature_tags.rst
@@ -85,8 +85,6 @@ Here is a list of most feature tags in Godot. Keep in mind they are **case-sensi
 +-----------------+--------------------------------------------------------+
 | **s3tc**        | Textures using S3TC (DXT/BC) compression are supported |
 +-----------------+--------------------------------------------------------+
-| **pvrtc**       | Textures using PVRTC compression are supported         |
-+-----------------+--------------------------------------------------------+
 
 Custom features
 ---------------


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot-docs/pull/5816.

[Support for PVRTC was removed in 4.0alpha.](https://github.com/godotengine/godot-proposals/issues/3688)