### PR TITLE
Adding info on how to use Color constants

### DIFF
--- a/classes/class_color.rst
+++ b/classes/class_color.rst
@@ -23,6 +23,18 @@ If you want to supply values in a range of 0 to 255, you should use :ref:`@GDScr
 
 \ **Note:** In a boolean context, a Color will evaluate to ``false`` if it's equal to ``Color(0, 0, 0, 1)`` (opaque black). Otherwise, a Color will always evaluate to ``true``.
 
+Using constants:
+
+.. tabs::
+ .. tab:: GDScript
+
+    Color.DESIRED_COLOR # see the constants cheatsheet below to view all constants
+
+ .. tab:: C#
+
+    Colors.DesiredColor # (mind the s at Color*s*)
+
+
 \ `Color constants cheatsheet <https://raw.githubusercontent.com/godotengine/godot-docs/master/img/color_constants.png>`__
 
 Tutorials


### PR DESCRIPTION
I believe it is worth mentionning on the doc how to access Color constants with C# because it is slighty different from GDScript but not as expected. Besides that, there isn't any info on how to access constants here yet

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
