### PR TITLE
Document registering an autoload when an editor plugin is enabled

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -399,3 +399,35 @@ C++ modules.
 You can make your own plugins to help yourself and share them in the
 `Asset Library <https://godotengine.org/asset-library/>`_ so that people
 can benefit from your work.
+
+.. _doc_making_plugins_autoload:
+
+Registering autoloads/singletons in plugins
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is possible for editor plugins to automatically register
+:ref:`autoloads <doc_singletons_autoload>` when the plugin is enabled.
+This also includes unregistering the autoload when the plugin is disabled.
+
+This makes setting up plugins faster for users, as they no longer have to manually
+add autoloads to their project settings if your editor plugin requires the use of
+an autoload.
+
+Use the following code to register a singleton from an editor plugin:
+
+::
+
+    @tool
+    extends EditorPlugin
+
+    # Replace this value with a PascalCase autoload name, as per the GDScript style guide.
+    const AUTOLOAD_NAME = "SomeAutoload"
+
+
+    func _enter_tree():
+        # The autoload can be a scene or script file.
+        add_autoload_singleton(AUTOLOAD_NAME, "res://addons/my_addon/some_autoload.tscn")
+
+
+    func _exit_tree():
+        remove_autoload_singleton(AUTOLOAD_NAME)

--- a/tutorials/scripting/singletons_autoload.rst
+++ b/tutorials/scripting/singletons_autoload.rst
@@ -40,6 +40,12 @@ Autoloading nodes and scripts can give us these characteristics.
     Godot won't make an AutoLoad a "true" singleton as per the singleton design
     pattern. It may still be instanced more than once by the user if desired.
 
+.. tip::
+
+    If you're creating an autoload as part of an editor plugin, consider
+    :ref:`registering it automatically in the Project Settings <doc_making_plugins_autoload>`
+    when the plugin is enabled.
+
 AutoLoad
 --------
 


### PR DESCRIPTION
See https://www.reddit.com/r/godot/comments/wvlpre/can_i_create_autoloads_without_using_the_gui_menu/.

Can be cherry-picked to `3.x`, but **remember to replace `@tool` with `tool`.**