### PR TITLE
Fix NDC coordinates for Vulkan in Screen-reading shaders

### DIFF
--- a/tutorials/shaders/screen-reading_shaders.rst
+++ b/tutorials/shaders/screen-reading_shaders.rst
@@ -152,6 +152,6 @@ The following code retrieves the 3D position below the pixel being drawn:
 
     void fragment() {
         float depth = textureLod(DEPTH_TEXTURE, SCREEN_UV, 0.0).r;
-        vec4 upos = INV_PROJECTION_MATRIX * vec4(SCREEN_UV * 2.0 - 1.0, depth * 2.0 - 1.0, 1.0);
+        vec4 upos = INV_PROJECTION_MATRIX * vec4(SCREEN_UV * 2.0 - 1.0, depth, 1.0);
         vec3 pixel_position = upos.xyz / upos.w;
     }


### PR DESCRIPTION
Equivalent of #5276 and #5277 for Screen-reading shaders.