### PR TITLE
Disable font ligatures globally

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -261,6 +261,8 @@ legend,
 .rst-versions {
     /* Use a system font stack for better performance (no Web fonts required) */
     font-family: var(--system-font-family);
+    /* Some fonts that we use (namely JetBrains Mono) can come with ligatures. It's better to opt-in if needed. */
+    font-variant-ligatures: none;
 }
 
 h1,


### PR DESCRIPTION
In https://github.com/godotengine/godot-docs/pull/6457 I've disabled font ligatures in JB Mono for code blocks and inline code tags, but they seem to appear in other places as well. So it's better to just disable them throughout and then enable them wherever it may be needed.

Here's an example of this issue:

![chrome_2022-12-06_20-01-40](https://user-images.githubusercontent.com/11782833/205977113-739c4b66-2c7a-4e78-854e-7da189115c59.png)
