### PR TITLE
Singletons tutorial has deprecated methods.

### DIFF
--- a/tutorials/scripting/singletons_autoload.rst
+++ b/tutorials/scripting/singletons_autoload.rst
@@ -165,7 +165,7 @@ means that the last child of root is always the loaded scene.
 
         public override void _Ready()
         {
-            Viewport root = GetTree().GetRoot();
+            Viewport root = GetTree().Root;
             CurrentScene = root.GetChild(root.GetChildCount() - 1);
         }
     }
@@ -233,10 +233,10 @@ current scene and replace it with the requested one.
         CurrentScene = nextScene.Instance();
 
         // Add it to the active scene, as child of root.
-        GetTree().GetRoot().AddChild(CurrentScene);
+        GetTree().Root.AddChild(CurrentScene);
 
         // Optionally, to make it compatible with the SceneTree.change_scene() API.
-        GetTree().SetCurrentScene(CurrentScene);
+        GetTree().CurrentScene = CurrentScene;
     }
 
 Using :ref:`Object.call_deferred() <class_Object_method_call_deferred>`,

--- a/tutorials/scripting/singletons_autoload.rst
+++ b/tutorials/scripting/singletons_autoload.rst
@@ -151,7 +151,7 @@ means that the last child of root is always the loaded scene.
     var current_scene = null
 
     func _ready():
-        var root = get_tree().get_root()
+        var root = get_tree().root
         current_scene = root.get_child(root.get_child_count() - 1)
 
  .. code-tab:: csharp
@@ -200,10 +200,10 @@ current scene and replace it with the requested one.
         current_scene = s.instance()
 
         # Add it to the active scene, as child of root.
-        get_tree().get_root().add_child(current_scene)
+        get_tree().root.add_child(current_scene)
 
         # Optionally, to make it compatible with the SceneTree.change_scene() API.
-        get_tree().set_current_scene(current_scene)
+        get_tree().current_scene = current_scene
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
Replaced deprecated C# methods with their new versions in the singletons/autoload tutorial page.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
