### PR TITLE
Fix links to sections in the Introduction

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -316,14 +316,21 @@ article ol,
 .wy-plain-list-disc,
 .wy-plain-list-decimal,
 .rst-content ol.arabic,
-.rst-content .section ul,
-.rst-content .toctree-wrapper ul,
-.rst-content .section ol {
+.rst-content .toctree-wrapper ul {
     /* Increase the line height slightly to account for the different font */
     line-height: 25px;
 }
 
-.rst-content section ul li {
+/* Depending on the environment, it can be a section tag or a div with the section class. */
+.rst-content section ul,
+.rst-content section ol,
+.rst-content .section ul,
+.rst-content .section ol {
+    /* Increase the line height slightly to account for the different font */
+    line-height: 25px;
+}
+.rst-content section ul li,
+.rst-content .section ul li {
     /* Increase spacing between list items. */
     margin-top: 8px;
     margin-bottom: 8px;

--- a/about/introduction.rst
+++ b/about/introduction.rst
@@ -75,30 +75,30 @@ attribution to "Juan Linietsky, Ariel Manzur and the Godot Engine community".
 Organization of the documentation
 ---------------------------------
 
-This documentation is organized in five sections with an impressively
+This documentation is organized in several sections with an impressively
 unbalanced distribution of contents – but the way it is split up should be
 relatively intuitive:
 
-- The :ref:`sec-general` section contains this introduction as well as
+- The **About** section contains this introduction as well as
   the information about the engine, its history, its licensing, authors, etc. It
   also contains the :ref:`doc_faq`.
-- The :ref:`sec-learn` section is the *raison d'être* of this
+- The **Getting Started** section is the *raison d'être* of this
   documentation, as it contains all the necessary information on using the
   engine to make games. It starts with the :ref:`Step by step
   <toc-learn-step_by_step>` tutorial which should be the entry point for all
   new users.
-- The :ref:`sec-tutorials` section can be read as needed,
+- The **Manual** section can be read as needed,
   in any order. It contains feature-specific tutorials and documentation.
-- The :ref:`sec-contributing` section gives the information related to contributing to
+- The **Contributing** section gives the information related to contributing to
   the engine development, e.g. how to report bugs, help with the documentation, etc.
   It also contains subsections intended for advanced users and contributors
   to the engine development, with the information on compiling the engine,
   contributing to the editor, or developing C++ modules.
-- The :ref:`sec-community` section is dedicated to the life of its community.
+- The **Community** section is dedicated to the life of its community.
   It points to various community channels like Godot Contributors Chat and
   Discord and contains a list of recommended third-party tutorials outside
   of this documentation.
-- Finally, the :ref:`sec-class-ref` is the documentation of the Godot API,
+- Finally, the **Class reference** is the documentation of the Godot API,
   which is also available directly within the engine's script editor. It is
   generated automatically from a file in the main source repository, therefore
   the generated files of the documentation are not meant to be modified. See


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-docs/issues/6533. Supersedes https://github.com/godotengine/godot-docs/pull/6340 since I was in the neighborhood.

The text is a bit more blind now without accent-colored links, but we can think about a better layout for this section later.

I also fixed some styling related to HTML lists. There's been some ambiguity due to Sphinx building pages differently on production and locally (not sure why, e.g. it uses `<section>` in production, but `<div class="section">` locally, which is the cause of the ambiguity here). It's not major, but makes comparing changes harder.