### PR TITLE
Update Pausing Games tutorial to match the 4.0 API

### DIFF
--- a/tutorials/scripting/pausing_games.rst
+++ b/tutorials/scripting/pausing_games.rst
@@ -48,25 +48,27 @@ You can also alter the property with code:
  .. code-tab:: gdscript GDScript
 
     func _ready():
-        pause_mode = Node.PAUSE_MODE_PROCESS
+        process_mode = Node.PROCESS_MODE_PAUSABLE
 
  .. code-tab:: csharp
 
     public override void _Ready()
     {
-        PauseMode = Node.PauseModeEnum.Process;
+        ProcessMode = Node.ProcessModeEnum.Pausable;
     }
 
 This is what each mode tells a node to do:  
 
 -  **Inherit**: Process depending on the state of the parent,
    grandparent, etc. The first parent that has a non-Inherit state.
--  **Pausable**: Stop the node no matter what (and children in Inherit
-   mode). When paused this node will not process.
--  **WhenPaused**:
--  **Always**: Process the node no matter what (and children in Inherit
-   mode). Paused or not this node will process.
--  **Disabled**: The node will not process at all.
+-  **Pausable**: Process the node (and its children in Inherit
+   mode) only when the game is not paused.
+-  **WhenPaused**: Process the node (and its children in Inherit
+   mode)only when the game is paused.
+-  **Always**: Process the node (and its children in Inherit
+   mode) no matter what . Paused or not this node will process.
+-  **Disabled**: The node (and its children in Inherit
+   mode) will not process at all.
 
 By default, all nodes have this property in the "Inherit" state. If the
 parent is set to "Inherit", then the grandparent will be checked and so
@@ -76,8 +78,7 @@ every node will be paused. Several things happen when a node stops processing.
 
 The ``_process``, ``_physics_process``, ``_input``, and ``_input_event`` functions
 will not be called. However signals still work and cause their connected function to
-run, even if that function's script is attached to a node that has its pause
-mode set to "Stop".
+run, even if that function's script is attached to a node that is not currently being processed.
 
 Animation nodes will pause their current animation, audio nodes
 will pause their current audio stream, and particles will pause. These resume

--- a/tutorials/scripting/pausing_games.rst
+++ b/tutorials/scripting/pausing_games.rst
@@ -64,9 +64,9 @@ This is what each mode tells a node to do:
 -  **Pausable**: Process the node (and its children in Inherit
    mode) only when the game is not paused.
 -  **WhenPaused**: Process the node (and its children in Inherit
-   mode)only when the game is paused.
+   mode) *only* when the game is paused.
 -  **Always**: Process the node (and its children in Inherit
-   mode) no matter what . Paused or not this node will process.
+   mode) no matter what. Paused or not, this node will process.
 -  **Disabled**: The node (and its children in Inherit
    mode) will not process at all.
 


### PR DESCRIPTION
Some parts of the page were referring to the 3.x API, I've updated them following the observed behavior and API of 4.0beta9

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
