### PR TITLE
Document the `double` and `single` feature tags

### DIFF
--- a/tutorials/export/feature_tags.rst
+++ b/tutorials/export/feature_tags.rst
@@ -64,6 +64,10 @@ Here is a list of most feature tags in Godot. Keep in mind they are **case-sensi
 +-----------------+----------------------------------------------------------+
 | **standalone**  | Running on a non-editor build                            |
 +-----------------+----------------------------------------------------------+
+| **double**      | Running on a double-precision build                      |
++-----------------+----------------------------------------------------------+
+| **single**      | Running on a single-precision build                      |
++-----------------+----------------------------------------------------------+
 | **64**          | Running on a 64-bit build (any architecture)             |
 +-----------------+----------------------------------------------------------+
 | **32**          | Running on a 32-bit build (any architecture)             |


### PR DESCRIPTION
This updates the list of available feature tags with `double` and `single`, which are introduced in godotengine/godot#69538.

These feature tags signify whether the engine was built with (what's now called) `precision=double` or (the default) `precision=single`.