### PR TITLE
Fix `websocket_url` on the minimal WebSocket client example

### DIFF
--- a/tutorials/networking/websocket.rst
+++ b/tutorials/networking/websocket.rst
@@ -53,7 +53,7 @@ This example will show you how to create a WebSocket connection to a remote serv
         _client.connect("data_received", self, "_on_data")
 
         # Initiate connection to the given URL.
-        var err = _client.connect_to_url(websocket_url)
+        var err = _client.connect_to_url(websocket_url, ["lws-mirror-protocol"])
         if err != OK:
             print("Unable to connect")
             set_process(false)

--- a/tutorials/networking/websocket.rst
+++ b/tutorials/networking/websocket.rst
@@ -37,7 +37,7 @@ This example will show you how to create a WebSocket connection to a remote serv
     extends Node
 
     # The URL we will connect to
-    export var websocket_url = "ws://echo.websocket.org"
+    export var websocket_url = ""wss://libwebsockets.org""
 
     # Our WebSocketClient instance
     var _client = WebSocketClient.new()

--- a/tutorials/networking/websocket.rst
+++ b/tutorials/networking/websocket.rst
@@ -37,7 +37,7 @@ This example will show you how to create a WebSocket connection to a remote serv
     extends Node
 
     # The URL we will connect to
-    export var websocket_url = ""wss://libwebsockets.org""
+    export var websocket_url = "wss://libwebsockets.org"
 
     # Our WebSocketClient instance
     var _client = WebSocketClient.new()


### PR DESCRIPTION
The current URL on the "Minimal Client Example" is no longer functional and needs to be updated to a working one.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
