### PR TITLE
Improve step-by-step a little (3.x)

### DIFF
--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -108,7 +108,7 @@ our node's ``texture``.
 
     By default, the Inspector displays a node's properties in "Title Case", with
     capitalized words separated by a space. In GDScript code, these properties
-    are in "snake_case", lowercase, and words separated by an underscore.
+    are in "snake_case", which is lowercase with words separated by an underscore.
 
     You can hover any property's name in the Inspector to see a description and
     its identifier in code.
@@ -135,7 +135,7 @@ this function.
 .. note:: GDScript is an indent-based language. The tab at the start of the line
           that says ``print()`` is necessary for the code to work. If you omit
           it or don't indent a line correctly, the editor will highlight it in
-          red and display the following error message: "Unexpected indentation."
+          red and display the following error message: "Indented block expected".
 
 Save the scene if you haven't already, then press :kbd:`F6` to run it. Look at
 the Output bottom panel that expands. It should display "Hello, world!"
@@ -155,16 +155,15 @@ angular speed in radians per second.
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    extends Sprite
-
     var speed = 400
     var angular_speed = PI
 
-Member variables sit at the top of the script, before functions. Every node
+Member variables sit near the top of the script, after any "extends" lines,
+but before functions. Every node
 instance with this script attached to it will have its own copy of the ``speed``
 and ``angular_speed`` properties.
 
-.. note:: As in some other engines, angles in Godot work in radians by default,
+.. note:: Angles in Godot work in radians by default,
           but you have built-in functions and properties available if you prefer
           to calculate angles in degrees instead.
 

--- a/getting_started/step_by_step/scripting_languages.rst
+++ b/getting_started/step_by_step/scripting_languages.rst
@@ -14,9 +14,9 @@ will write your first script using GDScript.
 inherit all functions and properties of the node they attach to.
 
 For example, take a game where a Camera2D node follows a ship. The Camera2D node
-follows its parent by default. Imagine you want it to shake when the player
-takes damage. As this feature is not built-into Godot, you would attach a script
-to it and code the camera shake.
+follows its parent by default. Imagine you want the camera to shake when the player
+takes damage. As this feature is not built into Godot, you would attach a script
+to the Camera2D node and code the shake.
 
 .. image:: img/scripting_camera_shake.gif
 
@@ -49,7 +49,7 @@ with Godot.
 
 For C#, you will need an external code editor like
 `VSCode <https://code.visualstudio.com/>`_ or Visual Studio. While C# support is
-now mature, you will also find fewer learning resources for it compared to
+now mature, you will find fewer learning resources for it compared to
 GDScript. That's why we recommend C# mainly to users who already have experience
 with the language.
 
@@ -70,9 +70,7 @@ to save you time coding games. Its features include:
   information from the scene it's attached to.
 - Built-in vector and transform types, making it efficient for heavy use of
   linear algebra, a must for games.
-- Supports multiple threads as efficiently as statically typed languages. This
-  is one of the features we couldn't provide easily with a third-party language
-  like Lua or Python.
+- Supports multiple threads as efficiently as statically typed languages.
 - No `garbage collection
   <https://en.wikipedia.org/wiki/Garbage_collection_(computer_science)>`_, as
   this feature eventually gets in the way when creating games. The engine counts
@@ -138,7 +136,7 @@ non-programmers like game designers and artists.
 .. image:: img/scripting_visualscript.png
 
 You can use other languages to create custom blocks that are specific to your
-game. For example, to script AIs, quests, or dialogues. That's where the
+game, for example, to script AIs, quests, or dialogues. That's where the
 strength of VisualScript lies.
 
 While it provides all the basic building blocks you need to code complete games,
@@ -161,7 +159,7 @@ or even restart Godot.
 You can use any version of the language or mix compiler brands and versions for
 the generated shared libraries, thanks to our use of an internal C API Bridge.
 
-This language is the best choice for performance. You don't need to use it
+GDNative is the best choice for performance. You don't need to use it
 throughout an entire game, as you can write other parts in GDScript, C#, or
 VisualScript.
 

--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -15,7 +15,7 @@ In this lesson, we will look at signals. They are messages that nodes emit when
 something specific happens to them, like a button being pressed. Other nodes can
 connect to that signal and call a function when the event occurs.
 
-It is a delegation mechanism built into Godot that allows one game object to
+Signals are a delegation mechanism built into Godot that allows one game object to
 react to a change in another without them referencing one another. Using signals
 limits `coupling
 <https://en.wikipedia.org/wiki/Coupling_(computer_programming)>`_ and keeps your
@@ -76,7 +76,7 @@ If you don't see the handles, ensure the select tool is active in the toolbar.
 Click and drag on the button itself to move it closer to the sprite.
 
 You can also write a label on the Button by editing its Text property in the
-Inspector.
+Inspector. Enter "Toggle motion".
 
 .. image:: img/signals_08_toggle_motion_text.png
 
@@ -85,6 +85,8 @@ Your scene tree and viewport should look like this.
 .. image:: img/signals_09_scene_setup.png
 
 Save your newly created scene. You can then run it with :kbd:`F6`.
+At the moment, the button will be visible, but nothing will happen if you
+press it.
 
 Connecting a signal in the editor
 ---------------------------------
@@ -121,10 +123,10 @@ editor generates one for you. By convention, we name these callback methods
 
    The advanced view lets you connect to any node and any built-in
    function, add arguments to the callback, and set options. You can
-   toggle the mode in the window's bottom-right by clicking the radio
+   toggle the mode in the window's bottom-right by clicking the Advanced
    button.
 
-Click the connect button to complete the signal connection and jump to the
+Click the Connect button to complete the signal connection and jump to the
 Script workspace. You should see the new method with a connection icon in the
 left margin.
 
@@ -266,6 +268,9 @@ at the bottom of our script and use it to toggle our sprite's visibility.
 The ``visible`` property is a boolean that controls the visibility of our node.
 The line ``visible = not visible`` toggles the value. If ``visible`` is
 ``true``, it becomes ``false``, and vice-versa.
+
+If you run the scene now, you will see that the sprite blinks on and off, at one
+second intervals.
 
 Complete script
 ---------------


### PR DESCRIPTION
3.5 version of PR #5969. Will also apply to 3.4.

Quite a few, but minor, changes to grammar, clarity, etc., including removing some unnecessary and distracting phrases, to the step-by-step tutorial.