### PR TITLE
Renames / fixes for Godot 4

### DIFF
--- a/tutorials/best_practices/godot_notifications.rst
+++ b/tutorials/best_practices/godot_notifications.rst
@@ -26,7 +26,7 @@ much so that Godot exposes many of them with dedicated functions:
 - ``_draw()`` : NOTIFICATION_DRAW
 
 What users might *not* realize is that notifications exist for types other
-than Node alone:
+than Node alone, for example:
 
 - :ref:`Object::NOTIFICATION_POSTINITIALIZE <class_Object_constant_NOTIFICATION_POSTINITIALIZE>`:
   a callback that triggers during object initialization. Not accessible to scripts.
@@ -34,10 +34,6 @@ than Node alone:
 - :ref:`Object::NOTIFICATION_PREDELETE <class_Object_constant_NOTIFICATION_PREDELETE>`:
   a callback that triggers before the engine deletes an Object, i.e. a
   'destructor'.
-
-- :ref:`MainLoop::NOTIFICATION_WM_MOUSE_ENTER <class_MainLoop_constant_NOTIFICATION_WM_MOUSE_ENTER>`:
-  a callback that triggers when the mouse enters the window in the operating
-  system that displays the game content.
 
 And many of the callbacks that *do* exist in Nodes don't have any dedicated
 methods, but are still quite useful.
@@ -48,11 +44,6 @@ methods, but are still quite useful.
 - :ref:`Node::NOTIFICATION_UNPARENTED <class_Node_constant_NOTIFICATION_UNPARENTED>`:
   a callback that triggers anytime one removes a child node from another
   node.
-
-- :ref:`Popup::NOTIFICATION_POST_POPUP <class_Popup_constant_NOTIFICATION_POST_POPUP>`:
-  a callback that triggers after a Popup node completes any ``popup*`` method.
-  Note the difference from its ``about_to_show`` signal which triggers
-  *before* its appearance.
 
 One can access all these custom notifications from the universal
 ``_notification`` method.

--- a/tutorials/best_practices/scene_organization.rst
+++ b/tutorials/best_practices/scene_organization.rst
@@ -217,7 +217,7 @@ in another context without any extra changes to its API.
 
   To avoid creating and maintaining such documentation, one converts the
   dependent node ("child" above) into a tool script that implements
-  :ref:`_get_configuration_warning() <class_Node_method__get_configuration_warning>`.
+  ``_get_configuration_warning()``.
   Returning a non-empty string from it will make the Scene dock generate a
   warning icon with the string as a tooltip by the node. This is the same icon
   that appears for nodes such as the
@@ -370,9 +370,9 @@ own place in the hierarchy as a sibling or some other relation.
   1. The **declarative** solution: place a :ref:`Node <class_Node>` in between
      them. As nodes with no transform, Nodes will not pass along such
      information to their children.
-  2. The **imperative** solution: Use the ``set_as_toplevel`` setter for the
-     :ref:`CanvasItem <class_CanvasItem_method_set_as_top_level>` or
-     :ref:`Node3D <class_Node3D_method_set_as_top_level>` node. This will make
+  2. The **imperative** solution: Use the ``top_level`` property for the
+     :ref:`CanvasItem <class_CanvasItem_property_top_level>` or
+     :ref:`Node3D <class_Node3D_property_top_level>` node. This will make
      the node ignore its inherited transform.
 
 .. note::

--- a/tutorials/inputs/input_examples.rst
+++ b/tutorials/inputs/input_examples.rst
@@ -210,7 +210,7 @@ the :kbd:`T`:
         }
     }
 
-.. tip:: See :ref:`@GlobalScope_KeyList <enum_@GlobalScope_KeyList>` for a list of keycode
+.. tip:: See :ref:`@GlobalScope_Key <enum_@GlobalScope_Key>` for a list of keycode
         constants.
 
 .. warning::
@@ -261,7 +261,7 @@ different when it's :kbd:`Shift + T`:
         }
     }
 
-.. tip:: See :ref:`@GlobalScope_KeyList <enum_@GlobalScope_KeyList>` for a list of keycode
+.. tip:: See :ref:`@GlobalScope_Key <enum_@GlobalScope_Key>` for a list of keycode
         constants.
 
 Mouse events
@@ -275,7 +275,7 @@ means that all mouse events will contain a ``position`` property.
 Mouse buttons
 ~~~~~~~~~~~~~
 
