### PR TITLE
Improved title of 3d_text.rst for descriptive navigation

### DIFF
--- a/tutorials/3d/3d_text.rst
+++ b/tutorials/3d/3d_text.rst
@@ -1,7 +1,10 @@
 .. _doc_3d_text:
 
+3D text
+=======
+
 Introduction
-============
+------------
 
 In a project there may be times when text needs to be created as
 part of a 3D scene and not just in the HUD. Godot provides two

--- a/tutorials/3d/3d_text.rst
+++ b/tutorials/3d/3d_text.rst
@@ -6,7 +6,7 @@
 Introduction
 ------------
 
-In a project there may be times when text needs to be created as
+In a project, there may be times when text needs to be created as
 part of a 3D scene and not just in the HUD. Godot provides two
 methods to do this. The Label3D node and the text mesh for a
 MeshInstance3D node.


### PR DESCRIPTION
Previously, it displayed as "Introduction" under the 3D tab, making it incredibly unclear what the page was actually about. If I understand ReadTheDocs generation of the menu correctly, this will give it a much clearer and more descriptive name of "3D text" in the navigation menu.
I based my exact title on the format of the "3D lights and shadows" documentation title, figuring it was the closest in content type to what is included in the 3D Text documentation.