### PR TITLE
Pin additional build requirements to avoid syntax highlighting issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,19 @@
-# Base dependencies
-
 # Sync with readthedocs:
 # https://github.com/readthedocs/readthedocs.org/blob/master/requirements/pip.txt
 # https://github.com/readthedocs/readthedocs.org/blob/master/requirements/docs.txt
+
+# Base dependencies
+pygments==2.14.0
+
+# Sphinx base and RTD theme.
 sphinx==4.4.0
 sphinx_rtd_theme==1.1.1
 
-# Code tabs extension for GDScript/C#
+# Sphinx extensions.
+
+# Code tabs extension to display codeblocks in different languages as tabs.
 sphinx-tabs==3.4.0
-
-# Custom 404 error page (more useful than the default)
+# Custom 404 error page (more useful than the default).
 sphinx-notfound-page==0.8.3
-
-# Adds Open Graph tags in the HTML `<head>` tag
+# Adds Open Graph tags in the HTML `<head>` tag.
 sphinxext-opengraph==0.7.5

--- a/tutorials/plugins/editor/inspector_plugins.rst
+++ b/tutorials/plugins/editor/inspector_plugins.rst
@@ -243,7 +243,7 @@ followed by ``set_bottom_editor()`` to position it below the name.
     func refresh_control_text():
         property_control.text = "Value: " + str(current_value)
 
- .. code-tab:: none C#
+ .. code-tab:: csharp
 
     // RandomIntEditor.cs
     #if TOOLS


### PR DESCRIPTION
If you've had your dependencies installed for a long time, you may have an outdated version of Pygments that fails to parse some constructs, such as string interpolation with `$` in C#. Installing `requirements.txt` again didn't update Pygments for me, resolving that my local version, 2.9.0, was enough to meet the dependency requirement in one of the packages.

So to solve this this PR pins Pygments specifically to the same version RTD uses, 2.14.0. This solved all syntax highlighter issues for my local builds. CI builds seems to be unaffected, because they probably install everything anew every time.

There is still one issue with the GLSL snippet here:
https://docs.godotengine.org/en/latest/tutorials/shaders/shader_reference/shader_preprocessor.html#define

It is possible that it's somehow incorrect, so I pinged rendering folks about it on RC. But it can also be fixed with a later PR.