### PR TITLE
Add the top navigation bar

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1093,3 +1093,29 @@ kbd.compound > .kbd,
     border-left-color: var(--code-example-bad-color);
     border-left-width: 8px;
 }
+
+/* Top-level navigation. */
+.godot-menu-top {
+    border-bottom: 1px solid var(--hr-color);
+    margin: 0 -8px 16px -8px;
+    padding-bottom: 8px;
+}
+
+.godot-menu-top ul {
+    display: flex;
+    justify-content: space-between;
+}
+
+.godot-menu-top li {
+    padding: 8px 12px;
+}
+
+.godot-menu-top li a::before {
+    display: none;
+}
+
+@media screen and (max-width: 900px) {
+    .godot-menu-top {
+        display: none;
+    }
+}

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -22,3 +22,20 @@
 {% block htmltitle -%}
 <title>{{ godot_title_prefix }}{{ title|striptags|e }}{{ titlesuffix }}</title>
 {% endblock -%}
+
+{% block content -%}
+<div class="godot-menu-top">
+  <ul>
+    <li><a href="/about/index.html">About</a></li>
+    <li><a href="/getting_started/index.html">Getting Started</a></li>
+    <li><a href="/tutorials/index.html">Tutorials</a></li>
+    <li><a href="/development/index.html">Development</a></li>
+    <li><a href="/community/index.html">Community</a></li>
+    <li><a href="/classes/index.html">Class Reference</a></li>
+  </ul>
+</div>
+
+{{ super() }}
+{% endblock -%}
+
+


### PR DESCRIPTION
So I made this thing...

![image](https://user-images.githubusercontent.com/11782833/179579252-fb7a1ffd-c4bc-4469-832b-b656a9afcfe3.png)

_(The learn how to contribute thing is from https://github.com/godotengine/godot-docs/pull/5947, unrelated)._

I got rather annoyed having to scroll through the side bar every time I need to find something. Using the search is slow and unreliable, so browsing the sidebar is usually faster. But it's still a sidebar, tiny and constricted. So I thought that maybe we could have top navigation for sections. And so I made it. It's not even hacky, as editing and extending templates is supported by RTD and Sphinx.

However, I'm not sure it is useful in the end. First of all, most of those links lead nowhere... We just don't have landing pages for sections as there is no normal way to navigate there. If we did have them, we don't really have any content for them, other than tables of content. And putting TOCs there makes them hardly any more useful than the sidebar.

So, maybe we could actually create interesting landings for those sections, add some nice looking blocks for tutorial categories, add descriptions? This PR covers the technical part of adding the navigations, so it's only a matter of coming up with what content we can push there.

Marking this as draft as I'm not certain about this feature yet, but I'd like to use this PR for discussion.