### PR TITLE
update "Apply Reset" option location

### DIFF
--- a/tutorials/animation/introduction.rst
+++ b/tutorials/animation/introduction.rst
@@ -341,7 +341,7 @@ where they were.
 
 If you want to reset the tracks in the editor, select the AnimationPlayer node,
 open the **Animation** bottom panel then choose **Apply Reset** in the
-animation editor's **Animation** dropdown menu.
+animation editor's **Edit** dropdown menu.
 
 When adding tracks on new animations, the editor will ask you to automatically
 create a RESET track when using the keyframe icon next to a property in the inspector.


### PR DESCRIPTION
Under USING RESET tracks, it said the "Apply Reset" option was in the "Animation" dropdown menu.  It's actually located in the "Edit" dropdown menu.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
