### PR TITLE
C#:  Avoid accessing expensive properties of Godot C# objects multiple times if possible

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -292,7 +292,42 @@ the performance of C# in Godot — while generally in the same order of magnitud
 — is roughly **~4×** that of GDScript in some naive cases. C++ is still
 a little faster; the specifics are going to vary according to your use case.
 GDScript is likely fast enough for most general scripting workloads.
-C# is faster, but requires some expensive marshalling when talking to Godot.
+
+Most properties of Godot C# objects that are based on ``Godot.Object``
+(e.g. any ``Node`` like ``Control`` or ``Node3D`` like ``Camera3D``) require some expensive marshalling as they are
+talking to Godots C++ core.
+Any code that needs to access or modify such properties multiple times should assign values into a local
+variable and overwrite their values only once if possible:
+
+.. code-block:: csharp
+
+    using Godot;
+    using System;
+
+    public class YourCustomClass : Node3D
+    {
+        private void ExpensiveReposition()
+        {
+            for (var i = 0; i < 10; i++)
+            {
+                // Position is read and set 10 times which incurs expensive marshalling.
+                // Furthermore the object is repositioned 10 times in 3D space which takes additional time.
+                Position += new Vector(i, i);
+            }
+        }
+
+        private void Reposition()
+        {
+            // a variable is used to avoid re-marshalling Position on every loop
+            var newPosition = Position;
+            for (var i = 0; i < 10; i++)
+            {
+                newPosition += new Vector(i, i);
+            }
+            // setting the position only once avoid expensive marshalling and repositioning in 3D space
+            Position = newPosition;
+        }
+    }
 
 Using NuGet packages in Godot
 -----------------------------

--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -294,8 +294,8 @@ a little faster; the specifics are going to vary according to your use case.
 GDScript is likely fast enough for most general scripting workloads.
 
 Most properties of Godot C# objects that are based on ``Godot.Object``
-(e.g. any ``Node`` like ``Control`` or ``Node3D`` like ``Camera3D``) require native (interop) calls as they are
-talking to Godot's C++ core.
+(e.g. any ``Node`` like ``Control`` or ``Node3D`` like ``Camera3D``) require native (interop) calls as they talk to
+Godot's C++ core.
 Consider assigning values of such properties into a local variable if you need to modify or read them multiple times at
 a single code location:
 

--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -318,13 +318,13 @@ variable and overwrite their values only once if possible:
 
         private void Reposition()
         {
-            // a variable is used to avoid re-marshalling Position on every loop
+            // A variable is used to avoid re-marshalling Position on every loop.
             var newPosition = Position;
             for (var i = 0; i < 10; i++)
             {
                 newPosition += new Vector(i, i);
             }
-            // setting the position only once avoid expensive marshalling and repositioning in 3D space
+            // Setting the position only once avoid expensive marshalling and repositioning in 3D space.
             Position = newPosition;
         }
     }

--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -294,8 +294,8 @@ a little faster; the specifics are going to vary according to your use case.
 GDScript is likely fast enough for most general scripting workloads.
 
 Most properties of Godot C# objects that are based on ``Godot.Object``
-(e.g. any ``Node`` like ``Control`` or ``Node3D`` like ``Camera3D``) require some expensive marshalling as they are
-talking to Godots C++ core.
+(e.g. any ``Node`` like ``Control`` or ``Node3D`` like ``Camera3D``) require some
+expensive marshalling as they are talking to Godot's C++ core.
 Any code that needs to access or modify such properties multiple times should assign values into a local
 variable and overwrite their values only once if possible:
 

--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -329,11 +329,11 @@ a single code location:
         }
     }
 
-Passing raw arrays (such as ``byte[]``) or `string` to Godot's C# API requires marshalling which is
+Passing raw arrays (such as ``byte[]``) or ``string`` to Godot's C# API requires marshalling which is
 comparatively pricey.
 
