### PR TITLE
Add editor's experimental Android support (and comment on web) to FAQ

### DIFF
--- a/about/faq.rst
+++ b/about/faq.rst
@@ -47,10 +47,7 @@ Which platforms are supported by Godot?
 * Linux, \*BSD
 * Android
 * iOS
-
-.. note:: Godot 4.0 does not support Web exporting (HTML5) yet.
-          A previous version, e.g. Godot 3.X, can be used instead to
-          export to web.
+* Web
 
 Both 32- and 64-bit binaries are supported where it makes sense, with 64
 being the default.

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -38,6 +38,7 @@ Which platforms are supported by Godot?
 * Windows
 * macOS
 * Linux, \*BSD
+* Android (experimental)
 
 **For exporting your games:**
 
@@ -46,7 +47,10 @@ Which platforms are supported by Godot?
 * Linux, \*BSD
 * Android
 * iOS
-* Web
+
+.. note:: Godot 4.0 does not support Web exporting (HTML5) yet.
+          A previous version, e.g. Godot 3.X, can be used instead to
+          export to web.
 
 Both 32- and 64-bit binaries are supported where it makes sense, with 64
 being the default.


### PR DESCRIPTION
This is master version of #5975 (3.5) pull request.

Android was announced:
https://godotengine.org/article/dev-snapshot-godot-3-5-beta-3

although it isn't on any stable release/doesn't seem 100%
recommended yet, so marking it as experimental.

Commenting the lack of support of the Web exporting, that may be
unavailable for 4.0, and suggesting to use 3.X instead. This
seems to be planned for 4.1, but not promising anything just in
case.