### PR TITLE
Always point to latest Pyston release

### DIFF
--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -266,7 +266,7 @@ only compatible with Linux. Pyston can speed up incremental builds significantly
 often by a factor between 1.5× and 2×. Pyston can be combined with Clang and LLD
 to get even faster builds.
 
-- Download the `latest portable Pyston release <https://github.com/pyston/pyston/releases/tag/pyston_2.3.2>`__.
+- Download the `latest portable Pyston release <https://github.com/pyston/pyston/releases/latest>`__.
 - Extract the portable ``.tar.gz`` to a set location, such as ``$HOME/.local/opt/pyston/`` (create folders as needed).
 - Use ``cd`` to reach the extracted Pyston folder from a terminal,
   then run ``./pyston -m pip install scons`` to install SCons within Pyston.


### PR DESCRIPTION
Hi
I'm one of the Pyston developers and noticed that godot is mentioning it in the docs for speeding up SCons.
We just had a new release (2.3.4) which slightly improves the incremental build time on my machine.
I think it makes sense to change the link to always point to our latest release.
Thanks