### PR TITLE
Update navigationserver2d to use a better tutorial

### DIFF
--- a/classes/class_navigationserver2d.rst
+++ b/classes/class_navigationserver2d.rst
@@ -40,7 +40,7 @@ This server keeps tracks of any call and executes them during the sync phase. Th
 Tutorials
 ---------
 
-- `2D Navigation Demo <https://godotengine.org/asset-library/asset/117>`__
+- `2D Navigation Server Demo <https://godotengine.org/asset-library/asset/6799>`__
 
 .. rst-class:: classref-reftable-group
 


### PR DESCRIPTION
(first time attempting to contribute to an open source project like this, so I apologize in advance for any faux-pases I will inevitably commit) 
I have modified the existing asset that uses the deprecated Navigation node so the project now uses Navigaiton2DServer. This makes the tutorial more relevant for this documentation page. 
My new asset is currently pending, so here a link to the github repo that will be referenced in the asset: https://github.com/yurivwarmerdam/navigation 
Obviously this change should only be merged once my asset has been approved.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
