### PR TITLE
Remove extraneous space in the 3D game tutorial's Mob script

### DIFF
--- a/getting_started/first_3d_game/09.adding_animations.rst
+++ b/getting_started/first_3d_game/09.adding_animations.rst
@@ -477,7 +477,7 @@ And the *Mob*'s script.
        $AnimationPlayer.playback_speed = random_speed / min_speed
 
 
-    func squash():
+   func squash():
        emit_signal("squashed")
        queue_free()
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