-Capturing mouse buttons is very similar to handling key events. :ref:`@GlobalScope_ButtonList <enum_@GlobalScope_ButtonList>`
+Capturing mouse buttons is very similar to handling key events. :ref:`@GlobalScope_MouseButton <enum_@GlobalScope_MouseButton>`
 contains a list of ``BUTTON_*`` constants for each possible button, which will
 be reported in the event's ``button_index`` property. Note that the scrollwheel
 also counts as a button - two buttons, to be precise, with both

--- a/tutorials/inputs/inputevent.rst
+++ b/tutorials/inputs/inputevent.rst
@@ -91,8 +91,8 @@ received input, in order:
    event will not spread any more. The unhandled input callback is ideal for full-screen gameplay events, so they are not received when a GUI is active.
 4. If no one wanted the event so far, and a :ref:`Camera3D <class_Camera3D>` is assigned
    to the Viewport with :ref:`Object Picking <class_viewport_property_physics_object_picking>` turned on, a ray to the physics world (in the ray direction from
-   the click) will be cast. (For the root viewport, this can also be enabled in :ref:`Project Settings <class_ProjectSettings_property_physics/common/enable_object_picking>`) If this ray hits an object, it will call the
-   :ref:`CollisionObject._input_event() <class_CollisionObject_method__input_event>` function in the relevant
+   the click) will be cast. (For the root viewport, this can also be enabled in :ref:`Project Settings <class_ProjectSettings_property_physics/common/enable_object_picking>`.) If this ray hits an object, it will call the
+   :ref:`CollisionObject._input_event() <class_CollisionObject3D_method__input_event>` function in the relevant
    physics object (bodies receive this callback by default, but areas do
    not. This can be configured through :ref:`Area3D <class_Area3D>` properties).
 5. Finally, if the event was unhandled, it will be passed to the next

--- a/tutorials/math/beziers_and_curves.rst
+++ b/tutorials/math/beziers_and_curves.rst
@@ -250,7 +250,7 @@ Traversal
 
 The last common use case for the curves is to traverse them. Because of what was mentioned before regarding constant speed, this is also difficult.
 
-To make this easier, the curves need to be *baked* into equidistant points. This way, they can be approximated with regular interpolation (which can be improved further with a cubic option). To do this, just use the :ref:`Curve.interpolate_baked()<class_Curve_method_interpolate_baked>` method together with
+To make this easier, the curves need to be *baked* into equidistant points. This way, they can be approximated with regular interpolation (which can be improved further with a cubic option). To do this, just use the :ref:`Curve3D.sample_baked()<class_Curve3D_method_sample_baked>` method together with
 :ref:`Curve2D.get_baked_length()<class_Curve2D_method_get_baked_length>`. The first call to either of them will bake the curve internally.
 
 Traversal at constant speed, then, can be done with the following pseudo-code:

--- a/tutorials/math/interpolation.rst
+++ b/tutorials/math/interpolation.rst
@@ -68,7 +68,7 @@ Transform interpolation
 -----------------------
 
 It is also possible to interpolate whole transforms (make sure they have either uniform scale or, at least, the same non-uniform scale).
-For this, the function :ref:`Transform.interpolate_with() <class_Transform_method_interpolate_with>` can be used.
+For this, the function :ref:`Transform3D.interpolate_with() <class_Transform3D_method_interpolate_with>` can be used.
 
 Here is an example of transforming a monkey from Position1 to Position2:
 

--- a/tutorials/math/random_number_generation.rst
+++ b/tutorials/math/random_number_generation.rst
@@ -38,7 +38,7 @@ The randomize() method
 ----------------------
 
 In global scope, you can find a :ref:`randomize()
-<class_@GDScript_method_randomize>` method. **This method should be called only
+<class_@GlobalScope_method_randomize>` method. **This method should be called only
 once when your project starts to initialize the random seed.** Calling it
 multiple times is unnecessary and may impact performance negatively.
 
@@ -58,7 +58,7 @@ Putting it in your main scene script's ``_ready()`` method is a good choice:
     }
 
 You can also set a fixed random seed instead using :ref:`seed()
-<class_@GDScript_method_seed>`. Doing so will give you *deterministic* results
+<class_@GlobalScope_method_seed>`. Doing so will give you *deterministic* results
 across runs:
 
 .. tabs::
@@ -97,7 +97,7 @@ Getting a random number
 Let's look at some of the most commonly used functions and methods to generate
 random numbers in Godot.
 
