### PR TITLE
Designing the mob scene - Typo and simplification

### DIFF
--- a/getting_started/first_3d_game/04.mob_scene.rst
+++ b/getting_started/first_3d_game/04.mob_scene.rst
@@ -69,7 +69,7 @@ Godot has a node that detects when objects leave the screen,
     reason to use pools is to avoid freezes with garbage-collected languages
     like C# or Lua. GDScript uses a different technique to manage memory,
     reference counting, which doesn't have that caveat. You can learn more
-    about that here :ref:`doc_gdscript_basics_memory_management`.
+    about that in :ref:`doc_gdscript_basics_memory_management`.
 
 Select the *Mob* node and add a *VisibilityNotifier* as a child of it. Another
 box, pink this time, appears. When this box completely leaves the screen, the
@@ -212,11 +212,6 @@ Leaving the screen
 We still have to destroy the mobs when they leave the screen. To do so, we'll
 connect our *VisibilityNotifier* node's ``screen_exited`` signal to the *Mob*.
 
-Head back to the 3D viewport by clicking on the *3D* label at the top of the
-editor. You can also press :kbd:`Ctrl + F2` (:kbd:`Alt + 2` on macOS).
-
-|image8|
-
 Select the *VisibilityNotifier* node and on the right side of the interface,
 navigate to the *Node* dock. Double-click the *screen_exited()* signal.
 
@@ -226,7 +221,7 @@ Connect the signal to the *Mob*.
 
 |image10|
 
-This will take you back to the script editor and add a new function for you,
+This will add a new function for you,
 ``_on_VisibilityNotifier_screen_exited()``. From it, call the ``queue_free()``
 method. This will destroy the mob instance when the *VisibilityNotifier* \'s box
 leaves the screen.


### PR DESCRIPTION
In "[Removing monsters off-screen](https://docs.godotengine.org/en/stable/getting_started/first_3d_game/04.mob_scene.html#removing-monsters-off-screen)" > Note:
"You can learn more about that **here** Memory management." should be:
"You can learn more about that **in** Memory management."

In "[Leaving the screen](https://docs.godotengine.org/en/stable/getting_started/first_3d_game/04.mob_scene.html#leaving-the-screen)":
"Head back to the 3D viewport by clicking on the 3D label at the top of the editor. You can also press Ctrl + F2 (Alt + 2 on macOS)." seems unnecessary.

And then:
"This will take you back to the script editor and add a new function for you," could be:
"This will add a new function for you,"

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
