### PR TITLE
Remove "Core" from .NET SDK, simplify Mono mention

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -43,21 +43,19 @@ Setting up C# for Godot
 Prerequisites
 ~~~~~~~~~~~~~
 
-Install the latest stable version of
-`.NET Core SDK <https://dotnet.microsoft.com/download/dotnet-core>`__
-(3.1 as of writing).
+Install the latest stable version of the
+`.NET SDK <https://dotnet.microsoft.com/download>`__, previously known as the
+.NET Core SDK.
 
 As of Godot 3.2.3, installing Mono SDK is not a requirement anymore,
 except it is required if you are building the engine from source.
 
-Godot bundles the parts of Mono needed to run already compiled games,
-however Godot does not include the tools required to build and compile
-games, such as MSBuild. These tools need to be installed separately.
-The required tools are included in the .NET Core SDK. MSBuild is also
-included in the Mono SDK, but it can't build C# projects with the new
-``csproj`` format, therefore .NET Core SDK is required for Godot 3.2.3+.
+Godot bundles the parts of Mono needed to run already compiled games.
+However, Godot does not bundle the tools required to build and compile
+games, such as MSBuild and the C# compiler. These are
+included in the .NET SDK, which needs to be installed separately.
 
-In summary, you must have installed .NET Core SDK
+In summary, you must have installed the .NET SDK
 **and** the Mono-enabled version of Godot.
 
 Additional notes


### PR DESCRIPTION
The .NET Core SDK is simply the .NET SDK as of .NET 5. This is what you see on https://dotnet.microsoft.com/download.

This PR changes the text to remove "Core", and removes the reference to .NET Core 3.1 to avoid confusing people. (Some people see 3.1 and assume they must download *that* version, rather than the latest stable.)

Also removes the reference to Godot 3.2.3 to make the paragraph simpler to read.

---

This applies to 3.x.