### PR TITLE
Hide excessive elements from the RTD panel, improve the looks

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1438,6 +1438,24 @@ p + .classref-constant {
     color: var(--navbar-level-1-color);
 }
 
+.rst-versions .rst-current-version,
+.rst-versions .rst-other-versions {
+    padding: 12px 14px;
+}
+
+.rst-versions .rst-other-versions {
+    color: var(--navbar-heading-color);
+}
+
+.rst-versions .rst-other-versions dl + dl {
+    margin-top: 4px;
+}
+
+.rst-versions .rst-other-versions hr {
+    border-color: var(--hr-color);
+    margin: 12px 0;
+}
+
 .rst-versions .rst-other-versions small {
     color: var(--navbar-level-3-color);
 }
@@ -1446,20 +1464,24 @@ p + .classref-constant {
     text-decoration: underline;
 }
 
-.rst-versions .rst-other-versions {
-    color: var(--navbar-heading-color);
+/* This will hide every segment of the panel, starting with the 4th. */
+.rst-versions .rst-other-versions .injected dl:nth-child(n+4) {
+    display: none;
 }
 
 .rst-versions .rst-current-version {
     background-color: var(--navbar-current-background-color);
+    border-bottom: 1px solid var(--hr-color);
 }
-
 .rst-versions .rst-current-version:hover {
     background-color: var(--navbar-current-background-color-hover);
 }
-
 .rst-versions .rst-current-version:active {
     background-color: var(--navbar-current-background-color-active);
+}
+
+.rst-versions .rst-current-version .fa {
+    line-height: 20px;
 }
 
 /* Hide the obnoxious automatic highlight from the search context. */


### PR DESCRIPTION
The "Read the Docs" panel, that gets injected on the live instance, has a few elements that I'd consider excessive. This makes it more cognitively heavy than it needs to be, which sucks for a panel that is used to switch between versions and languages most of the time.

Unfortunately, the layout of the panel is not very well marked up, so I can only resort to tangential information to hide the unnecessary elements, such as GitHub links (we already have them at the top) and a search field (we already have that as well). But it works, until they change something about it, which is as much as we can hope with these things.

I also made smaller visual changes to make the panel a bit tidier and better fitting into our design. Overall it should be slightly nicer to work with, and it should take noticeably less space.

[Before](https://user-images.githubusercontent.com/11782833/209449012-efe42b84-d666-4d4d-b815-494c12e030c4.png) | [After](https://user-images.githubusercontent.com/11782833/209449014-7dbf5a4e-d86a-436b-82a2-8339545396cb.png)
