### PR TITLE
Use official CC BY 3.0 terminology and resources

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,7 +4,7 @@ Godot Engine is developed by a community of voluntary contributors who
 contribute on all areas, including writing and maintaining the documentation.
 
 It is impossible to list them all; nevertheless, this file aims at listing
-the writers who contributed significant patches to this CC-BY licensed
+the writers who contributed significant patches to this CC BY licensed
 documentation on the `godot-docs` repository.
 
 GitHub usernames are indicated in parentheses, or as sole entry when no other

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -17,7 +17,7 @@ In short:
 * You are free to modify, distribute, redistribute, and remix Godot to your heart's content, for any reason, both non-commercially and commercially.
 
 All the contents of this accompanying documentation are published under
-the permissive Creative Commons Attribution 3.0 (`CC-BY 3.0 <https://creativecommons.org/licenses/by/3.0/>`_) license, with attribution
+the permissive Creative Commons Attribution 3.0 (`CC BY 3.0 <https://creativecommons.org/licenses/by/3.0/>`_) license, with attribution
 to "Juan Linietsky, Ariel Manzur and the Godot Engine community."
 
 Logos and icons are generally under the same Creative Commons license. Note

--- a/about/introduction.rst
+++ b/about/introduction.rst
@@ -69,7 +69,7 @@ open source `Sphinx <http://www.sphinx-doc.org>`_ and `ReadTheDocs
           <https://hosted.weblate.org/projects/godot-engine/godot-docs/>`_.
 
 All the contents are under the permissive Creative Commons Attribution 3.0
-(`CC-BY 3.0 <https://creativecommons.org/licenses/by/3.0/>`_) license, with
+(`CC BY 3.0 <https://creativecommons.org/licenses/by/3.0/>`_) license, with
 attribution to "Juan Linietsky, Ariel Manzur and the Godot Engine community".
 
 Organization of the documentation

--- a/community/contributing/contributing_to_the_documentation.rst
+++ b/community/contributing/contributing_to_the_documentation.rst
@@ -180,9 +180,9 @@ License
 -------
 
 This documentation and every page it contains is published under the terms of
-the `Creative Commons Attribution 3.0 license (CC-BY-3.0)
-<https://tldrlegal.com/license/creative-commons-attribution-(cc)>`_, with
-attribution to "Juan Linietsky, Ariel Manzur and the Godot community".
+the `Creative Commons Attribution 3.0 license (CC BY 3.0)
+<https://creativecommons.org/licenses/by/3.0/>`_, with attribution to "Juan
+Linietsky, Ariel Manzur and the Godot community".
 
 By contributing to the documentation on the GitHub repository, you agree that
 your changes are distributed under this license.

--- a/conf.py
+++ b/conf.py
@@ -77,7 +77,7 @@ master_doc = "index"
 # General information about the project
 project = "Godot Engine"
 copyright = (
-    "2014-2022, Juan Linietsky, Ariel Manzur and the Godot community (CC-BY 3.0)"
+    "2014-2022, Juan Linietsky, Ariel Manzur and the Godot community (CC BY 3.0)"
 )
 author = "Juan Linietsky, Ariel Manzur and the Godot community"
 


### PR DESCRIPTION
This change makes the docs repo always use the official abbreviation (CC BY 3.0) for its license. Previously, it would sometimes use “CC-BY 3.0” or “CC-BY-3.0”. This change also make the docs repo always point to [the official Commons deed][1] for more information about CC BY 3.0. Previously, it would sometimes link to [an unofficial source][2].

[1]: <https://creativecommons.org/licenses/by/3.0/>
[2]: <https://tldrlegal.com/license/creative-commons-attribution-(cc)>

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
