### PR TITLE
Fixed incorrect Texture type in example

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -250,7 +250,7 @@ dialog. For that, change the ``custom_node.gd`` script to the following:
             // Initialization of the plugin goes here.
             // Add the new type with a name, a parent type, a script and an icon.
             var script = GD.Load<Script>("MyButton.cs");
-            var texture = GD.Load<Texture>("icon.png");
+            var texture = GD.Load<Texture2D>("icon.png");
             AddCustomType("MyButton", "Button", script, texture);
         }
 


### PR DESCRIPTION
In the 4th C# code block, the `texture` variable is loaded as a `Texture` resource, when `AddCustomType` requires it to be a `Texture2D`.