### PR TITLE
Add C# documentation for the export section

### DIFF
--- a/tutorials/export/exporting_for_dedicated_servers.rst
+++ b/tutorials/export/exporting_for_dedicated_servers.rst
@@ -124,8 +124,8 @@ or server binary is detected:
 .. tabs::
  .. code-tab:: gdscript
 
-    # Note: Feature tags are case-sensitive! It's "Server", not "server".
-    if OS.has_feature("Server"):
+    # Note: Feature tags are case-sensitive! It's "server", not "Server".
+    if OS.has_feature("server"):
         # Run your server startup code here...
         # Note that using this check may break unit testing scripts when
         # running them with headless or server binaries.
@@ -133,8 +133,8 @@ or server binary is detected:
 
  .. code-tab:: csharp
 
-    // Note: Feature tags are case-sensitive! It's "Server", not "server".
-    if (OS.HasFeature("Server"))
+    // Note: Feature tags are case-sensitive! It's "server", not "Server".
+    if (OS.HasFeature("server"))
     {
         // Run your server startup code here...
         // Note that using this check may break unit testing scripts when

--- a/tutorials/export/exporting_for_dedicated_servers.rst
+++ b/tutorials/export/exporting_for_dedicated_servers.rst
@@ -96,7 +96,10 @@ Starting the dedicated server
 If both your client and server are part of the same Godot project, you will have
 to add a way to start the server directly using a command-line argument. This
 can be done by adding the following code snippet in your main scene (or a
-singleton)'s ``_ready()`` method::
+singleton)'s ``_ready()`` method:
+
+.. tabs::
+ .. code-tab:: gdscript
 
     if "--server" in OS.get_cmdline_args():
         # Run your server startup code here...
@@ -104,8 +107,22 @@ singleton)'s ``_ready()`` method::
         # a Godot binary (headless or not) with the `--server` command-line argument.
         pass
 
+ .. code-tab:: csharp
+
+    using System.Linq;
+
+    if (OS.GetCmdlineArgs().Contains("--server"))
+    {
+        // Run your server startup code here...
+        // Using this check, you can start a dedicated server by running
+        // a Godot binary (headless or not) with the `--server` command-line argument.
+    }
+
 Alternatively, you can make the dedicated server always start up if a headless
-or server binary is detected::
+or server binary is detected:
+
+.. tabs::
+ .. code-tab:: gdscript
 
     # Note: Feature tags are case-sensitive! It's "Server", not "server".
     if OS.has_feature("Server"):
@@ -113,6 +130,16 @@ or server binary is detected::
         # Note that using this check may break unit testing scripts when
         # running them with headless or server binaries.
         pass
+
+ .. code-tab:: csharp
+
+    // Note: Feature tags are case-sensitive! It's "Server", not "server".
+    if (OS.HasFeature("Server"))
+    {
+        // Run your server startup code here...
+        // Note that using this check may break unit testing scripts when
+        // running them with headless or server binaries.
+    }
 
 If your client and server are separate Godot projects, your server should most
 likely be configured in a way where running the main scene starts a server

--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -276,25 +276,41 @@ same name. It takes a string as an argument and executes it as JavaScript code.
 This allows interacting with the browser in ways not possible with script
 languages integrated into Godot.
 
-::
+.. tabs::
+ .. code-tab:: gdscript
 
     func my_func():
         JavaScript.eval("alert('Calling JavaScript per GDScript!');")
 
+ .. code-tab:: csharp
+     
+    private void MyFunc()
+    {
+        JavaScript.Eval("alert('Calling JavaScript per C#!');")
+    }
+
 The value of the last JavaScript statement is converted to a GDScript value and
 returned by ``eval()`` under certain circumstances:
 
- * JavaScript ``number`` is returned as GDScript :ref:`class_float`
- * JavaScript ``boolean`` is returned as GDScript :ref:`class_bool`
- * JavaScript ``string`` is returned as GDScript :ref:`class_String`
- * JavaScript ``ArrayBuffer``, ``TypedArray`` and ``DataView`` are returned as
-   GDScript :ref:`PackedByteArray<class_PackedByteArray>`
+ * JavaScript ``number`` is returned as :ref:`class_float`
+ * JavaScript ``boolean`` is returned as :ref:`class_bool`
+ * JavaScript ``string`` is returned as :ref:`class_String`
+ * JavaScript ``ArrayBuffer``, ``TypedArray`` and ``DataView`` are returned as :ref:`PackedByteArray<class_PackedByteArray>`
 
