### PR TITLE
Update android_in_app_purchases.rst

### DIFF
--- a/tutorials/platform/android/android_in_app_purchases.rst
+++ b/tutorials/platform/android/android_in_app_purchases.rst
@@ -19,8 +19,14 @@ Getting started
 ***************
 
 Make sure you have enabled and successfully set up :ref:`Android Custom Builds <doc_android_custom_build>`.
-Grab the ``GodotGooglePlayBilling`` plugin binary and config from the `releases page <https://github.com/godotengine/godot-google-play-billing/releases>`__
-and put both into `res://android/plugins`.
+Follow the compiling instructions on the ``GodotGooglePlayBilling`` `github page <https://github.com/godotengine/godot-google-play-billing>`__.
+
+.. note::
+
+    If you use a custom build you possibly have to put your own `godot-lib.***.release.aar` file in the `./godot-google-play-billing/libs/` folder.
+
+Then put the files `./godot-google-play-billing/build/outputs/aar/GodotGooglePlayBilling.***.release.aar` and `./GodotGooglePlayBilling.gdap` into your project in the `res://android/plugins` folder.
+
 The plugin should now show up in the Android export settings, where you can enable it.
 
 


### PR DESCRIPTION
The link to https://github.com/godotengine/godot-google-play-billing/releases is misleading, because the releases there are to old. You have to compile the project yourself, because otherwise google rejects the .aar upload because of using old api. Furthermore the described methods and signals correspond to the new Version and not the released Version 1.0.1 Hope my English will do.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
