### PR TITLE
Removed repetitive reference to NodePath

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -495,7 +495,8 @@ very fast to compare, which makes them good candidates for dictionary keys.
 :ref:`NodePath <class_NodePath>`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A pre-parsed path to a node or a node property. They are useful to interact with
+A pre-parsed path to a node or a node property.  It can be
+easily assigned to, and from, a String. They are useful to interact with
 the tree to get a node, or affecting properties like with :ref:`Tweens <class_Tween>`.
 
 Vector built-in types
@@ -576,12 +577,6 @@ Engine built-in types
 
 Color data type contains ``r``, ``g``, ``b``, and ``a`` fields. It can
 also be accessed as ``h``, ``s``, and ``v`` for hue/saturation/value.
-
-:ref:`NodePath <class_NodePath>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Compiled path to a node used mainly in the scene system. It can be
-easily assigned to, and from, a String.
 
 :ref:`RID <class_RID>`
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Removed repetitive mentions of NodePath 
Fixes #6554 
URL to the documentation page:
https://docs.godotengine.org/en/latest/tutorials/scripting/gdscript/gdscript_basics.html#nodepath https://docs.godotengine.org/en/latest/tutorials/scripting/gdscript/gdscript_basics.html#id1

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
