### PR TITLE
Rename print_x_times -> print_n_times

### DIFF
--- a/tutorials/scripting/cross_language_scripting.rst
+++ b/tutorials/scripting/cross_language_scripting.rst
@@ -29,7 +29,7 @@ The following two scripts will be used as references throughout this page.
         for element in arr:
             print(element)
 
-    func print_x_times(msg : String, n : int) -> void:
+    func print_n_times(msg : String, n : int) -> void:
         for i in range(n):
             print(msg)
 


### PR DESCRIPTION
Change code to match the rest of the documentation. C# examples
use PrintNTimes and calls print_n_times, so change gdscript to match.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
