### PR TITLE
Change build flags in Godot 4 docs to current variants

### DIFF
--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -149,13 +149,16 @@ manager.
 
 .. note:: If you are compiling Godot for production use, then you can
           make the final executable smaller and faster by adding the
-          SCons option ``production=yes``.
+          SCons option `production=yes`.
           
-          If you wish, you can also enable features piecemeal such as 
-          `optimize=speed_trace`, or `use_lto=yes` which will enable
+          If you wish, you can also enable features piecemeal with 
+          `optimize=speed` and/or `lto=full` which will enable
           speed optimizations and link-time optimizations independently.
+          
           In particular, you may not be able to build with LTO on with a weaker computer, 
-          as it can use quite a lot of RAM (up to 7GB).
+          as it can use quite a lot of RAM (up to 7GB). In this case, you may still be able to get
+          some benefits with weaker (but more memory-friendly) settings such as `lto=thin`, or
+          `lto=auto` which should choose a reasonable configuration for your machine.
 
 .. note:: If you want to use separate editor settings for your own Godot builds
           and official releases, you can enable

--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -149,35 +149,18 @@ manager.
 
 .. note:: If you are compiling Godot for production use, then you can
           make the final executable smaller and faster by adding the
-          SCons option ``target=release_debug``.
-
-          If you are compiling Godot with GCC, you can make the binary
-          even smaller and faster by adding the SCons option ``use_lto=yes``.
-          As link-time optimization is a memory-intensive process,
-          this will require about 7 GB of available RAM while compiling.
+          SCons option ``production=yes``.
+          
+          If you wish, you can also enable features piecemeal such as 
+          `optimize=speed_trace`, or `use_lto=yes` which will enable
+          speed optimizations and link-time optimizations independently.
+          In particular, you may not be able to build with LTO on with a weaker computer, 
+          as it can use quite a lot of RAM (up to 7GB).
 
 .. note:: If you want to use separate editor settings for your own Godot builds
           and official releases, you can enable
           :ref:`doc_data_paths_self_contained_mode` by creating a file called
           ``._sc_`` or ``_sc_`` in the ``bin/`` folder.
-
-Compiling a headless/server build
----------------------------------
-
-To compile a *headless* build which provides editor functionality to export
-projects in an automated manner, use::
-
-    scons -j8 platform=server tools=yes target=release_debug
-
-To compile a debug *server* build which can be used with
-:ref:`remote debugging tools <doc_command_line_tutorial>`, use::
-
-    scons -j8 platform=server tools=no target=release_debug
-
-To compile a *server* build which is optimized to run dedicated game servers,
-use::
-
-    scons -j8 platform=server tools=no target=release
 
 Building export templates
 -------------------------
@@ -197,15 +180,15 @@ following parameters:
 
 ::
 
-    scons platform=linuxbsd tools=no target=release bits=32
-    scons platform=linuxbsd tools=no target=release_debug bits=32
+    scons platform=linuxbsd tools=no production=yes bits=32
+    scons platform=linuxbsd tools=no production=yes optimize=speed_trace bits=32
 
 -  (64 bits)
 
 ::
 
-    scons platform=linuxbsd tools=no target=release bits=64
-    scons platform=linuxbsd tools=no target=release_debug bits=64
+    scons platform=linuxbsd tools=no optimize=speed bits=64
+    scons platform=linuxbsd tools=no target=speed_trace bits=64
 
 Note that cross-compiling for the opposite bits (64/32) as your host
 platform is not always straight-forward and might need a chroot environment.


### PR DESCRIPTION
I was trying to follow the build instructions for production and found that at some point on `master` the flags in `SConstruct` had changed - in particular the `target` values now only include `editor`, `template_release`, and `template_debug`. I made my best guess at the proper ones to use, this probably needs a revision pass by someone who builds Godot from source more often than me.

In particular, I had to remove the documentation for the `headless` section, as it's not entirely clear from `SConstruct` what you'd pass to do it. This probably also needs to be changed on the other platforms, but I haven't had the opportunity to check that yet.

Changelog:
- `target=release_debug` -> `optimize=speed_trace`
- `target=release` -> `optimize=speed` (may also need `debug_symbols=no`?)
- use `production=yes` as default option for production builds
- remove headless compilation as current way to do this is non-obvious with current build targets available, should be added before merging