### PR TITLE
Add macOS keyboard shortcut in Creating your first script

### DIFF
--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -168,7 +168,7 @@ this function.
           it or don't indent a line correctly, the editor will highlight it in
           red and display the following error message: "Indented block expected".
 
-Save the scene if you haven't already, then press :kbd:`F6` to run it. Look at
+Save the scene if you haven't already, then press :kbd:`F6` (:kbd:`Cmd + R` on macOS). to run it. Look at
 the Output bottom panel that expands. It should display "Hello, world!"
 
 .. image:: img/scripting_first_script_print_hello_world.png

--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -168,8 +168,9 @@ this function.
           it or don't indent a line correctly, the editor will highlight it in
           red and display the following error message: "Indented block expected".
 
-Save the scene if you haven't already, then press :kbd:`F6` (:kbd:`Cmd + R` on macOS). to run it. Look at
-the Output bottom panel that expands. It should display "Hello, world!"
+Save the scene if you haven't already, then press :kbd:`F6` (:kbd:`Cmd + R` on macOS)
+to run it. Look at the **Output** bottom panel that expands.
+It should display "Hello, world!".
 
 .. image:: img/scripting_first_script_print_hello_world.png
 


### PR DESCRIPTION
I was just working through the Step by Step intro and got thrown off for a few minutes by the `F6` keyboard shortcut on the [Creating your first script](https://docs.godotengine.org/en/stable/getting_started/step_by_step/scripting_first_script.html) page. After going through all the menus I figured out that it was `Cmd+R` on macOS and then I got moving again.

Then I noticed [a recent pull request here fixing exactly this kind of thing](https://github.com/godotengine/godot-docs/pull/5993), and figured you might be happy to have a fix for this one too!