### PR TITLE
Correct exceptions for the class reference badge

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -33,7 +33,6 @@
     --link-color-visited: #9b59b6;
     --class-reference-icon: url("data:image/svg+xml;base64,PHN2ZyBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLW1pdGVybGltaXQ9IjIiIHZpZXdCb3g9IjAgMCAxNiAxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJtNS4wMjkgMWMtLjk5OS0uMDExLTIuMDA5LjMxMi0zLjAyOSAxdjdjMi4wMTctMS4zNTMgNC4wMTctMS4zMTQgNiAwIDEuOTgzLTEuMzE0IDMuOTgzLTEuMzUzIDYgMHYtN2MtMS4wMi0uNjg4LTIuMDMtMS4wMTEtMy4wMjktMS0uNjYyLjAwNy0xLjMxOC4xNzMtMS45NzEuNDYzdjQuNTM3aC0xdi00Yy0uOTgyLS42NDUtMS45NzEtLjk4OS0yLjk3MS0xem0tNS4wMjkgOXY2aDJjMS42NDYgMCAzLTEuMzU0IDMtM3MtMS4zNTQtMy0zLTN6bTUgM2MwIDEuNjQ2IDEuMzU0IDMgMyAzczMtMS4zNTQgMy0zLTEuMzU0LTMtMy0zLTMgMS4zNTQtMyAzem02IDBjMCAxLjY0NiAxLjM1NCAzIDMgM2gxdi0yaC0xYy0uNTQ5IDAtMS0uNDUxLTEtMXMuNDUxLTEgMS0xaDF2LTJoLTFjLTEuNjQ2IDAtMyAxLjM1NC0zIDN6bS05LTFjLjU0OSAwIDEgLjQ1MSAxIDFzLS40NTEgMS0xIDF6bTYgMGMuNTQ5IDAgMSAuNDUxIDEgMXMtLjQ1MSAxLTEgMS0xLS40NTEtMS0xIC40NTEtMSAxLTF6IiBmaWxsPSIjNDE0MTQxIiBmaWxsLW9wYWNpdHk9Ii41OSIgZmlsbC1ydWxlPSJub256ZXJvIi8+PC9zdmc+Cg==");
     --external-reference-icon: url("data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjEyIiB3aWR0aD0iMTIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGcgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMjk4MGI5Ij48cGF0aCBkPSJtNy41IDcuMXYzLjRoLTZ2LTZoMy40Ii8+PHBhdGggZD0ibTUuNzY1IDFoNS4yMzV2NS4zOWwtMS41NzMgMS41NDctMS4zMS0xLjMxLTIuNzI0IDIuNzIzLTIuNjktMi42ODggMi44MS0yLjgwOC0xLjMxMy0xLjMxeiIvPjwvZz48L3N2Zz4K");
-    --classref-badge-text-color: hsl(0, 0%, 45%);
 
     --hr-color: #e1e4e5;
     --table-row-odd-background-color: #f3f6f6;
@@ -128,7 +127,6 @@
         --link-color-visited: #cb99f6;
         --class-reference-icon: url("data:image/svg+xml;base64,PHN2ZyBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLW1pdGVybGltaXQ9IjIiIHZpZXdCb3g9IjAgMCAxNiAxNiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJtNS4wMjkgMWMtLjk5OS0uMDExLTIuMDA5LjMxMi0zLjAyOSAxdjdjMi4wMTctMS4zNTMgNC4wMTctMS4zMTQgNiAwIDEuOTgzLTEuMzE0IDMuOTgzLTEuMzUzIDYgMHYtN2MtMS4wMi0uNjg4LTIuMDMtMS4wMTEtMy4wMjktMS0uNjYyLjAwNy0xLjMxOC4xNzMtMS45NzEuNDYzdjQuNTM3aC0xdi00Yy0uOTgyLS42NDUtMS45NzEtLjk4OS0yLjk3MS0xem0tNS4wMjkgOXY2aDJjMS42NDYgMCAzLTEuMzU0IDMtM3MtMS4zNTQtMy0zLTN6bTUgM2MwIDEuNjQ2IDEuMzU0IDMgMyAzczMtMS4zNTQgMy0zLTEuMzU0LTMtMy0zLTMgMS4zNTQtMyAzem02IDBjMCAxLjY0NiAxLjM1NCAzIDMgM2gxdi0yaC0xYy0uNTQ5IDAtMS0uNDUxLTEtMXMuNDUxLTEgMS0xaDF2LTJoLTFjLTEuNjQ2IDAtMyAxLjM1NC0zIDN6bS05LTFjLjU0OSAwIDEgLjQ1MSAxIDFzLS40NTEgMS0xIDF6bTYgMGMuNTQ5IDAgMSAuNDUxIDEgMXMtLjQ1MSAxLTEgMS0xLS40NTEtMS0xIC40NTEtMSAxLTF6IiBmaWxsPSIjYmZiZmJmIiBmaWxsLW9wYWNpdHk9Ii41OSIgZmlsbC1ydWxlPSJub256ZXJvIi8+PC9zdmc+Cg==");
         --external-reference-icon: url("data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjEyIiB3aWR0aD0iMTIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGcgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjOGNmIj48cGF0aCBkPSJtNy41IDcuMXYzLjRoLTZ2LTZoMy40Ii8+PHBhdGggZD0ibTUuNzY1IDFoNS4yMzV2NS4zOWwtMS41NzMgMS41NDctMS4zMS0xLjMxLTIuNzI0IDIuNzIzLTIuNjktMi42ODggMi44MS0yLjgwOC0xLjMxMy0xLjMxeiIvPjwvZz48L3N2Zz4K");
