### PR TITLE
Fix missing quote in GDScript reference

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -992,7 +992,7 @@ Here are some examples of expressions::
     do_something() # Function call.
     [1, 2, 3] # Array definition.
     {A = 1, B = 2} # Dictionary definition.
-    preload("res://icon.png) # Preload builtin function.
+    preload("res://icon.png") # Preload builtin function.
     self # Reference to current instance.
 
 Identifiers, attributes, and subscripts are valid assignment targets. Other expressions cannot be on the left side of


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

There was a missing quotation mark :)
