### PR TITLE
Remove Flynn's Arcades from list of console porting companies

### DIFF
--- a/tutorials/platform/consoles.rst
+++ b/tutorials/platform/consoles.rst
@@ -67,14 +67,12 @@ Following is the list of providers:
   Switch and PS4 porting and publishing of Godot games.
 - `Pineapple Works <https://pineapple.works/>`_ offers
   Switch, Xbox One & Xbox Series X/S (GDK) porting and publishing of Godot games (GDScript/C#).
-- `Flynn's Arcade <https://www.flynnsarcades.com/>`_ offers
-  Switch porting and publishing of Godot games.
 - `RAWRLAB games <https://www.rawrlab.com/>`_ offers
   Switch porting of Godot games.
 - `mazette! games <https://mazette.games/>`_ offers
   Switch, Xbox One and Xbox Series X/S porting and publishing of Godot games.
 
-If your company offers porting and/or publishing services for Godot games,
+If your company offers porting, or porting *and* publishing services for Godot games,
 feel free to
 `open an issue or pull request <https://github.com/godotengine/godot-docs>`_
 to add your company to the list above.


### PR DESCRIPTION
Flynn's Arcades actually only does publishing, with porting being done by RAWRLAB games.

The list should only contain companies that have actually developed ports, rather than companies who are just publishing games to consoles using third-party ports.

See https://github.com/godotengine/godot-docs/pull/5939#issuecomment-1206416335.


<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->