### PR TITLE
Replace call to non-existent function get_editor_main_control()

### DIFF
--- a/tutorials/plugins/editor/making_main_screen_plugins.rst
+++ b/tutorials/plugins/editor/making_main_screen_plugins.rst
@@ -109,7 +109,7 @@ Here is the full plugin script:
     func _enter_tree():
         main_panel_instance = MainPanel.instantiate()
         # Add the main panel to the editor's main viewport.
-        get_editor_interface().get_editor_main_control().add_child(main_panel_instance)
+        get_editor_interface().get_editor_main_screen().add_child(main_panel_instance)
         # Hide the main panel. Very much required.
         _make_visible(false)
 
@@ -141,8 +141,8 @@ a reference to the scene, and we instance it into `main_panel_instance`.
 
 The ``_enter_tree()`` function is called before ``_ready()``. This is where
 we instance the main panel scene, and add them as children of specific parts
-of the editor. We use ``get_editor_interface().get_editor_main_control()`` to
-obtain the main editor control and add our main panel instance as a child to it.
+of the editor. We use ``get_editor_interface().get_editor_main_screen()`` to
+obtain the main editor screen and add our main panel instance as a child to it.
 We call the ``_make_visible(false)`` function to hide the main panel so
 it doesn't compete for space when first activating the plugin.
 


### PR DESCRIPTION
get_editor_interface().get_editor_main_control() no longer exists. `get_editor_main_control()` has been replaced with `get_editor_main_screen()`.

I changed all the occurrences in code, as well as adapted the text  describing this accordingly.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