-The function :ref:`randi() <class_@GDScript_method_randi>` returns a random
+The function :ref:`randi() <class_@GlobalScope_method_randi>` returns a random
 number between 0 and 2^32-1. Since the maximum value is huge, you most likely
 want to use the modulo operator (``%``) to bound the result between 0 and the
 denominator:
@@ -119,7 +119,7 @@ denominator:
     // Prints a random integer between 10 and 60.
     GD.Print(GD.Randi() % 51 + 10);
 
-:ref:`randf() <class_@GDScript_method_randf>` returns a random floating-point
+:ref:`randf() <class_@GlobalScope_method_randf>` returns a random floating-point
 number between 0 and 1. This is useful to implement a
 :ref:`doc_random_number_generation_weighted_random_probability` system, among
 other things.
@@ -145,7 +145,7 @@ varying by the deviation (1.0 by default):
     random.Randomize();
     GD.Print(random.Randfn());
 
-:ref:`rand_range() <class_@GDScript_method_rand_range>` takes two arguments
+:ref:`randf_range() <class_@GlobalScope_method_randf_range>` takes two arguments
 ``from`` and ``to``, and returns a random floating-point number between ``from``
 and ``to``:
 
@@ -153,12 +153,7 @@ and ``to``:
  .. code-tab:: gdscript GDScript
 
     # Prints a random floating-point number between -4 and 6.5.
-    print(rand_range(-4, 6.5))
-
- .. code-tab:: csharp
-
-    // Prints a random floating-point number between -4 and 6.5.
-    GD.Print(GD.RandRange(-4, 6.5));
+    print(randf_range(-4, 6.5))
 
 :ref:`RandomNumberGenerator.randi_range()
 <class_RandomNumberGenerator_method_randi_range>` takes two arguments ``from``
@@ -174,7 +169,7 @@ and ``to``, and returns a random integer between ``from`` and ``to``:
 
  .. code-tab:: csharp
 
-    # Prints a random integer number between -10 and 10.
+    // Prints a random integer number between -10 and 10.
     random.Randomize();
     GD.Print(random.RandiRange(-10, 10));
 
@@ -328,7 +323,7 @@ We can apply similar logic from arrays to dictionaries as well:
 Weighted random probability
 ---------------------------
 
-The :ref:`randf() <class_@GDScript_method_randf>` method returns a
+The :ref:`randf() <class_@GlobalScope_method_randf>` method returns a
 floating-point number between 0.0 and 1.0. We can use this to create a
 "weighted" probability where different outcomes have different likelihoods:
 

--- a/tutorials/networking/high_level_multiplayer.rst
+++ b/tutorials/networking/high_level_multiplayer.rst
@@ -56,15 +56,15 @@ Mid-level abstraction
 
 Before going into how we would like to synchronize a game across the network, it can be helpful to understand how the base network API for synchronization works.
 
-Godot uses a mid-level object :ref:`NetworkedMultiplayerPeer <class_NetworkedMultiplayerPeer>`.
+Godot uses a mid-level object :ref:`MultiplayerPeer <class_MultiplayerPeer>`.
 This object is not meant to be created directly, but is designed so that several C++ implementations can provide it.
 
 This object extends from :ref:`PacketPeer <class_PacketPeer>`, so it inherits all the useful methods for serializing, sending and receiving data. On top of that, it adds methods to set a peer, transfer mode, etc. It also includes signals that will let you know when peers connect or disconnect.
 
 This class interface can abstract most types of network layers, topologies and libraries. By default, Godot
-provides an implementation based on ENet (:ref:`NetworkedMultiplayerEnet <class_NetworkedMultiplayerENet>`),
-one based on WebRTC (:ref:`WebRTCMultiplayer <class_WebRTCMultiplayer>`), and one based on WebSocket
-(:ref:`WebSocketMultiplayerPeer <class_WebSocketMultiplayerPeer>`), but this could be used to implement
+provides an implementation based on ENet (:ref:`ENetMultiplayerPeer <class_ENetMultiplayerPeer>`),
+one based on WebRTC (:ref:`WebRTCMultiplayerPeer <class_WebRTCMultiplayerPeer>`), and one based on WebSocket
+(:ref:`WebSocketPeer <class_WebSocketPeer>`), but this could be used to implement
 mobile APIs (for ad hoc WiFi, Bluetooth) or custom device/console-specific networking APIs.
 
 For most common cases, using this object directly is discouraged, as Godot provides even higher level networking facilities.
