### PR TITLE
Improved distance_to()

### DIFF
--- a/classes/class_vector2.rst
+++ b/classes/class_vector2.rst
@@ -400,7 +400,7 @@ This method runs faster than :ref:`distance_to<class_Vector2_method_distance_to>
 
 - :ref:`float<class_float>` **distance_to** **(** :ref:`Vector2<class_Vector2>` to **)** |const|
 
-Returns the distance between this vector and ``to``.
+Returns the number of pixels between this vector and ``to`` halved.
 
 ----
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
I have improved (at least in my eyes, as I still don't 100% understand GDScript, so this may not have been a problem in the first place) the distance_to() documentation in the Vector2 Class.