### PR TITLE
Move OpenJDK installation before Android SDK in Exporting for Android

### DIFF
--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -13,6 +13,11 @@ Exporting for Android
 Exporting for Android has fewer requirements than compiling Godot for Android.
 The following steps detail what is needed to set up the Android SDK and the engine.
 
+Install OpenJDK 11
+------------------
+
+Download and install  `OpenJDK 11 <https://adoptium.net/?variant=openjdk11>`__.
+
 Download the Android SDK
 ------------------------
 
@@ -43,10 +48,6 @@ Download and install the Android SDK.
     If you are using Linux,
     **do not use an Android SDK provided by your distribution's repositories as it will often be outdated**.
 
-Install OpenJDK 11
-------------------
-
-Download and install  `OpenJDK 11 <https://adoptium.net/?variant=openjdk11>`__.
 
 Create a debug.keystore
 -----------------------


### PR DESCRIPTION
Re-ordering the steps since android sdk requires a jdk to be installed.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
