### PR TITLE
Fix typo in Exporting packs, patches, and mods

### DIFF
--- a/tutorials/export/exporting_pcks.rst
+++ b/tutorials/export/exporting_pcks.rst
@@ -82,9 +82,9 @@ process will build that type of file for the chosen platform.
        build of the engine or have access to one (distributed alongside or
        perhaps in the original game's files). The tool can then use the Godot
        executable to export a PCK file from the command line with
-       :ref:`OS.execute() <class_OS_method_execute>`. It makes the most sense for the
-       game to not use a tool-build though (for security) and for the modding
-       tools to *do* use a tool-enabled engine build.
+       :ref:`OS.execute() <class_OS_method_execute>`. The game itself shouldn't
+       use a tool-build of the engine (for security), so it's best to keep
+       the modding tool and game separate.
 
 Opening PCK files at runtime
 ----------------------------


### PR DESCRIPTION
Removes "to do use".