### PR TITLE
Fix typo in SkeletonModification2DPhysicalBones documentation

### DIFF
--- a/classes/class_skeletonmodification2dphysicalbones.rst
+++ b/classes/class_skeletonmodification2dphysicalbones.rst
@@ -67,7 +67,7 @@ Method Descriptions
 
 - void **fetch_physical_bones** **(** **)**
 
-Empties the list of :ref:`PhysicalBone2D<class_PhysicalBone2D>` nodes and populates it will all :ref:`PhysicalBone2D<class_PhysicalBone2D>` nodes that are children of the :ref:`Skeleton2D<class_Skeleton2D>`.
+Empties the list of :ref:`PhysicalBone2D<class_PhysicalBone2D>` nodes and populates it with all :ref:`PhysicalBone2D<class_PhysicalBone2D>` nodes that are children of the :ref:`Skeleton2D<class_Skeleton2D>`.
 
 ----
 


### PR DESCRIPTION
changed the word "will" to the word "with", which was originally a typo as far as I can tell.
