### PR TITLE
Position the player in the center of the screen

### DIFF
--- a/getting_started/first_2d_game/03.coding_the_player.rst
+++ b/getting_started/first_2d_game/03.coding_the_player.rst
@@ -99,13 +99,15 @@ value written in the script.
 .. image:: img/export_variable.png
 
 The ``_ready()`` function is called when a node enters the scene tree, which is
-a good time to find the size of the game window:
+a good time to find the size of the game window and position the player in the
+center of the screen:
 
 .. tabs::
  .. code-tab:: gdscript GDScript
 
     func _ready():
         screen_size = get_viewport_rect().size
+        position = screen_size / 2
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
The player is hidden in the top left corner which is confusing to a learner

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
