### PR TITLE
Remove obsolete C# methods from Using RigidBody2D

### DIFF
--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -293,16 +293,16 @@ For example, here is the code for an "Asteroids" style spaceship:
         public override void _IntegrateForces(Physics2DDirectBodyState state)
         {
             if (Input.IsActionPressed("ui_up"))
-                SetAppliedForce(_thrust.Rotated(Rotation));
+                AppliedForce = _thrust.Rotated(Rotation);
             else
-                SetAppliedForce(new Vector2());
+                AppliedForce = new Vector2();
 
             var rotationDir = 0;
             if (Input.IsActionPressed("ui_right"))
                 rotationDir += 1;
             if (Input.IsActionPressed("ui_left"))
                 rotationDir -= 1;
-            SetAppliedTorque(rotationDir * _torque);
+            AppliedTorque = rotationDir * _torque;
         }
     }
 


### PR DESCRIPTION
`SetAppliedForce` and `SetAppliedTorque` have been deprecated in favor of the `AppliedForce` and `AppliedTorque` setters but the Physics Introduction still referenced them in the C# code snippet.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
