### PR TITLE
Update references to Color constants for Godot 4

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1721,9 +1721,9 @@ the :ref:`Signal.connect() <class_Signal_method_connect>` method::
     ...
     func _on_Character_health_changed(old_value, new_value):
         if old_value > new_value:
-            progress_bar.modulate = Color.red
+            progress_bar.modulate = Color.RED
         else:
-            progress_bar.modulate = Color.green
+            progress_bar.modulate = Color.GREEN
 
         # Imagine that `animate` is a user-defined function that animates the
         # bar filling up or emptying itself.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
Update references to color constants in GDScript to use uppercase. That's how it is now in Godot 4.x

Related Godot PR for the classes docs: https://github.com/godotengine/godot/pull/71368