### PR TITLE
add_camera_clarification.rst

### DIFF
--- a/classes/class_popup.rst
+++ b/classes/class_popup.rst
@@ -19,7 +19,7 @@ Base container control for popups and dialogs.
 Description
 -----------
 
-Popup is a base :ref:`Control<class_Control>` used to show dialogs and popups. It's a subwindow and modal by default (see :ref:`Control<class_Control>`) and has helpers for custom popup behavior. All popup methods ensure correct placement within the viewport.
+Popup is a base :ref:`Control<class_Control>` used to show dialogs and popups. It's a subwindow and modal by default (see :ref:`Control<class_Control>`) and has helpers for custom popup behavior. All popup methods ensure correct placement within the viewport, not the current Camera.
 
 Properties
 ----------


### PR DESCRIPTION
Clarifies that the popup is correctly placed within the viewport, which is not necessarily the current Camera. This removes confusion for users who expect the popup to fit into their Camera when that is not always the case.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
