### PR TITLE
fix: rename `ViewportContainer` to `SubViewportContainer`

### DIFF
--- a/tutorials/rendering/multiple_resolutions.rst
+++ b/tutorials/rendering/multiple_resolutions.rst
@@ -427,8 +427,8 @@ performance significantly while keeping the HUD and other 2D elements crisp.
 
 This is done by using the root Viewport node only for 2D elements, then creating
 a Viewport node to display the 3D world and displaying it using a
-ViewportContainer or TextureRect node. There will effectively be two viewports
-in the final project. One upside of using TextureRect over ViewportContainer is
+SubViewportContainer or TextureRect node. There will effectively be two viewports
+in the final project. One upside of using TextureRect over SubViewportContainer is
 that it allows enable linear filtering. This makes scaled 3D viewports look
 better in many cases.
 

--- a/tutorials/rendering/viewports.rst
+++ b/tutorials/rendering/viewports.rst
@@ -89,7 +89,7 @@ Scale & stretching
 ------------------
 
 :ref:`Viewports <class_Viewport>` have a "size" property, which represents the size of the :ref:`Viewport <class_Viewport>`
-in pixels. For :ref:`Viewports <class_Viewport>` which are children of :ref:`ViewportContainers <class_ViewportContainer>`,
+in pixels. For :ref:`Viewports <class_Viewport>` which are children of :ref:`SubViewportContainers <class_SubViewportContainer>`,
 these values are overridden, but for all others, this sets their resolution.
 
 It is also possible to scale the 2D content and make the :ref:`Viewport <class_Viewport>` resolution
@@ -162,13 +162,13 @@ it using (for example):
 Viewport Container
 ------------------
 
-If the :ref:`Viewport <class_Viewport>` is a child of a :ref:`ViewportContainer <class_ViewportContainer>`, it will become active and display anything it has inside. The layout looks like this:
+If the :ref:`Viewport <class_Viewport>` is a child of a :ref:`SubViewportContainer <class_SubViewportContainer>`, it will become active and display anything it has inside. The layout looks like this:
 
 .. image:: img/container.png
 
-The :ref:`Viewport <class_Viewport>` will cover the area of its parent :ref:`ViewportContainer <class_ViewportContainer>` completely
-if :ref:`Stretch<class_ViewportContainer_property_stretch>` is set to ``true`` in :ref:`ViewportContainer <class_ViewportContainer>`.
-Note: The size of the :ref:`ViewportContainer <class_ViewportContainer>` cannot be smaller than the size of the :ref:`Viewport <class_Viewport>`.
+The :ref:`Viewport <class_Viewport>` will cover the area of its parent :ref:`SubViewportContainer <class_SubViewportContainer>` completely
+if :ref:`Stretch<class_SubViewportContainer_property_stretch>` is set to ``true`` in :ref:`SubViewportContainer <class_SubViewportContainer>`.
+Note: The size of the :ref:`SubViewportContainer <class_SubViewportContainer>` cannot be smaller than the size of the :ref:`Viewport <class_Viewport>`.
 
 Rendering
 ---------

--- a/tutorials/scripting/change_scenes_manually.rst
+++ b/tutorials/scripting/change_scenes_manually.rst
@@ -131,7 +131,7 @@ a scene's data between scene changes (adding the scene to the root node).
         GetTree().GetRoot().AddChild(scene);
 
 Perhaps instead they wish to display multiple scenes at the same time using
-:ref:`ViewportContainers <class_ViewportContainer>`. This is optimal in
+:ref:`SubViewportContainers <class_SubViewportContainer>`. This is optimal in
 cases where the intent is to render different content in different parts of the
 screen. Minimaps and split-screen multiplayer are good examples.
 

--- a/tutorials/shaders/advanced_postprocessing.rst
+++ b/tutorials/shaders/advanced_postprocessing.rst
@@ -12,7 +12,7 @@ uses the depth buffer. You should already be familiar with post-processing
 generally and, in particular, with the methods outlined in the :ref:`custom post-processing tutorial <doc_custom_postprocessing>`.
 
 In the previous post-processing tutorial, we rendered the scene to a :ref:`Viewport <class_Viewport>`
-and then rendered the Viewport in a :ref:`ViewportContainer <class_ViewportContainer>`
+and then rendered the Viewport in a :ref:`SubViewportContainer <class_SubViewportContainer>`
 to the main scene. One limitation of this method is that we could not access the
 depth buffer because the depth buffer is only available in spatial shaders and
 Viewports do not maintain depth information.

--- a/tutorials/ui/gui_containers.rst
+++ b/tutorials/ui/gui_containers.rst
@@ -152,11 +152,11 @@ Mouse wheel and touch drag (when touch is available) are also valid ways to pan 
 As in the example above, one of the most common ways to use this container is together with a *VBoxContainer* as child.
 
 
-ViewportContainer
-^^^^^^^^^^^^^^^^^
+SubViewportContainer
+^^^^^^^^^^^^^^^^^^^^
 
 This is a special control that will only accept a single *Viewport* node as child, and it will display
-it as if it was an image (via :ref:`ViewportContainer <class_ViewportContainer>`).
+it as if it was an image (via :ref:`SubViewportContainer <class_SubViewportContainer>`).
 
 Creating custom Containers
 --------------------------


### PR DESCRIPTION
This PR renames `ViewportContainer` to `SubViewportContainer`  according to 3to4 converter:

https://github.com/godotengine/godot/blob/bbac8198f89c0cbf0da4293201e54aa847947370/editor/project_converter_3_to_4.cpp#L1533


However if this was just a class rename, then there's another discrepancy. [Viewports tutorial says](https://github.com/godotengine/godot-docs/blob/master/tutorials/rendering/viewports.rst#scale--stretching):

> For **Viewports** which are children of **ViewportContainers** (...)

but the class documentation of **Viewport** says it's inherited only from `Node` and `Object`, see:

https://github.com/godotengine/godot-docs/blob/master/classes/class_viewport.rst#viewport