-::
+.. tabs::
+ .. code-tab:: gdscript
 
     func my_func2():
         var js_return = JavaScript.eval("var myNumber = 1; myNumber + 2;")
         print(js_return) # prints '3.0'
+
+ .. code-tab:: csharp
+
+    private void MyFunc2()
+    {
+        var jsReturn = JavaScript.Eval("var myNumber = 1; myNumber + 2;");
+        GD.Print(jsReturn); // prints '3.0'
+    }
 
 Any other JavaScript value is returned as ``null``.
 
@@ -302,7 +318,10 @@ HTML5 export templates may be :ref:`built <doc_compiling_for_web>` without
 support for the singleton to improve security. With such templates, and on
 platforms other than HTML5, calling ``JavaScript.eval`` will also return
 ``null``. The availability of the singleton can be checked with the
-``JavaScript`` :ref:`feature tag <doc_feature_tags>`::
+``JavaScript`` :ref:`feature tag <doc_feature_tags>`:
+
+.. tabs::
+ .. code-tab:: gdscript
 
     func my_func3():
         if OS.has_feature('JavaScript'):
@@ -312,14 +331,41 @@ platforms other than HTML5, calling ``JavaScript.eval`` will also return
         else:
             print("The JavaScript singleton is NOT available")
 
+ .. code-tab:: csharp
+    
+    private void MyFunc3()
+    {
+        if (OS.HasFeature("JavaScript"))
+        {
+            JavaScript.eval("console.log('The JavaScript singleton is available')");
+        }
+        else
+        {
+            GD.Print("The Javascript singleton is NOT available");
+        }
+    }
+
 .. tip:: GDScript's multi-line strings, surrounded by 3 quotes ``"""`` as in
          ``my_func3()`` above, are useful to keep JavaScript code readable.
 
 The ``eval`` method also accepts a second, optional Boolean argument, which
 specifies whether to execute the code in the global execution context,
-defaulting to ``false`` to prevent polluting the global namespace::
+defaulting to ``false`` to prevent polluting the global namespace:
+
+.. tabs::
+ .. code-tab:: gdscript
 
     func my_func4():
         # execute in global execution context,
         # thus adding a new JavaScript global variable `SomeGlobal`
         JavaScript.eval("var SomeGlobal = {};", true)
+
+ .. code-tab:: csharp
+
+    private void MyFunc4()
+    {
+        // execute in global execution context,
+        // thus adding a new JavaScript global variable `SomeGlobal`
+        JavaScript.Eval("var SomeGlobal = {};", true);
+    }
+

--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -270,7 +270,7 @@ of its original size with gzip compression.
 Calling JavaScript from script
 ------------------------------
 
-In web builds, the ``JavaScript`` singleton is implemented. It offers a single
+In web builds, the ``JavaScriptBridge`` singleton is implemented. It offers a single
 method called ``eval`` that works similarly to the JavaScript function of the
 same name. It takes a string as an argument and executes it as JavaScript code.
 This allows interacting with the browser in ways not possible with script
@@ -280,13 +280,13 @@ languages integrated into Godot.
  .. code-tab:: gdscript
 
     func my_func():
-        JavaScript.eval("alert('Calling JavaScript per GDScript!');")
+        JavaScriptBridge.eval("alert('Calling JavaScript per GDScript!');")
 
  .. code-tab:: csharp
      
     private void MyFunc()
     {
-        JavaScript.Eval("alert('Calling JavaScript per C#!');")
+        JavaScriptBridge.Eval("alert('Calling JavaScript per C#!');")
     }
 
 The value of the last JavaScript statement is converted to a GDScript value and
@@ -301,14 +301,14 @@ returned by ``eval()`` under certain circumstances:
  .. code-tab:: gdscript
 
     func my_func2():
-        var js_return = JavaScript.eval("var myNumber = 1; myNumber + 2;")
+        var js_return = JavaScriptBridge.eval("var myNumber = 1; myNumber + 2;")
         print(js_return) # prints '3.0'
 
  .. code-tab:: csharp
 
     private void MyFunc2()
     {
-        var jsReturn = JavaScript.Eval("var myNumber = 1; myNumber + 2;");
+        var jsReturn = JavaScriptBridge.Eval("var myNumber = 1; myNumber + 2;");
         GD.Print(jsReturn); // prints '3.0'
     }
 
