### PR TITLE
Improve side-aligned image positioning

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -217,6 +217,7 @@ legend,
     font-weight: 500;
 }
 
+/* See <https://github.com/godotengine/godot-docs/pull/5876> for context. */
 .rst-content .align-right,
 .rst-content .align-left {
 	clear: both;

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -217,6 +217,11 @@ legend,
     font-weight: 500;
 }
 
+.rst-content .align-right,
+.rst-content .align-left {
+	clear: both;
+}
+
 .rst-content div.figure p.caption {
     /* Tweak caption styling to be closer to typical captions */
     text-align: center;


### PR DESCRIPTION
This PR improves how images are displayed when they are left- or right-aligned and are closely following other similarly aligned images.

Images that are aligned to either side have their CSS `float` property set to either `left` or `right`. Text floats around them. A problem may arise if there is not enough text between two such images to fully fill out the space between. In that case, the second image will be placed next to the other image and somewhat below it. See the **Before** example below. This is how `float` behaves.

To prevent this, CSS provides the `clear` property. If set, floating elements will not be placed next to other floating elements depending on which `clear` value is set. Options are `left`, `right`, and `both`. This PR uses the latter to make sure that all floating images appear below each other and never next to each other. See the **After** example below.

## Before:
![before](https://user-images.githubusercontent.com/8700280/173671608-ce3b9fce-6a6c-4568-a405-71dde496f758.png)

## After:
![after](https://user-images.githubusercontent.com/8700280/173671623-cec55cbc-5416-4c3e-862a-6f7753b790d3.PNG)
