### PR TITLE
Fixed outdated scons arguments for export templates.

### DIFF
--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -269,10 +269,12 @@ Creating Windows export templates
 Windows export templates are created by compiling Godot without the editor,
 with the following flags::
 
-    C:\godot> scons platform=windows tools=no target=release_debug bits=32
-    C:\godot> scons platform=windows tools=no target=release bits=32
-    C:\godot> scons platform=windows tools=no target=release_debug bits=64
-    C:\godot> scons platform=windows tools=no target=release bits=64
+    C:\godot> scons platform=windows tools=no target=template_debug bits=32
+    C:\godot> scons platform=windows tools=no target=template_release bits=32
+    C:\godot> scons platform=windows tools=no target=template_debug bits=64
+    C:\godot> scons platform=windows tools=no target=template_release bits=64
+
+Note: If you would like to make export templates for a build of godot that has 64 bit floats, append ``float=64`` to the end of the commands above.
 
 If you plan on replacing the standard export templates, copy these to the
 following location, replacing ``<version>`` with the version identifier


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
Also added a note to remind the reader to add the `float=64` flag if they want to make export templates for a Godot build that has 64 bit floats.