### PR TITLE
Change C++ animation name for consistency in Your first 2D game

### DIFF
--- a/getting_started/first_2d_game/03.coding_the_player.rst
+++ b/getting_started/first_2d_game/03.coding_the_player.rst
@@ -361,7 +361,7 @@ movement. Let's place this code at the end of the ``_process()`` function:
  .. code-tab:: cpp
 
         if (velocity.x != 0) {
-            _animated_sprite->set_animation("right");
+            _animated_sprite->set_animation("walk");
             _animated_sprite->set_flip_v(false);
             // See the note below about boolean assignment.
             _animated_sprite->set_flip_h(velocity.x < 0);


### PR DESCRIPTION
Change C++ animation title for left/right movement from "right" to "walk" to be consistent with the rest of the tutorial.
