### PR TITLE
Clarify NavigationServer created regions

### DIFF
--- a/tutorials/navigation/navigation_using_navigationregions.rst
+++ b/tutorials/navigation/navigation_using_navigationregions.rst
@@ -34,9 +34,9 @@ Regions can be enabled / disabled and if disabled will not contribute to future 
 Creating new navigation regions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-New navigation regions will automatically register to the default world navigation map.
+New NavigationRegion nodes will automatically register to the default world navigation map for their 2D/3D dimension.
 
-The region RID can be obtained from NavigationRegion Nodes with ``get_region_rid()``.
+The region RID can then be obtained from NavigationRegion Nodes with ``get_region_rid()``.
 
 .. tabs::
  .. code-tab:: gdscript GDScript
@@ -46,6 +46,8 @@ The region RID can be obtained from NavigationRegion Nodes with ``get_region_rid
     var navigationserver_region_rid : RID = get_region_rid()
 
 New regions can also be created with the NavigationServer API and added to any existing map.
+
+If regions are created with the NavigationServer API directly they need to be assigned a navigation map manually.
 
 .. tabs::
  .. code-tab:: gdscript GDScript


### PR DESCRIPTION
Clarify that NavigationServer created navigation regions do not join a navigation map automatically like a NavigationRegion node would. The server API created regions need a manual map assignment with region_set_map().

Related to this issue [here](https://github.com/godotengine/godot/issues/70855).

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
