### PR TITLE
Update first_look_at_the_editor.rst

### DIFF
--- a/getting_started/introduction/first_look_at_the_editor.rst
+++ b/getting_started/introduction/first_look_at_the_editor.rst
@@ -19,7 +19,7 @@ The Project manager
 -------------------
 
 When you launch Godot, the first window you see is the Project Manager. In the
-default tab, "Projects," you can manage existing projects, import or create new
+default tab, "Local Projects" you can manage existing projects, import or create new
 ones, and more.
 
 .. image:: img/editor_intro_project_manager.png

--- a/getting_started/introduction/first_look_at_the_editor.rst
+++ b/getting_started/introduction/first_look_at_the_editor.rst
@@ -19,7 +19,7 @@ The Project manager
 -------------------
 
 When you launch Godot, the first window you see is the Project Manager. In the
-default tab, "Local Projects" you can manage existing projects, import or create new
+default tab **Local Projects**, you can manage existing projects, import or create new
 ones, and more.
 
 .. image:: img/editor_intro_project_manager.png


### PR DESCRIPTION
Wrong tab name. It is currently called "Local Projects" in Godot 3.5.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
