### PR TITLE
Few fixes in shading_language

### DIFF
--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -596,7 +596,7 @@ Example below:
     }
 
 Varyings
-~~~~~~~~
+--------
 
 To send data from the vertex to the fragment (or light) processor function, *varyings* are
 used. They are set for every primitive vertex in the *vertex processor*, and the
@@ -676,7 +676,7 @@ Note that varying may not be assigned in custom functions or a *light processor*
 This limitation was introduced to prevent incorrect usage before initialization.
 
 Interpolation qualifiers
-~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------
 
 Certain values are interpolated during the shading pipeline. You can modify how
 these interpolations are done by using *interpolation qualifiers*.
@@ -707,7 +707,7 @@ There are two possible interpolation qualifiers:
 
 
 Uniforms
-~~~~~~~~
+--------
 
 Passing values to shaders is possible. These are global to the whole shader and
 are called *uniforms*. When a shader is later assigned to a material, the
@@ -731,7 +731,7 @@ GDScript:
 
   material.set_shader_uniform("colors", [Vector3(1, 0, 0), Vector3(0, 1, 0), Vector3(0, 0, 1)])
 
-.. note:: The first argument to ``set_shader_param`` is the name of the uniform
+.. note:: The first argument to ``set_shader_uniform`` is the name of the uniform
           in the shader. It must match *exactly* to the name of the uniform in
           the shader or else it will not be recognized.
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
