### PR TITLE
Nodes & Scenes: Added macOS shortcuts mentioning.

### DIFF
--- a/getting_started/step_by_step/nodes_and_scenes.rst
+++ b/getting_started/step_by_step/nodes_and_scenes.rst
@@ -134,7 +134,7 @@ Running the scene
 -----------------
 
 Everything's ready to run the scene! Press the Play Scene button in the
-top-right of the screen or press :kbd:`F6` or :kbd:`Cmd + R` (macOS).
+top-right of the screen or press :kbd:`F6` (:kbd:`Cmd + R` on macOS).
 
 .. image:: img/nodes_and_scenes_09_play_scene_button.png
 
@@ -169,8 +169,8 @@ Setting the main scene
 ----------------------
 
 To run our test scene, we used the Play Scene button. Another button next to it
-allows you to set and run the project's main scene. You can press :kbd:`F5` or :kbd:`Cmd + B` (macOS) to
-do so.
+allows you to set and run the project's main scene. You can press :kbd:`F5`
+(:kbd:`Cmd + B` on macOS) to do so.
 
 .. image:: img/nodes_and_scenes_13_play_button.png
 

--- a/getting_started/step_by_step/nodes_and_scenes.rst
+++ b/getting_started/step_by_step/nodes_and_scenes.rst
@@ -134,7 +134,7 @@ Running the scene
 -----------------
 
 Everything's ready to run the scene! Press the Play Scene button in the
-top-right of the screen or press :kbd:`F6`.
+top-right of the screen or press :kbd:`F6` or :kbd:`Cmd + R` (macOS).
 
 .. image:: img/nodes_and_scenes_09_play_scene_button.png
 
@@ -169,7 +169,7 @@ Setting the main scene
 ----------------------
 
 To run our test scene, we used the Play Scene button. Another button next to it
-allows you to set and run the project's main scene. You can press :kbd:`F5` to
+allows you to set and run the project's main scene. You can press :kbd:`F5` or :kbd:`Cmd + B` (macOS) to
 do so.
 
 .. image:: img/nodes_and_scenes_13_play_button.png


### PR DESCRIPTION
Unfortunately, suggested hotkeys don't work for macOS. 
I guess it will be useful to mention macOS shortcuts directly in the docs.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
