### PR TITLE
Replace File with FileAccess in plugin tutorial

### DIFF
--- a/tutorials/plugins/editor/import_plugins.rst
+++ b/tutorials/plugins/editor/import_plugins.rst
@@ -298,8 +298,6 @@ method. Our sample code is a bit long, so let's split in a few parts:
 
         var line = file.get_line()
 
-        file.close()
-
 The first part of our import method opens and reads the source file. We use the
 :ref:`FileAccess <class_FileAccess>` class to do that, passing the ``source_file``
 parameter which is provided by the editor.

--- a/tutorials/plugins/editor/import_plugins.rst
+++ b/tutorials/plugins/editor/import_plugins.rst
@@ -292,10 +292,9 @@ method. Our sample code is a bit long, so let's split in a few parts:
 ::
 
     func _import(source_file, save_path, options, r_platform_variants, r_gen_files):
-        var file = File.new()
-        var err = file.open(source_file, File.READ)
-        if err != OK:
-            return err
+        var file = FileAccess.open(source_file, FileAccess.READ)
+        if file == null:
+            return FileAccess.get_open_error()
 
         var line = file.get_line()
 
@@ -305,7 +304,9 @@ The first part of our import method opens and reads the source file. We use the
 :ref:`FileAccess <class_FileAccess>` class to do that, passing the ``source_file``
 parameter which is provided by the editor.
 
-If there's an error when opening the file, we return it to let the editor know
+If there's an error when opening the file, the ``file`` variable will be null.
+We use the :ref:`FileAccess <class_FileAccess>` ``get_open_error`` function to
+obtain the error from opening the file, and return it to let the editor know
 that the import wasn't successful.
 
 ::
@@ -375,7 +376,7 @@ would need to do something like the following:
 ::
 
     r_platform_variants.push_back("mobile")
-    return ResourceSaver.save(mobile_material, "%s.%s.%s" % [save_path, "mobile", get_save_extension()])
+    return ResourceSaver.save(mobile_material, "%s.%s.%s" % [save_path, "mobile", _get_save_extension()])
 
 The ``r_gen_files`` argument is meant for extra files that are generated during
 your import process and need to be kept. The editor will look at it to


### PR DESCRIPTION
The File class is no longer around in Godot 4, and has been replaced with the FileAccess class. I have updated the tutorial to reflect this, and also fixed a typo in the tutorial when referencing the local _get_save_extension function.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
