### PR TITLE
Fix example on how to use lld

### DIFF
--- a/development/compiling/compiling_for_linuxbsd.rst
+++ b/development/compiling/compiling_for_linuxbsd.rst
@@ -253,7 +253,7 @@ the default GCC + GNU ld setup:
 To do so, install Clang and the ``lld`` package from your distribution's package manager
 then use the following SCons command::
 
-    scons platform=linuxbsd use_llvm=yes use_lld=yes
+    scons platform=linuxbsd use_llvm=yes linker=lld
 
 After the build is completed, a new binary with a ``.llvm`` suffix will be
 created in the ``bin/`` folder.


### PR DESCRIPTION
The "use_lld=yes" was removed in Godot (c8479c0d4d). The new parameter which allows using lld is "linker=lld".