@@ -164,7 +164,7 @@ Server and Clients:
 The above signals are called on every peer connected to the server (including on the server) when a new peer connects or disconnects.
 Clients will connect with a unique ID greater than 1, while network peer ID 1 is always the server.
 Anything below 1 should be handled as invalid.
-You can retrieve the ID for the local system via :ref:`SceneTree.get_network_unique_id() <class_SceneTree_method_get_network_unique_id>`.
+You can retrieve the ID for the local system via ``SceneTree.get_network_unique_id()``.
 These IDs will be useful mostly for lobby management and should generally be stored, as they identify connected peers and thus players. You can also use IDs to send messages only to certain peers.
 
 Clients:
@@ -382,9 +382,9 @@ The network master of a node is the peer that has the ultimate authority over it
 When not explicitly set, the network master is inherited from the parent node, which if not changed, is always going to be the server (ID 1). Thus the server has authority over all nodes by default.
 
 The network master can be set
-with the function :ref:`Node.set_network_master(id, recursive) <class_Node_method_set_network_master>` (recursive is ``true`` by default and means the network master is recursively set on all child nodes of the node as well).
+with the function :ref:``Node.set_network_master(id, recursive)`` (recursive is ``true`` by default and means the network master is recursively set on all child nodes of the node as well).
 
-Checking that a specific node instance on a peer is the network master for this node for all connected peers is done by calling :ref:`Node.is_network_master() <class_Node_method_is_network_master>`. This will return ``true`` when executed on the server and ``false`` on all client peers.
+Checking that a specific node instance on a peer is the network master for this node for all connected peers is done by calling ``Node.is_network_master()``. This will return ``true`` when executed on the server and ``false`` on all client peers.
 
 If you have paid attention to the previous example, it's possible you noticed that each peer was set to have network master authority for their own player (Node) instead of the server:
 

--- a/tutorials/networking/http_request_class.rst
+++ b/tutorials/networking/http_request_class.rst
@@ -71,7 +71,7 @@ Below is all the code we need to make it work. The URL points to an online API m
 
 With this, you should see ``(hello:world)`` printed on the console; hello being a key, and world being a value, both of them strings.
 
-For more information on parsing JSON, see the class references for :ref:`JSON <class_JSON>` and :ref:`JSONParseResult <class_JSONParseResult>`.
+For more information on parsing JSON, see the class references for :ref:`JSON <class_JSON>`.
 
 Note that you may want to check whether the ``result`` equals ``RESULT_SUCCESS`` and whether a JSON parsing error occurred, see the JSON class reference and :ref:`HTTPRequest <class_HTTPRequest>` for more.
 

--- a/tutorials/networking/ssl_certificates.rst
+++ b/tutorials/networking/ssl_certificates.rst
@@ -8,7 +8,7 @@ Introduction
 
 It is often desired to use SSL connections for communications to avoid
 "man in the middle" attacks. Godot has a connection wrapper,
-:ref:`StreamPeerSSL <class_StreamPeerSSL>`,
+:ref:`StreamPeerTLS <class_StreamPeerTLS>`,
 which can take a regular connection and add security around it. The
 :ref:`HTTPClient <class_HTTPClient>`
 class also supports HTTPS by using this same wrapper.

--- a/tutorials/networking/webrtc.rst
+++ b/tutorials/networking/webrtc.rst
@@ -33,7 +33,7 @@ Peers connect to a signaling server (for example a WebSocket server) and send th
 Using WebRTC in Godot
 ---------------------
 
-WebRTC is implemented in Godot via two main classes :ref:`WebRTCPeerConnection <class_WebRTCPeerConnection>` and :ref:`WebRTCDataChannel <class_WebRTCDataChannel>`, plus the multiplayer API implementation :ref:`WebRTCMultiplayer <class_WebRTCMultiplayer>`. See section on :ref:`high-level multiplayer <doc_high_level_multiplayer>` for more details.
+WebRTC is implemented in Godot via two main classes :ref:`WebRTCPeerConnection <class_WebRTCPeerConnection>` and :ref:`WebRTCDataChannel <class_WebRTCDataChannel>`, plus the multiplayer API implementation :ref:`WebRTCMultiplayerPeer <class_WebRTCMultiplayerPeer>`. See section on :ref:`high-level multiplayer <doc_high_level_multiplayer>` for more details.
 
 .. note:: These classes are available automatically in HTML5, but **require an external GDNative plugin on native (non-HTML5) platforms**. Check out the `webrtc-native plugin repository <https://github.com/godotengine/webrtc-native>`__ for instructions and to get the latest `release <https://github.com/godotengine/webrtc-native/releases>`__.
 
