### PR TITLE
Increase spacing between list items to improve readability

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -251,6 +251,12 @@ article ol,
     line-height: 25px;
 }
 
+.rst-content section ul li {
+    /* Increase spacing between list items. */
+    margin-top: 8px;
+    margin-bottom: 8px;
+}
+
 body,
 .rst-content table.docutils thead {
     color: var(--body-color);


### PR DESCRIPTION
The spacing may be a bit high for single-line items, but it's definitely welcome for multi-line items.

## Preview

*Part of https://github.com/Calinou/godot-docs/tree/revamp-gi-docs, which uses a lot of lists like those.*

Before | After
-|-
![2022-07-20_01 11 56](https://user-images.githubusercontent.com/180032/179863706-3020326a-6eba-45ca-8a54-7d1f0ed7f307.png) | ![image](https://user-images.githubusercontent.com/180032/180030732-b316e9ca-518e-4760-ab47-9688076d3017.png)
