### PR TITLE
Compiling/macOS: Replace old `use_static_mvk` option with `use_volk`

### DIFF
--- a/development/compiling/compiling_for_macos.rst
+++ b/development/compiling/compiling_for_macos.rst
@@ -86,9 +86,10 @@ editor binary built with ``target=release_debug``::
 .. note::
 
     If you are building the ``master`` branch, you also need to include support
-    for the MoltenVK Vulkan portability library. You can do so either by
-    building it statically with ``use_static_mvk=yes``, or by including the
-    dynamic library in your ``.app`` bundle::
+    for the MoltenVK Vulkan portability library. By default, it will be linked
+    statically from your installation of the Vulkan SDK for macOS.
+    You can also choose to link it dynamically by passing ``use_volk=yes`` and
+    including the dynamic library in your ``.app`` bundle::
 
         mkdir -p Godot.app/Contents/Frameworks
         cp <Vulkan SDK path>/macOS/lib/libMoltenVK.dylib Godot.app/Contents/Frameworks/libMoltenVK.dylib
@@ -154,9 +155,10 @@ with the following commands (assuming a universal build, otherwise replace the
 .. note::
 
     If you are building the ``master`` branch, you also need to include support
-    for the MoltenVK Vulkan portability library. You can do so either by
-    building it statically with ``use_static_mvk=yes``, or by including the
-    dynamic library in your ``.app`` bundle::
+    for the MoltenVK Vulkan portability library. By default, it will be linked
+    statically from your installation of the Vulkan SDK for macOS.
+    You can also choose to link it dynamically by passing ``use_volk=yes`` and
+    including the dynamic library in your ``.app`` bundle::
 
         mkdir -p osx_template.app/Contents/Frameworks
         cp <Vulkan SDK path>/macOS/libs/libMoltenVK.dylib osx_template.app/Contents/Frameworks/libMoltenVK.dylib


### PR DESCRIPTION
The semantics are a bit awkward IMO as we're telling users to disable an option to enable static linking. This also comes a bit late so it's likely users already compiled with previous commands and then need to redo it with `use_volk=no` to have a portable .app.

I would suggest making `use_volk=no` the default for macOS, and document instead that `use_volk=yes` can be used to enable dynamic linking if wanted (which requires bundling the lib in the .app, or having the Vulkan SDK installed on the user machine). One potential drawback though is that it might take longer to link which might be annoying for macOS contributors doing debug builds. CC @bruvzg 

This PR can be merged as is anyway as it fixes an outdated bit of documentation, the above is just for discussion for further rework.