### PR TITLE
Fix NavigationRegion choice paralysis

### DIFF
--- a/tutorials/navigation/navigation_using_navigationregions.rst
+++ b/tutorials/navigation/navigation_using_navigationregions.rst
@@ -12,7 +12,7 @@ and :ref:`NavigationRegion3D<class_NavigationRegion3D>` respectively.
 Individual NavigationRegions upload their 2D NavigationPolygon or 3D NavigationMesh resource data to the NavigationServer.
 The NavigationServer map turns this information into a combined navigation map for pathfinding.
 
-To create a navigation region using the SceneTree add a ``NavigationRegion3D`` or ``NavigationRegion3D`` node to the scene.
+To create a navigation region using the SceneTree add a ``NavigationRegion2D`` or ``NavigationRegion3D`` node to the scene.
 All regions require a navigationmesh resource to function. See :ref:`doc_navigation_using_navigationmeshes` to learn how to create and apply navigationmeshes.
 
 NavigationRegions will automatically push ``global_transform`` changes to the region on the NavigationServer which makes them suitable for moving platforms.


### PR DESCRIPTION
Users were clearly overwhelmed with this choice what to pick.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
