### PR TITLE
Fix midword link wrapping issues using Javascript

### DIFF
--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -250,6 +250,30 @@ $(document).ready(() => {
     registerOnScrollEvent(mediaQuery);
   });
 
+  // Add line-break suggestions to class refernece navigation items.
+  const classReferenceLinks = document.querySelectorAll('.wy-menu-vertical > ul:last-of-type .reference.internal');
+  for (const linkItem of classReferenceLinks) {
+    let textNode = null;
+    linkItem.childNodes.forEach(it => {
+      if (it.nodeType === Node.TEXT_NODE) {
+        // If this is a text node and if it needs to be updated, store a reference.
+        let text = it.textContent;
+        if (!(text.includes(" ") || text.length < 10)) {
+          textNode = it;
+        }
+      }
+    });
+
+    if (textNode != null) {
+        let text = textNode.textContent;
+        // Adds suggested line-breaks, if needed, and replace the original text.
+        text = text.replace(/((?:(?<=[a-z])[A-Z0-9](?!$))|(?<!^)[A-Z](?=[a-z]))/gm, '<wbr>$1');
+
+        linkItem.removeChild(textNode);
+        linkItem.insertAdjacentHTML('beforeend', text);
+    }
+  }
+
   if (inDev) {
     // Add a compatibility notice using JavaScript so it doesn't end up in the
     // automatically generated `meta description` tag.

--- a/conf.py
+++ b/conf.py
@@ -196,7 +196,7 @@ if not on_rtd:
     html_css_files.append("css/dev.css")
 
 html_js_files = [
-    "js/custom.js?2", # Increment the number at the end when the file changes to bust the cache.
+    "js/custom.js?3", # Increment the number at the end when the file changes to bust the cache.
     ('https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js', {'defer': 'defer'}),
     ('js/algolia.js', {'defer': 'defer'})
 ]


### PR DESCRIPTION
Adds `<wbr>` (which is suggested linebreaks) to each reference links once the page is ready using RegEx.

![Capture d’écran du 2022-11-29 12-49-36](https://user-images.githubusercontent.com/270928/204607990-9fa26991-16a5-4a82-b2f4-e5a9bf9009ae.png)

![Capture d’écran du 2022-11-29 12-49-52](https://user-images.githubusercontent.com/270928/204608166-10f193e4-6013-4111-b8f2-e697f13c255b.png)

Similar to the objective of #6436, but more efficient.
