### PR TITLE
Fix misc syntax/style errors/warnings on documentation head

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -161,7 +161,7 @@ Vulkan 1.0, with Vulkan 1.1 and 1.2 features optionally used.
   or improve visuals on high-end systems.
 
   - 3D rendering can be scaled with bilinear filtering or
-    `AMD FidelityFX Super Resolution 1.0 https://www.amd.com/en/technologies/fidelityfx-super-resolution`__.
+    `AMD FidelityFX Super Resolution 1.0 <https://www.amd.com/en/technologies/fidelityfx-super-resolution>`__.
 
 - `OpenGL support planned for a future Godot 4.x release <https://godotengine.org/article/about-godot4-vulkan-gles3-and-gles2>`__.
 

--- a/development/cpp/configuring_an_ide/clion.rst
+++ b/development/cpp/configuring_an_ide/clion.rst
@@ -9,7 +9,7 @@ CLion
 Importing the project
 ---------------------
 
-CLion can import a project's `compilation database file <https://clang.llvm.org/docs/JSONCompilationDatabase.html>`, commonly named `compile_commands.json`__. To generate the compilation database file, open the terminal, change to the Godot root directory, and run:
+CLion can import a project's `compilation database file <https://clang.llvm.org/docs/JSONCompilationDatabase.html>`_, commonly named ``compile_commands.json``. To generate the compilation database file, open the terminal, change to the Godot root directory, and run:
 
 ::
 
@@ -20,7 +20,7 @@ Then, open the Godot root directory with CLion. CLion will import the compilatio
 Compiling and debugging the project
 -----------------------------------
 
-CLion does not support compiling and debugging Godot via SCons out of the box. This can be achived by creating a custom build target and run configuration in CLion. Before creating a custom build target, you must `compile Godot <https://docs.godotengine.org/en/stable/development/compiling/index.html>`__ once on the command line, to generate the Godot executable. Open the terminal, change into the Godot root directory, and execute:
+CLion does not support compiling and debugging Godot via SCons out of the box. This can be achived by creating a custom build target and run configuration in CLion. Before creating a custom build target, you must :ref:`compile Godot <toc-devel-compiling>` once on the command line, to generate the Godot executable. Open the terminal, change into the Godot root directory, and execute:
 
 ::
 
@@ -43,7 +43,7 @@ To add a custom build target that invokes SCons for compilation:
 .. figure:: img/clion-external-tools.png
    :align: center
 
-- Give the tool a name, e.g. ``Build Godot debug``, set **Program** to ``scons``, set **Arguments** to the compilation settings you want (see :ref:`toc-devel-compiling`), and set the **Working directory** to ``$ProjectFileDir$``, which equals the Godot root directory. Click **OK** to create the tool.
+- Give the tool a name, e.g. ``Build Godot debug``, set **Program** to ``scons``, set **Arguments** to the compilation settings you want (see :ref:`compiling Godot <toc-devel-compiling>`), and set the **Working directory** to ``$ProjectFileDir$``, which equals the Godot root directory. Click **OK** to create the tool.
 
    .. note:: CLion does not expand shell commands like ``scons -j$(nproc)``. Use concrete values instead, e.g. ``scons -j8``
 

--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -75,7 +75,7 @@ Main script
 
 Add a script to ``Main``. At the top of the script, we use 
 ``@export var mob_scene: PackedScene`` to allow us to choose the Mob scene we want
- to instance.
+to instance.
 
 .. tabs::
  .. code-tab:: gdscript GDScript

--- a/tutorials/animation/creating_movies.rst
+++ b/tutorials/animation/creating_movies.rst
@@ -126,7 +126,7 @@ Choosing an output format
 -------------------------
 
 Output formats are provided by the :ref:`MovieWriter <class_MovieWriter>` class.
-Godot has 2 built-in :ref:`MovieWriter <class_MovieWriter>`s, and more can be implemented by extensions:
+Godot has 2 built-in :ref:`MovieWriters <class_MovieWriter>`, and more can be implemented by extensions:
 
 AVI (recommended)
 ^^^^^^^^^^^^^^^^^

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -582,7 +582,7 @@ and ``size``. Also contains an ``end`` field which is
 vectors.
 
 :ref:`Transform3D <class_Transform3D>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 3D Transform contains a Basis field ``basis`` and a Vector3 field
 ``origin``.

--- a/tutorials/scripting/scene_unique_nodes.rst
+++ b/tutorials/scripting/scene_unique_nodes.rst
@@ -32,5 +32,7 @@ To use a unique node in a script, use the ``%`` symbol and the node's
 name in the path for ``get_node()``. For example:
 
 .. tabs::
+
  .. code-tab:: gdscript GDScript
+
     get_node("%RedButton").text = "Hello"


### PR DESCRIPTION
A number of errors and warnings have been fixed which caused
wrong references (code hidden, links not working), or in some cases
minor issues when parsing the source .rst files.

No content has been altered to the best of my ability.

This was done to avoid noise when sending PRs on top of it.

The only other warnings left are either class-related ones (I need to
learn a bit more of how that is automated from code) or changelong
references, which I am unsure if we want to fix those (the classes are
no longer there but changelogs are not supposed to change).