### PR TITLE
Add editor's support for Web and Android to FAQ

### DIFF
--- a/about/faq.rst
+++ b/about/faq.rst
@@ -38,6 +38,8 @@ Which platforms are supported by Godot?
 * Windows
 * macOS
 * X11 (Linux, \*BSD)
+* Web (Chrome 68 or later, Firefox 79 or later, Edge 79 or later), see: :ref:`using the web editor <doc_using_the_web_editor>`)
+* Android (experimental)
 
 **For exporting your games:**
 

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -38,7 +38,7 @@ Which platforms are supported by Godot?
 * Windows
 * macOS
 * X11 (Linux, \*BSD)
-* Web (Chrome 68 or later, Firefox 79 or later, Edge 79 or later), see: :ref:`using the web editor <doc_using_the_web_editor>`)
+* :ref:`Web <doc_using_the_web_editor>`
 * Android (experimental)
 
 **For exporting your games:**


### PR DESCRIPTION
Web editor is available since 3.3, and seems to be to the same
"level of support" as the other builds
* https://godotengine.org/download/
* https://editor.godotengine.org/releases/latest/

Android was announced:
https://godotengine.org/article/dev-snapshot-godot-3-5-beta-3

although it isn't on any stable release/doesn't seem 100%
recommended yet, so marking it as experimental.

I am targeting on this patch 3.5 only- my intention is to create
separate patches for master (which currently doesn't have
html support) and older versions.
