### PR TITLE
Remove reference to date and time in OS

### DIFF
--- a/classes/class_os.rst
+++ b/classes/class_os.rst
@@ -17,7 +17,7 @@ Operating System functions.
 Description
 -----------
 
-Operating System functions. OS wraps the most common functionality to communicate with the host operating system, such as the clipboard, video driver, date and time, timers, environment variables, execution of binaries, command line, etc.
+Operating System functions. OS wraps the most common functionality to communicate with the host operating system, such as the clipboard, video driver, timers, environment variables, execution of binaries, command line, etc.
 
 Tutorials
 ---------


### PR DESCRIPTION
Since they where moved to Time, lets remove the dangling reference.

Fixes: https://github.com/godotengine/godot/issues/66613

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
