### PR TITLE
[Instancing with signals] Updated to 4.0

### DIFF
--- a/tutorials/scripting/instancing_with_signals.rst
+++ b/tutorials/scripting/instancing_with_signals.rst
@@ -63,7 +63,7 @@ You could do this by adding the bullet to the main scene directly:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    var bullet_instance = Bullet.instance()
+    var bullet_instance = Bullet.instantiate()
     get_parent().add_child(bullet_instance)
 
  .. code-tab:: csharp
@@ -96,7 +96,7 @@ Here is the code for the player using signals to emit the bullet:
 
     func _input(event):
         if event is InputEventMouseButton:
-            if event.button_index == BUTTON_LEFT and event.pressed:
+            if event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
                 emit_signal("shoot", Bullet, rotation, position)
 
     func _process(delta):
@@ -135,11 +135,11 @@ In the main scene, we then connect the player's signal (it will appear in the
  .. code-tab:: gdscript GDScript
 
     func _on_Player_shoot(Bullet, direction, location):
-        var b = Bullet.instance()
-        add_child(b)
-        b.rotation = direction
-        b.position = location
-        b.velocity = b.velocity.rotated(direction)
+        var spawned_bullet = Bullet.instantiate()
+        add_child(spawned_bullet)
+        spawned_bullet.rotation = direction
+        spawned_bullet.position = location
+        spawned_bullet.velocity = spawned_bullet.velocity.rotated(direction)
 
  .. code-tab:: csharp
 

--- a/tutorials/scripting/instancing_with_signals.rst
+++ b/tutorials/scripting/instancing_with_signals.rst
@@ -129,7 +129,7 @@ Here is the code for the player using signals to emit the bullet:
     }
 
 In the main scene, we then connect the player's signal (it will appear in the
-"Node" tab).
+"Node" tab of the Inspector)
 
 .. tabs::
  .. code-tab:: gdscript GDScript

--- a/tutorials/scripting/instancing_with_signals.rst
+++ b/tutorials/scripting/instancing_with_signals.rst
@@ -97,7 +97,7 @@ Here is the code for the player using signals to emit the bullet:
     func _input(event):
         if event is InputEventMouseButton:
             if event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-                emit_signal("shoot", Bullet, rotation, position)
+                shoot.emit(Bullet, rotation, position)
 
     func _process(delta):
         look_at(get_global_mouse_position())


### PR DESCRIPTION
https://docs.godotengine.org/en/latest/tutorials/scripting/instancing_with_signals.html
Basically started with changing `instance()` to `instantiate()`, and `MouseButton`, which give error.

Was a good chance to also upgrade the badly named `b` variables into proper intuitive names, and also make the signal emission with 4.0 syntax: `signal.emit(var1, var2)` instead of `emit_signal("signal",var1,var2)`

It's a good tutorial, short and to the point, though kinda abstract so I don't think there is anything more to add; If I put an image above the final codeblock, on how to add a signal via UI, it would ruin the abstraction. The text explaining signals are in node tab of inspector is enough