### PR TITLE
Default Environment file consumes a lot of RAM

### DIFF
--- a/tutorials/performance/optimizing_3d_performance.rst
+++ b/tutorials/performance/optimizing_3d_performance.rst
@@ -159,3 +159,15 @@ There may also be rendering and physics glitches due to floating point error in
 large worlds. You may be able to use techniques such as orienting the world
 around the player (rather than the other way around), or shifting the origin
 periodically to keep things centred around ``Vector3(0, 0, 0)``.
+
+Environment File
+================
+
+The background and ambient light are configured in the Environment resource file.
+The settings inside this file can create more draws than necessary.
+The default environment file created when you start a new 3D project create a huge
+sky texture of 1024 x 512 pixels inside the RAM. If you don't need a sky texture, or
+want a custom sky texture with small size, delete the "default_env.tres" in your res:// directory
+and create a new WorldEnvironment node so you can create a new environment inside the Inspector panel.
+
+This will delete the default large Sky texture and save 1.5MB of RAM if you not add any other sky texture.


### PR DESCRIPTION
As requested in: https://github.com/godotengine/godot-docs/pull/6060 I am posting here the details:

Some very important things inside Godot have no information or documentation.
Here I am trying explain something I find and help GLES2 run with more speed in low hardware specs in old mobile phones.

The background and ambient light are configured in the Environment resource file.
The settings inside this file can create more draws than necessary.
The default environment file created when you start a new 3D project create a huge
sky texture of 1024 x 512 pixels inside the RAM. If you don't need a sky texture, or
want a custom sky texture with small size, delete the "default_env.tres" in your res:// directory
and create a new WorldEnvironment node so you can create a new environment inside the Inspector panel.

This will delete the default large Sky texture and save 1.5MB of RAM if you not add any other sky texture.

Bellow is some links with images and post about the topic to understand better.

See my report here: godotengine/godot#64183
And here: https://godotforums.org/d/30800-where-do-the-various-textures-in-the-debug-video-ram-monitor-come-from/14

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
