### PR TITLE
Make the TOC expand button easier to click

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1026,6 +1026,22 @@ kbd.compound > .kbd,
     margin-right: 0;
 }
 
+/* Make the expand icon a bit easier to hit. */
+.wy-menu-vertical li a button.toctree-expand {
+    position: relative;
+    width: 12px;
+    height: 18px;
+}
+
+.wy-menu-vertical li a button.toctree-expand:before {
+    position: absolute;
+    top: -3px;
+    left: -6px;
+    width: 24px;
+    height: 24px;
+    padding: 6px;
+}
+
 /* Banner panel in sidebar */
 .wy-nav-side .ethical-rtd.fixed {
     position: fixed;


### PR DESCRIPTION
So it's been annoying me for quite some time that the expand button has a very narrow hitbox. It matches almost exactly its visuals, which as we all know is not great from a usability standpoint. Ideally buttons such as this should have about twice as much padding around them for the actual hitbox area.

So this PR attempts to fix that. This is the new hitbox:

![chrome_2022-11-21_21-20-36](https://user-images.githubusercontent.com/11782833/203134351-e1f412b7-b065-414b-8141-b8450e5dca8d.png)

And here's a video of me clicking the button before...

https://user-images.githubusercontent.com/11782833/203134614-971dbadb-4a35-4f16-92da-72c7bad4db4d.mp4

... and after the change:

https://user-images.githubusercontent.com/11782833/203134637-3b2ea558-29b4-4835-a22b-6388ff507ef9.mp4

-----
As a result of the change in the styling to make this work, the button behaves slightly differently with multiline headings. Previously it would center vertically relative to the number of lines in the heading. Now it aligns next to the first line. I don't think it's a bad change, personally.

Here's [Before](https://user-images.githubusercontent.com/11782833/203135014-f99b4857-8121-431b-a4aa-f8dc51d493c1.png) and here's [After](https://user-images.githubusercontent.com/11782833/203135027-f9e8ada7-4212-4231-a434-de520dd4794f.png).