### PR TITLE
Document new shader built-ins (node position, camera pos/dir)

### DIFF
--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -162,6 +162,14 @@ shader, this value can be used as desired.
 +----------------------------------------+--------------------------------------------------------+
 | in mat4 **INV_PROJECTION_MATRIX**      | Clip space to view space transform.                    |
 +----------------------------------------+--------------------------------------------------------+
+| in vec3 **NODE_POSITION_WORLD**        | Node world space position.                             |
++----------------------------------------+--------------------------------------------------------+
+| in vec3 **NODE_POSITION_VIEW**         | Node view space position.                              |
++----------------------------------------+--------------------------------------------------------+
+| in vec3 **CAMERA_POSITION_WORLD**      | Camera world space position.                           |
++----------------------------------------+--------------------------------------------------------+
+| in vec3 **CAMERA_DIRECTION_WORLD**     | Camera world space direction.                          |
++----------------------------------------+--------------------------------------------------------+
 | in bool **OUTPUT_IS_SRGB**             | ``true`` when calculations happen in sRGB color space  |
 |                                        | (``true`` in GLES2, ``false`` in GLES3).               |
 +----------------------------------------+--------------------------------------------------------+
@@ -229,21 +237,6 @@ The default use of a Godot fragment processor function is to set up the material
 and to let the built-in renderer handle the final shading. However, you are not required to use all
 these properties, and if you don't write to them, Godot will optimize away the corresponding functionality.
 
-Below are examples of common variables calculated using the built-ins:
-
-.. code-block:: glsl
-
-    vec3 model_world_space = MODEL_MATRIX[3].xyz; // Object's world space position. This is the equivalent to global_transform.origin in GDScript.
-    mat3 model_transform_basis = mat3(MODEL_MATRIX); // Object's world space transform basis. This is the equivalent to global_transform.basis in GDScript.
-    vec3 camera_world_space = INV_VIEW_MATRIX[3].xyz; // Camera's world space position. This is the equivalent to camera.global_transform.origin in GDScript.
-    vec3 camera_eye_world_space = VIEW_MATRIX[3].xyz; // Camera eye vector in world space direction of the camera.
-    vec3 camera_to_object_world_space = normalize(MODEL_MATRIX[3].xyz - INV_VIEW_MATRIX[3].xyz); // Camera's direction to the object in world space.
-
-.. note::
-
-    A commonly used alternative to ``MODEL_MATRIX[3].xyz`` is to use ``vec3 origin = (MODEL_MATRIX * vec4(0,0,0,1)).xyz``. It is more efficient to use ``MODEL_MATRIX[3].xyz`` as it avoids the matrix multiplication. 
-
-
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
 | Built-in                               | Description                                                                                      |
 +========================================+==================================================================================================+
@@ -277,6 +270,12 @@ Below are examples of common variables calculated using the built-ins:
 | in mat4 **PROJECTION_MATRIX**          | View space to clip space transform.                                                              |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
 | in mat4 **INV_PROJECTION_MATRIX**      | Clip space to view space transform.                                                              |
++----------------------------------------+--------------------------------------------------------------------------------------------------+
+| in vec3 **NODE_POSITION_WORLD**        | Node world space position                                                                        |
++----------------------------------------+--------------------------------------------------------------------------------------------------+
+| in vec3 **NODE_POSITION_VIEW**         | Node view space position                                                                         |
++----------------------------------------+--------------------------------------------------------------------------------------------------+
+| in vec3 **CAMERA_POSITION_WORLD**      | Camera world space position                                                                      |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
 | in vec3 **VERTEX**                     | Vertex that comes from vertex function (default, in view space).                                 |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Following up on this PR: https://github.com/godotengine/godot/pull/63597
Documents the new shader built-ins introduced by this PR.
```
NODE_POSITION_WORLD = Node world space position
NODE_POSITION_VIEW = Node view position
CAMERA_POSITION_WORLD = Camera world space position
CAMERA_DIRECTION_WORLD = Camera world space direction
```
