### PR TITLE
Fix incorrect indentation in code sample in Creating movies

### DIFF
--- a/tutorials/animation/creating_movies.rst
+++ b/tutorials/animation/creating_movies.rst
@@ -238,9 +238,9 @@ quit the project when the animation is finished:
         animation_finished.connect(_on_animation_player_animation_finished)
 
     func _on_animation_player_animation_finished(_anim_name):
-	    if OS.has_feature("movie"):
-		    print("Done recording movie.")
-		    get_tree().quit()
+        if OS.has_feature("movie"):
+            print("Done recording movie.")
+            get_tree().quit()
 
 Using high-quality graphics settings
 ------------------------------------


### PR DESCRIPTION
It was caused by tab characters being used for indentation instead of spaces. Originally reported here: https://twitter.com/pattle_bass/status/1552000694189805568