### PR TITLE
Add a custom local template for the RTD panel

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1405,7 +1405,7 @@ p + .classref-constant {
     position: fixed;
 }
 
-/* Version selector (only visible on Read the Docs) */
+/* Read the Docs flyout panel, with language and version selectors. */
 
 .rst-versions {
     background-color: var(--navbar-current-background-color);

--- a/_templates/versions.html
+++ b/_templates/versions.html
@@ -1,0 +1,60 @@
+{# Add rst-badge after rst-versions for small badge style. #}
+{% set display_version = version -%}
+{% set listed_languages = ({"en":"#", "de":"#", "es":"#", "fr":"#"}).items() -%}
+{% set listed_versions = ({"stable":"#", "latest":"#"}).items() -%}
+
+{% if READTHEDOCS and current_version %}
+  {% set display_version = current_version -%}
+{% endif %}
+{% if READTHEDOCS and versions %}
+  {% set listed_versions = versions -%}
+{% endif %}
+
+<div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
+  <span class="rst-current-version" data-toggle="rst-current-version">
+    <span class="fa fa-book"> Read the Docs</span>
+    v: {{ display_version }}
+    <span class="fa fa-caret-down"></span>
+  </span>
+  <div class="rst-other-versions">
+    {#
+      The contents of this element will be replaced in production.
+      But we can still have some mock data for testing.
+    #}
+
+    <dl>
+      <dt>{{ _('Languages') }}</dt>
+      {% for slug, url in listed_languages %}
+        <dd><a href="{{ url }}">{{ slug }}</a></dd>
+      {% endfor %}
+    </dl>
+    <dl>
+      <dt>{{ _('Versions') }}</dt>
+      {% for slug, url in listed_versions %}
+        <dd><a href="{{ url }}">{{ slug }}</a></dd>
+      {% endfor %}
+    </dl>
+    <dl>
+      {# Translators: The phrase "Read the Docs" is not translated #}
+      <dt>{{ _('On Read the Docs') }}</dt>
+        <dd>
+          <a href="//{{ PRODUCTION_DOMAIN }}/projects/{{ slug }}">{{ _('Project Home') }}</a>
+        </dd>
+        <dd>
+          <a href="//{{ PRODUCTION_DOMAIN }}/projects/{{ slug }}/builds/">{{ _('Builds') }}</a>
+        </dd>
+        <dd>
+          <a href="//{{ PRODUCTION_DOMAIN }}/projects/{{ slug }}/downloads/">{{ _('Downloads') }}</a>
+        </dd>
+    </dl>
+
+    <hr>
+    <small>
+      <span>Hosted by <a href="https://readthedocs.org">Read the Docs</a></span>
+      <span> · </span>
+      <a href="https://docs.readthedocs.io/page/privacy-policy.html">Privacy Policy</a>
+    </small>
+
+    {##}
+  </div>
+</div>


### PR DESCRIPTION
It's been a given for quite some time that the flyout "Read the Docs" panel is not accessible when doing local development. This means that creating and testing PRs that need to account for it, or change its style was not trivial. Apparently, this doesn't have to be the case:

![image](https://user-images.githubusercontent.com/11782833/209722844-279f2255-78bf-4595-bbb6-22e6ef977816.png)

This panel is two-fold. First, there is actually a template for it, and it does exist in the initial HTML layout in one form. It's just that the template explicitly disables any output if you are not on the RTD. This is an easy fix, and all we need to do is to add a custom template for it and put it alongside other custom templates we have. Works perfectly locally.

There is the second part though, that template is partially overridden in production. When a page is loaded, some content from the template gets replaced by dynamic content, generated specifically for our instance:

![chrome_2022-12-27_23-31-10](https://user-images.githubusercontent.com/11782833/209723131-c9f50263-6524-4d35-bff7-06a6c51c9bbb.png)

So we need to be careful and make sure our template has the necessary elements for the injection to work. Otherwise we won't be able to use the data from RTD. But on the flip side, we can have pretty much any mock data we want. We can also customize the looks further than just with CSS, but we shouldn't touch the element that gets its contents replaced. And we can't do anything about the bits which are injected. So my hacky CSS from https://github.com/godotengine/godot-docs/pull/6512 is still necessary.

Overall, this makes development and testing of the UI much nicer. I can't test if this won't cause problems on the RTD side of things, but it shouldn't. The faux template that is generated as a part of the initial HTML is pretty much the same as this one, so for the production instance it shouldn't be any different.