### PR TITLE
Moved icon spec to itemised list

### DIFF
--- a/community/asset_library/submitting_to_assetlib.rst
+++ b/community/asset_library/submitting_to_assetlib.rst
@@ -170,8 +170,8 @@ is required in the submission form here as well.
     in the AssetLib search results and on the asset's page). Should be an image
     in either the PNG or JPG format.
     
-    The **icon** should be a square, its aspect ratio should be 1:1. It should
-    also ideally have a minimum resolution of 64x64 pixels.
+    The **icon** must be square (1:1 aspect ratio). It should have a minimum
+    resolution of 128×128 pixels.
   
 * **License**:
     The license under which you are distributing the asset. The list

--- a/community/asset_library/submitting_to_assetlib.rst
+++ b/community/asset_library/submitting_to_assetlib.rst
@@ -110,9 +110,6 @@ library a better place for all users.
   keep with their project, so a copy ensures they always have those files handy
   (and helps them fulfill your licensing terms).
 
-* The **icon** should be a square, its aspect ratio should be 1:1. It should
-  also ideally have a minimum resolution of 64x64 pixels.
-
 * While the asset library allows more than just GitHub, consider
   hosting your asset's source code on **GitHub**. Other services may not
   work reliably, and a lack of familiarity can be a barrier to contributors.
@@ -172,6 +169,10 @@ is required in the submission form here as well.
     The URL to your asset's icon (which will be used as a thumbnail
     in the AssetLib search results and on the asset's page). Should be an image
     in either the PNG or JPG format.
+    
+    The **icon** should be a square, its aspect ratio should be 1:1. It should
+    also ideally have a minimum resolution of 64x64 pixels.
+  
 * **License**:
     The license under which you are distributing the asset. The list
     includes a variety of free and open-source software licenses, such as GPL


### PR DESCRIPTION
The icon specifications should not be considered a recommendation, but rather a requirement. Either way, the details of its ratio and size should be included with each form entry is described - as that is the natural place to look for it.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
