### PR TITLE
Update C# code samples in Getting Started and Tutorials

### DIFF
--- a/getting_started/first_2d_game/03.coding_the_player.rst
+++ b/getting_started/first_2d_game/03.coding_the_player.rst
@@ -36,7 +36,6 @@ Start by declaring the member variables this object will need:
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
     public partial class Player : Area2D
     {

--- a/getting_started/first_2d_game/04.creating_the_enemy.rst
+++ b/getting_started/first_2d_game/04.creating_the_enemy.rst
@@ -65,7 +65,9 @@ Add a script to the ``Mob`` like this:
 
  .. code-tab:: csharp
 
-    public class Mob : RigidBody2D
+    using Godot;
+
+    public partial class Mob : RigidBody2D
     {
         // Don't forget to rebuild the project.
     }

--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -107,7 +107,9 @@ Now add this script to ``HUD``:
 
  .. code-tab:: csharp
 
-    public class HUD : CanvasLayer
+    using Godot;
+
+    public partial class HUD : CanvasLayer
     {
         // Don't forget to rebuild the project so the editor knows about the new signal.
         

--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -208,7 +208,7 @@ Your complete ``Sprite2D.gd`` code should look like the following.
 
     using Godot;
 
-    public class Sprite : Godot.Sprite2D
+    public partial class Sprite : Sprite2D
     {
         private float Speed = 400;
         private float AngularSpeed = Mathf.Pi;
@@ -370,7 +370,7 @@ Here is the complete ``Sprite2D.gd`` file for reference.
 
     using Godot;
 
-    public class Sprite : Godot.Sprite2D
+    public partial class Sprite : Sprite2D
     {
         private float Speed = 400;
         private float AngularSpeed = Mathf.Pi;
@@ -423,7 +423,7 @@ reaches 0.
 
     using Godot;
 
-    public class CustomSignal : Node2D
+    public partial class CustomSignal : Node2D
     {
         [Signal]
         public delegate void HealthDepletedEventHandler();
@@ -477,7 +477,7 @@ names between parentheses:
 
     using Godot;
 
-    public class CustomSignal : Node
+    public partial class CustomSignal : Node
     {
         [Signal]
         public delegate void HealthChangedEventHandler(int oldValue, int newValue);

--- a/tutorials/2d/2d_movement.rst
+++ b/tutorials/2d/2d_movement.rst
@@ -56,7 +56,6 @@ Add a script to the character body and add the following code:
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
     public partial class Movement : CharacterBody2D
     {
@@ -123,7 +122,6 @@ while up/down moves it forward or backward in whatever direction it's facing.
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
     public partial class Movement : CharacterBody2D
     {
@@ -182,7 +180,6 @@ is set by the mouse position instead of the keyboard. The character will always
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
     public partial class Movement : CharacterBody2D
     {
@@ -246,7 +243,6 @@ on the screen will cause the player to move to the target location.
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
     public partial class Movement : CharacterBody2D
     {

--- a/tutorials/2d/2d_sprite_animation.rst
+++ b/tutorials/2d/2d_sprite_animation.rst
@@ -88,7 +88,9 @@ released.
 
  .. code-tab:: csharp
 
-    public class Character : CharacterBody2D
+    using Godot;
+
+    public partial class Character : CharacterBody2D
     {
         private AnimatedSprite2D _animatedSprite;
 
@@ -227,7 +229,9 @@ released.
 
  .. code-tab:: csharp
 
-    public class Character : CharacterBody2D
+    using Godot;
+
+    public partial class Character : CharacterBody2D
     {
         private AnimationPlayer _animationPlayer;
 

--- a/tutorials/2d/custom_drawing_in_2d.rst
+++ b/tutorials/2d/custom_drawing_in_2d.rst
@@ -82,7 +82,9 @@ redrawn if modified:
 
  .. code-tab:: csharp
 
-    public class CustomNode2D : Node2D
+    using Godot;
+
+    public partial class CustomNode2D : Node2D
     {
         private Texture _texture;
         public Texture Texture
@@ -122,7 +124,9 @@ call ``queue_redraw()`` from the ``_process()`` callback, like this:
 
  .. code-tab:: csharp
 
-    public class CustomNode2D : Node2D
+    using Godot;
+
+    public partial class CustomNode2D : Node2D
     {
         public override void _Draw()
         {
@@ -326,7 +330,9 @@ using ``get_node()``.
 
  .. code-tab:: csharp
 
-    public class CustomNode2D : Node2D
+    using Godot;
+
+    public partial class CustomNode2D : Node2D
     {
         private float _rotationAngle = 50;
         private float _angleFrom = 75;

--- a/tutorials/best_practices/data_preferences.rst
+++ b/tutorials/best_practices/data_preferences.rst
@@ -248,8 +248,10 @@ tree structures.
 
   .. code-tab:: csharp
 
+    using Godot;
+
     // Can decide whether to expose getters/setters for properties later
-    public class TreeNode : Object
+    public partial class TreeNode : Object
     {
         private TreeNode _parent = null;
 

--- a/tutorials/best_practices/godot_interfaces.rst
+++ b/tutorials/best_practices/godot_interfaces.rst
@@ -481,7 +481,9 @@ accesses:
   .. code-tab:: csharp
 
     // Child.cs
-    public class Child : Node
+    using Godot;
+
+    public partial class Child : Node
     {
         public FuncRef FN = null;
 
@@ -493,7 +495,9 @@ accesses:
     }
 
     // Parent.cs
-    public class Parent : Node
+    using Godot;
+
+    public partial class Parent : Node
     {
         public Node Child;
 

--- a/tutorials/best_practices/godot_notifications.rst
+++ b/tutorials/best_practices/godot_notifications.rst
@@ -113,7 +113,9 @@ deltatime methods as needed.
 
   .. code-tab:: csharp
 
-    public class MyNode : Node
+    using Godot;
+
+    public partial class MyNode : Node
     {
 
         // Called every frame, even when the engine detects no input.
@@ -171,7 +173,9 @@ instantiation:
 
   .. code-tab:: csharp
 
-    public class MyNode : Node
+    using Godot;
+
+    public partial class MyNode : Node
     {
         private string _test = "one";
 
@@ -255,7 +259,9 @@ nodes that one might create at runtime.
 
   .. code-tab:: csharp
 
-    public class MyNode : Node
+    using Godot;
+
+    public partial class MyNode : Node
     {
         public Node ParentCache = null;
 

--- a/tutorials/best_practices/logic_preferences.rst
+++ b/tutorials/best_practices/logic_preferences.rst
@@ -83,11 +83,10 @@ either? Let's see an example:
 
   .. code-tab:: csharp
 
-    using System;
     using Godot;
 
     // C# and other languages have no concept of "preloading".
-    public class MyBuildings : Node
+    public partial class MyBuildings : Node
     {
         //This is a read-only field, it can only be assigned when it's declared or during a constructor.
         public readonly PackedScene Building = ResourceLoader.Load<PackedScene>("res://building.tscn");

--- a/tutorials/best_practices/scene_organization.rst
+++ b/tutorials/best_practices/scene_organization.rst
@@ -179,7 +179,7 @@ in another context without any extra changes to its API.
       // Parent
       GetNode<Left>("Left").Target = GetNode("Right/Receiver");
 
-      public class Left : Node
+      public partial class Left : Node
       {
           public Node Target = null;
 
@@ -189,7 +189,7 @@ in another context without any extra changes to its API.
           }
       }
 
-      public class Right : Node
+      public partial class Right : Node
       {
           public Node Receiver = null;
 

--- a/tutorials/best_practices/scenes_versus_scripts.rst
+++ b/tutorials/best_practices/scenes_versus_scripts.rst
@@ -23,38 +23,37 @@ But, choosing which one to use can be a dilemma. Creating script instances
 is identical to creating in-engine classes whereas handling scenes requires
 a change in API:
 
-    .. tabs::
-      .. code-tab:: gdscript GDScript
+.. tabs::
+  .. code-tab:: gdscript GDScript
 
-        const MyNode = preload("my_node.gd")
-        const MyScene = preload("my_scene.tscn")
-        var node = Node.new()
-        var my_node = MyNode.new() # Same method call
-        var my_scene = MyScene.instantiate() # Different method call
-        var my_inherited_scene = MyScene.instantiate(PackedScene.GEN_EDIT_STATE_MAIN) # Create scene inheriting from MyScene
+    const MyNode = preload("my_node.gd")
+    const MyScene = preload("my_scene.tscn")
+    var node = Node.new()
+    var my_node = MyNode.new() # Same method call
+    var my_scene = MyScene.instantiate() # Different method call
+    var my_inherited_scene = MyScene.instantiate(PackedScene.GEN_EDIT_STATE_MAIN) # Create scene inheriting from MyScene
 
-      .. code-tab:: csharp
+  .. code-tab:: csharp
 
-        using System;
-        using Godot;
+    using Godot;
 
-        public class Game : Node
+    public partial class Game : Node
+    {
+        public readonly Script MyNodeScr = (Script)ResourceLoader.Load("MyNode.cs");
+        public readonly PackedScene MySceneScn = (PackedScene)ResourceLoader.Load("MyScene.tscn");
+        public Node ANode;
+        public Node MyNode;
+        public Node MyScene;
+        public Node MyInheritedScene;
+
+        public Game()
         {
-            public readonly Script MyNodeScr = (Script)ResourceLoader.Load("MyNode.cs");
-            public readonly PackedScene MySceneScn = (PackedScene)ResourceLoader.Load("MyScene.tscn");
-            public Node ANode;
-            public Node MyNode;
-            public Node MyScene;
-            public Node MyInheritedScene;
-
-            public Game()
-            {
-                ANode = new Node();
-                MyNode = new MyNode(); // Same syntax
-                MyScene = MySceneScn.Instantiate(); // Different. Instantiated from a PackedScene
-                MyInheritedScene = MySceneScn.Instantiate(PackedScene.GenEditState.Main); // Create scene inheriting from MyScene
-            }
+            ANode = new Node();
+            MyNode = new MyNode(); // Same syntax
+            MyScene = MySceneScn.Instantiate(); // Different. Instantiated from a PackedScene
+            MyInheritedScene = MySceneScn.Instantiate(PackedScene.GenEditState.Main); // Create scene inheriting from MyScene
         }
+    }
 
 Also, scripts will operate a little slower than scenes due to the
 speed differences between engine and script code. The larger and more complex
@@ -161,10 +160,9 @@ with it, and finally adds it as a child of the ``Main`` node:
 
   .. code-tab:: csharp
 
-    using System;
     using Godot;
 
-    public class Main : Resource
+    public partial class Main : Resource
     {
         public Node Child { get; set; }
 

--- a/tutorials/inputs/input_examples.rst
+++ b/tutorials/inputs/input_examples.rst
@@ -86,9 +86,8 @@ attach the following script:
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
-    public class Node : Godot.Node
+    public partial class Node : Godot.Node
     {
         public override void _Input(InputEvent inputEvent)
         {
@@ -346,9 +345,8 @@ node:
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
-    public class Node2D : Godot.Node2D
+    public partial class Node2D : Godot.Node2D
     {
         private bool dragging = false;
         private int clickRadius = 32; // Size of the sprite.

--- a/tutorials/networking/http_client_class.rst
+++ b/tutorials/networking/http_client_class.rst
@@ -124,7 +124,9 @@ It will connect and fetch a website.
 
  .. code-tab:: csharp
 
-    class HTTPTest : SceneTree
+    using Godot;
+
+    public partial class HTTPTest : SceneTree
     {
         // HTTPClient demo.
         // This simple class can make HTTP requests; it will not block, but it needs to be polled.

--- a/tutorials/networking/http_request_class.rst
+++ b/tutorials/networking/http_request_class.rst
@@ -48,7 +48,9 @@ Below is all the code we need to make it work. The URL points to an online API m
 
     .. code-tab:: csharp
 
-        class HTTPRequestDemo : CanvasLayer
+        using Godot;
+        
+        public partial class HTTPRequestDemo : CanvasLayer
         {
             public override void _Ready()
             {

--- a/tutorials/performance/using_multimesh.rst
+++ b/tutorials/performance/using_multimesh.rst
@@ -75,9 +75,8 @@ efficient for millions of objects, but for a few thousands, GDScript should be f
  .. code-tab:: csharp C#
 
     using Godot;
-    using System;
 
-    public class YourClassName : MultiMeshInstance3D
+    public partial class YourClassName : MultiMeshInstance3D
     {
         public override void _Ready()
         {

--- a/tutorials/physics/kinematic_character_2d.rst
+++ b/tutorials/physics/kinematic_character_2d.rst
@@ -64,9 +64,8 @@ or lose precision if the frame rate is too high or too low.
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
-    public class PhysicsScript : CharacterBody2D
+    public partial class PhysicsScript : CharacterBody2D
     {
         public override void _PhysicsProcess(float delta)
         {
@@ -128,9 +127,8 @@ So, let's move our sprite downwards until it hits the floor:
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
-    public class PhysicsScript : CharacterBody2D
+    public partial class PhysicsScript : CharacterBody2D
     {
         public override void _PhysicsProcess(float delta)
         {
@@ -162,9 +160,8 @@ little more like a regular game character:
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
-    public class PhysicsScript : CharacterBody2D
+    public partial class PhysicsScript : CharacterBody2D
     {
         const float gravity = 200.0f;
         Vector2 velocity;
@@ -213,9 +210,8 @@ This adds basic support for walking when pressing left and right:
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
-    public class PhysicsScript : CharacterBody2D
+    public partial class PhysicsScript : CharacterBody2D
     {
         const float gravity = 200.0f;
         const int walkSpeed = 200;

--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -275,7 +275,9 @@ For example, here is the code for an "Asteroids" style spaceship:
 
  .. code-tab:: csharp
 
-    class Spaceship : RigidBody2D
+    using Godot;
+
+    public partial class Spaceship : RigidBody2D
     {
         private Vector2 _thrust = new Vector2(0, -250);
         private float _torque = 20000;
@@ -366,7 +368,9 @@ occurred:
 
  .. code-tab:: csharp
 
-    class Body : PhysicsBody2D
+    using Godot;
+
+    public partial class Body : PhysicsBody2D
     {
         private Vector2 _velocity = new Vector2(250, 250);
 
@@ -396,7 +400,9 @@ Or to bounce off of the colliding object:
 
  .. code-tab:: csharp
 
-    class Body : PhysicsBody2D
+    using Godot;
+
+    public partial class Body : PhysicsBody2D
     {
         private Vector2 _velocity = new Vector2(250, 250);
 
@@ -455,7 +461,9 @@ the ground (including slopes) and jump when standing on the ground:
 
  .. code-tab:: csharp
 
-    class Body : CharacterBody2D
+    using Godot;
+
+    public partial class Body : CharacterBody2D
     {
         private float _runSpeed = 350;
         private float _jumpSpeed = -1000;

--- a/tutorials/physics/ray-casting.rst
+++ b/tutorials/physics/ray-casting.rst
@@ -177,7 +177,9 @@ collision object node:
 
  .. code-tab:: csharp
 
-    class Body : CharacterBody2D
+    using Godot;
+
+    public partial class Body : CharacterBody2D
     {
         public override void _PhysicsProcess(float delta)
         {
@@ -211,7 +213,9 @@ member variable:
 
  .. code-tab:: csharp
 
-    class Body : CharacterBody2D
+    using Godot;
+
+    public partial class Body : CharacterBody2D
     {
         public override void _PhysicsProcess(float delta)
         {

--- a/tutorials/physics/rigid_body.rst
+++ b/tutorials/physics/rigid_body.rst
@@ -50,7 +50,9 @@ Here is a custom ``look_at()`` method that will work reliably with rigid bodies:
 
  .. code-tab:: csharp
 
-    class Body : RigidBody
+    using Godot;
+
+    public partial class Body : RigidBody3D
     {
         private void LookFollow(PhysicsDirectBodyState state, Transform3D currentTransform, Vector3 targetPosition)
         {

--- a/tutorials/physics/using_area_2d.rst
+++ b/tutorials/physics/using_area_2d.rst
@@ -78,7 +78,9 @@ use ``area_entered``. However, let's assume our player is a ``CharacterBody2D``
 
  .. code-tab:: csharp
 
-    public class Coin : Area2D
+    using Godot;
+
+    public partial class Coin : Area2D
     {
 
         public void OnCoinBodyEntered(PhysicsBody2D body)

--- a/tutorials/physics/using_character_body_2d.rst
+++ b/tutorials/physics/using_character_body_2d.rst
@@ -254,9 +254,8 @@ Attach a script to the CharacterBody2D and add the following code:
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
-    public class KBExample : CharacterBody2D
+    public partial class KBExample : CharacterBody2D
     {
         public int Speed = 250;
         private Vector2 _velocity = new Vector2();
@@ -358,9 +357,8 @@ uses the mouse pointer. Here is the code for the Player, using ``move_and_slide(
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
-    public class KBExample : CharacterBody2D
+    public partial class KBExample : CharacterBody2D
     {
         private PackedScene _bullet = (PackedScene)GD.Load("res://Bullet.tscn");
         public int Speed = 200;
@@ -434,9 +432,8 @@ And the code for the Bullet:
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
-    public class Bullet : CharacterBody2D
+    public partial class Bullet : CharacterBody2D
     {
         public int Speed = 750;
         private Vector2 _velocity = new Vector2();
@@ -531,9 +528,8 @@ Here's the code for the player body:
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
-    public class KBExample : CharacterBody2D
+    public partial class KBExample : CharacterBody2D
     {
         [Export] public int RunSpeed = 100;
         [Export] public int JumpSpeed = -400;

--- a/tutorials/plugins/editor/inspector_plugins.rst
+++ b/tutorials/plugins/editor/inspector_plugins.rst
@@ -66,7 +66,7 @@ you should remove the instance you have added by calling
     using Godot;
 
     [Tool]
-    public class Plugin : EditorPlugin
+    public partial class Plugin : EditorPlugin
     {
         private MyInspectorPlugin _plugin;
 
@@ -141,7 +141,7 @@ specifically add :ref:`class_EditorProperty`-based controls.
     #if TOOLS
     using Godot;
 
-    public class MyInspectorPlugin : EditorInspectorPlugin
+    public partial class MyInspectorPlugin : EditorInspectorPlugin
     {
         public override bool CanHandle(Object @object)
         {
@@ -249,7 +249,7 @@ followed by ``set_bottom_editor()`` to position it below the name.
     #if TOOLS
     using Godot;
 
-    public class RandomIntEditor : EditorProperty
+    public partial class RandomIntEditor : EditorProperty
     {
         // The main control for editing the property.
         private Button _propertyControl = new Button();

--- a/tutorials/plugins/editor/making_main_screen_plugins.rst
+++ b/tutorials/plugins/editor/making_main_screen_plugins.rst
@@ -59,7 +59,6 @@ Add five extra methods such that the script looks like this:
 
     #if TOOLS
     using Godot;
-    using System;
 
     [Tool]
     public partial class MainScreenPlugin : EditorPlugin
@@ -129,7 +128,6 @@ Add a script to the button like this:
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
     [Tool]
     public partial class PrintHello : Button
@@ -199,7 +197,6 @@ Here is the full plugin script:
 
     #if TOOLS
     using Godot;
-    using System;
 
     [Tool]
     public partial class MainScreenPlugin : EditorPlugin

--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -127,10 +127,9 @@ like this:
 
     #if TOOLS
     using Godot;
-    using System;
 
     [Tool]
-    public class CustomNode : EditorPlugin
+    public partial class CustomNode : EditorPlugin
     {
         public override void _EnterTree()
         {
@@ -191,10 +190,9 @@ clicked. For that, we'll need a script that extends from
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
     [Tool]
-    public class MyButton : Button
+    public partial class MyButton : Button
     {
         public override void _EnterTree()
         {
@@ -240,10 +238,9 @@ dialog. For that, change the ``custom_node.gd`` script to the following:
 
     #if TOOLS
     using Godot;
-    using System;
 
     [Tool]
-    public class CustomNode : EditorPlugin
+    public partial class CustomNode : EditorPlugin
     {
         public override void _EnterTree()
         {
@@ -366,10 +363,9 @@ The script could look like this:
 
     #if TOOLS
     using Godot;
-    using System;
 
     [Tool]
-    public class CustomDock : EditorPlugin
+    public partial class CustomDock : EditorPlugin
     {
         Control dock;
 

--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -129,10 +129,9 @@ and open a script, and change it to this:
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
     [Tool]
-    public class MySprite : Sprite2D
+    public partial class MySprite : Sprite2D
     {
         public override void _Process(float delta)
         {
@@ -205,10 +204,9 @@ Add and export a variable speed to the script. The function set_speed after
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
     [Tool]
-    public class MySprite : Sprite2D
+    public partial class MySprite : Sprite2D
     {
         private float speed = 1;
 

--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -204,9 +204,8 @@ Here's a blank C# script with some comments to demonstrate how it works.
 .. code-block:: csharp
 
     using Godot;
-    using System;
 
-    public class YourCustomClass : Node
+    public partial class YourCustomClass : Node
     {
         // Member variables here, example:
         private int a = 2;
@@ -302,7 +301,6 @@ a single code location:
 .. code-block:: csharp
 
     using Godot;
-    using System;
 
     public class YourCustomClass : Node3D
     {

--- a/tutorials/scripting/c_sharp/c_sharp_differences.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_differences.rst
@@ -100,7 +100,7 @@ Example:
 
     using Godot;
 
-    public class MyNode : Node
+    public partial class MyNode : Node
     {
         [Export]
         private NodePath _nodePath;

--- a/tutorials/scripting/c_sharp/c_sharp_exports.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_exports.rst
@@ -13,7 +13,9 @@ Exporting is done by using the ``[Export]`` attribute.
 
 .. code-block:: csharp
 
-    public class ExportExample : Node3D
+    using Godot;
+
+    public partial class ExportExample : Node3D
     {
         [Export]
         private int Number = 5;

--- a/tutorials/scripting/c_sharp/c_sharp_features.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_features.rst
@@ -153,7 +153,9 @@ Consequently, any ``Node`` or ``Reference`` will be compatible automatically, bu
 
 .. code-block:: csharp
 
-    public class DataObject : Godot.Object
+    using Godot;
+
+    public partial class DataObject : Godot.Object
     {
         public string Field1 { get; set; }
         public string Field2 { get; set; }

--- a/tutorials/scripting/cross_language_scripting.rst
+++ b/tutorials/scripting/cross_language_scripting.rst
@@ -35,7 +35,9 @@ The following two scripts will be used as references throughout this page.
 
  .. code-tab:: csharp
 
-    public class MyCSharpNode : Node
+    using Godot;
+
+    public partial class MyCSharpNode : Node
     {
         public String str1 = "bar";
         public String str2 { get { return "barbar"; } }

--- a/tutorials/scripting/idle_and_physics_processing.rst
+++ b/tutorials/scripting/idle_and_physics_processing.rst
@@ -90,7 +90,9 @@ single Label node, with the following script attached to it:
 
  .. code-tab:: csharp
 
-    public class CustomLabel : Label
+    using Godot;
+
+    public partial class CustomLabel : Label
     {
         private float _time;
 

--- a/tutorials/scripting/instancing_with_signals.rst
+++ b/tutorials/scripting/instancing_with_signals.rst
@@ -37,7 +37,9 @@ given velocity:
 
  .. code-tab:: csharp
 
-    public class Bullet : Area2D
+    using Godot;
+
+    public partial class Bullet : Area2D
     {
         Vector2 Velocity = new Vector2();
 
@@ -104,7 +106,9 @@ Here is the code for the player using signals to emit the bullet:
 
  .. code-tab:: csharp
 
-    public class Player : Sprite2D
+    using Godot;
+
+    public partial class Player : Sprite2D
     {
         [Signal]
         delegate void ShootEventHandler(PackedScene bullet, Vector2 direction, Vector2 location);

--- a/tutorials/scripting/resources.rst
+++ b/tutorials/scripting/resources.rst
@@ -227,7 +227,6 @@ Attach a script to it named ``bot_stats.gd`` (or just create a new script, and t
   .. code-tab:: csharp
 
         // BotStats.cs
-        using System;
         using Godot;
 
         namespace ExampleProject
@@ -278,7 +277,6 @@ Now, create a :ref:`CharacterBody3D <class_CharacterBody3D>`, name it ``Bot``, a
   .. code-tab:: csharp
 
         // Bot.cs
-        using System;
         using Godot;
 
         namespace ExampleProject
@@ -328,7 +326,6 @@ Now, select the :ref:`CharacterBody3D <class_CharacterBody3D>` node which we nam
             print(data)
       .. code-tab:: csharp
 
-        using System;
         using Godot;
 
         public partial class BotStatsTable : Resource
@@ -381,7 +378,6 @@ Now, select the :ref:`CharacterBody3D <class_CharacterBody3D>` node which we nam
             ResourceSaver.save(my_res, "res://my_res.tres")
       .. code-tab:: csharp
 
-        using System;
         using Godot;
 
         public partial class MyNode : Node

--- a/tutorials/scripting/singletons_autoload.rst
+++ b/tutorials/scripting/singletons_autoload.rst
@@ -163,9 +163,8 @@ means that the last child of root is always the loaded scene.
  .. code-tab:: csharp
 
     using Godot;
-    using System;
 
-    public class Global : Godot.Node
+    public partial class Global : Node
     {
         public Node CurrentScene { get; set; }
 

--- a/tutorials/ui/gui_containers.rst
+++ b/tutorials/ui/gui_containers.rst
@@ -184,7 +184,7 @@ Here is an example of a container that fits children to its rect size:
 
     using Godot;
 
-    public class CustomContainer : Container
+    public partial class CustomContainer : Container
     {
         public override void _Notification(int what)
         {


### PR DESCRIPTION
Add ``partial`` to all classes derived from Godot.Object.
Add ``using Godot`` and ``using System`` for consistency across all examples, in this order.
Remove ``Godot.*`` Namespace for ``signals.rst``.
Remove unneedet indentation in ``scenes_versus_scripts.rst``.
Change ``RigidBody`` to ``RigidBody3D`` in ``rigid_body.rst``
Change codetab identifier from ``none C#`` to ``csharp`` in ``inspector_plugins.rst``

(I left the ``Godot.Object`` in ``c_sharp_features.rst``, because it it referenced inside the text above)

The "Your first 3D game" is not included, because of the big refactor PR of it.