-The implicit conversion from `string` to `NodePath` or `StringName` incur both the native interop and marshalling
-costs as the `string` has to be marshalled and passed to the respective native constructor via a native call.
+The implicit conversion from ``string`` to ``NodePath`` or ``StringName`` incur both the native interop and marshalling
+costs as the ``string`` has to be marshalled and passed to the respective native constructor.
 
 Using NuGet packages in Godot
 -----------------------------

--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -312,7 +312,7 @@ variable and overwrite their values only once if possible:
             {
                 // Position is read and set 10 times which incurs expensive marshalling.
                 // Furthermore the object is repositioned 10 times in 3D space which takes additional time.
-                Position += new Vector(i, i);
+                Position += new Vector3(i, i);
             }
         }
 
@@ -322,7 +322,7 @@ variable and overwrite their values only once if possible:
             var newPosition = Position;
             for (var i = 0; i < 10; i++)
             {
-                newPosition += new Vector(i, i);
+                newPosition += new Vector3(i, i);
             }
             // Setting Position only once avoid expensive marshalling and repositioning in 3D space.
             Position = newPosition;

--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -324,7 +324,7 @@ variable and overwrite their values only once if possible:
             {
                 newPosition += new Vector(i, i);
             }
-            // Setting the position only once avoid expensive marshalling and repositioning in 3D space.
+            // Setting Position only once avoid expensive marshalling and repositioning in 3D space.
             Position = newPosition;
         }
     }

--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -294,10 +294,10 @@ a little faster; the specifics are going to vary according to your use case.
 GDScript is likely fast enough for most general scripting workloads.
 
 Most properties of Godot C# objects that are based on ``Godot.Object``
-(e.g. any ``Node`` like ``Control`` or ``Node3D`` like ``Camera3D``) require some
-expensive marshalling as they are talking to Godot's C++ core.
-Any code that needs to access or modify such properties multiple times should assign values into a local
-variable and overwrite their values only once if possible:
+(e.g. any ``Node`` like ``Control`` or ``Node3D`` like ``Camera3D``) require native (interop) calls as they are
+talking to Godot's C++ core.
+Consider assigning values of such properties into a local variable if you need to modify or read them multiple times at
+a single code location:
 
 .. code-block:: csharp
 
@@ -310,7 +310,7 @@ variable and overwrite their values only once if possible:
         {
             for (var i = 0; i < 10; i++)
             {
-                // Position is read and set 10 times which incurs expensive marshalling.
+                // Position is read and set 10 times which incurs native interop.
                 // Furthermore the object is repositioned 10 times in 3D space which takes additional time.
                 Position += new Vector3(i, i);
             }
@@ -318,16 +318,22 @@ variable and overwrite their values only once if possible:
 
         private void Reposition()
         {
-            // A variable is used to avoid re-marshalling Position on every loop.
+            // A variable is used to avoid native interop for Position on every loop.
             var newPosition = Position;
             for (var i = 0; i < 10; i++)
             {
                 newPosition += new Vector3(i, i);
             }
-            // Setting Position only once avoid expensive marshalling and repositioning in 3D space.
+            // Setting Position only once avoids native interop and repositioning in 3D space.
             Position = newPosition;
         }
     }
+
+Passing raw arrays (such as ``byte[]``) or `string` to Godot's C# API requires marshalling which is
+comparatively pricey.
+
+The implicit conversion from `string` to `NodePath` or `StringName` incur both the native interop and marshalling
+costs as the `string` has to be marshalled and passed to the respective native constructor via a native call.
 
 Using NuGet packages in Godot
 -----------------------------


### PR DESCRIPTION
As explained [here](https://github.com/godotengine/godot-proposals/discussions/4007#discussioncomment-4141292), C# code should avoid unnecessarily reading / writing C# (most) properties of `Godot.Object` based classes as such operations incur marshalling overhead.

This PR adds a passage to the C# performance related documentation which explains the issue while giving an example on how to avoid such costs.

Feel free to edit this to sound like the rest of the documentation.
I am also open for feedback on how to adapt the initial version and reworking it myself :)