### PR TITLE
Added correct reference to Frames property

### DIFF
--- a/getting_started/first_2d_game/02.player_scene.rst
+++ b/getting_started/first_2d_game/02.player_scene.rst
@@ -58,7 +58,7 @@ Click on the ``Player`` node and add (:kbd:`Ctrl + A`) a child node :ref:`Animat
 appearance and animations for our player. Notice that there is a warning symbol
 next to the node. An ``AnimatedSprite2D`` requires a :ref:`SpriteFrames
 <class_SpriteFrames>` resource, which is a list of the animations it can
-display. To create one, find the ``Sprite Frames`` property in the Inspector and click
+display. To create one, find the ``Sprite Frames`` property under the ``Animation`` tab in the Inspector and click
 "[empty]" -> "New SpriteFrames". Click again to open the "SpriteFrames" panel:
 
 .. image:: img/spriteframes_panel.webp


### PR DESCRIPTION
Added more clear instruction for finding `Frames` properties. Earlier it was harder to find `Frames` properties as it is now hidden inside `Animation` tab.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