@@ -212,4 +212,4 @@ This will print something similar to this:
 Remote signaling with WebSocket
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A more advanced demo using WebSocket for signaling peers and :ref:`WebRTCMultiplayer <class_WebRTCMultiplayer>` is available in the `godot demo projects <https://github.com/godotengine/godot-demo-projects>`_ under `networking/webrtc_signaling`.
+A more advanced demo using WebSocket for signaling peers and :ref:`WebRTCMultiplayerPeer <class_WebRTCMultiplayerPeer>` is available in the `godot demo projects <https://github.com/godotengine/godot-demo-projects>`_ under `networking/webrtc_signaling`.

--- a/tutorials/performance/using_servers.rst
+++ b/tutorials/performance/using_servers.rst
@@ -34,8 +34,8 @@ rendering, physics, sound, etc. The scene system is built on top of them and use
 The most common servers are:
 
 * :ref:`RenderingServer <class_RenderingServer>`: handles everything related to graphics.
-* :ref:`PhysicsServer <class_PhysicsServer>`: handles everything related to 3D physics.
-* :ref:`Physics2DServer <class_Physics2DServer>`: handles everything related to 2D physics.
+* :ref:`PhysicsServer3D <class_PhysicsServer3D>`: handles everything related to 3D physics.
+* :ref:`PhysicsServer2D <class_PhysicsServer2D>`: handles everything related to 2D physics.
 * :ref:`AudioServer <class_AudioServer>`: handles everything related to audio.
 
 Explore their APIs and you will realize that all the functions provided are low-level
@@ -73,9 +73,9 @@ For nodes, there are many functions available:
   and :ref:`CanvasItem <class_CanvasItem>` nodes)
   contains functions to get the *RenderingServer Canvas*, and the *Physics2DServer Space*. This
   allows creating 2D objects directly with the server API and using them.
-* The :ref:`VisualInstance<class_VisualInstance>` class, allows getting the scenario *instance* and
-  *instance base* via the :ref:`VisualInstance.get_instance() <class_VisualInstance_method_get_instance>`
-  and :ref:`VisualInstance.get_base() <class_VisualInstance_method_get_base>` respectively.
+* The :ref:`VisualInstance3D<class_VisualInstance3D>` class, allows getting the scenario *instance* and
+  *instance base* via the :ref:`VisualInstance3D.get_instance() <class_VisualInstance3D_method_get_instance>`
+  and :ref:`VisualInstance3D.get_base() <class_VisualInstance3D_method_get_base>` respectively.
 
 Try exploring the nodes and resources you are familiar with and find the functions to obtain the server *RIDs*.
 
@@ -157,7 +157,7 @@ The 3D APIs are different from the 2D ones, so the instantiation API must be use
 Creating a 2D RigidBody and moving a sprite with it
 ---------------------------------------------------
 
-This creates a :ref:`RigidBody2D <class_RigidBody2D>` using the :ref:`Physics2DServer <class_Physics2DServer>` API,
+This creates a :ref:`RigidBody2D <class_RigidBody2D>` using the :ref:`PhysicsServer2D <class_PhysicsServer2D>` API,
 and moves a :ref:`CanvasItem <class_CanvasItem>` when the body moves.
 
 .. tabs::
@@ -193,12 +193,12 @@ and moves a :ref:`CanvasItem <class_CanvasItem>` when the body moves.
         Physics2DServer.body_set_force_integration_callback(body, self, "_body_moved", 0)
 
 The 3D version should be very similar, as 2D and 3D physics servers are identical (using
-:ref:`RigidBody3D <class_RigidBody3D>` and :ref:`PhysicsServer <class_PhysicsServer>` respectively).
+:ref:`RigidBody3D <class_RigidBody3D>` and :ref:`PhysicsServer3D <class_PhysicsServer3D>` respectively).
 
 Getting data from the servers
 -----------------------------
 
-Try to **never** request any information from ``RenderingServer``, ``PhysicsServer`` or ``Physics2DServer``
+Try to **never** request any information from ``RenderingServer``, ``PhysicsServer2D`` or ``PhysicsServer3D``
 by calling functions unless you know what you are doing. These servers will often run asynchronously
 for performance and calling any function that returns a value will stall them and force them to process
 anything pending until the function is actually called. This will severely decrease performance if you

