### PR TITLE
Fix order of EXTRA_MATRIX and WORLD_MATRIX

### DIFF
--- a/tutorials/shaders/shader_reference/canvas_item_shader.rst
+++ b/tutorials/shaders/shader_reference/canvas_item_shader.rst
@@ -75,7 +75,7 @@ it manually with the following code:
 
     void vertex() {
 
-        VERTEX = (EXTRA_MATRIX * (WORLD_MATRIX * vec4(VERTEX, 0.0, 1.0))).xy;
+        VERTEX = (WORLD_MATRIX * (EXTRA_MATRIX * vec4(VERTEX, 0.0, 1.0))).xy;
     }
 
 .. note:: ``WORLD_MATRIX`` is actually a modelview matrix. It takes input in local space and transforms it


### PR DESCRIPTION
in CanvasItem Shader reference page

See implementation in Godot:
https://github.com/godotengine/godot/blob/cf157a804fda7f030f280c9a778e9e672022c682/drivers/gles3/shaders/canvas.glsl#L225-L228

Extra matrix comes first, then World matrix

This change is not relevant for master