### PR TITLE
Introduction - Wrong number

### DIFF
--- a/about/introduction.rst
+++ b/about/introduction.rst
@@ -75,7 +75,7 @@ attribution to "Juan Linietsky, Ariel Manzur and the Godot Engine community".
 Organization of the documentation
 ---------------------------------
 
-This documentation is organized in five sections with an impressively
+This documentation is organized in six sections with an impressively
 unbalanced distribution of contents – but the way it is split up should be
 relatively intuitive:
 


### PR DESCRIPTION
[About » Introduction](https://docs.godotengine.org/en/stable/about/introduction.html)

"This documentation is organized in five sections"
should be:
"This documentation is organized in six sections"

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
