### PR TITLE
Fix various typos

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -561,7 +561,7 @@ Windowing and OS integration
 
    - Doesn't use exclusive fullscreen, which allows for fast alt-tabbing. The
      downside is that the screen resolution can't be changed this way. For 3D
-     resolution scaling, use the appropriatee project settings or the equivalent
+     resolution scaling, use the appropriate project settings or the equivalent
      Viewport property. For 2D resolution scaling, use a second Viewport node
      to render the game world with a different size.
 

--- a/classes/class_packedbytearray.rst
+++ b/classes/class_packedbytearray.rst
@@ -318,7 +318,7 @@ Returns a new ``PackedByteArray`` with the data decompressed. Set ``buffer_size`
 
 Returns a new ``PackedByteArray`` with the data decompressed. Set the compression mode using one of :ref:`CompressionMode<enum_File_CompressionMode>`'s constants. **This method only accepts gzip and deflate compression modes.**\ 
 
-This method is potentially slower than ``decompress``, as it may have to re-allocate its output buffer multiple times while decompressing, whereas ``decompress`` knows it's output buffer size from the beginning.
+This method is potentially slower than ``decompress``, as it may have to re-allocate its output buffer multiple times while decompressing, whereas ``decompress`` knows its output buffer size from the beginning.
 
 GZIP has a maximal compression ratio of 1032:1, meaning it's very possible for a small compressed payload to decompress to a potentially very large output. To guard against this, you may provide a maximum size this function is allowed to allocate in bytes via ``max_output_size``. Passing -1 will allow for unbounded output. If any positive value is passed, and the decompression exceeds that amount in bytes, then an error will be returned.
 

--- a/classes/class_physicalbone2d.rst
+++ b/classes/class_physicalbone2d.rst
@@ -21,7 +21,7 @@ The ``PhysicalBone2D`` node is a :ref:`RigidDynamicBody2D<class_RigidDynamicBody
 
 \ **Note:** To have the Bone2D nodes visually follow the ``PhysicalBone2D`` node, use a :ref:`SkeletonModification2DPhysicalBones<class_SkeletonModification2DPhysicalBones>` modification on the :ref:`Skeleton2D<class_Skeleton2D>` node with the :ref:`Bone2D<class_Bone2D>` nodes.
 
-\ **Note:** The PhysicalBone2D node does not automatically create a :ref:`Joint2D<class_Joint2D>` node to keep ``PhysicalBone2D`` nodes together. You will need to create these manually. For most cases, you want to use a :ref:`PinJoint2D<class_PinJoint2D>` node. The ``PhysicalBone2D`` node can automatically configure the :ref:`Joint2D<class_Joint2D>` node once it's been created as a child node.
+\ **Note:** The PhysicalBone2D node does not automatically create a :ref:`Joint2D<class_Joint2D>` node to keep ``PhysicalBone2D`` nodes together. You will need to create these manually. For most cases, you want to use a :ref:`PinJoint2D<class_PinJoint2D>` node. The ``PhysicalBone2D`` node can automatically configure the :ref:`Joint2D<class_Joint2D>` node once its been created as a child node.
 
 Properties
 ----------

--- a/classes/class_webxrinterface.rst
+++ b/classes/class_webxrinterface.rst
@@ -294,7 +294,7 @@ The :ref:`reference_space_reset<class_WebXRInterface_signal_reference_space_rese
 | *Getter* | get_optional_features()      |
 +----------+------------------------------+
 
-A comma-seperated list of optional features used by :ref:`XRInterface.initialize<class_XRInterface_method_initialize>` when setting up the WebXR session.
+A comma-separated list of optional features used by :ref:`XRInterface.initialize<class_XRInterface_method_initialize>` when setting up the WebXR session.
 
 If a user's browser or device doesn't support one of the given features, initialization will continue, but you won't be able to use the requested feature.
 
@@ -328,7 +328,7 @@ Possible values come from `WebXR's XRReferenceSpaceType <https://developer.mozil
 | *Getter* | get_requested_reference_space_types()      |
 +----------+--------------------------------------------+
 
-A comma-seperated list of reference space types used by :ref:`XRInterface.initialize<class_XRInterface_method_initialize>` when setting up the WebXR session.
+A comma-separated list of reference space types used by :ref:`XRInterface.initialize<class_XRInterface_method_initialize>` when setting up the WebXR session.
 
 The reference space types are requested in order, and the first on supported by the users device or browser will be used. The :ref:`reference_space_type<class_WebXRInterface_property_reference_space_type>` property contains the reference space type that was ultimately used.
 
