### PR TITLE
Docs update print_line_rich

### DIFF
--- a/development/cpp/common_engine_methods_and_macros.rst
+++ b/development/cpp/common_engine_methods_and_macros.rst
@@ -28,7 +28,7 @@ Print text
     // This supports a subset of BBCode tags supported by RichTextLabel
     // and will also appear formatted in the editor Output panel.
     // On Windows, this requires Windows 10 or later to work in the terminal.
-    print_rich("[b]Bold[/b], [color=red]Red text[/color]")
+    print_line_rich("[b]Bold[/b], [color=red]Red text[/color]");
 
     // Prints a formatted error or warning message with a trace.
     ERR_PRINT("Message");

--- a/development/cpp/common_engine_methods_and_macros.rst
+++ b/development/cpp/common_engine_methods_and_macros.rst
@@ -28,7 +28,7 @@ Print text
     // This supports a subset of BBCode tags supported by RichTextLabel
     // and will also appear formatted in the editor Output panel.
     // On Windows, this requires Windows 10 or later to work in the terminal.
-    print_line_rich("[b]Bold[/b], [color=red]Red text[/color]")
+    print_rich("[b]Bold[/b], [color=red]Red text[/color]")
 
     // Prints a formatted error or warning message with a trace.
     ERR_PRINT("Message");


### PR DESCRIPTION
Minor edit to docs to match actual function name of `print_rich` 

`print_line_rich` doesn't seem to exist (anymore)?
