### PR TITLE
Update gdscript signal connection example "Complete script"

### DIFF
--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -350,7 +350,7 @@ Here is the complete ``Sprite2D.gd`` file for reference.
 
     func _ready():
         var timer = get_node("Timer")
-        timer.connect("timeout", self, "_on_Timer_timeout")
+        timer.timeout.connect(_on_Timer_timeout)
 
 
     func _process(delta):


### PR DESCRIPTION
https://github.com/godotengine/godot-docs/pull/5587 updated the isolated gdscript signal connection example to Godot 4, but missed the "Complete script" section, where all examples are summarized in a single gdscript script.

This PR fixes that by updating the example in the "Complete script" section.