### PR TITLE
Fixes typo saying `Main` where it should say `HUD`

### DIFF
--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -262,7 +262,7 @@ seconds, then return to the title screen and, after a brief pause, show the
           can be very useful to add delays such as in the above code, where we
           want to wait some time before showing the "Start" button.
 
-Add the code below to ``Main`` to update the score
+Add the code below to ``HUD`` to update the score
 
 .. tabs::
  .. code-tab:: gdscript GDScript


### PR DESCRIPTION
I was confused at first by this because the code was outputting an error, but then I understood that the code should be in `HUD` script.