### PR TITLE
tutorials/physics/ray-casting: Update missing v4 fixes

### DIFF
--- a/tutorials/physics/ray-casting.rst
+++ b/tutorials/physics/ray-casting.rst
@@ -109,7 +109,8 @@ may be used. For example:
     func _physics_process(delta):
         var space_state = get_world_2d().direct_space_state
         # use global coordinates, not local to node
-        var result = space_state.intersect_ray(Vector2(0, 0), Vector2(50, 100))
+        var query = PhysicsRayQueryParameters2D.create(Vector2(0, 0), Vector2(50, 100))
+        var result = space_state.intersect_ray(query)
 
  .. code-tab:: csharp
 
@@ -117,7 +118,8 @@ may be used. For example:
     {
         var spaceState = GetWorld2d().DirectSpaceState;
         // use global coordinates, not local to node
-        var result = spaceState.IntersectRay(new Vector2(), new Vector2(50, 100));
+        var query = PhysicsRayQueryParameters2D.create(new Vector2(), new Vector2(50, 100));
+        var result = spaceState.IntersectRay(query);
     }
 
 The result is a dictionary. If the ray didn't hit anything, the dictionary will
@@ -173,7 +175,9 @@ collision object node:
 
     func _physics_process(delta):
         var space_state = get_world_2d().direct_space_state
-        var result = space_state.intersect_ray(global_position, enemy_position, [self])
+        var query = PhysicsRayQueryParameters2D.create(global_position, enemy_position)
+        query.exclude = [self]
+        var result = space_state.intersect_ray(query)
 
  .. code-tab:: csharp
 
@@ -182,7 +186,9 @@ collision object node:
         public override void _PhysicsProcess(float delta)
         {
             var spaceState = GetWorld2d().DirectSpaceState;
-            var result = spaceState.IntersectRay(globalPosition, enemyPosition, new Godot.Collections.Array { this });
+            var query = PhysicsRayQueryParameters2D.create(globalPosition, enemyPosition);
+            query.exclude = new Godot.Collections.Array { this };
+            var result = spaceState.IntersectRay(query);
         }
     }
 
@@ -206,8 +212,9 @@ member variable:
 
     func _physics_process(delta):
         var space_state = get_world_2d().direct_space_state
-        var result = space_state.intersect_ray(global_position, enemy_position,
-                                [self], collision_mask)
+        var query = PhysicsRayQueryParameters2D.create(global_position, enemy_position, 
+            collision_mask, [self]) 
+        var result = space_state.intersect_ray(query)
 
  .. code-tab:: csharp
 
@@ -216,8 +223,9 @@ member variable:
         public override void _PhysicsProcess(float delta)
         {
             var spaceState = GetWorld2d().DirectSpaceState;
-            var result = spaceState.IntersectRay(globalPosition, enemyPosition,
-                            new Godot.Collections.Array { this }, CollisionMask);
+            var query = PhysicsRayQueryParameters2D.create(globalPosition, enemyPosition,
+                CollisionMask, new Godot.Collections.Array { this });
+            var result = spaceState.IntersectRay(query);
         }
     }
 

--- a/tutorials/physics/ray-casting.rst
+++ b/tutorials/physics/ray-casting.rst
@@ -163,10 +163,9 @@ as shown in the following image:
 
 .. image:: img/raycast_falsepositive.png
 
-To avoid self-intersection, the ``intersect_ray()`` function can take an
-optional third parameter which is an array of exceptions. This is an
-example of how to use it from a CharacterBody2D or any other
-collision object node:
+To avoid self-intersection, the ``intersect_ray()`` parameters object can take an
+array of exceptions via its ``exclude`` property. This is an example of how to use it 
+from a CharacterBody2D or any other collision object node:
 
 .. tabs::
  .. code-tab:: gdscript GDScript
@@ -201,9 +200,9 @@ While the exceptions method works fine for excluding the parent body, it becomes
 very inconvenient if you need a large and/or dynamic list of exceptions. In
 this case, it is much more efficient to use the collision layer/mask system.
 
-The optional fourth argument for ``intersect_ray()`` is a collision mask. For
-example, to use the same mask as the parent body, use the ``collision_mask``
-member variable:
+The ``intersect_ray()`` parameters object can also be supplied a collision mask.
+For example, to use the same mask as the parent body, use the ``collision_mask``
+member variable. The array of exceptions can be supplied as the last argument as well:
 
 .. tabs::
  .. code-tab:: gdscript GDScript

--- a/tutorials/physics/ray-casting.rst
+++ b/tutorials/physics/ray-casting.rst
@@ -186,7 +186,7 @@ from a CharacterBody2D or any other collision object node:
         {
             var spaceState = GetWorld2d().DirectSpaceState;
             var query = PhysicsRayQueryParameters2D.create(globalPosition, enemyPosition);
-            query.exclude = new Godot.Collections.Array { this };
+            query.Exclude = new Godot.Collections.Array { this };
             var result = spaceState.IntersectRay(query);
         }
     }

--- a/tutorials/physics/ray-casting.rst
+++ b/tutorials/physics/ray-casting.rst
@@ -87,13 +87,13 @@ And in 3D:
  .. code-tab:: gdscript GDScript
 
     func _physics_process(delta):
-        var space_state = get_world().direct_space_state
+        var space_state = get_world_3d().direct_space_state
 
  .. code-tab:: csharp
 
     public override void _PhysicsProcess(float delta)
     {
-        var spaceState = GetWorld().DirectSpaceState;
+        var spaceState = GetWorld3d().DirectSpaceState;
     }
 
 Raycast query
@@ -205,7 +205,7 @@ member variable:
     extends CharacterBody2D
 
     func _physics_process(delta):
-        var space_state = get_world().direct_space_state
+        var space_state = get_world_2d().direct_space_state
         var result = space_state.intersect_ray(global_position, enemy_position,
                                 [self], collision_mask)
 

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -297,7 +297,9 @@ these properties, and if you don't write to them, Godot will optimize away the c
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
 | sampler2D **DEPTH_TEXTURE**            | Built-in Texture for reading depth from the screen. Must convert to linear using INV_PROJECTION. |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
-| out float **DEPTH**                    | Custom depth value (0..1).                                                                       |
+| out float **DEPTH**                    | Custom depth value (0..1). If ``DEPTH`` is being written to in any shader branch, then you are   |
+|                                        | responsible for setting the ``DEPTH`` for **all** other branches. Otherwise, the graphics API    |
+|                                        | will leave them uninitialized.                                                                   |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
 | inout vec3 **NORMAL**                  | Normal that comes from vertex function (default, in view space).                                 |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
There were a few missing method name changes (`_2d`, `_3d`, etc)

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
