### PR TITLE
Fix doctool command

### DIFF
--- a/development/cpp/custom_modules_in_cpp.rst
+++ b/development/cpp/custom_modules_in_cpp.rst
@@ -573,7 +573,7 @@ Run command:
 
    ::
 
-      user@host:~/godot/bin$ ./bin/<godot_binary> --doctool .
+      user@host:~/godot$ ./bin/<godot_binary> --doctool .
 
 Now if you go to the ``godot/modules/summator/doc_classes`` folder, you will see
 that it contains a ``Summator.xml`` file, or any other classes, that you referenced


### PR DESCRIPTION
This PR fixes the doctool command in the _Writing custom documentation_ section of the _Custom modules in C++_ page. The example incorrectly contains the `bin` folder as its current working directory, while the target path already contains that folder. The `bin` folder should be removed from the cwd path, as `doctool` was designed to be run in the main source folder.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
