### PR TITLE
External Editor: add info about debugger setting option

### DIFF
--- a/tutorials/3d/mesh_lod.rst
+++ b/tutorials/3d/mesh_lod.rst
@@ -14,7 +14,7 @@ On this page, you'll learn:
   (and alternatives you can explore if it doesn't meet your expectations).
 
 Introduction
--------
+------------
 
 Historically, level of detail in 3D games involved manually authoring meshes
 with lower geometry density, then configuring the distance thresholds at which

--- a/tutorials/editor/external_editor.rst
+++ b/tutorials/editor/external_editor.rst
@@ -46,9 +46,16 @@ Some example Exec Flags for various editors include:
 | Emacs               | ``emacs +{line}:{col} {file}``                      |
 +---------------------+-----------------------------------------------------+
 
-.. note:: For Visual Studio Code, you will have to point to the ``code.cmd``
+.. note:: For Visual Studio Code on Windows, you will have to point to the ``code.cmd``
           file. For Emacs, you can call ``emacsclient`` instead of ``emacs`` if
           you use the server mode.
+
+
+Using External Editor in Debugger
+---------------------------------
+
+Using external editor in debugger is determined by a separate option in settings.
+For details see :ref:`Script editor debug tools and options <doc_debugger_tools_and_options>`.
 
 Official editor plugins
 -----------------------

--- a/tutorials/scripting/debug/overview_of_debugging_tools.rst
+++ b/tutorials/scripting/debug/overview_of_debugging_tools.rst
@@ -72,6 +72,8 @@ Sync Script Changes
 Any script that is saved will be reloaded on the running game. When used
 remotely on a device, this is more efficient with the network filesystem.
 
+.. _doc_debugger_tools_and_options:
+
 Script editor debug tools and options
 -------------------------------------
 
@@ -87,8 +89,9 @@ The **Break** button causes a break in the script like a breakpoint would.
 a function if possible. Otherwise, it does the same thing as **Step Over**.
 
 The **Keep Debugger Open** option keeps the debugger open after a scene
-has been closed. And the **Debug with External Editor** option lets you
-debug your game with an external editor.
+has been closed.
+The **Debug with External Editor** option lets you debug your game with an external editor.
+This option is also accessible in Editor Settings -> Debugger.
 
 .. warning::
 

--- a/tutorials/scripting/debug/overview_of_debugging_tools.rst
+++ b/tutorials/scripting/debug/overview_of_debugging_tools.rst
@@ -91,7 +91,7 @@ a function if possible. Otherwise, it does the same thing as **Step Over**.
 The **Keep Debugger Open** option keeps the debugger open after a scene
 has been closed.
 The **Debug with External Editor** option lets you debug your game with an external editor.
-This option is also accessible in Editor Settings -> Debugger.
+This option is also accessible in **Editor Settings > Debugger**.
 
 .. warning::
 


### PR DESCRIPTION
When user configure the external editor, it's not obvious that the editor needs to be configured separately for the debugger (see my issue https://github.com/godotengine/godot/issues/65554 ). 

This PR adds a mention about the debugger setting into the External Editor chapter, and elaborate a bit more about the other way how the External Editor can be turned on for debugger.

There's a few minor irrelevant improvements too.