### PR TITLE
Update references to OpenSimplexNoise to use FastNoiseLite

### DIFF
--- a/tutorials/math/random_number_generation.rst
+++ b/tutorials/math/random_number_generation.rst
@@ -442,21 +442,20 @@ time, or anything else.
 
 To achieve this, you can use random *noise* functions. Noise functions are
 especially popular in procedural generation to generate realistic-looking
-terrain. Godot provides :ref:`class_opensimplexnoise` for this, which supports
+terrain. Godot provides :ref:`class_fastnoiselite` for this, which supports
 1D, 2D, 3D, and 4D noise. Here's an example with 1D noise:
 
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    var _noise = OpenSimplexNoise.new()
+    var _noise = FastNoiseLite.new()
 
     func _ready():
         randomize()
-        # Configure the OpenSimplexNoise instance.
+        # Configure the FastNoiseLite instance.
         _noise.seed = randi()
-        _noise.octaves = 4
-        _noise.period = 20.0
-        _noise.persistence = 0.8
+        _noise.fractal_octaves = 4
+        _noise.frequency = 1.0 / 20.0
 
         for i in 100:
             # Prints a slowly-changing series of floating-point numbers
@@ -465,16 +464,15 @@ terrain. Godot provides :ref:`class_opensimplexnoise` for this, which supports
 
  .. code-tab:: csharp
 
-    private OpenSimplexNoise _noise = new OpenSimplexNoise();
+    private FastNoiseLite _noise = new FastNoiseLite();
 
     public override void _Ready()
     {
         GD.Randomize();
-        // Configure the OpenSimplexNoise instance.
+        // Configure the FastNoiseLite instance.
         _noise.Seed = (int)GD.Randi();
-        _noise.Octaves = 4;
-        _noise.Period = 20.0f;
-        _noise.Persistence = 0.8f;
+        _noise.FractalOctaves = 4;
+        _noise.Frequency = 1.0f / 20.0f;
 
         for (int i = 0; i < 100; i++)
         {

--- a/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
@@ -179,9 +179,9 @@ If you open it up, you'll see a section called "noise".
 
 Click beside it where it says "[empty]" and select "New NoiseTexture". Then in
 your NoiseTexture click beside where it says "Noise" and select "New
-OpenSimplexNoise".
+NoiseTexture".
 
-.. note:: :ref:`OpenSimplexNoise <class_opensimplexnoise>` is used by the NoiseTexture to
+.. note:: :ref:`FastNoiseLite <class_fastnoiselite>` is used by the NoiseTexture to
           generate a heightmap.
 
 Once you set it up and should look like this.
@@ -305,7 +305,7 @@ do that by passing in a second noise texture.
   uniform sampler2D normalmap;
 
 Set this second uniform texture to another NoiseTexture with another
-OpenSimplexNoise. But this time, check **As Normalmap**.
+FastNoiseLite. But this time, check **As Normalmap**.
 
 .. image:: img/normal-set.png
 


### PR DESCRIPTION
As mentioned in #5821 since [this change](https://github.com/godotengine/godot/pull/56718) OpenSimplexNoise was replaced by FastNoiseLite.

This pull request changes all the OpenSimplexNoise I found in the doc to FastNoiseLite and updates the code examples.

*Bugsquad edit: closes https://github.com/godotengine/godot-docs/issues/5821*