### PR TITLE
Update "Your first 2d game" UI placement doc

### DIFF
--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -70,26 +70,46 @@ use the following settings:
 ScoreLabel
 ~~~~~~~~~~
 
--  *Layout* : "Top Wide"
 -  *Text* : ``0``
 -  *Align* : "Center"
+-  *Anchor* :
+
+   -  Right: ``1``
+-  *Margin*: 
+
+   -  Set all to ``0``
 
 Message
 ~~~~~~~~~~~~
 
--  *Layout* : "HCenter Wide"
 -  *Text* : ``Dodge the Creeps!``
 -  *Align* : "Center"
 -  *Autowrap* : "On"
+-  *Anchor* :
+
+   -  Top: ``0.5``
+   -  Right: ``1``
+   -  Bottom: ``0.5``
+-  *Margin* :
+
+   -  Top: ``-79``
+   -  Bottom: ``79``
 
 StartButton
 ~~~~~~~~~~~
 
 -  *Text* : ``Start``
--  *Layout* : "Center Bottom"
+-  *Anchor* :
+
+   -  Left: ``0.5``
+   -  Top: ``1``
+   -  Right: ``0.5``
+   -  Bottom: ``1``
 -  *Margin* :
 
+   -  Left: ``-90``
    -  Top: ``-200``
+   -  Right: ``90``
    -  Bottom: ``-100``
 
 On the ``MessageTimer``, set the ``Wait Time`` to ``2`` and set the ``One Shot``


### PR DESCRIPTION
I believe the instructions in this section are outdated: https://docs.godotengine.org/en/stable/getting_started/first_2d_game/06.heads_up_display.html#scorelabel

Specifically, this `Layout` property does not seem to exist anymore:

```
Layout : "Top Wide"
...
Layout : "HCenter Wide"
...
etc
```

I had trouble figuring out how to get my UI to look like what was in the picture until I downloaded the demo project and found the correct values there: https://github.com/godotengine/godot-demo-projects/blob/06bdeb97dc245912998d42a8c001d83dcc557e0f/2d/dodge_the_creeps/HUD.tscn#L23