### PR TITLE
Warning for Blender-glTF-export: Blend shape animations cannot be imported

### DIFF
--- a/tutorials/assets_pipeline/importing_scenes.rst
+++ b/tutorials/assets_pipeline/importing_scenes.rst
@@ -52,6 +52,10 @@ text based format and the binary data in a separate binary file. This can be use
 changes in a text based format. The second is you need the texture files separate from the material file. If you don't need
 either of those glTF binary files are fine.
 
+.. warning::
+
+    Blend shape animations cannot be imported - they require manual animation within Godot.
+
 .. note::
 
     Blender does not export emissive textures with the glTF file. If your model


### PR DESCRIPTION
*Bugsquad edit: `3.5` counterpart of https://github.com/godotengine/godot-docs/pull/6001.*

PR targets branch `3.5`, the same change is (most likely: https://github.com/godotengine/godot/pull/53865) not relevant  in `master`.

* warning about this issue: https://github.com/godotengine/godot/issues/38443
