### PR TITLE
Add a Nix flake as a reproducible build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ logo.h
 # Output of list-unused-images.sh tool
 tmp-unused-images
 tmp-unused-images-history
+
+# nix build results
+*result*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,132 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1672152762,
+        "narHash": "sha256-U8iWWHgabN07zfbgedogMVWrEP1Zywyf3Yx3OYHSSgE=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "19e0f88324d90509141e192664ded98bb88ef9b2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mach-nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "pypi-deps-db": "pypi-deps-db"
+      },
+      "locked": {
+        "lastModified": 1654084003,
+        "narHash": "sha256-j/XrVVistvM+Ua+0tNFvO5z83isL+LBgmBi9XppxuKA=",
+        "owner": "davhau",
+        "repo": "mach-nix",
+        "rev": "7e14360bde07dcae32e5e24f366c83272f52923f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "davhau",
+        "ref": "3.5.0",
+        "repo": "mach-nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1643805626,
+        "narHash": "sha256-AXLDVMG+UaAGsGSpOtQHPIKB+IZ0KSd9WS77aanGzgc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "554d2d8aa25b6e583575459c297ec23750adb6cb",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1671359686,
+        "narHash": "sha256-3MpC6yZo+Xn9cPordGz2/ii6IJpP2n8LE8e/ebUXLrs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "04f574a1c0fde90b51bf68198e2297ca4e7cccf4",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1672353432,
+        "narHash": "sha256-oZfgp/44/o2tWiylV30cR+DLyWTJ+5dhsdWZVpzs3e4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "913a47cd064cc06440ea84e5e0452039a85781f0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pypi-deps-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1643877077,
+        "narHash": "sha256-jv8pIvRFTP919GybOxXE5TfOkrjTbdo9QiCO1TD3ZaY=",
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "rev": "da53397f0b782b0b18deb72ef8e0fb5aa7c98aa3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "mach-nix": "mach-nix",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "A Flake for godot-docs";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-22.11";
+    mach-nix.url = "github:davhau/mach-nix/3.5.0";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+  outputs = { self, nixpkgs, mach-nix, flake-parts }@inputs:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      perSystem = { config, self', inputs', pkgs, system, ... }: {
+        packages = let
+          mach-nix = (import inputs.mach-nix { pkgs = inputs.mach-nix.inputs.nixpkgs.legacyPackages.${system}; });
+          requirements = mach-nix.mkPython {
+            requirements = ''
+              sphinx==4.4.0
+              sphinx_rtd_theme==1.0.0
+              sphinx-tabs
+              sphinx-notfound-page
+              sphinxext-opengraph
+              sphinx-tabs
+            '';
+          };
+        in
+        {
+          default = pkgs.stdenv.mkDerivation {
+            name = "godot-docs-html";
+            src = self;
+            nativeBuildInputs = [
+              requirements
+              pkgs.python3Packages.setuptools
+            ];
+            buildPhase = ''
+              make html
+            '';
+            installPhase = ''
+              mkdir -p $out
+              mv _build/html/* $out
+            '';
+          };
+        };
+      };
+    };
+}


### PR DESCRIPTION
This adds a Nix flake with a `default` output named "godot-docs-html", that can be built with `nix build`. The main outputs that can be built are:

This will produce a result:

```
❯ nix build
❯ ls result/
404.html     _downloads       objects.inv     _static
about        genindex.html    robots.txt      tutorials
classes      getting_started  search.html
community    _images          searchindex.js
development  index.html       _sources
```

Nix builds are deterministic, and reproducible long-term. The requirements.txt file at the root of this repository doesn't provide enough information to be reproducible, since it doesn't store the sha256 of the dependency when it was originally built, only the version number. This doesn't allow us to verify that it hasn't changed in the meantime. Thankfully the mach-nix library (which you can see in the flake inputs) allowed me to reproduce the godot-docs, since it stores a frozen package database, which is similar to a lockfile.

If we were to update godot-docs to a more recent version of the packages, then it may be possible to reproduce it without the [mach-nix ](https://github.com/DavHau/mach-nix) library, or still using mach-nix and `(builtins.readfile ./requirements.txt)` which would allow you to keep the requirements.txt as a source of truth. It would be better to move to a system like [poetry](https://python-poetry.org/) that creates lockfiles, or to move away from python and use something more reproducible and lockfile based like [mdbook ](https://rust-lang.github.io/mdBook/)(rust) instead. 

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
