### PR TITLE
Updated velocity_computed signal description

### DIFF
--- a/classes/class_navigationagent3d.rst
+++ b/classes/class_navigationagent3d.rst
@@ -118,7 +118,7 @@ Notifies when the player defined target, set with :ref:`set_target_location<clas
 
 - **velocity_computed** **(** :ref:`Vector3<class_Vector3>` safe_velocity **)**
 
-Notifies when the collision avoidance velocity is calculated. Emitted by :ref:`set_velocity<class_NavigationAgent3D_method_set_velocity>`.
+Notifies when the collision avoidance velocity is calculated. Emitted by :ref:`set_velocity<class_NavigationAgent3D_method_set_velocity>`. Only emitted when :ref:`bool<class_bool>` is enabled.
 
 Property Descriptions
 ---------------------


### PR DESCRIPTION
This signal is only emitted when avoidance_enabled is enabled/true, but the documentation does not reference this. Adding this note for clarity.