### PR TITLE
Make the navigation sidebar less crowded and noisy

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -30,6 +30,7 @@
     --content-wrap-background-color: #efefef;
     --content-background-color: #fcfcfc;
     --logo-opacity: 1.0;
+
     --navbar-background-color: #333f67;
     --navbar-background-color-hover: #29355c;
     --navbar-background-color-active: #212d51;
@@ -37,9 +38,14 @@
     --navbar-current-background-color-hover: #182343;
     --navbar-current-background-color-active: #131e3b;
     --navbar-category-active-color: rgba(255 115 129 / 10%);
+    --navbar-current-color: #f1f9ff;
     --navbar-level-1-color: #c3e3ff;
     --navbar-level-2-color: #b8d6f0;
     --navbar-level-3-color: #a3c4e1;
+    --navbar-expand-base-color: #81a3c2;
+    --navbar-expand-hover-color: #c3e3ff;
+    --navbar-expand-active-color: #f1f9ff;
+    --navbar-dimmed-color: #a3c4e1;
     --navbar-heading-color: #ff7381;
     --navbar-scrollbar-color: #d45a66;
     --navbar-scrollbar-hover-color: #b14550;
@@ -141,6 +147,7 @@
         --content-background-color: #2e3236;
         /* Decrease the logo opacity when using the dark theme to be less distracting */
         --logo-opacity: 0.85;
+
         --navbar-background-color: #25282b;
         --navbar-background-color-hover: #333639;
         --navbar-background-color-active: #111417;
@@ -148,9 +155,14 @@
         --navbar-current-background-color-hover: #44474a;
         --navbar-current-background-color-active: #222528;
         --navbar-category-active-color: rgba(238 115 129 / 10%);
+        --navbar-current-color: #fefefe;
         --navbar-level-1-color: #ddd;
         --navbar-level-2-color: #ccc;
         --navbar-level-3-color: #bbb;
+        --navbar-expand-base-color: #80848e;
+        --navbar-expand-hover-color: #ccc;
+        --navbar-expand-active-color: #ddd;
+        --navbar-dimmed-color: #bbb;
         --navbar-heading-color: #ee7381;
         --navbar-scrollbar-color: #be5460;
         --navbar-scrollbar-hover-color: #963e48;
