### PR TITLE
Document changing Windows export template icon without external tools

### DIFF
--- a/tutorials/export/changing_application_icon_for_windows.rst
+++ b/tutorials/export/changing_application_icon_for_windows.rst
@@ -61,6 +61,11 @@ use the ``Icon`` setting.
 Changing the file icon
 ----------------------
 
+In Godot 3.5 and later, you can change the file icon without
+external tools using `godoticon <https://github.com/pkowal1982/godoticon>`__.
+Changing the file icon this way should work for executables containing
+an embedded PCK.
+
 .. warning::
 
     There are `known issues <https://github.com/godotengine/godot/issues/33466>`__


### PR DESCRIPTION
As 3.5 is out info about godoticon script should probably get here.

*Bugsuad edit: `3.5` version of https://github.com/godotengine/godot-docs/pull/5739.*