### PR TITLE
Fix Navigation index order to make thematically more sense

### DIFF
--- a/tutorials/navigation/index.rst
+++ b/tutorials/navigation/index.rst
@@ -5,19 +5,19 @@ Navigation
    :maxdepth: 1
    :name: toc-learn-features-navigation
 
-   navigation_introduction_2d.rst
-   navigation_introduction_3d.rst
-   navigation_using_navigationmaps
-   navigation_different_actor_types
-   navigation_different_actor_locomotion
-   navigation_using_navigationobstacles
-   navigation_using_navigationmeshes
+   navigation_introduction_2d
+   navigation_introduction_3d
    navigation_using_navigationservers
+   navigation_using_navigationmaps
+   navigation_using_navigationregions
+   navigation_using_navigationmeshes
+   navigation_using_navigationpaths
    navigation_using_navigationagents
+   navigation_using_navigationobstacles
+   navigation_using_navigationlayers
    navigation_using_agent_avoidance
    navigation_debug_tools
    navigation_connecting_navmesh
-   navigation_using_navigationlayers
+   navigation_different_actor_types
+   navigation_different_actor_locomotion
    navigation_different_actor_area_access
-   navigation_using_navigationpaths
-   navigation_using_navigationregions


### PR DESCRIPTION
The original index from all the Navigation pullrequests was ordered from beginner / core topics to more sophisticated / focused / niche topics but this got mixed up due to splitting the pr's and the order the pr's were merged.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