@@ -1215,6 +1227,8 @@ p + .classref-constant {
 
 .wy-side-nav-search {
     background-color: var(--navbar-background-color);
+    color: var(--navbar-level-1-color);
+    margin-right: 8px;
 }
 
 .wy-side-nav-search.fixed {
@@ -1266,7 +1280,22 @@ p + .classref-constant {
     opacity: 0.55;
 }
 
-/* Navigation bar */
+/* Version branch label below the logo */
+.wy-side-nav-search > div.version {
+    color: var(--navbar-dimmed-color);
+    font-size: 14px;
+    opacity: 0.9;
+}
+
+/* Navigational top bar (mobile only) */
+
+.wy-nav-top,
+.wy-nav-top a {
+    background-color: var(--navbar-background-color);
+    color: var(--navbar-level-1-color);
+}
+
+/* Navigational sidebar */
 
 .wy-nav-side {
     background-color: var(--navbar-background-color);
@@ -1287,117 +1316,132 @@ p + .classref-constant {
     letter-spacing: 0.75px;
 }
 
-/* Mobile navigation */
+/* Default styling of navigation items */
 
-.wy-nav-top,
-.wy-nav-top a {
+.wy-menu-vertical li {
     background-color: var(--navbar-background-color);
+}
+.wy-menu-vertical li.current {
+    background-color: var(--navbar-current-background-color);
+}
+
+.wy-menu-vertical li > a {
     color: var(--navbar-level-1-color);
+    font-size: 92%;
+    line-height: 20px;
+    padding: .4045em 1.618em;
 }
-
-/* Version branch label below the logo */
-.wy-side-nav-search > div.version {
-    color: var(--navbar-level-3-color);
-    font-size: 14px;
-    opacity: 0.9;
-}
-
-/* First level of navigation items */
-
-.wy-menu-vertical a {
-    color: var(--navbar-level-1-color);
-}
-
-.wy-menu-vertical a:hover {
+.wy-menu-vertical li > a:hover {
     background-color: var(--navbar-background-color-hover);
     color: var(--navbar-level-1-color);
 }
-
-.wy-menu-vertical a:active {
+.wy-menu-vertical li > a:active {
     background-color: var(--navbar-background-color-active);
 }
 
-.wy-menu-vertical li.toctree-l1 > a {
-    padding: .4045em 1.918em;
-}
-
-.wy-menu-vertical li.toctree-l1.current > a {
-    border: none;
-}
-
-.wy-side-nav-search, .wy-menu-vertical a, .wy-menu-vertical a button.toctree-expand,
-.wy-menu-vertical li.toctree-l1 a button.toctree-expand,
-.wy-menu-vertical li.toctree-l2 a button.toctree-expand {
-    color: var(--navbar-level-3-color);
+.wy-menu-vertical li > a button.toctree-expand {
+    color: var(--navbar-expand-base-color) !important;
     opacity: 0.9;
     margin-right: 8px;
-}
 
-.wy-side-nav-search, .wy-menu-vertical a, .wy-menu-vertical a:hover button.toctree-expand,
-.wy-menu-vertical li.toctree-l1 a:hover button.toctree-expand,
-.wy-menu-vertical li.toctree-l2 a:hover button.toctree-expand {
-    color: var(--navbar-level-2-color);
-    opacity: 1;
-}
-
-.wy-side-nav-search, .wy-menu-vertical a, .wy-menu-vertical a:active button.toctree-expand,
-.wy-menu-vertical li.toctree-l1 a:active button.toctree-expand,
-.wy-menu-vertical li.toctree-l2 a:active button.toctree-expand {
-    color: var(--navbar-level-1-color);
-    opacity: 1;
-}
-
-/* Second (and higher) levels of navigation items */
-
-.wy-menu-vertical li.current a {
-    /* Make long words always display on a single line, keep wrapping for multiple words */
-    /* This fixes the class reference titles' display with very long class names */
-    display: flex;
-}
-
-.wy-menu-vertical li.current a,
-.wy-menu-vertical li.toctree-l2.current > a,
-.wy-menu-vertical li.toctree-l2.current li.toctree-l3 > a,
-.wy-menu-vertical li.toctree-l2.current li.toctree-l4 > a {
-    background-color: var(--navbar-current-background-color);
-    color: var(--navbar-level-2-color);
-    border-color: var(--navbar-current-background-color);
-}
-
-.wy-menu-vertical li.current a:hover,
-.wy-menu-vertical li.toctree-l2.current > a:hover,
-.wy-menu-vertical li.toctree-l2.current li.toctree-l3 > a:hover,
-.wy-menu-vertical li.toctree-l3.current li.toctree-l4 > a:hover {
-    background-color: var(--navbar-current-background-color-hover);
-}
-
-.wy-menu-vertical li.current a:active,
-.wy-menu-vertical li.toctree-l2.current > a:active,
-.wy-menu-vertical li.toctree-l2.current li.toctree-l3 > a:active,
-.wy-menu-vertical li.toctree-l3.current li.toctree-l4 > a:active {
-    background-color: var(--navbar-current-background-color-active);
-}
-
-.wy-menu-vertical a {
-    /* This overrides 8px margin added in other multi-selector rules */
-    margin-right: 0;
-}
-
-/* Make the expand icon a bit easier to hit. */
-.wy-menu-vertical li a button.toctree-expand {
+    /* Make the expand icon a bit easier to hit. */
     position: relative;
     width: 12px;
     min-width: 12px; /* Forces the size to stay this way in the flexbox model. */
     height: 18px;
 }
+.wy-menu-vertical li.current > a button.toctree-expand {
+    color: var(--navbar-current-color) !important;
+}
+.wy-menu-vertical li > a:hover button.toctree-expand {
+    color: var(--navbar-expand-hover-color) !important;
+    opacity: 1;
+}
+.wy-menu-vertical li > a:active button.toctree-expand {
+    color: var(--navbar-expand-active-color) !important;
+    opacity: 1;
+}
 
-.wy-menu-vertical li a button.toctree-expand:before {
+/* Make the expand icon a bit easier to hit. */
+.wy-menu-vertical li > a button.toctree-expand:before {
     position: absolute;
-    top: -3px;
+    top: -2px;
     left: -6px;
     width: 24px;
     height: 24px;
     padding: 6px;
+}
+
+.wy-menu-vertical li.current > a,
+.wy-menu-vertical li.toctree-l2.current > a {
+    background-color: var(--navbar-current-background-color-hover);
+    border-bottom: 2px solid var(--navbar-current-background-color);
+    color: var(--navbar-current-color);
+    font-weight: 600;
+
+    /* Make long words always display on a single line, keep wrapping for multiple words */
+    /* This fixes the class reference titles' display with very long class names */
+    display: flex;
+}
+.wy-menu-vertical li.current > a:hover,
+.wy-menu-vertical li.toctree-l2.current > a:hover {
+    background-color: var(--navbar-current-background-color-hover);
+}
+.wy-menu-vertical li.current > a:active,
+.wy-menu-vertical li.toctree-l2.current > a:active {
+    background-color: var(--navbar-current-background-color-active);
+}
+
+/* Slightly adjust first level items. */
+.wy-menu-vertical li.toctree-l1 > a,
+.wy-menu-vertical li.toctree-l1.current > a {
+    border: none;
+    padding: .4045em 1.918em;
+}
+.wy-menu-vertical li.toctree-l1.current > a {
+    border-bottom: 2px solid var(--navbar-current-background-color);
+}
+
+/* Override styling for children of the current item. */
+.wy-menu-vertical li.current li > a,
+.wy-menu-vertical li.toctree-l2.current li > a,
+.wy-menu-vertical li.toctree-l2.current li.toctree-l3 > a,
+.wy-menu-vertical li.toctree-l2.current li.toctree-l4 > a {
+    background-color: var(--navbar-current-background-color);
+    border: none;
+    border-bottom: 2px solid var(--navbar-current-background-color);
+    color: var(--navbar-level-2-color);
+}
+.wy-menu-vertical li.current li > a:hover,
+.wy-menu-vertical li.toctree-l2.current li > a:hover,
+.wy-menu-vertical li.toctree-l2.current li.toctree-l3 > a:hover,
+.wy-menu-vertical li.toctree-l2.current li.toctree-l4 > a:hover {
+    background-color: var(--navbar-current-background-color-hover);
+}
+.wy-menu-vertical li.current li > a:active,
+.wy-menu-vertical li.toctree-l2.current li > a:active,
+.wy-menu-vertical li.toctree-l2.current li.toctree-l3 > a:active,
+.wy-menu-vertical li.toctree-l2.current li.toctree-l4 > a:active {
+    background-color: var(--navbar-current-background-color-active);
+}
+
+.wy-menu-vertical li.toctree-l2.current li > a,
+.wy-menu-vertical li.toctree-l2.current li.toctree-l3 > a,
+.wy-menu-vertical li.toctree-l2.current li.toctree-l4 > a {
+    color: var(--navbar-level-3-color);
+}
+.wy-menu-vertical li.toctree-l2.current li > a:hover,
+.wy-menu-vertical li.toctree-l2.current li.toctree-l3 > a:hover,
+.wy-menu-vertical li.toctree-l2.current li.toctree-l4 > a:hover {
+    color: var(--navbar-level-1-color);
+}
+
+.wy-menu-vertical li.current li.current > a,
+.wy-menu-vertical li.toctree-l2.current li.current > a,
+.wy-menu-vertical li.toctree-l2.current li.toctree-l3.current > a,
+.wy-menu-vertical li.toctree-l2.current li.toctree-l4.current > a {
+    color: var(--navbar-current-color);
+    font-weight: 600;
 }
 
 /* Banner panel in sidebar */
@@ -1459,7 +1503,7 @@ p + .classref-constant {
 }
 
 .rst-versions .rst-other-versions small {
-    color: var(--navbar-level-3-color);
+    color: var(--navbar-dimmed-color);
 }
 
 .rst-versions .rst-other-versions dd a:hover {

--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -200,10 +200,21 @@ const registerSidebarObserver = (function(){
     // theme adds an extra button to fold and unfold the tree without navigating away.
     // But that means that the buttons are added after the initial load, so we need to
     // improvise to detect clicks on these buttons.
+    const scrollElement = document.querySelector('.wy-menu-vertical');
     const registerLinkHandler = (linkChildren) => {
       linkChildren.forEach(it => {
         if (it.nodeType === Node.ELEMENT_NODE && it.classList.contains('toctree-expand')) {
           it.addEventListener('click', () => {
+            // Toggling a different item will close the currently opened one,
+            // which may shift the clicked item out of the view. We correct for that.
+            const menuItem = it.parentNode;
+            const baseScrollOffset = scrollElement.scrollTop + scrollElement.offsetTop;
+            const maxScrollOffset = baseScrollOffset + scrollElement.offsetHeight;
+
+            if (menuItem.offsetTop < baseScrollOffset || menuItem.offsetTop > maxScrollOffset) {
+              menuItem.scrollIntoView();
+            }
+
             callback();
           });
         }
@@ -212,7 +223,7 @@ const registerSidebarObserver = (function(){
 
     const navigationSections = document.querySelectorAll('.wy-menu-vertical ul');
     navigationSections.forEach(it => {
-      if (typeof it.previousSibling === 'undefined' || it.previousSibling.tagName != 'A') {
+      if (it.previousSibling == null || typeof it.previousSibling === 'undefined' || it.previousSibling.tagName != 'A') {
         return;
       }
 

--- a/conf.py
+++ b/conf.py
@@ -189,14 +189,14 @@ html_extra_path = ["robots.txt"]
 html_css_files = [
     'css/algolia.css',
     'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css',
-    "css/custom.css?5", # Increment the number at the end when the file changes to bust the cache.
+    "css/custom.css?6", # Increment the number at the end when the file changes to bust the cache.
 ]
 
 if not on_rtd:
     html_css_files.append("css/dev.css")
 
 html_js_files = [
-    "js/custom.js?3", # Increment the number at the end when the file changes to bust the cache.
+    "js/custom.js?4", # Increment the number at the end when the file changes to bust the cache.
     ('https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js', {'defer': 'defer'}),
     ('js/algolia.js', {'defer': 'defer'})
 ]


### PR DESCRIPTION
I find that our sidebar is very crowded as is. Every navigation item is short and font size quickly becomes way too small. One of the problems is that our navigation includes both global navigation (sections and pages) and local navigation (titles and subtitles).

I think at some point we would probably need to move away from it. I think Calinou has found us a new theme that has that solved, but we can also keep evolving our own. I've experimented with this a bit, and have a good idea how to add a second, local table of content somewhere on the page. On the right side of the article, perhaps? I'll play around with it a bit more and come back with what I manage to create.

But for the time being, no reason we couldn't do touch-ups to make the side menu more manageable for users. I've tried to improve spacing, increase the font size, slightly, and add better indication for currently selected items. I think this yields an overall improvement, though huge categories and branches with many sublevels feel impossible to save. But maybe my vision is just getting blurred, and it's fine.

Here are some comparisons:

[Before](https://user-images.githubusercontent.com/11782833/209705098-114052e0-ae25-49c7-8b51-b84c8df4d5d6.png) | [After](https://user-images.githubusercontent.com/11782833/209705104-bbda3dfd-1e39-4cc0-9634-124844db3616.png)

_As you can witness here, short, tiny, low-level subtitles don't look great. But arguably they haven't looked great before neither. That's what a separate local TOC panel would help with._

[Before](https://user-images.githubusercontent.com/11782833/209705108-8b84a5d2-01f5-4eb2-adcd-46f6cf1bbb42.png) | [After](https://user-images.githubusercontent.com/11782833/209705115-7d6a6624-90a2-4189-b966-28867985ce6c.png)

[Before](https://user-images.githubusercontent.com/11782833/209705116-f145902c-bc24-4d19-b41b-065298be139c.png) | [After](https://user-images.githubusercontent.com/11782833/209705125-1a04ccea-6187-46f9-9d69-057ec8e648c3.png)

[Before](https://user-images.githubusercontent.com/11782833/209705142-fcb5a8f7-76bf-49a6-9240-9e9df53f0b4c.png) | [After](https://user-images.githubusercontent.com/11782833/209705150-14798f87-24e8-47b7-be62-2d6453647908.png)

[Before](https://user-images.githubusercontent.com/11782833/209705160-dfa62f68-c41f-4612-b9ac-63cf2f145bfb.png) | [After](https://user-images.githubusercontent.com/11782833/209705167-4d1423a8-d5be-4307-a455-8549510a93f2.png)

I also fixed an annoyance when you open a different branch inside of a category, and the previously opened category closes, so your current category disappears from view.

<details>
<summary>Before</summary>

https://user-images.githubusercontent.com/11782833/209705456-9d25cb66-83a3-4a23-a459-8a1f828d83a4.mp4
</details>

<details>
<summary>After</summary>

https://user-images.githubusercontent.com/11782833/209705462-e3eb9715-143b-42a2-a12a-8a33c3ac3d77.mp4
</details>

-----
There are more changes to the CSS file than technically necessary, but I wanted to clean it up a bit, as there were excessive style definitions and unused rules too. I started by streamlining it, and then did my changes.