### PR TITLE
Updated sample code using new constant in Godot 4

### DIFF
--- a/tutorials/scripting/pausing_games.rst
+++ b/tutorials/scripting/pausing_games.rst
@@ -48,7 +48,7 @@ You can also alter the property with code:
  .. code-tab:: gdscript GDScript
 
     func _ready():
-        pause_mode = Node.PAUSE_MODE_PROCESS
+        pause_mode = Node.PROCESS_MODE_ALWAYS
 
  .. code-tab:: csharp
 

--- a/tutorials/scripting/pausing_games.rst
+++ b/tutorials/scripting/pausing_games.rst
@@ -48,7 +48,7 @@ You can also alter the property with code:
  .. code-tab:: gdscript GDScript
 
     func _ready():
-        pause_mode = Node.PROCESS_MODE_ALWAYS
+        process_mode = Node.PROCESS_MODE_ALWAYS
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
Node.PAUSE_MODE_PROCESS has been changed to Node.PROCESS_MODE_ALWAYS in Godot 4.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
