### PR TITLE
Add warning about importing c#

### DIFF
--- a/tutorials/scripting/cross_language_scripting.rst
+++ b/tutorials/scripting/cross_language_scripting.rst
@@ -89,6 +89,9 @@ with :ref:`new() <class_CSharpScript_method_new>`.
     ``Invalid call. Nonexistent function `new` in base``.
 
     For example, MyCoolNode.cs should contain a class named MyCoolNode.
+    
+    The C# class needs to derive a Godot class, for example ``Godot.Object``.
+    Otherwise, the same error will occur.
 
     You also need to check your ``.cs`` file is referenced in the project's
     ``.csproj`` file. Otherwise, the same error will occur.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
It took me a couple hours to understand why I wasn't able to import a custom C# class from GDScript and figured that other people might find this information important.