### PR TITLE
3.6 Tweaking the built-in DEPTH causes flickers back and forth

### DIFF
--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -287,7 +287,9 @@ these properties, and if you don't write to them, Godot will optimize away the c
 +-----------------------------------+--------------------------------------------------------------------------------------------------+
 | sampler2D **DEPTH_TEXTURE**       | Built-in Texture for reading depth from the screen. Must convert to linear using INV_PROJECTION. |
 +-----------------------------------+--------------------------------------------------------------------------------------------------+
-| out float **DEPTH**               | Custom depth value (0..1).                                                                       |
+| out float **DEPTH**               | Custom depth value (0..1). If ``DEPTH`` is being written to in any shader branch, then you are   |
+|                                   | responsible for setting the ``DEPTH`` for **all** other branches. Otherwise, the graphics API    |
+|                                   | will leave them uninitialized.                                                                   |
 +-----------------------------------+--------------------------------------------------------------------------------------------------+
 | in vec2 **SCREEN_UV**             | Screen UV coordinate for current pixel.                                                          |
 +-----------------------------------+--------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Backport for: https://github.com/godotengine/godot-docs/pull/6429

Tweaking the built-in DEPTH causes flickers back and forth because the Graphics API is uninitialized. 