### PR TITLE
Fix Navigation doc for different actor types due to recent renames

### DIFF
--- a/tutorials/navigation/navigation_different_actor_types.rst
+++ b/tutorials/navigation/navigation_different_actor_types.rst
@@ -11,56 +11,56 @@ The same approach can be used to distinguish between e.g. landwalking, swimming 
 
 .. note::
 
-   Agents are exclusively defined by a radius and height value for baking navmeshes, pathfinding and avoidance. More complex shapes are not supported.
+   Agents are exclusively defined by a radius and height value for baking navigation meshes, pathfinding and avoidance. More complex shapes are not supported.
 
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    # create navigationmesh resources for each actor size
-    var navmesh_standard_size : NavigationMesh = NavigationMesh.new()
-    var navmesh_small_size : NavigationMesh = NavigationMesh.new()
-    var navmesh_huge_size : NavigationMesh = NavigationMesh.new()
+    # create navigation mesh resources for each actor size
+    var navigation_mesh_standard_size : NavigationMesh = NavigationMesh.new()
+    var navigation_mesh_small_size : NavigationMesh = NavigationMesh.new()
+    var navigation_mesh_huge_size : NavigationMesh = NavigationMesh.new()
     
     # set appropriated agent parameters
-    navmesh_standard_size.agent_radius = 0.5
-    navmesh_standard_size.agent_height = 1.8
-    navmesh_small_size.agent_radius = 0.25
-    navmesh_small_size.agent_height = 0.7
-    navmesh_huge_size.agent_radius = 1.5
-    navmesh_huge_size.agent_height = 2.5
+    navigation_mesh_standard_size.agent_radius = 0.5
+    navigation_mesh_standard_size.agent_height = 1.8
+    navigation_mesh_small_size.agent_radius = 0.25
+    navigation_mesh_small_size.agent_height = 0.7
+    navigation_mesh_huge_size.agent_radius = 1.5
+    navigation_mesh_huge_size.agent_height = 2.5
     
     # get the root node for the baking to parse geometry
-    var root_node : Node3D = get_node("NavmeshRootNode")
+    var root_node : Node3D = get_node("NavigationMeshBakingRootNode")
     
     # bake the navigation geometry for each agent size
-    NavigationMeshGenerator.bake(navmesh_standard_size, root_node)
-    NavigationMeshGenerator.bake(navmesh_small_size, root_node)
-    NavigationMeshGenerator.bake(navmesh_huge_size, root_node)
+    NavigationMeshGenerator.bake(navigation_mesh_standard_size, root_node)
+    NavigationMeshGenerator.bake(navigation_mesh_small_size, root_node)
+    NavigationMeshGenerator.bake(navigation_mesh_huge_size, root_node)
     
     # create different navigation maps on the NavigationServer
-    var nav_map_standard : RID = NavigationServer3D.map_create()
-    var nav_map_small : RID = NavigationServer3D.map_create()
-    var nav_map_huge : RID = NavigationServer3D.map_create()
+    var navigation_map_standard : RID = NavigationServer3D.map_create()
+    var navigation_map_small : RID = NavigationServer3D.map_create()
+    var navigation_map_huge : RID = NavigationServer3D.map_create()
     
     # create a region for each map
-    var nav_map_standard_region : RID = NavigationServer3D.region_create()
-    var nav_map_small_region : RID = NavigationServer3D.region_create()
-    var nav_map_huge_region : RID = NavigationServer3D.region_create()
+    var navigation_map_standard_region : RID = NavigationServer3D.region_create()
+    var navigation_map_small_region : RID = NavigationServer3D.region_create()
+    var navigation_map_huge_region : RID = NavigationServer3D.region_create()
     
-    # set navigationmesh for each region
-    NavigationServer3D.region_set_navmesh(nav_map_standard_region, navmesh_standard_size)
-    NavigationServer3D.region_set_navmesh(nav_map_small_region, navmesh_small_size)
-    NavigationServer3D.region_set_navmesh(nav_map_huge_region, navmesh_huge_size)
+    # set navigation mesh for each region
+    NavigationServer3D.region_set_navigation_mesh(navigation_map_standard_region, navigation_mesh_standard_size)
+    NavigationServer3D.region_set_navigation_mesh(navigation_map_small_region, navigation_mesh_small_size)
+    NavigationServer3D.region_set_navigation_mesh(navigation_map_huge_region, navigation_mesh_huge_size)
     
     # add regions to maps
-    nav_map_standard_region.region_set_map(nav_map_standard_region, nav_map_standard)
-    nav_map_small_region.region_set_map(nav_map_small_region, nav_map_small)
-    nav_map_huge_region.region_set_map(nav_map_huge_region, nav_map_huge)
+    navigation_map_standard_region.region_set_map(navigation_map_standard_region, navigation_map_standard)
+    navigation_map_small_region.region_set_map(navigation_map_small_region, navigation_map_small)
+    navigation_map_huge_region.region_set_map(navigation_map_huge_region, navigation_map_huge)
     
     # wait a physics frame for sync
     await get_tree().physics_frame
     
     # query paths for each size
-    var path_standard_agent = NavigationServer3D.map_get_path(nav_map_standard, start_pos, end_pos, true)
-    var path_small_agent = NavigationServer3D.map_get_path(navmesh_small_size, start_pos, end_pos, true)
-    var path_huge_agent = NavigationServer3D.map_get_path(nav_map_huge, start_pos, end_pos, true)
+    var path_standard_agent = NavigationServer3D.map_get_path(navigation_map_standard, start_pos, end_pos, true)
+    var path_small_agent = NavigationServer3D.map_get_path(navigation_mesh_small_size, start_pos, end_pos, true)
+    var path_huge_agent = NavigationServer3D.map_get_path(navigation_map_huge, start_pos, end_pos, true)


### PR DESCRIPTION
Fixes Navigation doc for different actor types due to recent renames.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
