### PR TITLE
Changed pause_mode to process_mode in sample code

### DIFF
--- a/tutorials/scripting/pausing_games.rst
+++ b/tutorials/scripting/pausing_games.rst
@@ -48,7 +48,7 @@ You can also alter the property with code:
  .. code-tab:: gdscript GDScript
 
     func _ready():
-        pause_mode = Node.PAUSE_MODE_PROCESS
+        process_mode = Node.PROCESS_MODE_ALWAYS
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
In Godot 4 pause_mode is now process_mode on Node. The constants holing possible values or the process_mode have also changed (e.g. Node.PROCESS_MODE_ALWAYS instead of Node.PAUSE_MODE_PROCESS). The sample GDScript code was outdated on master. The sample C# code seems outdated too.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
