### PR TITLE
Fix incorrect input port in visual_shader_plugins.rst

### DIFF
--- a/tutorials/plugins/editor/visual_shader_plugins.rst
+++ b/tutorials/plugins/editor/visual_shader_plugins.rst
@@ -77,9 +77,9 @@ all you need to initialize your plugin.
     func _get_input_port_type(port):
         match port:
             0:
-                return VisualShaderNode.PORT_TYPE_VECTOR
+                return VisualShaderNode.PORT_TYPE_VECTOR_3D
             1:
-                return VisualShaderNode.PORT_TYPE_VECTOR
+                return VisualShaderNode.PORT_TYPE_VECTOR_3D
             2:
                 return VisualShaderNode.PORT_TYPE_SCALAR
             3:


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
