### PR TITLE
Fix inline code display in GDScript reference

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -715,7 +715,7 @@ Signals are better used by getting them from actual objects, e.g. ``$Button.butt
 Contains an object and a function, which is useful for passing functions as
 values (e.g. when connecting to signals).
 
-Getting a method as a member returns a callable.``var x = $Sprite2D.rotate``
+Getting a method as a member returns a callable. ``var x = $Sprite2D.rotate``
 will set the value of ``x`` to a callable with ``$Sprite2D`` as the object and
 ``rotate`` as the method.
 


### PR DESCRIPTION
Fix missing spaces, display exception.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