--- a/tutorials/physics/kinematic_character_2d.rst
+++ b/tutorials/physics/kinematic_character_2d.rst
@@ -110,8 +110,7 @@ Moving the kinematic character
 
 Go back to the character scene, and open the script, the magic begins
 now! Kinematic body will do nothing by default, but it has a
-useful function called
-:ref:`CharacterBody2D.move_and_collide() <class_CharacterBody2D_method_move_and_collide>`.
+useful function called ``CharacterBody2D.move_and_collide()``.
 This function takes a :ref:`Vector2 <class_Vector2>` as
 an argument, and tries to apply that motion to the kinematic body. If a
 collision happens, it stops right at the moment of the collision.

--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -247,7 +247,7 @@ care - altering the ``position``, ``linear_velocity``, or other physics properti
 of a rigid body can result in unexpected behavior. If you need to alter any
 of the physics-related properties, you should use the :ref:`_integrate_forces() <class_RigidBody2D_method__integrate_forces>`
 callback instead of ``_physics_process()``. In this callback, you have access
-to the body's :ref:`Physics2DDirectBodyState <class_Physics2DDirectBodyState>`,
+to the body's :ref:`PhysicsDirectBodyState2D <class_PhysicsDirectBodyState2D>`,
 which allows for safely changing properties and synchronizing them with
 the physics engine.
 
@@ -311,9 +311,9 @@ Contact reporting
 
 By default, rigid bodies do not keep track of contacts, because this can
 require a huge amount of memory if many bodies are in the scene. To enable
-contact reporting, set the :ref:`contacts_reported <class_RigidBody2D_property_contacts_reported>`
+contact reporting, set the :ref:`max_contacts_reported <class_RigidBody2D_property_max_contacts_reported>`
 property to a non-zero value. The contacts can then be obtained via
-:ref:`Physics2DDirectBodyState.get_contact_count() <class_Physics2DDirectBodyState_method_get_contact_count>`
+:ref:`PhysicsDirectBodyState2D.get_contact_count() <class_PhysicsDirectBodyState2D_method_get_contact_count>`
 and related functions.
 
 Contact monitoring via signals can be enabled via the :ref:`contact_monitor <class_RigidBody2D_property_contact_monitor>`
@@ -341,7 +341,7 @@ After a collision, you may want the body to bounce, to slide along a wall,
 or to alter the properties of the object it hit. The way you handle collision
 response depends on which method you used to move the CharacterBody2D.
 
-:ref:`move_and_collide <class_CharacterBody2D_method_move_and_collide>`
+:ref:`move_and_collide <class_PhysicsBody2D_method_move_and_collide>`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When using ``move_and_collide()``, the function returns a
@@ -355,7 +355,7 @@ occurred:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    extends CharacterBody2D
+    extends PhysicsBody2D
 
     var velocity = Vector2(250, 250)
 
@@ -366,7 +366,7 @@ occurred:
 
  .. code-tab:: csharp
 
