### PR TITLE
Removed CollisionObject2D references

### DIFF
--- a/getting_started/first_2d_game/04.creating_the_enemy.rst
+++ b/getting_started/first_2d_game/04.creating_the_enemy.rst
@@ -18,7 +18,7 @@ Click Scene -> New Scene and add the following nodes:
 - :ref:`RigidDynamicBody2D <class_RigidDynamicBody2D>` (named ``Mob``)
 
    - :ref:`AnimatedSprite2D <class_AnimatedSprite2D>`
-   - :ref:`CollisionShape2D <class_CollisionShape2D>`
+   - :ref:`CollisionObject2D <class_CollisionObject2D>`
    - :ref:`VisibleOnScreenNotifier2D <class_VisibleOnScreenNotifier2D>`
 
 Don't forget to set the children so they can't be selected, like you did with


### PR DESCRIPTION
As the 2nd step doesn't work with CollisionShape2D, I've removed it to match the demo https://github.com/godotengine/godot-demo-projects/tree/master/2d/dodge_the_creeps

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
