### PR TITLE
Add "dotnet CLI" option to all C# editor docs

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -116,6 +116,7 @@ After reading the "Prerequisites" section, you can download and install
 In Godot's **Editor → Editor Settings** menu:
 
 - Set **Mono** -> **Editor** -> **External Editor** to **Visual Studio Code**.
+- Set **Mono** -> **Builds** -> **Build Tool** to **dotnet CLI**.
 
 In Visual Studio Code:
 
@@ -151,6 +152,7 @@ While installing Visual Studio, select these workloads:
 In Godot's **Editor → Editor Settings** menu:
 
 - Set **Mono** -> **Editor** -> **External Editor** to **Visual Studio**.
+- Set **Mono** -> **Builds** -> **Build Tool** to **dotnet CLI**.
 
 Next, you need to download the Godot Visual Studio extension from github
 `here <https://github.com/godotengine/godot-csharp-visualstudio/releases>`__.


### PR DESCRIPTION
The JetBrains Rider section contains this line:

> - Set **Mono** -> **Builds** -> **Build Tool** to **dotnet CLI**.

This actually applies just as much to the other editors, so this PR adds the note for them, too.

---

Other Build Tool options tend not to work, and they're only there for advanced edge cases, until Godot 4.1. https://github.com/godotengine/godot-website/pull/341#issuecomment-861342791. We get this Build Tool question in the C# Discord chat very frequently, so I think it's worth at least trying to document a little better.

The error people commonly ask about is this:

> The SDK 'Microsoft.NET.Sdk' specified could not be found.

Usually it seems to be because they had Visual Studio installed at some point earlier and Godot picked that old version of MSBuild that doesn't have (full?) support for the project style used in Godot 3.2.3+.

---

This applies to 3.x.