### PR TITLE
make the section describing wiring up the hit signal slightly more verbose

### DIFF
--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -73,7 +73,7 @@ Your scene should look like this:
 Main script
 ~~~~~~~~~~~
 
-Add a script to ``Main``. At the top of the script, we use 
+Add a script to ``Main``. At the top of the script, we use
 ``@export var mob_scene: PackedScene`` to allow us to choose the Mob scene we want
 to instance.
 
@@ -202,17 +202,19 @@ You can assign this property's value in two ways:
   property.
 - Click the down arrow next to "[empty]" and choose "Load". Select ``Mob.tscn``.
 
-Next, select the ``Player`` node in the Scene dock, and access the Node dock on
-the sidebar. Make sure to have the Signals tab selected in the Node dock.
+Next, select the instance of the ``Player`` scene under ``Main`` node in the Scene dock,
+and access the Node dock on the sidebar. Make sure to have the Signals tab selected
+in the Node dock.
 
 You should see a list of the signals for the ``Player`` node. Find and
 double-click the ``hit`` signal in the list (or right-click it and select
 "Connect..."). This will open the signal connection dialog. We want to make a
 new function named ``game_over``, which will handle what needs to happen when a
 game ends. Type "game_over" in the "Receiver Method" box at the bottom of the
-signal connection dialog and click "Connect". Add the following code to the new
-function, as well as a ``new_game`` function that will set everything up for a
-new game:
+signal connection dialog and click "Connect". You are aiming to have the ``hit``` signal
+emitted from ``Player`` and handled in the ``Master`` script. Add the following code
+to the new function, as well as a ``new_game`` function that will set
+everything up for a new game:
 
 .. tabs::
  .. code-tab:: gdscript GDScript

--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -211,8 +211,8 @@ double-click the ``hit`` signal in the list (or right-click it and select
 "Connect..."). This will open the signal connection dialog. We want to make a
 new function named ``game_over``, which will handle what needs to happen when a
 game ends. Type "game_over" in the "Receiver Method" box at the bottom of the
-signal connection dialog and click "Connect". You are aiming to have the ``hit``` signal
-emitted from ``Player`` and handled in the ``Master`` script. Add the following code
+signal connection dialog and click "Connect". You are aiming to have the ``hit`` signal
+emitted from ``Player`` and handled in the ``Main`` script. Add the following code
 to the new function, as well as a ``new_game`` function that will set
 everything up for a new game:
 


### PR DESCRIPTION
As a new user I was following this tutorial and it wasn't clear to me that I had to have the instanced player selected and not the player scene itself. I got some help in discord and figured out what I needed to do and so I thought I'd push a tweak to the tutorial to hopefully make it clearer for the next person.


