### PR TITLE
Documentation missing method keyword in C# fix

### DIFF
--- a/tutorials/scripting/nodes_and_scene_instances.rst
+++ b/tutorials/scripting/nodes_and_scene_instances.rst
@@ -216,7 +216,7 @@ as a child of your current node.
 
  .. code-tab:: csharp
 
-    var instance = scene.();
+    var instance = scene.Instance();
     AddChild(instance);
 
 The advantage of this two-step process is you can keep a packed scene loaded and


### PR DESCRIPTION
### Description
line 219 missing "Instance" after "scene."

### Issue
https://github.com/godotengine/godot-docs/issues/5942

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
