### PR TITLE
Fix: C# example for custom resource tutorial

### DIFF
--- a/tutorials/scripting/resources.rst
+++ b/tutorials/scripting/resources.rst
@@ -244,11 +244,11 @@ Attach a script to it named ``bot_stats.gd`` (or just create a new script, and t
                 // Make sure that every parameter has a default value.
                 // Otherwise, there will be problems with creating and editing
                 // your resource via the inspector.
-                public BotStats(int health = 0, Resource subResource = null, String[] strings = null)
+                public BotStats()
                 {
-                    Health = health;
-                    SubResource = subResource;
-                    Strings = strings ?? new String[0];
+                    Health = 0;
+                    SubResource = null;
+                    Strings = new String[0];
                 }
             }
         }


### PR DESCRIPTION
The C# example for a custom resource script is wrong. It is going to produce a `Cannot construct temporary MonoObject because the class does not define a parameterless constructor` error.

```csharp
public BotStats(int health = 0, Resource subResource = null, String[] strings = null)
{
    Health = health;
    SubResource = subResource;
    Strings = strings ?? new String[0];
}
```

Using default values for constructor parameters in C# doesn't consider such constructor as parameterless. The constructor in the example should look as follows:

```csharp
public BotStats()
{
    Health = 0;
    SubResource = null;
    Strings = new String[0];
}
```
