### PR TITLE
[2D Game Tutorial] Explicit add child node clarification

### DIFF
--- a/getting_started/first_2d_game/02.player_scene.rst
+++ b/getting_started/first_2d_game/02.player_scene.rst
@@ -53,8 +53,8 @@ or :kbd:`Cmd + S` on macOS.
 Sprite animation
 ~~~~~~~~~~~~~~~~
 
-Click on the ``Player`` node and add an :ref:`AnimatedSprite2D
-<class_AnimatedSprite2D>` node as a child. The ``AnimatedSprite2D`` will handle the
+Click on the ``Player`` node and add a child node (*Ctrl+A*): :ref:`AnimatedSprite2D
+<class_AnimatedSprite2D>`. The ``AnimatedSprite2D`` will handle the
 appearance and animations for our player. Notice that there is a warning symbol
 next to the node. An ``AnimatedSprite2D`` requires a :ref:`SpriteFrames
 <class_SpriteFrames>` resource, which is a list of the animations it can

--- a/getting_started/first_2d_game/02.player_scene.rst
+++ b/getting_started/first_2d_game/02.player_scene.rst
@@ -53,7 +53,7 @@ or :kbd:`Cmd + S` on macOS.
 Sprite animation
 ~~~~~~~~~~~~~~~~
 
-Click on the ``Player`` node and add a child node (*Ctrl+A*): :ref:`AnimatedSprite2D
+Click on the ``Player`` node and add a child node :kbd:`Ctrl + A` :ref:`AnimatedSprite2D
 <class_AnimatedSprite2D>`. The ``AnimatedSprite2D`` will handle the
 appearance and animations for our player. Notice that there is a warning symbol
 next to the node. An ``AnimatedSprite2D`` requires a :ref:`SpriteFrames

--- a/getting_started/first_2d_game/02.player_scene.rst
+++ b/getting_started/first_2d_game/02.player_scene.rst
@@ -53,7 +53,7 @@ or :kbd:`Cmd + S` on macOS.
 Sprite animation
 ~~~~~~~~~~~~~~~~
 
-Click on the ``Player`` node and add a child node :kbd:`Ctrl + A` :ref:`AnimatedSprite2D
+Click on the ``Player`` node and add (:kbd:`Ctrl + A`) a child node :ref:`AnimatedSprite2D
 <class_AnimatedSprite2D>`. The ``AnimatedSprite2D`` will handle the
 appearance and animations for our player. Notice that there is a warning symbol
 next to the node. An ``AnimatedSprite2D`` requires a :ref:`SpriteFrames


### PR DESCRIPTION
Added explicit "add child node" instead of "add animated sprite 2d node as a child"
Also added Ctrl+A shortcut so users get slowly familiarized with the optimal workflow