### PR TITLE
[2D Game Tutorial] Position2D conversion to Node2D

### DIFF
--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -23,7 +23,7 @@ Now, add the following nodes as children of ``Main``, and name them as shown
   every second
 - :ref:`Timer <class_Timer>` (named ``StartTimer``) - to give a delay before
   starting
-- :ref:`Position2D <class_Position2D>` (named ``StartPosition``) - to indicate
+- :ref:`Node2D <class_Node2D>` (named ``StartPosition``) - to indicate
   the player's start position
 
 Set the ``Wait Time`` property of each of the ``Timer`` nodes as follows:


### PR DESCRIPTION
Position2D exists in stable (3.5) https://docs.godotengine.org/en/stable/classes/class_position2d.html?highlight=position2d It does not exist in 4.x https://docs.godotengine.org/en/latest/search.html?q=position2d&check_keywords=yes&area=default https://docs.godotengine.org/en/latest/classes/class_position2d.html?highlight=position2d

So the user is now no longer confused why he cannot create this class and why its not class-highlighted either