### PR TITLE
Corrected sample code in import_plugins.rst

### DIFF
--- a/tutorials/plugins/editor/import_plugins.rst
+++ b/tutorials/plugins/editor/import_plugins.rst
@@ -195,7 +195,7 @@ plugin:
 
 ::
 
-    func get_preset_count():
+    func _get_preset_count():
         return Presets.size()
 
 The :ref:`_get_preset_count() <class_EditorImportPlugin_method__get_preset_count>` method
@@ -205,8 +205,8 @@ now, but we can make this method future-proof by returning the size of our
 
 ::
 
-    func _get_preset_name(preset):
-        match preset:
+    func _get_preset_name(preset_index):
+        match preset_index:
             Presets.DEFAULT:
                 return "Default"
             _:
@@ -228,8 +228,8 @@ you do this you have to be careful when you add more presets.
 
 ::
 
-    func _get_import_options(preset):
-        match preset:
+    func _get_import_options(path, preset_index):
+        match preset_index:
             Presets.DEFAULT:
                 return [{
                            "name": "use_red_anyway",
@@ -260,20 +260,20 @@ shows the possible keys:
 
 The ``name`` and ``default_value`` keys are **mandatory**, the rest are optional.
 
-Note that the ``get_import_options`` method receives the preset number, so you
+Note that the ``_get_import_options`` method receives the preset number, so you
 can configure the options for each different preset (especially the default
 value). In this example we use the ``match`` statement, but if you have lots of
 options and the presets only change the value you may want to create the array
 of options first and then change it based on the preset.
 
-.. warning:: The ``get_import_options`` method is called even if you don't
-             define presets (by making ``get_preset_count`` return zero). You
+.. warning:: The ``_get_import_options`` method is called even if you don't
+             define presets (by making ``_get_preset_count`` return zero). You
              have to return an array even it's empty, otherwise you can get
              errors.
 
 ::
 
-    func _get_option_visibility(option, options):
+    func _get_option_visibility(path, option_name, options):
         return true
 
 For the
@@ -299,8 +299,6 @@ method. Our sample code is a bit long, so let's split in a few parts:
             return FileAccess.get_open_error()
 
         var line = file.get_line()
-
-        file.close()
 
 The first part of our import method opens and reads the source file. We use the
 :ref:`FileAccess <class_FileAccess>` class to do that, passing the ``source_file``
@@ -340,13 +338,13 @@ as the value we got before.
 
 ::
 
-    return ResourceSaver.save(material, "%s.%s" % [save_path, get_save_extension()])
+    return ResourceSaver.save(material, "%s.%s" % [save_path, _get_save_extension()])
 
 This is the last part and quite an important one, because here we save the made
 resource to the disk. The path of the saved file is generated and informed by
 the editor via the ``save_path`` parameter. Note that this comes **without** the
 extension, so we add it using :ref:`string formatting <doc_gdscript_printf>`. For
-this we call the ``get_save_extension`` method that we defined earlier, so we
+this we call the ``_get_save_extension`` method that we defined earlier, so we
 can be sure that they won't get out of sync.
 
 We also return the result from the
@@ -376,7 +374,7 @@ would need to do something like the following:
 ::
 
     r_platform_variants.push_back("mobile")
-    return ResourceSaver.save(mobile_material, "%s.%s.%s" % [save_path, "mobile", get_save_extension()])
+    return ResourceSaver.save(mobile_material, "%s.%s.%s" % [save_path, "mobile", _get_save_extension()])
 
 The ``r_gen_files`` argument is meant for extra files that are generated during
 your import process and need to be kept. The editor will look at it to
@@ -391,7 +389,7 @@ in a different file:
 
     var next_pass = StandardMaterial3D.new()
     next_pass.albedo_color = color.inverted()
-    var next_pass_path = "%s.next_pass.%s" % [save_path, get_save_extension()]
+    var next_pass_path = "%s.next_pass.%s" % [save_path, _get_save_extension()]
 
     err = ResourceSaver.save(next_pass, next_pass_path)
     if err != OK:


### PR DESCRIPTION
The sample code listed the function ``get_import_options`` when it most likely meant ``_get_import_options`` (with an underscore in front). A similar mistake was made with ``_get_preset_count``. Some of the sample code also used the outdated File API instead of the FileAccess API, and some of the EditorImportPlugin functions had missing parameters.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
