### PR TITLE
Improve clarity surrounding Timer's `time_left` value

### DIFF
--- a/classes/class_timer.rst
+++ b/classes/class_timer.rst
@@ -207,7 +207,7 @@ Processing callback. See :ref:`TimerProcessCallback<enum_Timer_TimerProcessCallb
 
 The timer's remaining time in seconds. Returns 0 if the timer is inactive.
 
-\ **Note:** You cannot set this value. To change the timer's remaining time, use :ref:`start<class_Timer_method_start>`.
+\ **Note:** This value is read-only and cannot be set. It is based on ``wait_time``, which can be set using :ref:`start<class_Timer_method_start>`.
 
 .. rst-class:: classref-item-separator
 


### PR DESCRIPTION
closes #6537

Added some clarity to the `time_left` value and how it works

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
