### PR TITLE
Fix typo in GDScript reference: 'user' -> 'use'

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1356,7 +1356,7 @@ the ``is`` keyword can be used::
         entity.apply_damage()
 
 To call a function in a *super class* (i.e. one ``extend``-ed in your current
-class), user the ``super`` keyword::
+class), use the ``super`` keyword::
 
     super(args)
 


### PR DESCRIPTION
user the ``super`` keyword -> use the ``super`` keyword

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
