### PR TITLE
Add exit condition to prevent thread from hanging in resource_queue.gd

### DIFF
--- a/tutorials/io/files/resource_queue.gd
+++ b/tutorials/io/files/resource_queue.gd
@@ -3,7 +3,7 @@ extends Node
 var thread
 var mutex
 var semaphore
-var exit_thread := false
+var exit_thread = false
 
 var time_max = 100 # Milliseconds.
 

--- a/tutorials/io/files/resource_queue.gd
+++ b/tutorials/io/files/resource_queue.gd
@@ -1,6 +1,9 @@
+extends Node
+
 var thread
 var mutex
-var sem
+var semaphore
+var exit_thread := false
 
 var time_max = 100 # Milliseconds.
 
@@ -16,11 +19,11 @@ func _unlock(_caller):
 
 
 func _post(_caller):
-	sem.post()
+	semaphore.post()
 
 
 func _wait(_caller):
-	sem.wait()
+	semaphore.wait()
 
 
 func queue_resource(path, p_in_front = false):
@@ -135,11 +138,29 @@ func thread_process():
 
 func thread_func(_u):
 	while true:
+		mutex.lock()
+		var should_exit = exit_thread # Protect with Mutex.
+		mutex.unlock()
+
+		if should_exit:
+			break
 		thread_process()
 
 
 func start():
 	mutex = Mutex.new()
-	sem = Semaphore.new()
+	semaphore = Semaphore.new()
 	thread = Thread.new()
 	thread.start(self, "thread_func", 0)
+
+# Triggered by calling "get_tree().quit()".
+func _exit_tree():
+	mutex.lock()
+	exit_thread = true # Protect with Mutex.
+	mutex.unlock()
+
+	# Unblock by posting.
+	semaphore.post()
+
+	# Wait until it exits.
+	thread.wait_to_finish()


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->

The existing `resource_queue.gd` example present in the stable documentation (and used in @BastiaanOlij's video [Godot background loading](https://youtu.be/1oeOwPJ1XHM)) prevents your game from exiting when you call `get_tree().quit()`, because the created thread keeps on hanging after that.

The example provided in the page [Using multiple threads](https://docs.godotengine.org/en/stable/tutorials/performance/threads/using_multiple_threads.html#semaphores) provides an exit condition to the thread, which I have added to the `resource_queue.gd` example (which is the one people trying to figure out background loading will end up looking at).

I also added an `extends Node` to the beginning of the script so it can be used in autoload by default and renamed variable `sem` to `semaphore` for clarity and to keep it consistent with the "Using multiple threads" example.