### PR TITLE
Update documentation changelog for 4.1

### DIFF
--- a/about/docs_changelog.rst
+++ b/about/docs_changelog.rst
@@ -1,5 +1,3 @@
-:article_outdated: True
-
 .. _doc_docs_changelog:
 
 Documentation changelog
@@ -12,6 +10,121 @@ added since version 3.0.
 
 .. note:: This document only contains new pages so not all changes are reflected,
           many pages have been substantially updated but are not reflected in this document.
+
+New pages since version 4.0
+---------------------------
+
+Development
+^^^^^^^^^^^
+
+- :ref:`doc_internal_rendering_architecture`
+- :ref:`doc_using_sanitizers`
+
+Migrating
+^^^^^^^^^
+
+- :ref:`doc_upgrading_to_godot_4.1`
+
+Physics
+^^^^^^^
+
+- :ref:`doc_troubleshooting_physics_issues`
+
+New pages since version 3.6
+---------------------------
+
+2D
+^^
+
+- :ref:`doc_2d_antialiasing`
+
+3D
+^^
+
+- :ref:`doc_3d_antialiasing`
+- :ref:`doc_faking_global_illumination`
+- :ref:`doc_introduction_to_global_illumination`
+- :ref:`doc_mesh_lod`
+- :ref:`doc_occlusion_culling`
+- :ref:`doc_using_sdfgi`
+- :ref:`doc_using_decals`
+- :ref:`doc_visibility_ranges`
+- :ref:`doc_volumetric_fog`
+- :ref:`doc_variable_rate_shading`
+- :ref:`doc_physical_light_and_camera_units`
+
+Animation
+^^^^^^^^^
+
+- :ref:`doc_creating_movies`
+
+Assets pipeline
+^^^^^^^^^^^^^^^
+
+- :ref:`doc_retargeting_3d_skeletons`
+
+Development
+^^^^^^^^^^^
+
+- :ref:`doc_custom_platform_ports`
+
+Migrating
+^^^^^^^^^
+
+- :ref:`doc_upgrading_to_godot_4`
+
+Physics
+^^^^^^^
+
+- :ref:`doc_large_world_coordinates`
+
+Scripting
+^^^^^^^^^
+
+- :ref:`doc_custom_performance_monitors`
+- :ref:`doc_c_sharp_collections`
+- :ref:`doc_c_sharp_global_classes`
+- :ref:`doc_c_sharp_variant`
+
+Shaders
+^^^^^^^
+
+- :ref:`doc_compute_shaders`
+
+Workflow
+^^^^^^^^
+
+- :ref:`doc_pr_review_guidelines`
+
+XR
+^^
+
+- :ref:`doc_introducing_xr_tools`
+- :ref:`doc_xr_action_map`
+- :ref:`doc_deploying_to_android`
+
+New pages since version 3.5
+---------------------------
+
+None.
+
+New pages since version 3.4
+---------------------------
+
+3D
+^^
+
+- :ref:`doc_3d_text`
+
+Animation
+^^^^^^^^^
+
+- :ref:`doc_playing_videos`
+
+Editor
+^^^^^^
+
+- :ref:`doc_managing_editor_features`
 
 New pages since version 3.3
 ---------------------------
@@ -87,7 +200,6 @@ Math
 Platform-specific
 ^^^^^^^^^^^^^^^^^
 
-- :ref:`doc_android_custom_build`
 - :ref:`doc_plugins_for_ios`
 - :ref:`doc_ios_plugin`
 - :ref:`doc_html5_shell_classref`


### PR DESCRIPTION
This lists pages added between 3.6 and 4.1. Pages that will be added in both `master` and `3.6` branches after 3.5 was released should be added in the 3.6 section instead.

- See https://github.com/godotengine/godot-docs/issues/5121.