### PR TITLE
Update C# code example

### DIFF
--- a/tutorials/inputs/handling_quit_requests.rst
+++ b/tutorials/inputs/handling_quit_requests.rst
@@ -82,7 +82,7 @@ program termination, you should send the notification yourself:
 
  .. code-tab:: csharp
 
-    GetTree().GetRoot().PropagateNotification(NotificationWmCloseRequest)
+    GetTree().Root.PropagateNotification((int)NotificationWmCloseRequest)
 
 Sending this notification will inform all nodes about the program termination,
 but will not terminate the program itself *unlike in 3.X*. In order to achieve


### PR DESCRIPTION
Use the `Root` property instead of the deprecated `GetRoot` method. `PropagateNotification` accepts an `int` and not a `long`, and so `NotificationWmCloseRequest` needs to be cast to `int`.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