-    class Body : CharacterBody2D
+    class Body : PhysicsBody2D
     {
         private Vector2 _velocity = new Vector2(250, 250);
 
@@ -385,7 +385,7 @@ Or to bounce off of the colliding object:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    extends CharacterBody2D
+    extends PhysicsBody2D
 
     var velocity = Vector2(250, 250)
 
@@ -396,7 +396,7 @@ Or to bounce off of the colliding object:
 
  .. code-tab:: csharp
 
-    class Body : CharacterBody2D
+    class Body : PhysicsBody2D
     {
         private Vector2 _velocity = new Vector2(250, 250);
 

--- a/tutorials/physics/ragdoll_system.rst
+++ b/tutorials/physics/ragdoll_system.rst
@@ -18,7 +18,7 @@ Setting up the ragdoll
 Creating physical bones
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Like many other features in the engine, there is a node to set up a ragdoll: the :ref:`PhysicalBone <class_PhysicalBone>` node. To simplify the setup, you can generate ``PhysicalBone`` nodes with the "Create physical skeleton" feature in the skeleton node.
+Like many other features in the engine, there is a node to set up a ragdoll: the :ref:`PhysicalBone3D <class_PhysicalBone3D>` node. To simplify the setup, you can generate ``PhysicalBone`` nodes with the "Create physical skeleton" feature in the skeleton node.
 
 Open the platformer demo in Godot, and then the Robi scene. Select the ``Skeleton`` node. A skeleton button appears on the top bar menu:
 

--- a/tutorials/physics/ray-casting.rst
+++ b/tutorials/physics/ray-casting.rst
@@ -28,11 +28,11 @@ In the physics world, Godot stores all the low level collision and
 physics information in a *space*. The current 2d space (for 2D Physics)
 can be obtained by accessing
 :ref:`CanvasItem.get_world_2d().space <class_CanvasItem_method_get_world_2d>`.
-For 3D, it's :ref:`Node3D.get_world().space <class_Node3D_method_get_world>`.
+For 3D, it's :ref:`Node3D.get_world_3d().space <class_Node3D_method_get_world_3d>`.
 
 The resulting space :ref:`RID <class_RID>` can be used in
-:ref:`PhysicsServer <class_PhysicsServer>` and
-:ref:`Physics2DServer <class_Physics2DServer>` respectively for 3D and 2D.
+:ref:`PhysicsServer3D <class_PhysicsServer3D>` and
+:ref:`PhysicsServer2D <class_PhysicsServer2D>` respectively for 3D and 2D.
 
 Accessing space
 ---------------
@@ -45,8 +45,8 @@ callback. Accessing it from outside this function may result in an error
 due to space being *locked*.
 
 To perform queries into physics space, the
-:ref:`Physics2DDirectSpaceState <class_Physics2DDirectSpaceState>`
-and :ref:`PhysicsDirectSpaceState <class_PhysicsDirectSpaceState>`
+:ref:`PhysicsDirectSpaceState2D <class_PhysicsDirectSpaceState2D>`
+and :ref:`PhysicsDirectSpaceState3D <class_PhysicsDirectSpaceState3D>`
 must be used.
 
 Use the following code in 2D:
@@ -100,7 +100,7 @@ Raycast query
 -------------
 
 For performing a 2D raycast query, the method
-:ref:`Physics2DDirectSpaceState.intersect_ray() <class_Physics2DDirectSpaceState_method_intersect_ray>`
+:ref:`PhysicsDirectSpaceState2D.intersect_ray() <class_PhysicsDirectSpaceState2D_method_intersect_ray>`
 may be used. For example:
 
 .. tabs::
@@ -228,7 +228,7 @@ See :ref:`doc_physics_introduction_collision_layer_code_example` for details on 
 
 Casting a ray from screen to 3D physics space is useful for object
 picking. There is not much need to do this because
-:ref:`CollisionObject <class_CollisionObject>`
+:ref:`CollisionObject3D <class_CollisionObject3D>`
 has an "input_event" signal that will let you know when it was clicked,
 but in case there is any desire to do it manually, here's how.
 

--- a/tutorials/plugins/editor/inspector_plugins.rst
+++ b/tutorials/plugins/editor/inspector_plugins.rst
@@ -134,9 +134,9 @@ specifically add :ref:`class_EditorProperty`-based controls.
             return true
         else:
             return false
-            
+
  .. code-tab:: csharp
- 
+
     // MyInspectorPlugin.cs
     #if TOOLS
     using Godot;
@@ -190,6 +190,8 @@ You can display your custom widget in two ways. Use just the default ``add_child
 method to display it to the right of the property name, and use ``add_child()``
 followed by ``set_bottom_editor()`` to position it below the name.
 
+.. FIXME: The second tab has the C# lexer for hightlighting disabled for now, as the provided code causes errors.
+
 .. tabs::
  .. code-tab:: gdscript GDScript
 
@@ -237,11 +239,11 @@ followed by ``set_bottom_editor()`` to position it below the name.
         current_value = new_value
         refresh_control_text()
         updating = false
-    
+
     func refresh_control_text():
         property_control.text = "Value: " + str(current_value)
 
- .. code-tab:: csharp
+ .. code-tab:: none C#
 
     // RandomIntEditor.cs
     #if TOOLS

--- a/tutorials/rendering/index.rst
+++ b/tutorials/rendering/index.rst
@@ -8,4 +8,3 @@ Rendering
    viewports
    multiple_resolutions
    jitter_stutter
-   gles2_gles3_differences

--- a/tutorials/rendering/multiple_resolutions.rst
+++ b/tutorials/rendering/multiple_resolutions.rst
@@ -249,8 +249,9 @@ From scripts
 ^^^^^^^^^^^^
 
 To configure stretching at runtime from a script, use the
-``get_tree().set_screen_stretch()`` method (see
-:ref:`SceneTree.set_screen_stretch() <class_SceneTree_method_set_screen_stretch>`).
+``get_tree().root.content_scale_mode`` (see
+:ref:`Window.content_scale_mode <class_Window_property_content_scale_mode>`
+and the :ref:`ContentScaleMode <enum_Window_ContentScaleMode>` enum).
 
 Common use case scenarios
 -------------------------

--- a/tutorials/rendering/viewports.rst
+++ b/tutorials/rendering/viewports.rst
@@ -237,7 +237,7 @@ and then selecting the :ref:`Viewport <class_Viewport>` you want to use.
 .. image:: img/texturepath.png
 
 Every frame, the :ref:`Viewport <class_Viewport>`'s texture is cleared away with the default clear color (or a transparent
-color if :ref:`Transparent Bg<class_Viewport_property_transparent_bg>` is set to ``true``). This can be changed by setting :ref:`Clear Mode<class_Viewport_property_render_target_clear_mode>` to Never or Next Frame.
+color if :ref:`Transparent Bg<class_Viewport_property_transparent_bg>` is set to ``true``). This can be changed by setting ``Clear Mode`` to Never or Next Frame.
 As the name implies, Never means the texture will never be cleared, while next frame will
 clear the texture on the next frame and then set itself to Never.
 

