### PR TITLE
get_frame returns the cropped AtlasTexture

### DIFF
--- a/classes/class_spriteframes.rst
+++ b/classes/class_spriteframes.rst
@@ -39,7 +39,7 @@ Methods
 +---------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | :ref:`float<class_float>`                         | :ref:`get_animation_speed<class_SpriteFrames_method_get_animation_speed>` **(** :ref:`StringName<class_StringName>` anim **)** |const|                                                    |
 +---------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| :ref:`Texture2D<class_Texture2D>`                 | :ref:`get_frame<class_SpriteFrames_method_get_frame>` **(** :ref:`StringName<class_StringName>` anim, :ref:`int<class_int>` idx **)** |const|                                             |
+| :ref:`AtlasTexture<class_Texture2D>`                 | :ref:`get_frame<class_SpriteFrames_method_get_frame>` **(** :ref:`StringName<class_StringName>` anim, :ref:`int<class_int>` idx **)** |const|                                             |
 +---------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | :ref:`int<class_int>`                             | :ref:`get_frame_count<class_SpriteFrames_method_get_frame_count>` **(** :ref:`StringName<class_StringName>` anim **)** |const|                                                            |
 +---------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -119,9 +119,9 @@ The animation's speed in frames per second.
 
 .. _class_SpriteFrames_method_get_frame:
 
-- :ref:`Texture2D<class_Texture2D>` **get_frame** **(** :ref:`StringName<class_StringName>` anim, :ref:`int<class_int>` idx **)** |const|
+- :ref:`AtlasTexture<class_AtlasTexture>` **get_frame** **(** :ref:`StringName<class_StringName>` anim, :ref:`int<class_int>` idx **)** |const|
 
-Returns the animation's selected frame.
+Returns the ``AtlasTexture`` for the animation's selected frame.
 
 ----
 


### PR DESCRIPTION
The method `get_frame` does not only returns `Texture` class, it returns the `AtlasTexture` already cropped.
https://docs.godotengine.org/en/stable/classes/class_spriteframes.html#class-spriteframes-method-get-frame

Texture`  https://docs.godotengine.org/en/stable/classes/class_texture.html#class-texture
AtlasTexture`  https://docs.godotengine.org/en/stable/classes/class_atlastexture.html

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
