### PR TITLE
Update input_examples.rst

### DIFF
--- a/tutorials/inputs/input_examples.rst
+++ b/tutorials/inputs/input_examples.rst
@@ -203,7 +203,7 @@ the :kbd:`T`:
     {
         if (inputEvent is InputEventKey keyEvent && keyEvent.Pressed)
         {
-            if ((KeyList)keyEvent.Keycode == KeyList.T)
+            if ((KeyList)keyEvent.Scancode == KeyList.T)
             {
                 GD.Print("T was pressed");
             }


### PR DESCRIPTION
The C# [`InputKeyEvent`](https://docs.godotengine.org/en/stable/classes/class_inputeventkey.html#class-inputeventkey) doesn't have a `.Keycode` property - it has `.Scancode`. 

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
