### PR TITLE
Update 09.adding_animations.rst

### DIFF
--- a/getting_started/first_3d_game/09.adding_animations.rst
+++ b/getting_started/first_3d_game/09.adding_animations.rst
@@ -245,10 +245,12 @@ node structure, you can copy them to different scenes.
 For example, both the *Mob* and the *Player* scenes have a *Pivot* and a
 *Character* node, so we can reuse animations between them.
 
-Open the *Player* scene, select the animation player node and open the "float" animation.
-Next, click on **Animation > Copy**. Then open ``Mob.tscn`` and open its animation
-player. Click **Animation > Paste**. That's it; all monsters will now play the float
-animation.
+Open the *Player* scene, select the AnimationPlayer node and open the "float" 
+animation. Next, click on **Animation > Copy**. Then open ``Mob.tscn``, 
+create an AnimationPlayer child node and select it. Click **Animation > Paste** 
+and make sure that the button with an "A+" icon (Autoplay on Load) and the 
+looping arrows (Animation looping) are also turned on in the animation editor 
+in the bottom panel. That's it; all monsters will now play the float animation.
 
 We can change the playback speed based on the creature's ``random_speed``. Open
 the *Mob*'s script and at the end of the ``initialize()`` function, add the


### PR DESCRIPTION
Improved documentation for animating the enemies (Mob). I was wondering why the enemy animations were not playing after the animation copy and paste. This fixes it.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
