### PR TITLE
Add missing Navigation category

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -102,6 +102,7 @@ The main documentation for the site is organized into the following sections:
    tutorials/inputs/index
    tutorials/io/index
    tutorials/math/index
+   tutorials/navigation/index
    tutorials/networking/index
    tutorials/performance/index
    tutorials/physics/index

--- a/tutorials/navigation/index.rst
+++ b/tutorials/navigation/index.rst
@@ -1,3 +1,6 @@
+Navigation
+==========
+
 .. toctree::
    :maxdepth: 1
    :name: toc-learn-features-navigation


### PR DESCRIPTION
Add missing Navigation category.

I was looking for the Navigation category that exists in Godot 3.5 doc for the new NavigationServer.
I could not find it for Godot 4.0 but the doc page still exists so I guess not adding it to the main menu was just an oversight?

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
