### PR TITLE
Update 'velocity' with move_and_slide

### DIFF
--- a/tutorials/physics/kinematic_character_2d.rst
+++ b/tutorials/physics/kinematic_character_2d.rst
@@ -209,7 +209,7 @@ This adds basic support for walking when pressing left and right:
 
         # The second parameter of "move_and_slide" is the normal pointing up.
         # In the case of a 2D platformer, in Godot, upward is negative y, which translates to -1 as a normal.
-        move_and_slide(velocity, Vector2(0, -1))
+        velocity = move_and_slide(velocity, Vector2(0, -1))
 
  .. code-tab:: csharp
 
@@ -244,7 +244,7 @@ This adds basic support for walking when pressing left and right:
 
             // The second parameter of "MoveAndSlide" is the normal pointing up.
             // In the case of a 2D platformer, in Godot, upward is negative y, which translates to -1 as a normal.
-            MoveAndSlide(velocity, new Vector2(0, -1));
+            velocity = MoveAndSlide(velocity, new Vector2(0, -1));
         }
     }
 


### PR DESCRIPTION
`move_and_slide` returns the modified velocity, which should be updated in the code. If this is not done, `velocity` will keep increasing due to `velocity.y += delta * gravity`. If one adds a `jump` function to this code it'll not be able to jump, since the vector continues to increase in magnitude and never stops.

By updating the velocity with `move_and_slide` we make sure velocity is 0 when there's no movement, thus reflecting the actual velocity of the object.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
