### PR TITLE
Fix C# ChangeScene Method Name in Scene Tree tutorial.

### DIFF
--- a/tutorials/scripting/scene_tree.rst
+++ b/tutorials/scripting/scene_tree.rst
@@ -154,7 +154,7 @@ function:
 
     public void _MyLevelWasCompleted()
     {
-        GetTree().ChangeScene("res://levels/level2.tscn");
+        GetTree().ChangeSceneToFile("res://levels/level2.tscn");
     }
 
 Rather than using file paths, one can also use ready-made
@@ -175,7 +175,7 @@ function
     public void _MyLevelWasCompleted()
     {
         var nextScene = (PackedScene)ResourceLoader.Load("res://levels/level2.tscn");
-        GetTree().ChangeSceneTo(nextScene);
+        GetTree().ChangeSceneToPacked(nextScene);
     }
 
 These are quick and useful ways to switch scenes but have the drawback


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
This PR is made to fix the issue mentioned in: https://github.com/godotengine/godot-docs/issues/6519 

C# references to ChangeScene method have been updated to their appropriate name.

As this is my first attempt at PR on Github, please let me know if something is incorrectly done.