### PR TITLE
Fixed 2 'Introduction' in Navigation tutorial

### DIFF
--- a/tutorials/navigation/index.rst
+++ b/tutorials/navigation/index.rst
@@ -1,9 +1,6 @@
 Navigation
 ==========
 
-Godot provides multiple objects, classes and servers to facilitate grid-based or mesh-based navigation
-and pathfinding for 2D and 3D games. The following section provides a quick overview over all available
-navigation related objects in Godot for 2D scenes and their primary use.
 
 .. toctree::
    :maxdepth: 1

--- a/tutorials/navigation/index.rst
+++ b/tutorials/navigation/index.rst
@@ -1,6 +1,10 @@
 Navigation
 ==========
 
+Godot provides multiple objects, classes and servers to facilitate grid-based or mesh-based navigation
+and pathfinding for 2D and 3D games. The following section provides a quick overview over all available
+navigation related objects in Godot for 2D scenes and their primary use.
+
 .. toctree::
    :maxdepth: 1
    :name: toc-learn-features-navigation

--- a/tutorials/navigation/index.rst
+++ b/tutorials/navigation/index.rst
@@ -1,7 +1,6 @@
 Navigation
 ==========
 
-
 .. toctree::
    :maxdepth: 1
    :name: toc-learn-features-navigation

--- a/tutorials/navigation/navigation_introduction_2d.rst
+++ b/tutorials/navigation/navigation_introduction_2d.rst
@@ -3,6 +3,9 @@
 2D Navigation Overview
 ======================
 
+Godot provides multiple objects, classes and servers to facilitate grid-based or mesh-based navigation and pathfinding for 2D and 3D games. 
+The following section provides a quick overview over all available navigation related objects in Godot for 2D scenes and their primary use.
+
 Godot provides the following objects and classes for 2D navigation:
 
 - :ref:`Astar2D<class_Astar2D>`

--- a/tutorials/navigation/navigation_introduction_2d.rst
+++ b/tutorials/navigation/navigation_introduction_2d.rst
@@ -1,14 +1,7 @@
 .. _doc_navigation_overview_2d:
 
-Introduction
-===================
-
-Godot provides multiple objects, classes and servers to facilitate grid-based or mesh-based navigation
-and pathfinding for 2D and 3D games. The following section provides a quick overview over all available
-navigation related objects in Godot for 2D scenes and their primary use.
-
 2D Navigation Overview
-----------------------
+======================
 
 Godot provides the following objects and classes for 2D navigation:
 

--- a/tutorials/navigation/navigation_introduction_3d.rst
+++ b/tutorials/navigation/navigation_introduction_3d.rst
@@ -1,14 +1,8 @@
 .. _doc_navigation_overview_3d:
 
-Introduction
-===================
-
-Godot provides multiple objects, classes and servers to facilitate grid-based or mesh-based navigation
-and pathfinding for 2D and 3D games. The following section provides a quick overview over all available
-navigation related objects in Godot for 3D scenes and their primary use.
 
 3D Navigation Overview
-----------------------
+======================
 
 Godot provides the following objects and classes for 3D navigation:
 

--- a/tutorials/navigation/navigation_introduction_3d.rst
+++ b/tutorials/navigation/navigation_introduction_3d.rst
@@ -4,6 +4,9 @@
 3D Navigation Overview
 ======================
 
+Godot provides multiple objects, classes and servers to facilitate grid-based or mesh-based navigation and pathfinding for 2D and 3D games. 
+The following section provides a quick overview over all available navigation related objects in Godot for 3D scenes and their primary use.
+
 Godot provides the following objects and classes for 3D navigation:
 
 - :ref:`Astar3D<class_Astar3D>`


### PR DESCRIPTION
Moved the common navigation introduction to the main Navigation tutorial and renamed the individual 2D and 3D navigation to their respective correct names as mentioned in Issue #6261 

**Original preview:**
![image](https://user-images.githubusercontent.com/21677583/194332359-6cf121db-9e0a-4397-9395-b88e7522f4ef.png)

**Updated changes:**
![image](https://user-images.githubusercontent.com/21677583/194331942-2d2c0f65-08c1-4811-ba7b-c078eb429a59.png)

