### PR TITLE
Highlight link targets in the theme

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -255,6 +255,24 @@
     }
 }
 
+@keyframes target-highlight-fade {
+    from {
+        background-color: hsla(56, 100%, 50%, 0.2);
+    }
+
+    to {
+        background-color: hsla(56, 100%, 50%, 0.05);
+    }
+}
+
+*:target {
+    /* Highlight selected sections, with an animation to make it more noticeable initially. */
+    background-color: hsla(56, 100%, 50%, 0.05);
+    padding: 1rem 2rem 0.25rem 1rem;
+    margin: -1rem -2rem -0.25rem -1rem;
+    animation: target-highlight-fade 2.5s ease-out;
+}
+
 body,
 h1,
 h2,


### PR DESCRIPTION
This makes it easier to notice where the linked text is on the page, especially on tall monitors when linking at the bottom of a page.

## Preview

https://user-images.githubusercontent.com/180032/212127781-3ebf0b20-b90d-4daa-9af0-10a9e3aba75b.mp4