### PR TITLE
Warn about non-tool plugin scripts in C#

### DIFF
--- a/tutorials/plugins/editor/inspector_plugins.rst
+++ b/tutorials/plugins/editor/inspector_plugins.rst
@@ -141,6 +141,7 @@ specifically add :ref:`class_EditorProperty`-based controls.
     #if TOOLS
     using Godot;
 
+    [Tool]
     public class MyInspectorPlugin : EditorInspectorPlugin
     {
         public override bool CanHandle(Object @object)
@@ -247,6 +248,7 @@ followed by ``set_bottom_editor()`` to position it below the name.
     #if TOOLS
     using Godot;
 
+    [Tool]
     public class RandomIntEditor : EditorProperty
     {
         // The main control for editing the property.

--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -76,10 +76,10 @@ editor, and it must inherit from :ref:`class_EditorPlugin`.
 
     In addition to the EditorPlugin script, any other script that your plugin uses
     must *also* be a tool.
-      - Any GDScript without ``tool`` imported into the editor will act like
-        an empty file!
-      - Any C# class without ``[Tool]`` won't be reloaded when the project is
-        built forcing you to re-enable the plugin!
+    - Any GDScript without ``tool`` imported into the editor will act like
+      an empty file!
+    - Any C# class without ``[Tool]`` won't be reloaded when the project is
+      built forcing you to re-enable the plugin!
 
 It's important to deal with initialization and clean-up of resources.
 A good practice is to use the virtual function

--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -76,10 +76,8 @@ editor, and it must inherit from :ref:`class_EditorPlugin`.
 
     In addition to the EditorPlugin script, any other script that your plugin uses
     must *also* be a tool.
-    - Any GDScript without ``tool`` imported into the editor will act like
-      an empty file!
-    - Any C# class without ``[Tool]`` won't be reloaded when the project is
-      built forcing you to re-enable the plugin!
+    * Any GDScript without ``tool`` imported into the editor will act like an empty file!
+    * Any C# class without ``[Tool]`` won't be reloaded when the project is built forcing you to re-enable the plugin!
 
 It's important to deal with initialization and clean-up of resources.
 A good practice is to use the virtual function

--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -74,9 +74,12 @@ editor, and it must inherit from :ref:`class_EditorPlugin`.
 
 .. warning::
 
-    In addition to the EditorPlugin script, any other GDScript that your plugin uses
-    must *also* be a tool. Any GDScript without ``tool`` imported into the editor
-    will act like an empty file!
+    In addition to the EditorPlugin script, any other script that your plugin uses
+    must *also* be a tool.
+      - Any GDScript without ``tool`` imported into the editor will act like
+        an empty file!
+      - Any C# class without ``[Tool]`` won't be reloaded when the project is
+        built forcing you to re-enable the plugin!
 
 It's important to deal with initialization and clean-up of resources.
 A good practice is to use the virtual function


### PR DESCRIPTION
- Add warning about C# plugins not reloaded when they are not tools
- Add `[Tool]` attribute to plugin scripts in examples so they are not lost on reload (see https://github.com/godotengine/godot/issues/64381)
- This only applies to 3.x since https://github.com/godotengine/godot/pull/65266 is risky and won't be backported.

Not sure if using a list inside a warning is ok but I think it looks kind of ugly and I was getting an error but it seemed to work anyway.

```
tutorials/plugins/editor/making_plugins.rst:79: ERROR: Unexpected indentation.
```

![image](https://user-images.githubusercontent.com/3903059/188428801-ff0af61c-9387-4dd9-95de-a3170042c310.png)
