### PR TITLE
Clarify `hint_range` in Shading language

### DIFF
--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -736,7 +736,7 @@ GDScript:
 
 Any GLSL type except for *void* can be a uniform. Additionally, Godot provides
 optional shader hints to make the compiler understand for what the uniform is
-used.
+used, and how the editor should allow users to modify it.
 
 .. code-block:: glsl
 
@@ -757,7 +757,7 @@ Full list of hints below:
 +======================+================================================+======================================================+
 | **vec3, vec4**       | source_color                                   | Used as color.                                       |
 +----------------------+------------------------------------------------+------------------------------------------------------+
-| **int, float**       | hint_range(min, max[, step])                   | Used as range (with min/max/step).                   |
+| **int, float**       | hint_range(min, max[, step])                   | Restricted to values in a range (with min/max/step). |
 +----------------------+------------------------------------------------+------------------------------------------------------+
 | **sampler2D**        | source_color                                   | Used as albedo color.                                |
 +----------------------+------------------------------------------------+------------------------------------------------------+


### PR DESCRIPTION
Explain more about what hints do, because otherwise it's unclear what hint_range could mean. Saying that a value is used as a range, implies that it behaves like an iterable.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
