### PR TITLE
Replace `ButtonList` enum with `MouseButton`

### DIFF
--- a/tutorials/inputs/input_examples.rst
+++ b/tutorials/inputs/input_examples.rst
@@ -297,7 +297,7 @@ also counts as a button - two buttons, to be precise, with both
     {
         if (inputEvent is InputEventMouseButton mouseEvent && mouseEvent.Pressed)
         {
-            switch ((MouseButton)mouseEvent.ButtonIndex)
+            switch (mouseEvent.ButtonIndex)
             {
                 case MouseButton.Left:
                     GD.Print("Left button was clicked at ", {mouseEvent.Position});

--- a/tutorials/inputs/input_examples.rst
+++ b/tutorials/inputs/input_examples.rst
@@ -300,7 +300,7 @@ also counts as a button - two buttons, to be precise, with both
             switch (mouseEvent.ButtonIndex)
             {
                 case MouseButton.Left:
-                    GD.Print("Left button was clicked at ", {mouseEvent.Position});
+                    GD.Print($"Left button was clicked at {mouseEvent.Position}");
                     break;
                 case MouseButton.WheelUp:
                     GD.Print("Wheel up");

--- a/tutorials/inputs/input_examples.rst
+++ b/tutorials/inputs/input_examples.rst
@@ -297,12 +297,12 @@ also counts as a button - two buttons, to be precise, with both
     {
         if (inputEvent is InputEventMouseButton mouseEvent && mouseEvent.Pressed)
         {
-            switch ((ButtonList)mouseEvent.ButtonIndex)
+            switch ((MouseButton)mouseEvent.ButtonIndex)
             {
-                case ButtonList.Left:
+                case MouseButton.Left:
                     GD.Print("Left button was clicked at ", {mouseEvent.Position});
                     break;
-                case ButtonList.WheelUp:
+                case MouseButton.WheelUp:
                     GD.Print("Wheel up");
                     break;
             }


### PR DESCRIPTION
Switched `ButtonList` enum to `MouseButton` since `MouseButton` is defined in `InputEventMouse`, while `ButtonList` was undefined in `Godot` namespace.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
