### PR TITLE
Update required NDK version (3.5)

### DIFF
--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -28,7 +28,7 @@ Download and install the Android SDK.
     - Android SDK Platform 29
     - Android SDK Command-line Tools (latest)
     - CMake version 3.10.2.4988404
-    - NDK version 21.4.7075529
+    - NDK version r23c (23.2.8568313)
 
 - You can install it using the `command line tools <https://developer.android.com/studio/#command-tools>`__.
 


### PR DESCRIPTION
The required NDK version was recently updated [here](https://github.com/godotengine/godot/pull/61692) for the 3.x branch, and this change made it into the latest RC for 3.5. @Calinou I believe you've done android work before for the docs, is it okay to list the version as `r32c` and not `23.2.8568313`?

I'll make a master branch version of this PR once this is merged.
