### PR TITLE
added gcc-c++ in opensuse one-liners

### DIFF
--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -84,7 +84,7 @@ Distro-specific one-liners
 | **openSUSE**     | ::                                                                                                        |
 |                  |                                                                                                           |
 |                  |     sudo zypper install scons pkgconfig libX11-devel libXcursor-devel libXrandr-devel libXinerama-devel \ |
-|                  |             libXi-devel Mesa-libGL-devel alsa-devel libpulse-devel libudev-devel libGLU1                  |
+|                  |             libXi-devel Mesa-libGL-devel alsa-devel libpulse-devel libudev-devel gcc-c++ libGLU1          |
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **NetBSD**       | ::                                                                                                        |
 |                  |                                                                                                           |


### PR DESCRIPTION
this can solve an issue while compiling "g++ not found"

this can solve [issue](https://forums.opensuse.org/showthread.php/451945-bin-sh-g-command-not-found)