### PR TITLE
Make the maximum page width slightly bigger

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -541,6 +541,7 @@ footer,
 
 .wy-nav-content {
     background-color: var(--content-background-color);
+    max-width: 900px;
 }
 
 .wy-body-for-nav {
@@ -550,7 +551,7 @@ footer,
 @media only screen and (min-width: 769px) {
     .wy-body-for-nav {
         /* Center the page on wide displays for better readability */
-        max-width: 1100px;
+        max-width: 1200px;
         margin: 0 auto;
     }
 }


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-docs/issues/4532. This PR increases the maximum width of the page content by another 100px, making it 900px with the total width 1200px max. This is pretty much on par with GitHub, and shouldn't affect people with smaller resolutions in any way.

I'm not particularly swoon one way or another, but I don't see much harm in this change as well. So if it improves the experience for some, I'm for it.

**A normal tutorial page:**
[Before](https://user-images.githubusercontent.com/11782833/202878640-f040ee53-d098-412a-b68e-af1c53bd70af.png) | [After](https://user-images.githubusercontent.com/11782833/202878644-23b9a971-4cb1-43ea-a213-07c59e4f7cb4.png)

**A class reference page:**
[Before](https://user-images.githubusercontent.com/11782833/202878664-14693d43-448b-4f68-b5c0-a9b71b158809.png) | [After](https://user-images.githubusercontent.com/11782833/202878666-514a1235-514c-40d3-8c1b-ae0fdf5c19ff.png)
