### PR TITLE
Update Big O notation resource link

### DIFF
--- a/tutorials/best_practices/data_preferences.rst
+++ b/tutorials/best_practices/data_preferences.rst
@@ -10,7 +10,7 @@ Y or Z? This article covers a variety of topics related to these dilemmas.
 
   This article makes references to "[something]-time" operations. This
   terminology comes from algorithm analysis'
-  `Big O Notation <https://rob-bell.net/2009/06/a-beginners-guide-to-big-o-notation/>`_.
+  `Big O Notation <https://www.youtube.com/watch?v=D6xkbGLQesk>`_.
 
   Long-story short, it describes the worst-case scenario of runtime length.
   In laymen's terms:

--- a/tutorials/best_practices/data_preferences.rst
+++ b/tutorials/best_practices/data_preferences.rst
@@ -10,7 +10,7 @@ Y or Z? This article covers a variety of topics related to these dilemmas.
 
   This article makes references to "[something]-time" operations. This
   terminology comes from algorithm analysis'
-  `Big O Notation <https://www.youtube.com/watch?v=D6xkbGLQesk>`_.
+  `Big O Notation <https://towardsdatascience.com/introduction-to-big-o-notation-820d2e25d3fd>`_.
 
   Long-story short, it describes the worst-case scenario of runtime length.
   In laymen's terms:


### PR DESCRIPTION
Existing link to Big O notation resource, leads to a non working website. Therefore, a new link needs to be added.

I found [this video](https://www.youtube.com/watch?v=D6xkbGLQesk) to be a helpful guide in understanding Big O Notation. As such, I added this as a new resource for understanding Big O Notation in the docs.
