### PR TITLE
Hide the ref badge from RTD's version selector

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -344,6 +344,11 @@ a[href*="classes/"]::before {
     display: none;
 }
 
+/* Prevent the "ref" badge from appearing on Read the Docs inside of the version selector. */
+.rst-versions a[href*="classes/"]::before {
+    display: none;
+}
+
 hr,
 #search-results .search li:first-child,
 #search-results .search li {
@@ -1029,6 +1034,21 @@ kbd.compound > .kbd,
 
 .rst-versions {
     background-color: var(--navbar-current-background-color);
+}
+
+.rst-versions.shift-up {
+    overflow: visible;
+}
+
+.rst-versions.shift-up:before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: -8px;
+    width: 100%;
+    height: 8px;
+    pointer-events: none;
+    background: linear-gradient(transparent, hsla(0, 0%, 0%, 0.2));
 }
 
 @media only screen and (min-width: 769px) {


### PR DESCRIPTION
As noted by a user on Mastodon, if you open a class reference page in the latest branch, the version selector from Read the Docs starts to [look corrupted](https://user-images.githubusercontent.com/11782833/202868021-97137d69-102c-4264-973d-122f502a73c4.png). This is because those links appear to be valid for our styling rule that adds a "Ref" badge.

So I've added an exception. I've also updated the styling of the version selector a bit to add a drop shadow when it's expanded. As can be seen in the picture linked above, it blends quite easily with the sidebar content, which makes it hard to distinguish one from another. Here's how it all looks now:

![chrome_2022-11-19_22-18-27](https://user-images.githubusercontent.com/11782833/202868095-5d8728f1-79e9-4c56-a168-74937637053d.png)

When it is collapsed, there is no such problem, so the shadow is not added there. I also remove an overflow scroll rule from the expanded version because it conflicts with this change and doesn't seem to do anything useful, unless you are at an extremely small resolution. I wager, at this resolution it's hard to impossible to read the docs anyway, so removing the rule seems like a fine compromise for the updated look.