@@ -348,7 +348,7 @@ Possible values come from `WebXR's XRReferenceSpaceType <https://developer.mozil
 | *Getter* | get_required_features()      |
 +----------+------------------------------+
 
-A comma-seperated list of required features used by :ref:`XRInterface.initialize<class_XRInterface_method_initialize>` when setting up the WebXR session.
+A comma-separated list of required features used by :ref:`XRInterface.initialize<class_XRInterface_method_initialize>` when setting up the WebXR session.
 
 If a user's browser or device doesn't support one of the given features, initialization will fail and :ref:`session_failed<class_WebXRInterface_signal_session_failed>` will be emitted.
 

--- a/development/compiling/cross-compiling_for_ios_on_linux.rst
+++ b/development/compiling/cross-compiling_for_ios_on_linux.rst
@@ -31,7 +31,7 @@ Requirements
 -  `Clang >= 3.5 <http://clang.llvm.org>`__ for your development
    machine installed and in the ``PATH``. It has to be version >= 3.5
    to target ``arm64`` architecture.
--  `Fuse <https://github.com/libfuse/libfuse>`__ for mounting and umounting
+-  `Fuse <https://github.com/libfuse/libfuse>`__ for mounting and unmounting
    the dmg image.
 -  `darling-dmg <https://github.com/darlinghq/darling-dmg>`__, which
    needs to be built from source. The procedure for that is explained

--- a/development/cpp/configuring_an_ide/clion.rst
+++ b/development/cpp/configuring_an_ide/clion.rst
@@ -20,7 +20,7 @@ Then, open the Godot root directory with CLion. CLion will import the compilatio
 Compiling and debugging the project
 -----------------------------------
 
-CLion does not support compiling and debugging Godot via SCons out of the box. This can be achived by creating a custom build target and run configuration in CLion. Before creating a custom build target, you must :ref:`compile Godot <toc-devel-compiling>` once on the command line, to generate the Godot executable. Open the terminal, change into the Godot root directory, and execute:
+CLion does not support compiling and debugging Godot via SCons out of the box. This can be achieved by creating a custom build target and run configuration in CLion. Before creating a custom build target, you must :ref:`compile Godot <toc-devel-compiling>` once on the command line, to generate the Godot executable. Open the terminal, change into the Godot root directory, and execute:
 
 ::
 

--- a/tutorials/platform/android/android_in_app_purchases.rst
+++ b/tutorials/platform/android/android_in_app_purchases.rst
@@ -138,7 +138,7 @@ Example use of ``queryPurchases()``:
                     " debug message: ", query_result.debug_message)
 
 
-You should query purchases during startup after succesfully retrieving SKU details.
+You should query purchases during startup after successfully retrieving SKU details.
 Since the user may make a purchase or resolve a pending transaction from
 outside your app, you should recheck for purchases when resuming from the
 background. To accomplish this, you can use the ``billing_resume`` signal.

--- a/tutorials/scripting/c_sharp/c_sharp_exports.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_exports.rst
@@ -60,8 +60,8 @@ the following to list them:
     private Resource Resource;
 
 ..
-	Commenting out enum examples becuase I have been told they
-	require extra steps to actually work properly. The examples bellow
+	Commenting out enum examples because I have been told they
+	require extra steps to actually work properly. The examples below
 	will show up in the inspector but apparently do not function properly
 ..
 	Integers and strings hint enumerated values.

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -220,7 +220,7 @@ shader, this value can be used as desired.
 
 .. note::
 
-    ``MODELVIEW_MATRIX`` combines both the ``MODEL_MATRIX`` and ``VIEW_MATRIX`` and is better suited when floating point issues may arise. For example, if the object is very far away from the world origin, you may run into floating point issues when using the seperated ``MODE_MATRIX`` and ``VIEW_MATRIX``.
+    ``MODELVIEW_MATRIX`` combines both the ``MODEL_MATRIX`` and ``VIEW_MATRIX`` and is better suited when floating point issues may arise. For example, if the object is very far away from the world origin, you may run into floating point issues when using the separated ``MODE_MATRIX`` and ``VIEW_MATRIX``.
 
 Fragment built-ins
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Found via `codespell -q 3 -S ./LICENSE.txt,./tutorials/i18n,./_tools/codespell-ignore-lines.txt -L doubleclick,findn,lod,inout,nd,raison,te` and other means