### PR TITLE
Remove `print`s which make the program hang in Recording with microphone

### DIFF
--- a/tutorials/audio/recording_with_microphone.rst
+++ b/tutorials/audio/recording_with_microphone.rst
@@ -118,7 +118,6 @@ the recorded stream can be stored into the ``recording`` variable by calling
         print(recording.mix_rate)
         print(recording.stereo)
         var data = recording.get_data()
-        print(data)
         print(data.size())
         $AudioStreamPlayer.stream = recording
         $AudioStreamPlayer.play()
@@ -132,7 +131,6 @@ the recorded stream can be stored into the ``recording`` variable by calling
         GD.Print(_recording.MixRate);
         GD.Print(_recording.Stereo);
         byte[] data = _recording.Data;
-        GD.Print(data);
         GD.Print(data.Length);
         var audioStreamPlayer = GetNode<AudioStreamPlayer>("AudioStreamPlayer");
         audioStreamPlayer.Stream = _recording;


### PR DESCRIPTION
When I run the code as originally printed, it hangs. I'm pretty sure this is just because it's trying to print KBs of raw WAV binary to the console. I'm in GDscript but I imagine it happens in C# too.

The line `print(recording)` is fine because it just prints `[AudioStreamSample:1234]`.

The [sample project itself](https://github.com/godotengine/godot-demo-projects/blob/master/audio/mic_record/MicRecord.gd) also omits this line so this is really just bringing them in sync

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