--- a/tutorials/scripting/c_sharp/c_sharp_exports.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_exports.rst
@@ -341,7 +341,7 @@ Setting exported variables from a tool script
 When changing an exported variable's value from a script in
 :ref:`doc_gdscript_tool_mode`, the value in the inspector won't be updated
 automatically. To update it, call
-:ref:`property_list_changed_notify() <class_Object_method_property_list_changed_notify>`
+:ref:`notify_property_list_changed() <class_Object_method_notify_property_list_changed>`
 after setting the exported variable's value.
 
 Advanced exports

--- a/tutorials/scripting/gdscript/gdscript_exports.rst
+++ b/tutorials/scripting/gdscript/gdscript_exports.rst
@@ -305,7 +305,7 @@ Setting exported variables from a tool script
 When changing an exported variable's value from a script in
 :ref:`doc_gdscript_tool_mode`, the value in the inspector won't be updated
 automatically. To update it, call
-:ref:`property_list_changed_notify() <class_Object_method_property_list_changed_notify>`
+:ref:`notify_property_list_changed_notify() <class_Object_method_notify_property_list_changed>`
 after setting the exported variable's value.
 
 Advanced exports

--- a/tutorials/scripting/overridable_functions.rst
+++ b/tutorials/scripting/overridable_functions.rst
@@ -137,8 +137,8 @@ To learn more about inputs in Godot, see the :ref:`Input section <toc-learn-feat
     }
 
 There are some more overridable functions like
-:ref:`Node._get_configuration_warning()
-<class_Node_method__get_configuration_warning>`. Specialized node types provide
+:ref:`Node._get_configuration_warnings()
+<class_Node_method__get_configuration_warnings>`. Specialized node types provide
 more callbacks like :ref:`CanvasItem._draw() <class_CanvasItem_method__draw>` to
 draw programmatically or :ref:`Control._gui_input()
 <class_Control_method__gui_input>` to handle clicks and input on UI elements.

--- a/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
@@ -163,7 +163,7 @@ Noise is a very popular tool for faking the look of terrain. Think of it as
 similar to the cosine function where you have repeating hills except, with
 noise, each hill has a different height.
 
-Godot provides the :ref:`NoiseTexture <class_noisetexture>` resource for
+Godot provides the :ref:`NoiseTexture2D <class_noisetexture2D>` resource for
 generating a noise texture that can be accessed from a shader.
 
 To access a texture in a shader add the following code near the top of your

--- a/tutorials/ui/custom_gui_controls.rst
+++ b/tutorials/ui/custom_gui_controls.rst
@@ -25,7 +25,7 @@ Checking control size
 
 Unlike 2D nodes, "size" is important with controls, as it helps to
 organize them in proper layouts. For this, the
-:ref:`Control.rect_size <class_Control_property_rect_size>`
+:ref:`Control.size <class_Control_property_size>`
 property is provided. Checking it during ``_draw()`` is vital to ensure
 everything is kept in-bounds.
 


### PR DESCRIPTION
This fixes the remaining build errors outside of the class reference (caused by various Godot 4 changes and renames).