### PR TITLE
Score and replay - Grammar

### DIFF
--- a/getting_started/first_3d_game/08.score_and_replay.rst
+++ b/getting_started/first_3d_game/08.score_and_replay.rst
@@ -164,7 +164,7 @@ There, we increment the score and update the displayed text.
 
 The second line uses the value of the ``score`` variable to replace the
 placeholder ``%s``. When using this feature, Godot automatically converts values
-to text, which is convenient to output text in labels or using the ``print()``
+to text, which is convenient to output text in labels or to use the ``print()``
 function.
 
 .. seealso::


### PR DESCRIPTION
In "[Keeping track of the score](https://docs.godotengine.org/en/stable/getting_started/first_3d_game/08.score_and_replay.html#keeping-track-of-the-score)":
"which is convenient to output text in labels or **using** the print() function"
should be:
"which is convenient to output text in labels or **to use** the print() function"
or:
"which is convenient to output text in labels or **use** the print() function"

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
