### PR TITLE
Project Manager Polishing

### DIFF
--- a/getting_started/step_by_step/instancing.rst
+++ b/getting_started/step_by_step/instancing.rst
@@ -42,8 +42,10 @@ Let's use instancing in practice to see how it works in Godot. We invite
 you to download the ball's sample project we prepared for you:
 :download:`instancing.zip <files/instancing.zip>`.
 
-Extract the archive on your computer. Then, open Godot, and in the project
-manager, click the Import button to import the project.
+Extract the archive on your computer. To import it you need the project manager;
+The project manager is accessed by opening Godot, or if you already have Godot opened, click on *Project -> Quit to Project List* (Ctrl+Shift+Q)
+
+In the project manager, click the *Import* button to import the project.
 
 .. image:: img/instancing_import_button.png
 

--- a/getting_started/step_by_step/instancing.rst
+++ b/getting_started/step_by_step/instancing.rst
@@ -43,7 +43,7 @@ you to download the ball's sample project we prepared for you:
 :download:`instancing.zip <files/instancing.zip>`.
 
 Extract the archive on your computer. To import it, you need the project manager.
-The project manager is accessed by opening Godot, or if you already have Godot opened, click on *Project -> Quit to Project List* (Ctrl+Shift+Q)
+The project manager is accessed by opening Godot, or if you already have Godot opened, click on *Project -> Quit to Project List* (:kbd:`Ctrl + Shift + Q`)
 
 In the project manager, click the *Import* button to import the project.
 

--- a/getting_started/step_by_step/instancing.rst
+++ b/getting_started/step_by_step/instancing.rst
@@ -42,7 +42,7 @@ Let's use instancing in practice to see how it works in Godot. We invite
 you to download the ball's sample project we prepared for you:
 :download:`instancing.zip <files/instancing.zip>`.
 
-Extract the archive on your computer. To import it you need the project manager;
+Extract the archive on your computer. To import it, you need the project manager.
 The project manager is accessed by opening Godot, or if you already have Godot opened, click on *Project -> Quit to Project List* (Ctrl+Shift+Q)
 
 In the project manager, click the *Import* button to import the project.


### PR DESCRIPTION
https://docs.godotengine.org/en/latest/getting_started/step_by_step/instancing.html#in-practice

The logic behind this commit is my own experience as a newbie, where I had the project with the label opened, and on the "download this and just import it with project manager" part, i did not know how to open the project manager, and spent like 5 minutes before just closing and re-opening Godot

I think the idea behind this addition is good, but the phrasing may be bad/complicated, for what I wanted to add which is tl;dr: "If you have Godot open, go Project -> Quit to Project List"

Ah also, made "Import" with italic (some other doc page also has this, makes sense)

Feel free to deny this commit (could be argued its bloat)