### PR TITLE
Fix missing signal connection in code sample in Making HTTP requests

### DIFF
--- a/tutorials/networking/http_request_class.rst
+++ b/tutorials/networking/http_request_class.rst
@@ -38,6 +38,7 @@ Below is all the code we need to make it work. The URL points to an online API m
 
         func _ready():
             $HTTPRequest.connect("request_completed", self, "_on_request_completed")
+            $Button.connect("pressed", self, "_on_Button_pressed")
 
         func _on_Button_pressed():
             $HTTPRequest.request("http://www.mocky.io/v2/5185415ba171ea3a00704eed")


### PR DESCRIPTION
In the GDScript version of the example code, it does not have the user reading the tutorial connect the button's pressed signal to the script causing the "_on_Button_pressed" function to not run. Issue seems to apply to all versions that use this syntax for signal connections.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
