### PR TITLE
Add Clangd instructions for VS Code

### DIFF
--- a/development/cpp/configuring_an_ide/visual_studio_code.rst
+++ b/development/cpp/configuring_an_ide/visual_studio_code.rst
@@ -11,9 +11,7 @@ Importing the project
 
 - Make sure the C/C++ extension is installed. You can find instructions in
   the `official documentation <https://code.visualstudio.com/docs/languages/cpp>`_. Alternatively, `clangd <https://open-vsx.org/extension/llvm-vs-code-extensions/vscode-clangd>`_ can be used instead.
-- When using the clangd extension, run:
-::
-  `scons compiledb=True`
+- When using the clangd extension, run ``scons compiledb=True``.
 - From the Visual Studio Code's main screen open the Godot root folder with
   **File > Open Folder...**.
 - Press :kbd:`Ctrl + Shift + P` to open the command prompt window and enter *Configure Task*.

--- a/development/cpp/configuring_an_ide/visual_studio_code.rst
+++ b/development/cpp/configuring_an_ide/visual_studio_code.rst
@@ -10,8 +10,10 @@ Importing the project
 ---------------------
 
 - Make sure the C/C++ extension is installed. You can find instructions in
-  the `official documentation <https://code.visualstudio.com/docs/languages/cpp>`_. Alternatively, `clangd <https://open-vsx.org/extension/llvm-vs-code-extensions/vscode-clangd>` can be used instead.
-- When using the clangd extension, run `scons compiledb=True`
+  the `official documentation <https://code.visualstudio.com/docs/languages/cpp>`_. Alternatively, `clangd <https://open-vsx.org/extension/llvm-vs-code-extensions/vscode-clangd>`_ can be used instead.
+- When using the clangd extension, run:
+::
+  `scons compiledb=True`
 - From the Visual Studio Code's main screen open the Godot root folder with
   **File > Open Folder...**.
 - Press :kbd:`Ctrl + Shift + P` to open the command prompt window and enter *Configure Task*.

--- a/development/cpp/configuring_an_ide/visual_studio_code.rst
+++ b/development/cpp/configuring_an_ide/visual_studio_code.rst
@@ -10,7 +10,8 @@ Importing the project
 ---------------------
 
 - Make sure the C/C++ extension is installed. You can find instructions in
-  the `official documentation <https://code.visualstudio.com/docs/languages/cpp>`_.
+  the `official documentation <https://code.visualstudio.com/docs/languages/cpp>`_. Alternatively, `clangd <https://open-vsx.org/extension/llvm-vs-code-extensions/vscode-clangd>` can be used instead.
+- When using the clangd extension, run `scons compiledb=True`
 - From the Visual Studio Code's main screen open the Godot root folder with
   **File > Open Folder...**.
 - Press :kbd:`Ctrl + Shift + P` to open the command prompt window and enter *Configure Task*.

--- a/development/cpp/configuring_an_ide/visual_studio_code.rst
+++ b/development/cpp/configuring_an_ide/visual_studio_code.rst
@@ -11,7 +11,7 @@ Importing the project
 
 - Make sure the C/C++ extension is installed. You can find instructions in
   the `official documentation <https://code.visualstudio.com/docs/languages/cpp>`_. Alternatively, `clangd <https://open-vsx.org/extension/llvm-vs-code-extensions/vscode-clangd>`_ can be used instead.
-- When using the clangd extension, run ``scons compiledb=True``.
+- When using the clangd extension, run ``scons compiledb=yes``.
 - From the Visual Studio Code's main screen open the Godot root folder with
   **File > Open Folder...**.
 - Press :kbd:`Ctrl + Shift + P` to open the command prompt window and enter *Configure Task*.

--- a/development/cpp/configuring_an_ide/visual_studio_code.rst
+++ b/development/cpp/configuring_an_ide/visual_studio_code.rst
@@ -10,7 +10,9 @@ Importing the project
 ---------------------
 
 - Make sure the C/C++ extension is installed. You can find instructions in
-  the `official documentation <https://code.visualstudio.com/docs/languages/cpp>`_. Alternatively, `clangd <https://open-vsx.org/extension/llvm-vs-code-extensions/vscode-clangd>`_ can be used instead.
+  the `official documentation <https://code.visualstudio.com/docs/languages/cpp>`_.
+  Alternatively, `clangd <https://open-vsx.org/extension/llvm-vs-code-extensions/vscode-clangd>`_
+  can be used instead.
 - When using the clangd extension, run ``scons compiledb=yes``.
 - From the Visual Studio Code's main screen open the Godot root folder with
   **File > Open Folder...**.


### PR DESCRIPTION
Currently, instructions for VSCode suggest using Microsoft's official C/C++ extension when setting up an IDE for engine development. While that works, it's problematic for some distributions of VSCode (such as VSCodium) where the extension isn't included by default and connecting to the official marketplace may be undesirable.
This pull requests adds alternative instructions for the clangdb extension as they differ very slightly (one needs to run ``scons compiledb=True`` to ensure that the extension can comprehend headers in subdirectories of the project)