### PR TITLE
Add styling for call-to-action notes on the class reference

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -63,6 +63,9 @@
     --highlight-operator-color: #666666;
     --highlight-string-color: #4070a0;
 
+    --contribute-background-color: #d7dee8;
+    --contribute-text-color: #646e72;
+
     --admonition-note-background-color: #e7f2fa;
     --admonition-note-color: #404040;
     --admonition-note-title-background-color: #6ab0de;
@@ -153,6 +156,9 @@
         --highlight-function-color: #57b3ff;
         --highlight-operator-color: #abc8ff;
         --highlight-string-color: #ffeca1;
+
+        --contribute-background-color: #25282d;
+        --contribute-text-color: #7f939b;
 
         --admonition-note-background-color: #303d4f;
         --admonition-note-color: #bfeeff;
@@ -727,6 +733,18 @@ code,
 .highlight .sd /* Literal.String.Doc */,
 .highlight .sh /* Literal.String.Heredoc */ {
     color: var(--highlight-string-color);
+}
+
+/* Call to action for missing documentation */
+.rst-content .contribute {
+    background-color: var(--contribute-background-color);
+    color: var(--contribute-text-color);
+    padding: 12px;
+    margin-bottom: 12px;
+}
+
+.rst-content .contribute > p {
+    margin-bottom: 0;
 }
 
 /* Admonition tweaks */


### PR DESCRIPTION
A companion for https://github.com/godotengine/godot/pull/63203, adds the necessary styles for the new blocks. Looks like this:

[Dark theme](https://user-images.githubusercontent.com/11782833/202511418-13972bdf-cef8-4762-9115-3826ec5f1aff.png)
[Light theme](https://user-images.githubusercontent.com/11782833/202511607-454c3005-a7b2-4002-9080-94557e106aaa.png)

