### PR TITLE
Update links in README to fix broken URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@ add-on.
 
 All contributors are welcome to help on the Godot documentation.
 
-To get started, head to the [Contributing section](https://docs.godotengine.org/en/latest/community/contributing/index.html) of the online manual. There, you will find all the information you need to write and submit changes.
+To get started, head to the [Contributing section](https://docs.godotengine.org/en/latest/contributing/ways_to_contribute.html#contributing-to-the-documentation) of the online manual. There, you will find all the information you need to write and submit changes.
 
 Here are some quick links to the areas you might be interested in:
 
-1. [Contributing to the online manual](https://docs.godotengine.org/en/latest/community/contributing/contributing_to_the_documentation.html)
-2. [Contributing to the class reference](https://docs.godotengine.org/en/latest/community/contributing/updating_the_class_reference.html)
-3. [Content guidelines](https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html)
-4. [Writing guidelines](https://docs.godotengine.org/en/latest/community/contributing/docs_writing_guidelines.html)
-5. [Building the manual](https://docs.godotengine.org/en/latest/community/contributing/building_the_manual.html)
-6. [Translating the documentation](https://docs.godotengine.org/en/latest/community/contributing/editor_and_docs_localization.html)
+1. [Contributing to the online manual](https://docs.godotengine.org/en/latest/contributing/documentation/contributing_to_the_documentation.html)
+2. [Contributing to the class reference](https://docs.godotengine.org/en/latest/contributing/documentation/updating_the_class_reference.html)
+3. [Content guidelines](https://docs.godotengine.org/en/latest/contributing/documentation/content_guidelines.html)
+4. [Writing guidelines](https://docs.godotengine.org/en/latest/contributing/documentation/docs_writing_guidelines.html)
+5. [Building the manual](https://docs.godotengine.org/en/latest/contributing/documentation/building_the_manual.html)
+6. [Translating the documentation](https://docs.godotengine.org/en/latest/contributing/documentation/editor_and_docs_localization.html)
 
 ## License
 


### PR DESCRIPTION
The links on the "Contributing" section of the readme were out of date, this PR updates them to their new locations.

The page that didn't seem to have an exact analogue was `community/contributing/index.rst` (previously [at this link](https://docs.godotengine.org/en/3.5/community/contributing/index.html)), which seems to not be accessible with contributing moved to it's own section. In it's place I linked to the "Contributing to the documentation" section of the "Ways to contribute" page.