### PR TITLE
Add albedo color configured to white - Update class_multimesh.rst

### DIFF
--- a/classes/class_multimesh.rst
+++ b/classes/class_multimesh.rst
@@ -281,7 +281,7 @@ Returns the :ref:`Transform2D<class_Transform2D>` of a specific instance.
 
 Sets the color of a specific instance by *multiplying* the mesh's existing vertex colors.
 
-For the color to take effect, ensure that :ref:`use_colors<class_MultiMesh_property_use_colors>` is ``true`` on the ``MultiMesh`` and :ref:`BaseMaterial3D.vertex_color_use_as_albedo<class_BaseMaterial3D_property_vertex_color_use_as_albedo>` is ``true`` on the material.
+For the color to take effect, ensure that :ref:`use_colors<class_MultiMesh_property_use_colors>` is ``true`` on the ``MultiMesh``, :ref:`BaseMaterial3D.vertex_color_use_as_albedo<class_BaseMaterial3D_property_vertex_color_use_as_albedo>` is ``true`` on the material and albedo color of the material is set to pure white R: 255, G: 255, B: 255
 
 ----
 


### PR DESCRIPTION
If the user not set the albedo color to pure white, then the multiplicatiion with a diferent value than 1 will produce color totally wrong.
The pure white color r 255, g 255, b 255 internaly in Godot is 1 then the multiplication work ok.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
