### PR TITLE
Use exact name of AnimationPlayer node in Character animation

### DIFF
--- a/getting_started/first_3d_game/09.adding_animations.rst
+++ b/getting_started/first_3d_game/09.adding_animations.rst
@@ -17,7 +17,7 @@ Using the animation editor
 The engine comes with tools to author animations in the editor. You can then use
 the code to play and control them at runtime.
 
-Open the player scene, select the player node, and add an animation player node.
+Open the player scene, select the player node, and add an *AnimationPlayer* node.
 
 The *Animation* dock appears in the bottom panel.
 


### PR DESCRIPTION
This follows the convention in previous pages of the guide which refer to nodes by their exact names.
