### PR TITLE
Rename OSX to macOS and iPhoneOS to iOS. Update iOS build instructions.

### DIFF
--- a/community/contributing/bisecting_regressions.rst
+++ b/community/contributing/bisecting_regressions.rst
@@ -106,7 +106,7 @@ Compile Godot. This assumes you've set up a build environment:
 .. code-block:: shell
 
     # <platform> is the platform you're targeting for regression testing,
-    # like "windows", "x11" or "osx".
+    # like "windows", "x11" or "macos".
     $ scons platform=<platform> -j4
 
 Since building Godot takes a while, you want to dedicate as many CPU threads as

--- a/development/compiling/compiling_for_ios.rst
+++ b/development/compiling/compiling_for_ios.rst
@@ -20,7 +20,7 @@ Requirements
 
 If you are building the ``master`` branch:
 
--  Download and follow README instructions to build a static ``.a`` library
+-  Download and follow README instructions to build a static ``.xcframework``
    from the `MoltenVK SDK <https://github.com/KhronosGroup/MoltenVK#fetching-moltenvk-source-code>`__.
 
 .. seealso:: To get the Godot source code for compiling, see
@@ -36,56 +36,42 @@ Open a Terminal, go to the root dir of the engine source code and type:
 
 ::
 
-    $ scons p=iphone target=debug
+    $ scons p=ios target=debug
 
 for a debug build, or:
 
 ::
 
-    $ scons p=iphone target=release
+    $ scons p=ios target=release
 
