### PR TITLE
[2D Game Tutorial] Fixing the last codeblock to run on 4.0

### DIFF
--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -211,12 +211,12 @@ We also need to process what happens when the player loses. The code below will 
     func show_game_over():
         show_message("Game Over")
         # Wait until the MessageTimer has counted down.
-        await($MessageTimer, "timeout")
+        await $MessageTimer.timeout
 
         $Message.text = "Dodge the\nCreeps!"
         $Message.show()
         # Make a one-shot timer and wait for it to finish.
-        yield(get_tree().create_timer(1), "timeout")
+        await get_tree().create_timer(1.0).timeout
         $StartButton.show()
 
  .. code-tab:: csharp


### PR DESCRIPTION
https://docs.godotengine.org/en/latest/getting_started/first_2d_game/06.heads_up_display.html

The last code which makes the tutorial incompatible for 4.0 is this. I ran it locally on my 2D project to ensure it works. Basically to replace the yield one-shot timer, I used this https://docs.godotengine.org/en/latest/classes/class_scenetreetimer.html

Fixes https://github.com/godotengine/godot-docs/issues/6234 https://github.com/godotengine/godot-docs/issues/5498

------------------------

@Calinou Related to this: If I do an upgrade/polish of the 2D tutorial [like I did with 3.0](https://github.com/godotengine/godot-docs/pull/6243) where I upload more **.webp** images and clarify and ref hyperlink here and there, would it be accepted soon, or delayed until after .webp support? Ofc alongside 4.0.zip for demo projects. I'm asking because it will take a day or two (I already have the images which is the hard part), and if that upgrade is merged in 4+ months, I would rather schedule my priorities in another way.

I know that the focus is on fixing 4.0 bugs and reaching a stable exit out of beta (both are obviously of highest importance), but I ask because there are many users who are hyped for 4.0 and get filtered at the docs, and basically I don't know what is the acceptance requirement for merging a huge pull request like remaking/polishing an entire tutorial.