-        --classref-badge-text-color: hsl(0, 0%, 70%);
 
         --hr-color: #555;
         --table-row-odd-background-color: #3b3e41;
@@ -315,14 +313,15 @@ a.btn:hover {
     padding-right: 13px;
 }
 
-/* Distinguish class reference page links from "user manual" page links with a "ref" badge. */
-a[href*="classes/"] {
+/* Distinguish class reference page links from "user manual" page links with a class reference badge. */
+
+/* Remove text wrapping so that the badge is always on the same line as the anchor's text. */
+.rst-content a[href*="classes/"] {
     white-space: nowrap;
 }
-
-a[href*="classes/"]::after {
+/* Add an icon as a badge, after the anchor's text. */
+.rst-content a[href*="classes/"]::after {
     content: "";
-    color: var(--classref-badge-text-color);
     background-image: var(--class-reference-icon);
     display: inline-block;
     height: 16px;
@@ -331,27 +330,15 @@ a[href*="classes/"]::after {
     margin-left: 0.25rem;
 }
 
-/* Prevent the "ref" badge from appearing twice in the instant search results (not testable locally). */
-.wy-body-for-nav .search__result__single a[href*="classes/"]::before {
+/* Prevent the class reference badge from appearing twice in the instant search results (not testable locally). */
+.wy-body-for-nav .search__result__single a[href*="classes/"]::after {
     display: none;
 }
-
-.wy-body-for-nav .search__result__single a[href*="classes/"]:first-child::before {
-    display: inline;
+.wy-body-for-nav .search__result__single a[href*="classes/"]:first-child::after {
+    display: inline-block;
 }
-
-/* Prevent the "ref" badge from appearing several times per item in the dedicated search results page. */
-#search-results .context a[href*="classes/"]::before {
-    display: none;
-}
-
-/* Prevent the "ref" badge from appearing in the sidebar. */
-.wy-menu-vertical a[href*="classes/"]::before {
-    display: none;
-}
-
-/* Prevent the "ref" badge from appearing on Read the Docs inside of the version selector. */
-.rst-versions a[href*="classes/"]::before {
+/* Prevent the class reference badge from appearing several times per item in the dedicated search results page. */
+#search-results .context a[href*="classes/"]::after {
     display: none;
 }
 

--- a/conf.py
+++ b/conf.py
@@ -189,14 +189,14 @@ html_extra_path = ["robots.txt"]
 html_css_files = [
     'css/algolia.css',
     'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css',
-    "css/custom.css?1",
+    "css/custom.css?2", # Increment the number at the end when the file changes to bust the cache.
 ]
 
 if not on_rtd:
     html_css_files.append("css/dev.css")
 
 html_js_files = [
-    "js/custom.js?1",
+    "js/custom.js?1", # Increment the number at the end when the file changes to bust the cache.
     ('https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js', {'defer': 'defer'}),
     ('js/algolia.js', {'defer': 'defer'})
 ]


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot-docs/pull/6399. I forgot to properly update exceptions there, so you could see it in the sections of the sidebar again, for example.

Given the opportunity, I've tried to simplify the CSS rules at play, as we only really need the badge in the body of the page, not in the sidebar. This removes the need for a couple of exceptions (including the one I've just added with https://github.com/godotengine/godot-docs/pull/6395, eh).

Also added a note to the cache buster for future generations. We don't actually need to update it every time, just whenever we want the change to immediately rollout for everyone. Minor style fixes, for example, can still wait a day, as far as I'm concerned. It's still better to increment, but the worst that could happen if you forget to — cache would take up to 86400 seconds to invalidate.