### PR TITLE
Remove breadcrumb styling adjustments after the base theme update

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1633,11 +1633,3 @@ p + .classref-constant {
 .wy-menu-vertical p.caption + ul.active {
     display: block;
 }
-
-/* Top navigation, breadcrumbs */
-.wy-breadcrumbs li a {
-    padding: 0 5px;
-}
-.wy-breadcrumbs li a:first-child {
-    padding-left: 0;
-}

--- a/conf.py
+++ b/conf.py
@@ -189,7 +189,7 @@ html_extra_path = ["robots.txt"]
 html_css_files = [
     'css/algolia.css',
     'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css',
-    "css/custom.css?6", # Increment the number at the end when the file changes to bust the cache.
+    "css/custom.css?7", # Increment the number at the end when the file changes to bust the cache.
 ]
 
 if not on_rtd:


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot-docs/pull/6369, seems like breadcrumbs were slightly redesigned, and their styling was fixed. So we no longer need these lines, as they create unnecessary offsets.