### PR TITLE
Corrected an inaccuracy

### DIFF
--- a/getting_started/first_2d_game/03.coding_the_player.rst
+++ b/getting_started/first_2d_game/03.coding_the_player.rst
@@ -267,14 +267,16 @@ diagonal movement.
 We also check whether the player is moving so we can call ``play()`` or
 ``stop()`` on the AnimatedSprite2D.
 
-.. tip:: ``$`` is shorthand for ``get_node()``. So in the code above,
-         ``$AnimatedSprite2D.play()`` is the same as
-         ``get_node("AnimatedSprite2D").play()``.
-
-         In GDScript, ``$`` returns the node at the relative path from the
+.. tip:: In GDScript, ``$`` returns the node at the relative path from the
          current node, or returns ``null`` if the node is not found. Since
          AnimatedSprite2D is a child of the current node, we can use
          ``$AnimatedSprite2D``.
+
+         So in the code above, ``$AnimatedSprite2D.play()`` is the same as
+         calling ``get_node_or_null("AnimatedSprite2D").play()``.
+
+         
+
 
 Now that we have a movement direction, we can update the player's position. We
 can also use ``clamp()`` to prevent it from leaving the screen. *Clamping* a


### PR DESCRIPTION
If $ will in fact return null if not found, doesn't that mean that using $ is the same as get_node_or_null(), and not as previously stated get_node()?

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
