### PR TITLE
Fix the styling of the HTML shell reference

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -343,73 +343,82 @@ hr,
 }
 
 /* JavaScript documentation directives */
-.rst-content dl:not(.docutils) dt {
-    background-color: var(--admonition-note-background-color) !important;
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) dt,
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) dl:not(.field-list) > dt {
+    background-color: var(--admonition-note-background-color);
     border-color: var(--admonition-note-title-background-color);
     color: var(--admonition-note-color);
 }
-.rst-content dl:not(.docutils) dl dt {
-    background-color: var(--admonition-attention-background-color);
-    border-color: var(--admonition-attention-title-background-color);
-    color: var(--admonition-attention-color) !important;
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) dl dt {
+    background-color: transparent;
+    border-color: transparent;
+    color: var(--footer-color);
 }
-.rst-content dl:not(.docutils).class dt,
-.rst-content dl:not(.docutils).function dt,
-.rst-content dl:not(.docutils).method dt,
-.rst-content dl:not(.docutils).attribute dt {
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).class dt,
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).function dt,
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).method dt,
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).attribute dt {
+    font-weight: 600;
+    padding: 0 8px;
+    margin-bottom: 1px;
     width: 100%;
 }
-.rst-content dl:not(.docutils).class > dt,
-.rst-content dl:not(.docutils).function > dt,
-.rst-content dl:not(.docutils).method > dt,
-.rst-content dl:not(.docutils).attribute > dt {
-    font-size: 100%;
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).class > dt,
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).function > dt,
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).method > dt,
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).attribute > dt {
+    font-family: SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,Courier,monospace;
+    font-size: 90%;
     font-weight: normal;
     margin-bottom: 16px;
     padding: 6px 8px;
 }
-.rst-content dl:not(.docutils) tt.descclassname,
-.rst-content dl:not(.docutils) code.descclassname {
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) .sig-prename.descclassname {
     color: var(--highlight-type2-color);
     font-weight: normal;
 }
-.rst-content dl:not(.docutils) tt.descname,
-.rst-content dl:not(.docutils) code.descname {
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) .sig-name.descname {
     color: var(--highlight-function-color);
-    font-weight: normal;
+    font-weight: 700;
 }
-.rst-content dl:not(.docutils) .sig-paren,
-.rst-content dl:not(.docutils) .optional {
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) .sig-paren,
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) .optional {
     color: var(--highlight-operator-color) !important;
     font-weight: normal;
     padding: 0 2px;
 }
-.rst-content dl:not(.docutils) .optional {
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) .optional {
     font-style: italic;
 }
-.rst-content dl:not(.docutils) .sig-param,
-.rst-content dl:not(.docutils).class dt > em,
-.rst-content dl:not(.docutils).function dt > em,
-.rst-content dl:not(.docutils).method dt > em {
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) .sig-param,
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).class dt > em,
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).function dt > em,
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).method dt > em {
     color: var(--code-literal-color);
     font-style: normal;
     padding: 0 4px;
 }
-.rst-content dl:not(.docutils) .sig-param,
-.rst-content dl:not(.docutils).class dt > .optional ~ em,
-.rst-content dl:not(.docutils).function dt > .optional ~ em,
-.rst-content dl:not(.docutils).method dt > .optional ~ em {
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) .k {
+    font-style: normal;
+}
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) .sig-param,
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).class dt > .optional ~ em,
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).function dt > .optional ~ em,
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).method dt > .optional ~ em {
     color: var(--highlight-number-color);
     font-style: italic;
 }
-.rst-content dl:not(.docutils).class dt > em.property {
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).class dt > em.property {
     color: var(--highlight-keyword-color);
 }
-.rst-content dl:not(.docutils) dt a.headerlink {
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) dt a.headerlink {
     color: var(--link-color) !important;
 }
-.rst-content dl:not(.docutils) dt a.headerlink:visited {
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) dt a.headerlink:visited {
     color: var(--link-color-visited);
+}
+html.writer-html5 .rst-content dl.field-list > dd strong {
+    font-family: SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,Courier,monospace;
 }
 
 footer,

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -367,7 +367,7 @@ html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(
 html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).function > dt,
 html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).method > dt,
 html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple).attribute > dt {
-    font-family: SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,Courier,monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, Courier, monospace;
     font-size: 90%;
     font-weight: normal;
     margin-bottom: 16px;
@@ -418,7 +418,7 @@ html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(
     color: var(--link-color-visited);
 }
 html.writer-html5 .rst-content dl.field-list > dd strong {
-    font-family: SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,Courier,monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, Courier, monospace;
 }
 
 footer,


### PR DESCRIPTION
Seems that one of the updates to the sphinx RTD template [broke our styling](https://user-images.githubusercontent.com/11782833/187210479-0b2bf291-8a37-4af6-9907-b52737da196a.png) for the HTML reference.

So I did another pass to patch that up and maybe make the styling a bit better in general. `stable` also seems to be affected (as are 3.4 and 3.5), though 3.3 is not. I guess it's a matter of being deployed lately.

[Dark mode](https://user-images.githubusercontent.com/11782833/187210718-73b8489d-2cac-4b16-99b6-0fed64f14774.png)
[Light mode](https://user-images.githubusercontent.com/11782833/187210726-fc345e48-5cf7-4261-a09d-9ead0baceda3.png)
