### PR TITLE
Update the structure of the home page

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -918,12 +918,14 @@ code,
 
 /* Admonition tweaks */
 
+.rst-content .admonition,
 .rst-content .admonition.note,
 .rst-content .admonition.seealso {
     background-color: var(--admonition-note-background-color);
     color: var(--admonition-note-color);
 }
 
+.rst-content .admonition .admonition-title,
 .rst-content .admonition.note .admonition-title,
 .rst-content .admonition.seealso .admonition-title {
     background-color: var(--admonition-note-title-background-color);
@@ -1564,4 +1566,12 @@ p + .classref-constant {
 }
 .wy-menu-vertical p.caption + ul.active {
     display: block;
+}
+
+/* Top navigation, breadcrumbs */
+.wy-breadcrumbs li a {
+    padding: 0 5px;
+}
+.wy-breadcrumbs li a:first-child {
+    padding-left: 0;
 }

--- a/_templates/breadcrumbs.html
+++ b/_templates/breadcrumbs.html
@@ -9,6 +9,7 @@
 		font-size: 14px;
 		float: right;
 		clear: both;
+		padding-top: 4px;
 	}
 
 	@media screen and (max-width: 480px) {

--- a/index.rst
+++ b/index.rst
@@ -10,7 +10,7 @@ Godot Docs – *master* branch
 .. only:: i18n
 
   .. note:: This documentation is translated from the `original English one
-            <https://docs.godotengine.org/en/latest>`_ by community members
+            <https://docs.godotengine.org/en/stable>`_ by community members
             on `Weblate <https://hosted.weblate.org/projects/godot-engine/godot-docs>`_.
 
             Depending on the translation effort's completion level, you may
@@ -19,8 +19,9 @@ Godot Docs – *master* branch
             ones on Weblate.
 
             For the time being, localized translations are only available for
-            the "latest" (development) branch, but should be suitable to learn
-            how to use stable Godot releases nevertheless.
+            the "stable" branch. You can still view the English documentation for
+            other engine versions using the "Read the Docs" panel at the bottom
+            of the sidebar.
 
 Welcome to the official documentation of `Godot Engine <https://godotengine.org>`__,
 the free and open source community-driven 2D and 3D game engine! If you are new
@@ -28,9 +29,27 @@ to this documentation, we recommend that you read the
 :ref:`introduction page <doc_about_intro>` to get an overview of what this
 documentation has to offer.
 
-The table of contents below and in the sidebar should let you easily access the
-documentation for your topic of interest. You can also use the search function
-in the top-left corner.
+The table of contents in the sidebar should let you easily access the documentation
+for your topic of interest. You can also use the search function in the top-left corner.
+
+Get involved
+------------
+
+Godot Engine is an open source project developed by a community of volunteers.
+The documentation team can always use your feedback and help to improve the
+tutorials and class reference. If you don't understand something, or cannot find
+what you are looking for in the docs, help us make the documentation better
+by letting us know!
+
+Submit an issue or pull request on the `GitHub repository <https://github.com/godotengine/godot-docs/issues>`_,
+help us `translate the documentation <https://hosted.weblate.org/engage/godot-engine/>`_
+into your language, or talk to us on the ``#documentation`` channel on the
+`Godot Contributors Chat <https://chat.godotengine.org/>`_!
+
+.. centered:: |weblate_widget|
+
+Offline documentation
+---------------------
 
 To browse the documentation offline, you can use the mirror of the documentation
 hosted on `DevDocs <https://devdocs.io/godot/>`__. To enable offline browsing on
@@ -46,26 +65,12 @@ You can also `download an HTML copy <https://nightly.link/godotengine/godot-docs
 for offline reading (updated every Monday). Extract the ZIP archive then open
 the top-level ``index.html`` in a web browser.
 
-.. note:: Godot Engine is an open source project developed by a community of
-          volunteers. The documentation team can always use your
-          feedback and help to improve the tutorials and class reference. If
-          you don't understand something, or cannot find what you
-          are looking for in the docs, help us make the documentation better
-          by letting us know!
 
-          Submit an issue or pull request on the `GitHub repository
-          <https://github.com/godotengine/godot-docs/issues>`_,
-          help us `translate the documentation
-          <https://hosted.weblate.org/engage/godot-engine/>`_ into your
-          language, or talk to us on the
-          ``#documentation`` channel on the `Godot Contributors Chat
-          <https://chat.godotengine.org/>`_!
-
-.. centered:: |weblate_widget|
-
-The main documentation for the site is organized into the following sections:
+.. Below is the main table-of-content tree of the documentation website.
+   It is hidden on the page itself, but it makes up the sidebar for navigation.
 
 .. toctree::
+   :hidden:
    :maxdepth: 1
    :caption: About
    :name: sec-general
@@ -79,6 +84,7 @@ The main documentation for the site is organized into the following sections:
    about/complying_with_licenses
 
 .. toctree::
+   :hidden:
    :maxdepth: 1
    :caption: Getting started
    :name: sec-learn
@@ -91,6 +97,7 @@ The main documentation for the site is organized into the following sections:
 
 .. The sections below are sorted alphabetically. Please keep them that way.
 .. toctree::
+   :hidden:
    :maxdepth: 1
    :caption: Tutorials
    :name: sec-tutorials
@@ -121,6 +128,7 @@ The main documentation for the site is organized into the following sections:
 
 
 .. toctree::
+   :hidden:
    :maxdepth: 1
    :caption: Engine Development
    :name: sec-devel
@@ -132,6 +140,7 @@ The main documentation for the site is organized into the following sections:
 
 
 .. toctree::
+   :hidden:
    :maxdepth: 1
    :caption: Community
    :name: sec-community
@@ -143,16 +152,9 @@ The main documentation for the site is organized into the following sections:
 
 
 .. toctree::
+   :hidden:
    :maxdepth: 1
    :caption: Class reference
    :name: sec-class-ref
 
    classes/index
-
-
-.. Indices and tables
-.. ------------------
-..
-.. * :ref:`genindex`
-.. * :ref:`modindex`
-.. * :ref:`search`


### PR DESCRIPTION
While working on https://github.com/godotengine/godot-docs/pull/6509 I noticed that we could hide the entire TOC tree in the body of this article. I don't think there is a good reason to keep it, given that the sidebar with the navigation is right there. I assume the fact that it can be hidden without impacting the tree was never looked into.

So I decided to hide those trees, and that led me to do a bit of an overhaul for the entire page. I adjusted phrasing on some paragraphs, and moved them around too. The text is now broken into easily identifiable subsections, with more important content being placed higher.

Additionally I noticed that in the translation notice we incorrectly say that translations only apply to the latest branch, when in fact we only use translations with the stable branch. We also never mention the "Read the Docs" panel in the internationalized version of the notice, unlike the English one. So I fixed those problems with a slight change of the text.

I also noticed an issue with breadcrumbs that only sometimes manifest, so I improved its styling here as well.

-----
Anyway, here's a before and after of the entire page:

[Before](https://user-images.githubusercontent.com/11782833/209448256-6e9feb09-c805-43c1-a083-d529b31a1c19.png) | [After](https://user-images.githubusercontent.com/11782833/209448258-6d89a40d-3eb7-48d3-ba64-560023af1b31.png)