### PR TITLE
Fix styling issues in the sidebar

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1030,6 +1030,7 @@ kbd.compound > .kbd,
 .wy-menu-vertical li a button.toctree-expand {
     position: relative;
     width: 12px;
+    min-width: 12px; /* Forces the size to stay this way in the flexbox model. */
     height: 18px;
 }
 

--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -324,3 +324,8 @@ $(document).ready(() => {
     registerOnScrollEvent(mediaQuery);
   }
 });
+
+// Override the default implementation from doctools.js to avoid this behavior.
+Documentation.highlightSearchWords = function() {
+  // Nope.
+}


### PR DESCRIPTION
Noticed a couple of issues after testing the recent PRs on the live instance, both related to the fact that each link in the sidebar is displayed with `display: flex`, courtesy of https://github.com/godotengine/godot-docs/pull/3118.

The first issue is related to the highlighting of search results. While https://github.com/godotengine/godot-docs/pull/6407 addresses the look and the behavior for the main section of the page, the sidebar is not handled by it. Apparently, the function that adds the highlighting doesn't discriminate and adds it to the sidebar as well. It doesn't have any styling added there, but we still run into the issue due to the aforementioned flexbox.

![chrome_2022-11-22_04-56-44](https://user-images.githubusercontent.com/11782833/203198439-f473366c-44e7-4212-b054-cb5159813635.png)

As highlight is added with a span tag, it breaks up the text content into individual flexbox children, which then stick together. I didn't find a good CSS path to patch this, but luckily, we can just replace the whole method that does highlighting with nothing. It only affects the highlights added from the parameter in the URL query. Which we just removed with vengeance. So it making this method a dummy is absolutely safe. Highlighting still works on the dedicated search results page, as there it is added in a different manner.

The second issue is caused by me with https://github.com/godotengine/godot-docs/pull/6406 and not realizing we have this flexbox hack. The reason we have it is because we have very long unbreakable class names which turn into page titles in the class reference and cause all kinds of havoc. So the flexbox hack was used to make them behave without breaking multiline titles from other pages.

But I didn't recall that and so this happened:

![image](https://user-images.githubusercontent.com/11782833/203198327-cc00d689-660b-4a0b-aa03-7f6dc80c9342.png)

Despite having fixed width the button would still collapse into nothing, trying to make space for the label with the class name. Apparently, for flexbox children the min width property is set to `auto`, and so the parent can do whatever it wants to accommodate the children. This is quickly fixed by enforcing min width, though.