### PR TITLE
Update physics_introduction.rst

### DIFF
--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -320,6 +320,13 @@ Contact monitoring via signals can be enabled via the :ref:`contact_monitor <cla
 property. See :ref:`RigidBody2D <class_RigidBody2D>` for the list of available
 signals.
 
+.. note:: Rigid bodies do not detect collisions with ``Area2D`` nodes. If you need a rigid body to detect collisions with ``Area2D``, consider using the ``body`` argument in the ``Area2D``  ``_on_body_entered(body)`` signal to emit a signal from the rigid body: 
+.. tabs::
+ .. code-tab:: gdscript GDScript
+ 
+    func _on_Area2DName_body_entered(body):
+        body.emit_signal("body_entered", self)
+
 CharacterBody2D
 ---------------
 

--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -320,7 +320,12 @@ Contact monitoring via signals can be enabled via the :ref:`contact_monitor <cla
 property. See :ref:`RigidBody2D <class_RigidBody2D>` for the list of available
 signals.
 
-.. note:: Rigid bodies do not detect collisions with ``Area2D`` nodes. If you need a rigid body to detect collisions with ``Area2D``, consider using the ``body`` argument in the ``Area2D``  ``_on_body_entered(body)`` signal to emit a signal from the rigid body: 
+.. note::
+
+    Rigid bodies do not detect collisions with ``Area2D`` nodes. If you need a rigid body
+    to detect collisions with ``Area2D``, consider using the ``body`` argument in the ``Area2D``
+    ``_on_body_entered(body)`` signal to emit a signal from the rigid body: 
+
 .. tabs::
  .. code-tab:: gdscript GDScript
  


### PR DESCRIPTION
Judging by forum questions and answers, many people do not understand that rigid bodies do not detect collisions with Area2D nodes, but desire that functionality. It would be helpful to include a note in this introduction clarifying that point and providing one way to accomplish that goal.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
