### PR TITLE
Add notes for common C# bugs on Windows

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -152,10 +152,23 @@ In Godot's **Editor → Editor Settings** menu:
 
 - Set **Mono** -> **Editor** -> **External Editor** to **Visual Studio**.
 
-Next, you need to download the Godot Visual Studio extension from github
+Next, you can download the Godot Visual Studio extension from github
 `here <https://github.com/godotengine/godot-csharp-visualstudio/releases>`__.
 Double click on the downloaded file and follow the installation process.
 
+.. note:: The option to debug your game in Visual Studio may not appear after
+          installing the extension. To enable debugging, there is a
+          `workaround for Visual Studio 2019 <https://github.com/godotengine/godot-csharp-visualstudio/issues/10#issuecomment-720153256>`__.
+          There is
+          `a separate issue about this problem in Visual Studio 2022 <https://github.com/godotengine/godot-csharp-visualstudio/issues/28>`__.
+
+.. note:: If you see an error like "Unable to find package Godot.NET.Sdk",
+          your NuGet configuration may be incorrect and need to be fixed.
+
+          A simple way to fix the NuGet configuration file is to regenerate it.
+          In a file explorer window, go to ``%AppData%\NuGet``. Rename or delete
+          the ``NuGet.Config`` file. When you build your Godot project again,
+          the file will be automatically created with default values.
 
 Creating a C# script
 --------------------


### PR DESCRIPTION
Add notes for a few C# bugs that we see often in the C# Discord channel.

---

First, mention the issues with the Visual Studio extension. This has been a problem for a while ([Aug 27, 2020](https://github.com/godotengine/godot-csharp-visualstudio/issues/10#issue-687428489), Godot 3.2.3) and I think it's worth pointing it out here, where it might help inform people's choice of editor, or at least let them know that they aren't alone in having this problem and show how they might be able to work around it.

I also changed "you need to download the Godot Visual Studio extension from github" to "you can download" because it is not required, and some people are happy to use Visual Studio with Godot even without the extension working.

---

Second, a fix for a NuGet behavior that we also see often in the C# Discord where the user's default NuGet.Config file loses its nuget.org source. I have suspicions that it comes from a Visual Studio update issue, but all I know is that I've only seen it happen on Windows and some people who hit it knew they were using Visual Studio.

I'm not totally sure this section is the right place for it, but I haven't noticed a more general troubleshooting section that it might fit into better.

---

This applies to 3.x.