### PR TITLE
add mobs group with code

### DIFF
--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -413,6 +413,21 @@ click "Groups" and you can type a new group name and click "Add".
 
 .. image:: img/group_tab.png
 
+You might also need to add the mobs directly with code. At the end of _on_MobTimer_timeout() where the mob is instanced you can put the following line.
+
+.. tabs::
+ .. code-tab:: gdscript GDScript
+
+        mob.add_to_group("mobs")
+
+ .. code-tab:: csharp
+
+        #someone else fill in
+        
+ .. code-tab:: cpp
+
+        #someone else fill in
+
 Now all mobs will be in the "mobs" group. We can then add the following line to
 the ``new_game()`` function in ``Main``:
 


### PR DESCRIPTION
added mob to mobs group via code b/c only using interface to create mobs group (in Mob scene root node groups tab) + adding the group queue clear line :: prevented my game from starting and had 1 fish on screen... 

<strike>Somone else with more experience could tinker around with the groups or why the interface group editing wasn't doing the trick,</strike> [see next comment] but this is how I [initially] got my 2d game to clear the mobs. 

(Note: only gdscript in code viewer is included.) 

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
