### PR TITLE
Add mid-word wrapping to the sidebar

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1049,6 +1049,8 @@ kbd.compound > .kbd,
     /* Make long words always display on a single line, keep wrapping for multiple words */
     /* This fixes the class reference titles' display with very long class names */
     display: flex;
+    padding-right: .4045em;
+    overflow-wrap: anywhere;
 }
 
 .wy-menu-vertical li.current a,


### PR DESCRIPTION
We have a long-standing issue with the sidebar when it comes to class reference pages and their titles. Since those pages are called after their respective classes, and sometimes those classes have really long names, it becomes a problem when styling the sidebar. Ideally we want to support those titles comfortably, but we also want to support long titles of normal tutorial pages, where multiple words can wrap for several lines (typically, no more than 3). So ellipses are out of question, unless we get more control over how the sidebar is generated.

What we can do for now is allow long words to wrap at an arbitrary point. This is not an ideal solution, but it makes the whole title visible at every point. Naturally, it also has a side-effect for titles that barely go over the limit, resulting in single characters having to jump to the next line, which looks silly, but whatchu gonna do...

Won't sugarcoat it at all, so there are examples which won't be looking pretty with this change:

[Before](https://user-images.githubusercontent.com/11782833/204529895-66938a77-dce7-4b3d-9241-72ba31262e97.png) | [After](https://user-images.githubusercontent.com/11782833/204529907-967e98df-ed2b-4b48-aa29-6ac843cd036b.png)

[Before](https://user-images.githubusercontent.com/11782833/204529923-d35e1278-d274-40cb-b0c7-c98adc7a4d2a.png) | [After](https://user-images.githubusercontent.com/11782833/204529936-87f97549-d83f-45fa-aaba-a7d5c51f381e.png) | [One more](https://user-images.githubusercontent.com/11782833/204530956-2c4b40d7-14a5-4494-8d2a-7e91d977aca3.png)

Note that this [doesn't affect](https://user-images.githubusercontent.com/11782833/204530147-d4b72d73-c906-4a69-b666-53c19ff2fcfc.png) the normal long titles.

-----
Maybe it's better to leave it as is, but I thought I'd propose this anyway.