### PR TITLE
Fix missing var in NavigationAgent script example

### DIFF
--- a/tutorials/navigation/navigation_using_navigationagents.rst
+++ b/tutorials/navigation/navigation_using_navigationagents.rst
@@ -187,6 +187,7 @@ This script adds basic navigation movement to a CharacterBody3D with a Navigatio
 
     @export var movement_speed : float = 4.0
     @onready var navigation_agent : NavigationAgent3D = get_node("NavigationAgent3D")
+    var movement_delta : float
 
     func set_movement_target(movement_target : Vector3):
         navigation_agent.set_target_location(movement_target)


### PR DESCRIPTION
Fixes missing var for CharacterBody3D NavigationAgent script example.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
