### PR TITLE
[Styleguide] Removed setget

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -36,9 +36,9 @@ Here is a complete class example based on these guidelines:
     signal state_changed(previous, new)
 
     export var initial_state = NodePath()
-    var is_active = true setget set_is_active
+    var is_active = true set_is_active
 
-    @onready var _state = get_node(initial_state) setget set_state
+    @onready var _state = get_node(initial_state) set_state
     @onready var _state_name = _state.name
 
 
@@ -768,7 +768,7 @@ variables, in that order.
    export var max_health = 50
    export var attack = 5
 
-   var health = max_health setget set_health
+   var health = max_health set_health
 
    var _speed = 300.0
 


### PR DESCRIPTION
According to this docs page https://docs.godotengine.org/en/latest/tutorials/scripting/gdscript/gdscript_basics.html#properties (see note a bit below) `setget`'s functionality is now by default on all variables (at least if I didn't misunderstand it)

`setget` first of all doesn't compile in 4.0 and has been split into `get` and `set`.
This is the solution to solve setget pretty much https://godotengine.org/qa/137477/how-to-use-godot-4-setget

However, even with this pull request, I ask to not merge because the code in the first link still won't compile, because set_active and set_state in variable declarations won't compile. While I could tweak them to work like the link above, I ask what is the ideal/recommended way by the core devs who changed the setget, because this is a **styling guide** and not a demo project where the goal is to just compile and run.