### PR TITLE
Add C#/Mono console support by Pineapple Works

### DIFF
--- a/tutorials/platform/consoles.rst
+++ b/tutorials/platform/consoles.rst
@@ -66,7 +66,7 @@ Following is the list of providers:
 - `Lone Wolf Technology <http://www.lonewolftechnology.com/>`_ offers
   Switch and PS4 porting and publishing of Godot games.
 - `Pineapple Works <https://pineapple.works/>`_ offers
-  Switch, Xbox One and Xbox Series X/S porting and publishing of Godot games.
+  Switch, Xbox One & Xbox Series X/S (GDK) porting and publishing of Godot games (GDScript/C#).
 - `Flynn's Arcade <https://www.flynnsarcades.com/>`_ offers
   Switch porting and publishing of Godot games.
 - `RAWRLAB games <https://www.rawrlab.com/>`_ offers


### PR DESCRIPTION
We've recently completed tech which enables us to port Godot Mono games to Nintendo Switch and the Xbox family of consoles so we wanted to reflect that in the docs.
Also added GDK next to Xbox consoles to signify that we do native Xbox ports and not just use the deprecated UWP technology.

Tried to make our entry as short and concise as possible, but am open to further modifications if deemed more optimal.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
