### PR TITLE
Update Pause Mode documentation

### DIFF
--- a/tutorials/scripting/pausing_games.rst
+++ b/tutorials/scripting/pausing_games.rst
@@ -93,8 +93,8 @@ Pause Menu Example
 ------------------
 
 Here is an example of a pause menu. Create a popup or panel with controls
-inside, and set its pause mode to "Process" then hide it. By setting the
-root of the pause popup to "Process", all children and grandchildren will
+inside, and set its pause mode to "When Paused" or "Always" then hide it. By setting the
+root of the pause popup to "When Paused" or "Always", all children and grandchildren will
 inherit that state. This way, this branch of the scene tree will continue
 working when paused.
 

--- a/tutorials/scripting/pausing_games.rst
+++ b/tutorials/scripting/pausing_games.rst
@@ -93,8 +93,8 @@ Pause Menu Example
 ------------------
 
 Here is an example of a pause menu. Create a popup or panel with controls
-inside, and set its pause mode to "When Paused" or "Always" then hide it. By setting the
-root of the pause popup to "When Paused" or "Always", all children and grandchildren will
+inside, and set its pause mode to "When Paused" then hide it. By setting the
+root of the pause popup to "When Paused", all children and grandchildren will
 inherit that state. This way, this branch of the scene tree will continue
 working when paused.
 


### PR DESCRIPTION
In the Pause Mode documentation, in the Pause Menu example, it was still referring to the old "Process" pause mode. I changed it to refer to "When Paused" and "Always" (as both seemed correct to me)

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