@@ -316,32 +316,32 @@ Any other JavaScript value is returned as ``null``.
 
 HTML5 export templates may be :ref:`built <doc_compiling_for_web>` without
 support for the singleton to improve security. With such templates, and on
-platforms other than HTML5, calling ``JavaScript.eval`` will also return
+platforms other than HTML5, calling ``JavaScriptBridge.eval`` will also return
 ``null``. The availability of the singleton can be checked with the
-``JavaScript`` :ref:`feature tag <doc_feature_tags>`:
+``javascript`` :ref:`feature tag <doc_feature_tags>`:
 
 .. tabs::
  .. code-tab:: gdscript
 
     func my_func3():
-        if OS.has_feature('JavaScript'):
-            JavaScript.eval("""
-                console.log('The JavaScript singleton is available')
+        if OS.has_feature('javascript'):
+            JavaScriptBridge.eval("""
+                console.log('The JavaScriptBridge singleton is available')
             """)
         else:
-            print("The JavaScript singleton is NOT available")
+            print("The JavaScriptBridge singleton is NOT available")
 
  .. code-tab:: csharp
     
     private void MyFunc3()
     {
-        if (OS.HasFeature("JavaScript"))
+        if (OS.HasFeature("javascript"))
         {
-            JavaScript.eval("console.log('The JavaScript singleton is available')");
+            JavaScriptBridge.eval("console.log('The JavaScriptBridge singleton is available')");
         }
         else
         {
-            GD.Print("The Javascript singleton is NOT available");
+            GD.Print("The JavaScriptBridge singleton is NOT available");
         }
     }
 
@@ -358,7 +358,7 @@ defaulting to ``false`` to prevent polluting the global namespace:
     func my_func4():
         # execute in global execution context,
         # thus adding a new JavaScript global variable `SomeGlobal`
-        JavaScript.eval("var SomeGlobal = {};", true)
+        JavaScriptBridge.eval("var SomeGlobal = {};", true)
 
  .. code-tab:: csharp
 
@@ -366,6 +366,6 @@ defaulting to ``false`` to prevent polluting the global namespace:
     {
         // execute in global execution context,
         // thus adding a new JavaScript global variable `SomeGlobal`
-        JavaScript.Eval("var SomeGlobal = {};", true);
+        JavaScriptBridge.Eval("var SomeGlobal = {};", true);
     }
 

--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -318,13 +318,13 @@ HTML5 export templates may be :ref:`built <doc_compiling_for_web>` without
 support for the singleton to improve security. With such templates, and on
 platforms other than HTML5, calling ``JavaScriptBridge.eval`` will also return
 ``null``. The availability of the singleton can be checked with the
-``javascript`` :ref:`feature tag <doc_feature_tags>`:
+``web`` :ref:`feature tag <doc_feature_tags>`:
 
 .. tabs::
  .. code-tab:: gdscript
 
     func my_func3():
-        if OS.has_feature('javascript'):
+        if OS.has_feature('web'):
             JavaScriptBridge.eval("""
                 console.log('The JavaScriptBridge singleton is available')
             """)
@@ -335,9 +335,9 @@ platforms other than HTML5, calling ``JavaScriptBridge.eval`` will also return
     
     private void MyFunc3()
     {
-        if (OS.HasFeature("javascript"))
+        if (OS.HasFeature("web"))
         {
-            JavaScriptBridge.eval("console.log('The JavaScriptBridge singleton is available')");
+            JavaScriptBridge.Eval("console.log('The JavaScriptBridge singleton is available')");
         }
         else
         {

--- a/tutorials/export/feature_tags.rst
+++ b/tutorials/export/feature_tags.rst
@@ -19,9 +19,14 @@ Each *feature* is represented as a string, which can refer to many of the follow
 
 Features can be queried at run-time from the singleton API by calling:
 
-::
+.. tabs::
+ .. code-tab:: gdscript
 
     OS.has_feature(name)
+
+ .. code-tab:: csharp
+
+    OS.HasFeature(name);
 
 OS feature tags are used by GDExtension to determine which libraries to load.
 For example, a library for ``linux.debug.editor.x86_64`` will be


### PR DESCRIPTION
Adds C# examples for some articles in the Export section that only had GDScript examples.