### PR TITLE
Document binary variant decoding/encoding helper

### DIFF
--- a/tutorials/io/binary_serialization_api.rst
+++ b/tutorials/io/binary_serialization_api.rst
@@ -7,10 +7,12 @@ Introduction
 ------------
 
 Godot has a serialization API based on Variant. It's used for
-converting data types to an array of bytes efficiently. This API is used
-in the functions ``get_var`` and ``store_var`` of :ref:`class_FileAccess`
-as well as the packet APIs for :ref:`class_PacketPeer`. This format
-is *not* used for binary scenes and resources.
+converting data types to an array of bytes efficiently. This API is exposed
+via the global :ref:`bytes_to_var() <class_@GlobalScope_method_bytes_to_var>`
+and :ref:`var_to_bytes() <class_@GlobalScope_method_var_to_bytes>` functions,
+but it is also used in the ``get_var`` and ``store_var`` methods of
+:ref:`class_FileAccess` as well as the packet APIs for :ref:`class_PacketPeer`.
+This format is *not* used for binary scenes and resources.
 
 Full Objects vs Object instance IDs
 -----------------------------------


### PR DESCRIPTION
The global scope methods `bytes_to_var` and `var_to_bytes` are lower-level than the previously listed FileAccess/PacketPeer APIs.

Related to https://github.com/godotengine/godot/pull/71572