### PR TITLE
Fixed broken links to core API headers

### DIFF
--- a/development/cpp/core_types.rst
+++ b/development/cpp/core_types.rst
@@ -167,8 +167,8 @@ References:
 
 -  `core/templates/vector.h <https://github.com/godotengine/godot/blob/master/core/templates/vector.h>`__
 -  `core/templates/list.h <https://github.com/godotengine/godot/blob/master/core/templates/list.h>`__
--  `core/templates/set.h <https://github.com/godotengine/godot/blob/master/core/templates/vset.h>`__
--  `core/templates/map.h <https://github.com/godotengine/godot/blob/master/core/templates/vmap.h>`__
+-  `core/templates/set.h <https://github.com/godotengine/godot/blob/master/core/templates/hash_set.h>`__
+-  `core/templates/map.h <https://github.com/godotengine/godot/blob/master/core/templates/hash_map.h>`__
 
 String
 ------

--- a/development/cpp/core_types.rst
+++ b/development/cpp/core_types.rst
@@ -167,8 +167,8 @@ References:
 
 -  `core/templates/vector.h <https://github.com/godotengine/godot/blob/master/core/templates/vector.h>`__
 -  `core/templates/list.h <https://github.com/godotengine/godot/blob/master/core/templates/list.h>`__
--  `core/templates/set.h <https://github.com/godotengine/godot/blob/master/core/templates/set.h>`__
--  `core/templates/map.h <https://github.com/godotengine/godot/blob/master/core/templates/map.h>`__
+-  `core/templates/set.h <https://github.com/godotengine/godot/blob/master/core/templates/vset.h>`__
+-  `core/templates/map.h <https://github.com/godotengine/godot/blob/master/core/templates/vmap.h>`__
 
 String
 ------


### PR DESCRIPTION
Corrected the links in references.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
