### PR TITLE
Fix C# connect signal for 3.x

### DIFF
--- a/tutorials/plugins/editor/inspector_plugins.rst
+++ b/tutorials/plugins/editor/inspector_plugins.rst
@@ -264,7 +264,7 @@ followed by ``set_bottom_editor()`` to position it below the name.
             AddFocusable(_propertyControl);
             // Setup the initial state and connect to the signal to track changes.
             RefreshControlText();
-            _propertyControl.Pressed += OnButtonPressed;
+            _propertyControl.Connect("pressed", this, nameof(OnButtonPressed));
         }
 
         private void OnButtonPressed()


### PR DESCRIPTION
Follow-up to #5829

Sorry, I should have added a note for cherry-picking in my review. The connect syntax used in the C# example is only available in 4.0 so this PR uses the right syntax in 3.x.