### PR TITLE
added info on microphone sample format

### DIFF
--- a/classes/class_audioeffectcapture.rst
+++ b/classes/class_audioeffectcapture.rst
@@ -18,7 +18,7 @@ Description
 
 AudioEffectCapture is an AudioEffect which copies all audio frames from the attached audio effect bus into its internal ring buffer.
 
-Application code should consume these audio frames from this ring buffer using :ref:`get_buffer<class_AudioEffectCapture_method_get_buffer>` and process it as needed, for example to capture data from a microphone, implement application defined effects, or to transmit audio over the network.
+Application code should consume these audio frames from this ring buffer using :ref:`get_buffer<class_AudioEffectCapture_method_get_buffer>` and process it as needed, for example to capture data from a microphone, implement application defined effects, or to transmit audio over the network. When capturing audio data from a microphone, the format of the samples will be 32-bit floating point PCM.
 
 Properties
 ----------

--- a/classes/class_audioeffectcapture.rst
+++ b/classes/class_audioeffectcapture.rst
@@ -18,7 +18,7 @@ Description
 
 AudioEffectCapture is an AudioEffect which copies all audio frames from the attached audio effect bus into its internal ring buffer.
 
-Application code should consume these audio frames from this ring buffer using :ref:`get_buffer<class_AudioEffectCapture_method_get_buffer>` and process it as needed, for example to capture data from a microphone, implement application defined effects, or to transmit audio over the network. When capturing audio data from a microphone, the format of the samples will be 32-bit floating point PCM.
+Application code should consume these audio frames from this ring buffer using :ref:`get_buffer<class_AudioEffectCapture_method_get_buffer>` and process it as needed, for example to capture data from a microphone, implement application defined effects, or to transmit audio over the network. When capturing audio data from a microphone, the format of the samples will be stereo 32-bit floating point PCM.
 
 Properties
 ----------


### PR DESCRIPTION
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->

After some discussions on Discord, it seems reasonable to add this info to the documentation. While `AudioStreamSample` has a `get_format` method, `AudioStreamMicrophone` does not, and empirically I found that the sample format was 32-bit floating point PCM. I believe that this is also consistent with what I am reading in the code here:

permalink off master: https://github.com/godotengine/godot/blob/d120b099f528673fb6aebaa5d9cff0fa91a774d0/servers/audio/audio_stream.cpp#L269

I find this information useful as I have been using `AudioEffectCapture` to stream raw audio from the microphone to ASR services for speech-enhanced games, and while the use-cases which require this low-level sample format knowledge might be limited, this is at least one use-case.

(P.S. This is the first PR I've ever made to an open source repo, so I apologize if I'm not doing it right...)