### PR TITLE
Jumping and squashing monsters - Typos

### DIFF
--- a/getting_started/first_3d_game/06.jump_and_squash.rst
+++ b/getting_started/first_3d_game/06.jump_and_squash.rst
@@ -164,11 +164,11 @@ floating over it like the monsters.
 
 If the character is on the floor and the player presses "jump", we instantly
 give them a lot of vertical speed. In games, you really want controls to be
-responsive and giving instant speed boosts like these, while unrealistic, feel
+responsive and giving instant speed boosts like these, while unrealistic, feels
 great.
 
 Notice that the Y axis is positive upwards. That's unlike 2D, where the Y axis
-is positive downward.
+is positive downwards.
 
 Squashing monsters
 ------------------


### PR DESCRIPTION
In "[Jumping](https://docs.godotengine.org/en/stable/getting_started/first_3d_game/06.jump_and_squash.html#jumping)":
"In games, you really want controls to be responsive and **giving** instant speed boosts like these, while unrealistic, **feel** great."
should be:
"In games, you really want controls to be responsive and **giving** instant speed boosts like these, while unrealistic, **feels** great."
or:
"In games, you really want controls to be responsive and instant **speed boosts** like these, while unrealistic, **feel** great."

"Notice that the Y axis is positive **upwards**. That's unlike 2D, where the Y axis is positive **downward**."
should be:
"Notice that the Y axis is positive **upwards**. That's unlike 2D, where the Y axis is positive **downwards**."
or:
"Notice that the Y axis is positive **upward**. That's unlike 2D, where the Y axis is positive **downward**."

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
