### PR TITLE
Use 32 bits when converting back from bytes in Using compute shaders

### DIFF
--- a/tutorials/shaders/compute_shaders.rst
+++ b/tutorials/shaders/compute_shaders.rst
@@ -229,7 +229,7 @@ Let's retrieve the data and print the results to our console.
 
     # Read back the data from the buffer
     var output_bytes := rd.buffer_get_data(buffer)
-    var output := output_bytes.to_float64_array()
+    var output := output_bytes.to_float32_array()
     print("Input: ", input)
     print("Output: ", output)
 


### PR DESCRIPTION
This was probably missed when the tutorial was changed to use floats instead of doubles (https://github.com/godotengine/godot-docs/pull/6468)

Fixes #6570 