-for a release build (check ``platform/iphone/detect.py`` for the compiler
+for a release build (check ``platform/ios/detect.py`` for the compiler
 flags used for each configuration).
 
 Alternatively, you can run
 
 ::
 
-    $ scons p=iphone arch=x86_64 target=debug
+    $ scons p=ios target=debug ios_simulator=yes arch=x86_64
+    $ scons p=ios target=debug ios_simulator=yes arch=arm64
 
-for a Simulator executable.
+for a Simulator libraries.
 
-For recent devices, Apple requires 64-bit versions of application binaries when you are uploading to the Apple Store.
-The best way to provide these is to create a bundle in which there are both 32-bit and 64-bit binaries, so every device will be able to run the game.
-
-It can be done in three steps: first compile the 32-bit version, then compile the 64-bit version and then use ``lipo`` to bundle them into one "universal" binary.
-All those steps can be performed with following commands:
-
-::
-
-    $ scons p=iphone tools=no target=release arch=arm
-    $ scons p=iphone tools=no target=release arch=arm64
-    $ lipo -create bin/libgodot.iphone.opt.arm.a bin/libgodot.iphone.opt.arm64.a -output bin/libgodot.iphone.release.fat.a
-    $ lipo -create bin/libgodot_camera_module.iphone.opt.arm.a bin/libgodot_camera_module.iphone.opt.arm64.a -output bin/libgodot_camera_module.iphone.release.fat.a
-    $ lipo -create bin/libgodot_arkit_module.iphone.opt.arm.a bin/libgodot_arkit_module.iphone.opt.arm64.a -output bin/libgodot_arkit_module.iphone.release.fat.a
-
-If you also want to provide a simulator build (reduces the chance of any linker errors with dependencies), you'll need to build and lipo the ``x86_64`` architecture as well.
+To create an Xcode project like in the official builds, you need to use the
+template located in ``misc/dist/ios_xcode``. The release and debug libraries
+should be placed in ``libgodot.ios.debug.xcframework`` and ``libgodot.ios.release.xcframework`` respectively.
 
 ::
 
-    $ scons p=iphone tools=no target=release arch=arm
-    $ scons p=iphone tools=no target=release arch=arm64
-    $ scons p=iphone tools=no target=release arch=x86_64
-    $ lipo -create bin/libgodot.iphone.opt.arm.a bin/libgodot.iphone.opt.arm64.a bin/libgodot.iphone.opt.x86_64.a -output bin/libgodot.iphone.release.fat.a
-    $ lipo -create bin/libgodot_camera_module.iphone.opt.arm.a bin/libgodot_camera_module.iphone.opt.arm64.a bin/libgodot_camera_module.iphone.opt.x86_64.a -output bin/libgodot_camera_module.iphone.release.fat.a
-    $ lipo -create bin/libgodot_arkit_module.iphone.opt.arm.a bin/libgodot_arkit_module.iphone.opt.arm64.a bin/libgodot_arkit_module.iphone.opt.x86_64.a -output bin/libgodot_arkit_module.iphone.release.fat.a
+    $ cp -r misc/dist/ios_xcode .
+
+    $ cp libgodot.ios.debug.arm64.a ios_xcode/libgodot.ios.debug.xcframework/ios-arm64/libgodot.a
+    $ lipo -create libgodot.ios.debug.arm64.simulator.a libgodot.ios.debug.x86_64.simulator.a -output ios_xcode/libgodot.ios.debug.xcframework/ios-arm64_x86_64-simulator/libgodot.a
+
+    $ cp libgodot.ios.opt.arm64.a ios_xcode/libgodot.ios.release.xcframework/ios-arm64/libgodot.a
+    $ lipo -create libgodot.ios.opt.arm64.simulator.a libgodot.ios.opt.x86_64.simulator.a -output  ios_xcode/libgodot.ios.release.xcframework/ios-arm64_x86_64-simulator/libgodot.a
 
 Run
 ---
 
 To run on a device or simulator, follow these instructions:
 :ref:`doc_exporting_for_ios`.
-
-Replace or add your executable to the Xcode project, and change the
-"executable name" property on Info.plist accordingly if you use an
-alternative build.

--- a/development/compiling/compiling_for_macos.rst
+++ b/development/compiling/compiling_for_macos.rst
@@ -54,15 +54,15 @@ Start a terminal, go to the root directory of the engine source code.
 
 To compile for Intel (x86-64) powered Macs, use::
 
-    scons platform=osx arch=x86_64 --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=macos arch=x86_64 --jobs=$(sysctl -n hw.logicalcpu)
 
 To compile for Apple Silicon (ARM64) powered Macs, use::
 
-    scons platform=osx arch=arm64 --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=macos arch=arm64 --jobs=$(sysctl -n hw.logicalcpu)
 
 To support both architectures in a single "Universal 2" binary, run the above two commands and then use ``lipo`` to bundle them together::
 
-    lipo -create bin/godot.osx.tools.x86_64 bin/godot.osx.tools.arm64 -output bin/godot.osx.tools.universal
+    lipo -create bin/godot.macos.tools.x86_64 bin/godot.macos.tools.arm64 -output bin/godot.macos.tools.universal
 
 If all goes well, the resulting binary executable will be placed in the
 ``bin/`` subdirectory. This executable file contains the whole engine and
@@ -75,12 +75,12 @@ manager.
           ``._sc_`` or ``_sc_`` in the ``bin/`` folder.
 
 To create an ``.app`` bundle like in the official builds, you need to use the
-template located in ``misc/dist/osx_tools.app``. Typically, for an optimized
+template located in ``misc/dist/macos_tools.app``. Typically, for an optimized
 editor binary built with ``target=release_debug``::
 
-    cp -r misc/dist/osx_tools.app ./Godot.app
+    cp -r misc/dist/macos_tools.app ./Godot.app
     mkdir -p Godot.app/Contents/MacOS
-    cp bin/godot.osx.opt.tools.universal Godot.app/Contents/MacOS/Godot
+    cp bin/godot.macos.opt.tools.universal Godot.app/Contents/MacOS/Godot
     chmod +x Godot.app/Contents/MacOS/Godot
 
 .. note::
@@ -124,32 +124,32 @@ of those two architectures by leaving out the ``lipo`` step below.
 
 - For Intel x86_64::
 
-    scons platform=osx tools=no target=release arch=x86_64 --jobs=$(sysctl -n hw.logicalcpu)
-    scons platform=osx tools=no target=release_debug arch=x86_64 --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=macos tools=no target=release arch=x86_64 --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=macos tools=no target=release_debug arch=x86_64 --jobs=$(sysctl -n hw.logicalcpu)
 
 - For ARM64 (Apple M1)::
 
-    scons platform=osx tools=no target=release arch=arm64 --jobs=$(sysctl -n hw.logicalcpu)
-    scons platform=osx tools=no target=release_debug arch=arm64 --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=macos tools=no target=release arch=arm64 --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=macos tools=no target=release_debug arch=arm64 --jobs=$(sysctl -n hw.logicalcpu)
 
 To support both architectures in a single "Universal 2" binary, run the above
 two commands blocks and then use ``lipo`` to bundle them together::
 
-    lipo -create bin/godot.osx.opt.x86_64 bin/godot.osx.opt.arm64 -output bin/godot.osx.opt.universal
-    lipo -create bin/godot.osx.opt.debug.x86_64 bin/godot.osx.opt.debug.arm64 -output bin/godot.osx.opt.debug.universal
+    lipo -create bin/godot.macos.opt.x86_64 bin/godot.macos.opt.arm64 -output bin/godot.macos.opt.universal
+    lipo -create bin/godot.macos.opt.debug.x86_64 bin/godot.macos.opt.debug.arm64 -output bin/godot.macos.opt.debug.universal
 
 To create an ``.app`` bundle like in the official builds, you need to use the
-template located in ``misc/dist/osx_template.app``. The release and debug
-builds should be placed in ``osx_template.app/Contents/MacOS`` with the names
-``godot_osx_release.64`` and ``godot_osx_debug.64`` respectively. You can do so
+template located in ``misc/dist/macos_template.app``. The release and debug
+builds should be placed in ``macos_template.app/Contents/MacOS`` with the names
+``godot_macos_release.64`` and ``godot_macos_debug.64`` respectively. You can do so
 with the following commands (assuming a universal build, otherwise replace the
 ``.universal`` extension with the one of your arch-specific binaries)::
 
-    cp -r misc/dist/osx_template.app .
-    mkdir -p osx_template.app/Contents/MacOS
-    cp bin/godot.osx.opt.universal osx_template.app/Contents/MacOS/godot_osx_release.64
-    cp bin/godot.osx.opt.debug.universal osx_template.app/Contents/MacOS/godot_osx_debug.64
-    chmod +x osx_template.app/Contents/MacOS/godot_osx*
+    cp -r misc/dist/macos_template.app .
+    mkdir -p macos_template.app/Contents/MacOS
+    cp bin/godot.macos.opt.universal macos_template.app/Contents/MacOS/godot_macos_release.64
+    cp bin/godot.macos.opt.debug.universal macos_template.app/Contents/MacOS/godot_macos_debug.64
+    chmod +x macos_template.app/Contents/MacOS/godot_macos*
 
 .. note::
 
@@ -158,13 +158,13 @@ with the following commands (assuming a universal build, otherwise replace the
     building it statically with ``use_static_mvk=yes``, or by including the
     dynamic library in your ``.app`` bundle::
 
-        mkdir -p osx_template.app/Contents/Frameworks
-        cp <Vulkan SDK path>/macOS/libs/libMoltenVK.dylib osx_template.app/Contents/Frameworks/libMoltenVK.dylib
+        mkdir -p macos_template.app/Contents/Frameworks
+        cp <Vulkan SDK path>/macOS/libs/libMoltenVK.dylib macos_template.app/Contents/Frameworks/libMoltenVK.dylib
 
-You can then zip the ``osx_template.app`` folder to reproduce the ``osx.zip``
+You can then zip the ``macos_template.app`` folder to reproduce the ``macos.zip``
 template from the official Godot distribution::
 
-    zip -q -9 -r osx.zip osx_template.app
+    zip -q -9 -r macos.zip macos_template.app
 
 Cross-compiling for macOS from Linux
 ------------------------------------
@@ -193,8 +193,8 @@ repository/extracted the zip), e.g.::
 
 Now you can compile with SCons like you normally would::
 
-    scons platform=osx
+    scons platform=macos
 
 If you have an OSXCross SDK version different from the one expected by the SCons buildsystem, you can specify a custom one with the ``osxcross_sdk`` argument::
 
-    scons platform=osx osxcross_sdk=darwin15
+    scons platform=macos osxcross_sdk=darwin15

--- a/development/compiling/cross-compiling_for_ios_on_linux.rst
+++ b/development/compiling/cross-compiling_for_ios_on_linux.rst
@@ -141,22 +141,4 @@ way, with some additional arguments to provide the correct paths:
 
 ::
 
-    $ scons -j 4 platform=iphone arch=arm target=release_debug IPHONESDK="/path/to/iPhoneSDK" IPHONEPATH="/path/to/iostoolchain" ios_triple="arm-apple-darwin11-"
-    $ scons -j 4 platform=iphone arch=arm64 target=release_debug IPHONESDK="/path/to/iPhoneSDK" IPHONEPATH="/path/to/iostoolchain" ios_triple="arm-apple-darwin11-"
-
-Producing fat binaries
-~~~~~~~~~~~~~~~~~~~~~~
-
-Apple requires a fat binary with both architectures (``armv7`` and
-``arm64``) in a single file. To do this, use the
-``arm-apple-darwin11-lipo`` executable. The following example assumes
-you are in the root Godot source directory:
-
-::
-
-    $ /path/to/iostoolchain/usr/bin/arm-apple-darwin11-lipo -create bin/libgodot.iphone.opt.debug.arm.a bin/libgodot.iphone.opt.debug.arm64.a -output bin/libgodot.iphone.debug.fat.a
-    $ /path/to/iostoolchain/usr/bin/arm-apple-darwin11-lipo -create bin/libgodot_camera_module.iphone.opt.debug.arm.a bin/libgodot_camera_module.iphone.opt.debug.arm64.a -output bin/libgodot_camera_module.iphone.debug.fat.a
-    $ /path/to/iostoolchain/usr/bin/arm-apple-darwin11-lipo -create bin/libgodot_arkit_module.iphone.opt.debug.arm.a bin/libgodot_arkit_module.iphone.opt.debug.arm64.a -output bin/libgodot_arkit_module.iphone.debug.fat.a
-
-
-Then you will have iOS fat binaries in ``bin`` directory.
+    $ scons -j 4 platform=ios arch=arm64 target=release_debug IOS_SDK_PATH="/path/to/iPhoneSDK" IOS_TOOLCHAIN_PATH="/path/to/iostoolchain" ios_triple="arm-apple-darwin11-"

--- a/development/compiling/introduction_to_the_buildsystem.rst
+++ b/development/compiling/introduction_to_the_buildsystem.rst
@@ -334,7 +334,7 @@ platform:
     linux_x11_32_release
     linux_x11_64_debug
     linux_x11_64_release
-    osx.zip
+    macos.zip
     version.txt
     windows_32_debug.exe
     windows_32_release.exe

--- a/development/cpp/configuring_an_ide/xcode.rst
+++ b/development/cpp/configuring_an_ide/xcode.rst
@@ -82,7 +82,7 @@ To enable debugging support you need to edit the external build target's build a
 
 .. code-block:: shell
 
-  ln -f ${PROJECT_DIR}/godot/bin/godot.osx.tools.64 ${PROJECT_DIR}/godot/bin/godot
+  ln -f ${PROJECT_DIR}/godot/bin/godot.macos.tools.64 ${PROJECT_DIR}/godot/bin/godot
 
 .. figure:: img/xcode_7_setup_build_post_action.png
    :figclass: figure-w480
@@ -103,7 +103,7 @@ To enable debugging support you need to edit the external build target's build a
   tells the executable to open the specified project (must be provided as an *absolute* path
   to the project root, not the ``project.godot`` file).
 
-To check that everything is working, put a breakpoint in ``platform/osx/godot_main_osx.mm`` and
+To check that everything is working, put a breakpoint in ``platform/macos/godot_main_macos.mm`` and
 run the project.
 
 If you run into any issues, ask for help in one of

--- a/tutorials/scripting/gdnative/gdnative_cpp_example.rst
+++ b/tutorials/scripting/gdnative/gdnative_cpp_example.rst
@@ -115,7 +115,7 @@ Place the resulting ``api.json`` file in the project folder and add
 below.
 
 To generate and compile the bindings, use this command (replacing ``<platform>``
-with ``windows``, ``linux`` or ``osx`` depending on your OS):
+with ``windows``, ``linux`` or ``macos`` depending on your OS):
 
 To speed up compilation, add `-jN` at the end of the SCons command line where `N`
 is the number of CPU threads you have on your system. The example below uses 4 threads.


### PR DESCRIPTION
Followup for https://github.com/godotengine/godot/pull/63225

- Renames platforms.
- Updates iOS build instruction to use `.xcframework` instead of static libs.