### PR TITLE
Add link to top of article body to remove search highlight if it exists

### DIFF
--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -198,8 +198,15 @@ const registerSidebarObserver = (function(){
   };
 })();
 
+const hideSearchHighlight = function(){
+  Documentation.hideSearchWords();
+  document.querySelector('.highlight-link').remove();
+};
+
 $(document).ready(() => {
   const mediaQuery = window.matchMedia('only screen and (min-width: 769px)');
+  const articleBody = document.querySelector('div[itemprop="articleBody"]');
+  const url = new URL(location.href);
 
   registerOnScrollEvent(mediaQuery);
   mediaQuery.addListener(registerOnScrollEvent);
@@ -213,7 +220,7 @@ $(document).ready(() => {
     // automatically generated `meta description` tag.
     const strippedUrl = [location.protocol, '//', location.host, location.pathname].join('');
     const updatedUrl = strippedUrl.replace('/latest/', '/stable/');
-    document.querySelector('div[itemprop="articleBody"]').insertAdjacentHTML('afterbegin', `
+    articleBody.insertAdjacentHTML('afterbegin', `
       <div class="admonition attention">
         <p class="first admonition-title">Attention</p>
         <p>
@@ -227,7 +234,13 @@ $(document).ready(() => {
         </p>
       </div>
     `);
-  }
+  };
+
+  if (url.searchParams.has('highlight')) {
+    articleBody.insertAdjacentHTML('afterbegin', `<p class="highlight-link" style="text-align:center;">
+    <a href="javascript:hideSearchHighlight()">Hide Search Matches</a>
+  </p>`);
+  };
 
   // Load instant.page to prefetch pages upon hovering. This makes navigation feel
   // snappier. The script is dynamically appended as Read the Docs doesn't have


### PR DESCRIPTION
Fixes #5665
This is an alternate implementation of #5792. I decided to make this a new PR altogether as I felt this version was too different from the other one to just be commented feedback (first PR, apologies if this should be done differently!)

Reasons for this implementation (as opposed to the existing PR) are
- In certain cases highlights can be useful, so the user should have the option to hide them if they so choose
- Sphinx has a built-in `Documentation.hideSearchWords()` method that removes all highlights and updates the URL accordingly, all in one line (much cleaner)

In this version, it just adds a link to the top of the article body that can be clicked to hide the search highlights. It only shows if the `highlight` property exists in the URL, and is removed once clicked. It follows the same setup as described [here](https://sphinx-basic-ng.readthedocs.io/en/latest/usage/components/search-hide/), but in `custom.js` instead of a separate component referenced in the templates.

https://user-images.githubusercontent.com/18225391/187023570-4eee8871-3f01-437f-a1f9-2ce519f40a7e.mp4
