### PR TITLE
Document SSR not working with `SCREEN_TEXTURE`/`DEPTH_TEXTURE`

### DIFF
--- a/tutorials/3d/environment_and_post_processing.rst
+++ b/tutorials/3d/environment_and_post_processing.rst
@@ -241,7 +241,9 @@ A few user-controlled parameters are available to better tweak the technique:
 - **Depth Tolerance** can be used for screen-space-ray hit tolerance to gaps. The bigger the value, the more gaps will be ignored.
 - **Roughness** will apply a screen-space blur to approximate roughness in objects with this material characteristic.
 
-Keep in mind that screen-space-reflections only work for reflecting opaque geometry. Transparent objects can't be reflected.
+Keep in mind that screen-space-reflections only work for reflecting opaque
+geometry. Transparent materials won't be reflected, as they don't write to the depth buffer.
+This also applies to shaders that use ``SCREEN_TEXTURE`` or ``DEPTH_TEXTURE``.
 
 Screen-Space Ambient Occlusion (SSAO)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This note is also relevant for https://github.com/godotengine/godot-docs/pull/6273, but I plan to integrate it directly in that PR (not done yet).

This closes https://github.com/godotengine/godot/issues/44339.
<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

All pull requests for Godot 3 should usually go into `master`.
-->