### PR TITLE
Add VisualScript pending removal notice in Godot 4.0

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -379,6 +379,16 @@ Scripting
 
 - Maintained D, Kotlin, Python, Nim, and Rust bindings provided by the community.
 
+.. warning::
+
+    `Godot 4.0 will remove VisualScript from core entirely. <https://godotengine.org/article/godot-4-will-discontinue-visual-scripting>`__
+    As a result, creating new projects using visual scripting in Godot is not recommended.
+    Future Godot 4.x releases may have VisualScript reimplemented as an extension.
+
+    While Godot 3.x will keep VisualScript supported, we recommend
+    :ref:`trying out GDScript <toc-learn-scripting-gdscript>` instead,
+    especially if you intend to migrate your project to Godot 4.
+
 Audio
 ^^^^^
 

--- a/getting_started/introduction/godot_design_philosophy.rst
+++ b/getting_started/introduction/godot_design_philosophy.rst
@@ -108,6 +108,17 @@ game code. See `The Godot editor is a Godot game`_ below.
 *A State Machine editor plugin in Godot 2 by kubecz3k. It lets you
 manage states and transitions visually.*
 
+
+.. warning::
+
+    `Godot 4.0 will remove VisualScript from core entirely. <https://godotengine.org/article/godot-4-will-discontinue-visual-scripting>`__
+    As a result, creating new projects using visual scripting in Godot is not recommended.
+    Future Godot 4.x releases may have VisualScript reimplemented as an extension.
+
+    While Godot 3.x will keep VisualScript supported, we recommend
+    :ref:`trying out GDScript <toc-learn-scripting-gdscript>` instead,
+    especially if you intend to migrate your project to Godot 4.
+
 Open source
 -----------
 

--- a/getting_started/step_by_step/scripting_languages.rst
+++ b/getting_started/step_by_step/scripting_languages.rst
@@ -37,6 +37,16 @@ everything in GDScript or C#. It's your call.
 We provide this flexibility to answer the needs of different game projects and
 developers.
 
+.. warning::
+
+    `Godot 4.0 will remove VisualScript from core entirely. <https://godotengine.org/article/godot-4-will-discontinue-visual-scripting>`__
+    As a result, creating new projects using visual scripting in Godot is not recommended.
+    Future Godot 4.x releases may have VisualScript reimplemented as an extension.
+
+    While Godot 3.x will keep VisualScript supported, we recommend
+    :ref:`trying out GDScript <toc-learn-scripting-gdscript>` instead,
+    especially if you intend to migrate your project to Godot 4.
+
 Which language should I use?
 ----------------------------
 
@@ -128,6 +138,16 @@ or ClojureCLR. However, C# is the only officially supported .NET option.
 
 VisualScript
 ~~~~~~~~~~~~
+
+.. warning::
+
+    `Godot 4.0 will remove VisualScript from core entirely. <https://godotengine.org/article/godot-4-will-discontinue-visual-scripting>`__
+    As a result, creating new projects using visual scripting in Godot is not recommended.
+    Future Godot 4.x releases may have VisualScript reimplemented as an extension.
+
+    While Godot 3.x will keep VisualScript supported, we recommend
+    :ref:`trying out GDScript <toc-learn-scripting-gdscript>` instead,
+    especially if you intend to migrate your project to Godot 4.
 
 :ref:`Visual Scripting<doc_what_is_visual_script>` is a graph-based visual
 programming language where you connect blocks. It can be a great tool for

--- a/tutorials/scripting/visual_script/custom_visualscript_nodes.rst
+++ b/tutorials/scripting/visual_script/custom_visualscript_nodes.rst
@@ -3,6 +3,16 @@
 Custom VisualScript nodes
 =========================
 
+.. warning::
+
+    `Godot 4.0 will remove VisualScript from core entirely. <https://godotengine.org/article/godot-4-will-discontinue-visual-scripting>`__
+    As a result, creating new projects using visual scripting in Godot is not recommended.
+    Future Godot 4.x releases may have VisualScript reimplemented as an extension.
+
+    While Godot 3.x will keep VisualScript supported, we recommend
+    :ref:`trying out GDScript <toc-learn-scripting-gdscript>` instead,
+    especially if you intend to migrate your project to Godot 4.
+
 Custom nodes are written in GDScript and can then be used in VisualScript.
 This is useful for offloading complex code to GDScript and reusing it.
 

--- a/tutorials/scripting/visual_script/index.rst
+++ b/tutorials/scripting/visual_script/index.rst
@@ -1,6 +1,16 @@
 VisualScript
 ============
 
+.. warning::
+
+    `Godot 4.0 will remove VisualScript from core entirely. <https://godotengine.org/article/godot-4-will-discontinue-visual-scripting>`__
+    As a result, creating new projects using visual scripting in Godot is not recommended.
+    Future Godot 4.x releases may have VisualScript reimplemented as an extension.
+
+    While Godot 3.x will keep VisualScript supported, we recommend
+    :ref:`trying out GDScript <toc-learn-scripting-gdscript>` instead,
+    especially if you intend to migrate your project to Godot 4.
+
 .. toctree::
    :maxdepth: 3
    :name: toc-learn-scripting-visual_script


### PR DESCRIPTION
Related to #6127. See https://godotengine.org/article/godot-4-will-discontinue-visual-scripting.