### PR TITLE
we should state early on that it requires SCons

### DIFF
--- a/development/compiling/introduction_to_the_buildsystem.rst
+++ b/development/compiling/introduction_to_the_buildsystem.rst
@@ -8,7 +8,7 @@ Introduction to the buildsystem
 SCons
 -----
 
-Godot uses `SCons <https://www.scons.org/>`__ to build. We love it, we are
+Godot requires and uses `SCons <https://www.scons.org/>`__ to build. We love it, we are
 not changing it for anything else. We are not even sure other build
 systems are up to the task of building Godot. We constantly get requests
 to move the build system to CMake, or Visual Studio, but this is not


### PR DESCRIPTION
Following the documentation step by step, it was missed that SCons is actually needed on the system to build and not only "uses" it.  Much later the docs clarify the requirements, but it's useful to state this differently at the very beginning.  This simple change would have saved me about 15 mins or so.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
