### PR TITLE
Small edit to quit requests handling

### DIFF
--- a/tutorials/inputs/handling_quit_requests.rst
+++ b/tutorials/inputs/handling_quit_requests.rst
@@ -14,9 +14,8 @@ to go back otherwise).
 Handling the notification
 -------------------------
 
-On desktop platforms, the :ref:`MainLoop <class_MainLoop>`
-has a special ``MainLoop.NOTIFICATION_WM_QUIT_REQUEST`` notification that is
-sent to all nodes when quitting is requested.
+On desktop and web platforms, :ref:`Node <class_Node>`
+receives a special ``NOTIFICATION_WM_CLOSE_REQUEST`` notification when quitting is requested.
 
 On Android, ``MainLoop.NOTIFICATION_WM_GO_BACK_REQUEST`` is sent instead.
 Pressing the Back button will exit the application if
@@ -34,14 +33,14 @@ Handling the notification is done as follows (on any node):
  .. code-tab:: gdscript GDScript
 
     func _notification(what):
-        if what == MainLoop.NOTIFICATION_WM_QUIT_REQUEST:
+        if what == NOTIFICATION_WM_CLOSE_REQUEST:
             get_tree().quit() # default behavior
 
  .. code-tab:: csharp
 
     public override void _Notification(int what)
     {
-        if (what == MainLoop.NotificationWmQuitRequest)
+        if (what == NotificationWmCloseRequest)
             GetTree().Quit(); // default behavior
     }
 
@@ -75,8 +74,8 @@ Instead, you should send a quit request:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    get_tree().notification(MainLoop.NOTIFICATION_WM_QUIT_REQUEST)
+    get_tree().notification(NOTIFICATION_WM_CLOSE_REQUEST)
 
  .. code-tab:: csharp
 
-    GetTree().Notification(MainLoop.NotificationWmQuitRequest)
+    GetTree().Notification(NotificationWmCloseRequest)


### PR DESCRIPTION
Hey first edit here,

Here's a quick edit for something I just stumbled upon learning Godot 4, basically the notification MainLoop.NOTIFICATION_WM_QUIT_REQUEST changed to NOTIFICATION_WM_CLOSE_REQUEST. 

Would spare some people quite a bit of confusion I basically had to search through the source's commits since it not only moved but changed name.

It *is* already correctly listed in the Node page though.

I'm not really sure about the C# code examples though but I doubt it would be more complicated than this.