### PR TITLE
Change estimated Godot 4 release date to H1 2023

### DIFF
--- a/about/release_policy.rst
+++ b/about/release_policy.rst
@@ -88,7 +88,7 @@ on GitHub.
 +-------------+----------------------+--------------------------------------------------------------------------+
 | **Version** | **Release date**     | **Support level**                                                        |
 +-------------+----------------------+--------------------------------------------------------------------------+
-| Godot 4.0   | Q4 2022              | |unstable| *Alpha.* Current focus of development (unstable).             |
+| Godot 4.0   | H1 2023              | |unstable| *Alpha.* Current focus of development (unstable).             |
 +-------------+----------------------+--------------------------------------------------------------------------+
 | Godot 3.6   | Q4 2022              | |supported| *Beta.* Receives new features as well as bug fixes while     |
 |             |                      | under development.                                                       |


### PR DESCRIPTION
It's currently September, which leaves three months between the first beta and release, which seems unlikely (well, could be 3.5 months if released near Christmas), so I think it's time to update the estimated release date of Godot 4.

Also, considering the history of 3.x releases, I'm wondering if we should plan for Godot 3.6 to come out in Q1 2023, but in the meantime I have not changed it in this PR.