### PR TITLE
Remove search highlights from the page and the history

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1090,11 +1090,20 @@ kbd.compound > .kbd,
     background-color: var(--navbar-current-background-color-active);
 }
 
-/* Hide the obnoxious automatic highlight in search results */
+/* Hide the obnoxious automatic highlight from the search context. */
 .rst-content .highlighted {
     background-color: transparent;
+    box-shadow: none;
     font-weight: inherit;
     padding: 0;
+}
+/* Still slightly highlight matched parts on the dedicated search results page. */
+.rst-content #search-results .highlighted {
+    background-color: #ffcd0029;
+    border-radius: 2px;
+    color: var(--body-color);
+    font-weight: 600;
+    padding: 0 3px;
 }
 
 /* Allows the scrollbar to be shown in the sidebar */

--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -233,6 +233,14 @@ const registerSidebarObserver = (function(){
 })();
 
 $(document).ready(() => {
+  // Remove the search match highlights from the page, and adjust the URL in the
+  // navigation history.
+  const url = new URL(location.href);
+  if (url.searchParams.has('highlight')) {
+    Documentation.hideSearchWords();
+  }
+
+  // Initialize handlers for page scrolling and our custom sidebar.
   const mediaQuery = window.matchMedia('only screen and (min-width: 769px)');
 
   registerOnScrollEvent(mediaQuery);

--- a/conf.py
+++ b/conf.py
@@ -189,14 +189,14 @@ html_extra_path = ["robots.txt"]
 html_css_files = [
     'css/algolia.css',
     'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css',
-    "css/custom.css?2", # Increment the number at the end when the file changes to bust the cache.
+    "css/custom.css?3", # Increment the number at the end when the file changes to bust the cache.
 ]
 
 if not on_rtd:
     html_css_files.append("css/dev.css")
 
 html_js_files = [
-    "js/custom.js?1", # Increment the number at the end when the file changes to bust the cache.
+    "js/custom.js?2", # Increment the number at the end when the file changes to bust the cache.
     ('https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js', {'defer': 'defer'}),
     ('js/algolia.js', {'defer': 'defer'})
 ]


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-docs/issues/5665.
Supersedes https://github.com/godotengine/godot-docs/pull/5792.
Thanks to @the-sink for finding a built-in solution.

I've combined the two tweaks: first we remove the remaining styling from the articles, then we use the built-in method to update the URL (and it also removes the styling by removing the class from each node). While I guess a race condition as described in the previous PR is possible, due to the fact that we've adjusted the CSS to not show anything in particular, it doesn't matter anymore. User sees no flashes no anything, and their history is cleared.

I've opted to keep a highlight of sorts on the dedicated search results page, but I've tried to tune it to be less obnoxious and more guiding. You be the judge, of course, can remove it later too.

Here's it all in action:


https://user-images.githubusercontent.com/11782833/203140461-c1bfeef9-499b-4e6a-8e02-914241acffe6.mp4


And here are the dedicated search results with the adjusted styling:
[Light](https://user-images.githubusercontent.com/11782833/203140529-aff9d6c7-cd59-4455-8636-2c6d3bbd4108.png) | [Dark](https://user-images.githubusercontent.com/11782833/203140549-193f988e-74d9-469d-b90d-5f18695b8531.png)
