### PR TITLE
Update code samples in The Main Game Scene tutorial, remove randomize calls

### DIFF
--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -87,7 +87,9 @@ to instance.
 
  .. code-tab:: csharp
 
-    public class Main : Node
+    using Godot;
+
+    public partial class Main : Node
     {
         // Don't forget to rebuild the project so the editor knows about the new export variable.
 
@@ -152,25 +154,7 @@ to instance.
     };
 
     #endif // MAIN_H
-
-We also add a call to ``randomize()`` here so that the random number
-generator generates different random numbers each time the game is run:
-
-.. tabs::
- .. code-tab:: gdscript GDScript
-
-    func _ready():
-        randomize()
-
- .. code-tab:: csharp
-
-    public override void _Ready()
-    {
-        GD.Randomize();
-    }
-
- .. code-tab:: cpp
-
+    
     // This code goes in `main.cpp`.
     #include "main.hpp"
 
@@ -190,7 +174,6 @@ generator generates different random numbers each time the game is run:
         //_music = get_node<godot::AudioStreamPlayer>("Music");
         //_death_sound = get_node<godot::AudioStreamPlayer>("DeathSound");
         _random = (godot::Ref<godot::RandomNumberGenerator>)godot::RandomNumberGenerator::_new();
-        _random->randomize();
     }
 
 Click the ``Main`` node and you will see the ``Mob Scene`` property in the Inspector
@@ -356,7 +339,7 @@ Note that a new instance must be added to the scene using ``add_child()``.
         // obviously Mob and PathFollow2D, since they appear later on the line.
 
         // Create a new instance of the Mob scene.
-        var mob = MobScene.Instance<Mob>();
+        var mob = MobScene.Instantiate<Mob>();
 
         // Choose a random location on Path2D.
         var mobSpawnLocation = GetNode<PathFollow2D>("MobPath/MobSpawnLocation");
@@ -425,7 +408,6 @@ call to ``_ready()``:
  .. code-tab:: gdscript GDScript
 
     func _ready():
-        randomize()
         new_game()
 
  .. code-tab:: csharp


### PR DESCRIPTION
closes #6549 

Added ``using`` directive and ``partial`` keyword
Removed the randomize() call at startup, according to [comment](https://github.com/godotengine/godot-docs/pull/6008#issuecomment-1279210051).
(With the removal of the function call in _ready() the linked pull request is probably not valid anymore :/)
(please check c++ carefully, I'm not familiar with it)