### PR TITLE
Fix class name : change "string" to "String"

### DIFF
--- a/classes/class_dictionary.rst
+++ b/classes/class_dictionary.rst
@@ -67,7 +67,7 @@ You can access a dictionary's values by referencing the appropriate key. In the 
 
  .. code-tab:: gdscript
 
-    export(string, "White", "Yellow", "Orange") var my_color
+    export(String, "White", "Yellow", "Orange") var my_color
     var points_dict = {"White": 50, "Yellow": 75, "Orange": 100}
     func _ready():
         # We can't use dot syntax here as `my_color` is a variable.


### PR DESCRIPTION
Change case of "s" letter : "string" does not compile but "String" does (for gdScript)

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
