### PR TITLE
Replace all uses of `hint_color`/`hint_albedo` with `source_color`

### DIFF
--- a/tutorials/shaders/making_trees.rst
+++ b/tutorials/shaders/making_trees.rst
@@ -45,8 +45,8 @@ This is a spatial shader. There is no front/back culling (so leaves can be seen 
 
 .. code-block:: glsl
 
-    uniform sampler2D texture_albedo : hint_albedo;
-    uniform vec4 transmission : hint_color;
+    uniform sampler2D texture_albedo : source_color;
+    uniform vec4 transmission : source_color;
 
 Here, the texture is read, as well as a transmission color, which is used to add some back-lighting to the leaves, simulating subsurface scattering.
 

--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -750,7 +750,7 @@ used, and how the editor should allow users to modify it.
     uniform vec4 other_color : source_color = vec4(1.0);
 
 It's important to understand that textures that are supplied as color require
-hints for proper sRGB->linear conversion (i.e. ``hint_albedo``), as Godot's 3D
+hints for proper sRGB->linear conversion (i.e. ``source_color``), as Godot's 3D
 engine renders in linear color space.
 
 Full list of hints below:


### PR DESCRIPTION
These have been replaced in Godot 4.
This is my first PR to the Godot docs repository so i hope i got this right.