### PR TITLE
Jump Y velocity: changed '+=' to '='

### DIFF
--- a/getting_started/first_3d_game/06.jump_and_squash.rst
+++ b/getting_started/first_3d_game/06.jump_and_squash.rst
@@ -136,7 +136,7 @@ called ``move_and_slide()``.
 
        # Jumping.
        if is_on_floor() and Input.is_action_just_pressed("jump"):
-           velocity.y += jump_impulse
+           velocity.y = jump_impulse
 
        #...
 
@@ -149,7 +149,7 @@ called ``move_and_slide()``.
         // Jumping.
         if (IsOnFloor() && Input.IsActionJustPressed("jump"))
         {
-            _velocity.y += JumpImpulse;
+            _velocity.y = JumpImpulse;
         }
 
         // ...


### PR DESCRIPTION
This is more consistent with the bounce-jump code introduced later ("velocity.y = bounce_impulse"), and is generally more consistent with how jumping (and double-jumping) is coded in most games.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
