### PR TITLE
Update export templates location for Godot 4.0

### DIFF
--- a/development/compiling/compiling_for_android.rst
+++ b/development/compiling/compiling_for_android.rst
@@ -184,9 +184,9 @@ The newly-compiled templates (``android_debug.apk``
 and ``android_release.apk``) must be copied to Godot's templates folder
 with their respective names. The templates folder can be located in:
 
--  Windows: ``%APPDATA%\Godot\templates\<version>\``
--  Linux: ``$HOME/.local/share/godot/templates/<version>/``
--  macOS: ``$HOME/Library/Application Support/Godot/templates/<version>/``
+-  Windows: ``%APPDATA%\Godot\export_templates\<version>\``
+-  Linux: ``$HOME/.local/share/godot/export_templates/<version>/``
+-  macOS: ``$HOME/Library/Application Support/Godot/export_templates/<version>/``
 
 ``<version>`` is of the form ``major.minor[.patch].status`` using values from
 ``version.py`` in your Godot source repository (e.g. ``3.0.5.stable`` or ``3.1.dev``).

--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -215,7 +215,7 @@ must be copied to:
 
 ::
 
-    $HOME/.local/share/godot/templates/[gd-version]/
+    $HOME/.local/share/godot/export_templates/<version>/
 
 and named like this (even for \*BSD which is seen as "Linux/X11" by Godot):
 


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/63093.