### PR TITLE
Add C# examples to Creating your first script

### DIFF
--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -97,7 +97,7 @@ the following line of code:
 
  .. code-tab:: csharp C#
 
-    public class Sprite : Godot.Sprite
+    public class Sprite : Godot.Sprite2D
     // Declare member variables here. Examples:
     // private int a = 2;
     // private string b = "text";
@@ -326,7 +326,7 @@ Here is the complete ``Sprite2D.gd`` file for reference.
 
     using Godot;
 
-    public class Sprite : Godot.Sprite
+    public class Sprite : Godot.Sprite2D
     {
         private int Speed = 400;
         private float AngularSpeed = Mathf.Pi;

--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -28,8 +28,8 @@ The equivalent C# code has been included in another tab for convenience.
 .. seealso:: To learn more about GDScript, its keywords, and its syntax, head to
              the :ref:`GDScript reference<doc_gdscript>`.
 
-.. seealso:: To learn more about C#, head to
-    the :ref:`C# basics<doc_c_sharp>`
+.. seealso:: To learn more about C#, head to the :ref:`C# basics <doc_c_sharp>` page.
+
 Project setup
 -------------
 

--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -149,6 +149,7 @@ Add the following code to your script:
 
     func _init():
         print("Hello, world!")
+
  .. code-tab:: csharp C#
 
     public Sprite()
@@ -187,6 +188,7 @@ angular speed in radians per second.
 
     var speed = 400
     var angular_speed = PI
+
  .. code-tab:: csharp C#
 
     private int Speed = 400;
@@ -227,6 +229,7 @@ At the bottom of the script, define the function:
 
     func _process(delta):
         rotation += angular_speed * delta
+
  .. code-tab:: csharp C#
 
     public override void _Process(float delta)
@@ -270,6 +273,7 @@ them.
     var velocity = Vector2.UP.rotated(rotation) * speed
 
     position += velocity * delta
+
  .. code-tab:: csharp C#
 
     var velocity = Vector2.Up.Rotated(Rotation) * Speed;
@@ -322,6 +326,7 @@ Here is the complete ``Sprite2D.gd`` file for reference.
         var velocity = Vector2.UP.rotated(rotation) * speed
 
         position += velocity * delta
+
  .. code-tab:: csharp C#
 
     using Godot;

--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -21,12 +21,15 @@ Creating your first script
 In this lesson, you will code your first script to make the Godot icon turn in
 circles using GDScript. As we mentioned :ref:`in the introduction
 <toc-learn-introduction>`, we assume you have programming foundations.
+The equivalent C# code has been included in another tab for convenience.
 
 .. image:: img/scripting_first_script_rotating_godot.gif
 
 .. seealso:: To learn more about GDScript, its keywords, and its syntax, head to
              the :ref:`GDScript reference<doc_gdscript>`.
 
+.. seealso:: To learn more about C#, head to
+    the :ref:`C# basics<doc_c_sharp>`
 Project setup
 -------------
 
@@ -92,6 +95,25 @@ the following line of code:
 
     extends Sprite2D
 
+ .. code-tab:: csharp C#
+
+    public class Sprite : Godot.Sprite
+    // Declare member variables here. Examples:
+    // private int a = 2;
+    // private string b = "text";
+
+    // Called when the node enters the scene tree for the first time.
+    public override void _Ready()
+    {
+
+    }
+
+    //  // Called every frame. 'delta' is the elapsed time since the previous frame.
+    //  public override void _Process(float delta)
+    //  {
+    //
+    //  }
+
 Every GDScript file is implicitly a class. The ``extends`` keyword defines the
 class this script inherits or extends. In this case, it's ``Sprite2D``, meaning
 our script will get access to all the properties and functions of the Sprite2D
@@ -127,6 +149,13 @@ Add the following code to your script:
 
     func _init():
         print("Hello, world!")
+ .. code-tab:: csharp C#
+
+    public Sprite()
+    {
+        GD.Print("Hello, world!");
+    }
+
 
 Let's break it down. The ``func`` keyword defines a new function named
 ``_init``. This is a special name for our class's constructor. The engine calls
@@ -158,6 +187,10 @@ angular speed in radians per second.
 
     var speed = 400
     var angular_speed = PI
+ .. code-tab:: csharp C#
+
+    private int Speed = 400;
+    private float AngularSpeed = Mathf.Pi;
 
 Member variables sit near the top of the script, after any "extends" lines,
 but before functions. Every node
@@ -194,6 +227,12 @@ At the bottom of the script, define the function:
 
     func _process(delta):
         rotation += angular_speed * delta
+ .. code-tab:: csharp C#
+
+    public override void _Process(float delta)
+    {
+        Rotation += AngularSpeed * delta;
+    }
 
 The ``func`` keyword defines a new function. After it, we have to write the
 function's name and arguments it takes in parentheses. A colon ends the
@@ -231,6 +270,11 @@ them.
     var velocity = Vector2.UP.rotated(rotation) * speed
 
     position += velocity * delta
+ .. code-tab:: csharp C#
+
+    var velocity = Vector2.Up.Rotated(Rotation) * Speed;
+
+    Position += velocity * delta;
 
 As we already saw, the ``var`` keyword defines a new variable. If you put it at
 the top of the script, it defines a property of the class. Inside a function, it
@@ -278,3 +322,21 @@ Here is the complete ``Sprite2D.gd`` file for reference.
         var velocity = Vector2.UP.rotated(rotation) * speed
 
         position += velocity * delta
+ .. code-tab:: csharp C#
+
+    using Godot;
+
+    public class Sprite : Godot.Sprite
+    {
+        private int Speed = 400;
+        private float AngularSpeed = Mathf.Pi;
+
+        public override void _Process(float delta)
+        {
+            Rotation += AngularSpeed * delta;
+            var velocity = Vector2.Up.Rotated(Rotation) * Speed;
+
+            Position += velocity * delta;
+
+        }
+    }


### PR DESCRIPTION
All of my examples are built to match the v3.4.4-stable_mono_win64 as that is the only Mono-based version I have. There was something weird with Godot.Sprite not matching the name of Sprite2D but that might just be an engine implementation oddity. The examples I have provided compile and run on my local install though.  

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
