### PR TITLE
Update 3d example gd script code

### DIFF
--- a/getting_started/first_3d_game/03.player_movement_code.rst
+++ b/getting_started/first_3d_game/03.player_movement_code.rst
@@ -22,9 +22,9 @@ character.
    extends KinematicBody
 
    # How fast the player moves in meters per second.
-   export var speed = 14
+   @export var speed = 14
    # The downward acceleration when in the air, in meters per second squared.
-   export var fall_acceleration = 75
+   @export var fall_acceleration = 75
 
    var velocity = Vector3.ZERO
 
@@ -236,9 +236,9 @@ Here is the complete ``Player.gd`` code for reference.
    extends KinematicBody
 
    # How fast the player moves in meters per second.
-   export var speed = 14
+   @export var speed = 14
    # The downward acceleration when in the air, in meters per second squared.
-   export var fall_acceleration = 75
+   @export var fall_acceleration = 75
 
    var velocity = Vector3.ZERO
 

--- a/getting_started/first_3d_game/04.mob_scene.rst
+++ b/getting_started/first_3d_game/04.mob_scene.rst
@@ -103,9 +103,9 @@ the ``velocity``.
    extends KinematicBody
 
    # Minimum speed of the mob in meters per second.
-   export var min_speed = 10
+   @export var min_speed = 10
    # Maximum speed of the mob in meters per second.
-   export var max_speed = 18
+   @export var max_speed = 18
 
    var velocity = Vector3.ZERO
 
@@ -257,9 +257,9 @@ Here is the complete ``Mob.gd`` script for reference.
    extends KinematicBody
 
    # Minimum speed of the mob in meters per second.
-   export var min_speed = 10
+   @export var min_speed = 10
    # Maximum speed of the mob in meters per second.
-   export var max_speed = 18
+   @export var max_speed = 18
 
    var velocity = Vector3.ZERO
 

--- a/getting_started/first_3d_game/05.spawning_mobs.rst
+++ b/getting_started/first_3d_game/05.spawning_mobs.rst
@@ -163,7 +163,7 @@ always spawn following the same sequence.
 
    extends Node
 
-   export (PackedScene) var mob_scene
+   @export var mob_scene: PackedScene
 
 
    func _ready():
@@ -280,7 +280,7 @@ Here is the complete ``Main.gd`` script so far, for reference.
 
    extends Node
 
-   export (PackedScene) var mob_scene
+   @export var mob_scene: PackedScene
 
 
    func _ready():

--- a/getting_started/first_3d_game/06.jump_and_squash.rst
+++ b/getting_started/first_3d_game/06.jump_and_squash.rst
@@ -114,7 +114,7 @@ the ``jump_impulse``.
 
    #...
    # Vertical impulse applied to the character upon jumping in meters per second.
-   export var jump_impulse = 20
+   @export var jump_impulse = 20
 
  .. code-tab:: csharp
 
@@ -212,7 +212,7 @@ when jumping.
 
    # Vertical impulse applied to the character upon bouncing over a mob in
    # meters per second.
-   export var bounce_impulse = 16
+   @export var bounce_impulse = 16
 
  .. code-tab:: csharp
 

--- a/getting_started/first_3d_game/07.killing_player.rst
+++ b/getting_started/first_3d_game/07.killing_player.rst
@@ -234,9 +234,9 @@ Next is ``Mob.gd``.
    signal squashed
 
    # Minimum speed of the mob in meters per second.
-   export var min_speed = 10
+   @export var min_speed = 10
    # Maximum speed of the mob in meters per second.
-   export var max_speed = 18
+   @export var max_speed = 18
 
    var velocity = Vector3.ZERO
 
@@ -317,13 +317,13 @@ Finally, the longest script, ``Player.gd``.
    signal hit
 
    # How fast the player moves in meters per second.
-   export var speed = 14
+   @export var speed = 14
    # The downward acceleration when in the air, in meters per second squared.
-   export var fall_acceleration = 75
+   @export var fall_acceleration = 75
    # Vertical impulse applied to the character upon jumping in meters per second.
-   export var jump_impulse = 20
+   @export var jump_impulse = 20
    # Vertical impulse applied to the character upon bouncing over a mob in meters per second.
-   export var bounce_impulse = 16
+   @export var bounce_impulse = 16
 
    var velocity = Vector3.ZERO
 

--- a/getting_started/first_3d_game/08.score_and_replay.rst
+++ b/getting_started/first_3d_game/08.score_and_replay.rst
@@ -374,7 +374,7 @@ Here is the complete ``Main.gd`` script for reference.
 
    extends Node
 
-   export (PackedScene) var mob_scene
+   @export var mob_scene: PackedScene
 
 
    func _ready():

--- a/getting_started/first_3d_game/09.adding_animations.rst
+++ b/getting_started/first_3d_game/09.adding_animations.rst
@@ -288,13 +288,13 @@ Here's the *Player* script.
    signal hit
 
    # How fast the player moves in meters per second.
-   export var speed = 14
+   @export var speed = 14
    # The downward acceleration when in the air, in meters per second per second.
-   export var fall_acceleration = 75
+   @export var fall_acceleration = 75
    # Vertical impulse applied to the character upon jumping in meters per second.
-   export var jump_impulse = 20
+   @export var jump_impulse = 20
    # Vertical impulse applied to the character upon bouncing over a mob in meters per second.
-   export var bounce_impulse = 16
+   @export var bounce_impulse = 16
 
    var velocity = Vector3.ZERO
 
@@ -455,9 +455,9 @@ And the *Mob*'s script.
    signal squashed
 
    # Minimum speed of the mob in meters per second.
-   export var min_speed = 10
+   @export var min_speed = 10
    # Maximum speed of the mob in meters per second.
-   export var max_speed = 18
+   @export var max_speed = 18
 
    var velocity = Vector3.ZERO
 


### PR DESCRIPTION
I did notice that in [player movement for the 3d game](https://docs.godotengine.org/en/latest/getting_started/first_3d_game/03.player_movement_code.html), there were some `@` missing from the `export` keyword. This is a small update to add this `@` on all the exports on this code. 

This is my first MR, 
If I did something wrong, 
Please guide me in this process.