### PR TITLE
Updated tutorial for new set/get method for Godot4

### DIFF
--- a/tutorials/2d/custom_drawing_in_2d.rst
+++ b/tutorials/2d/custom_drawing_in_2d.rst
@@ -69,13 +69,11 @@ redrawn if modified:
 
     extends Node2D
 
-    export (Texture) var texture setget _set_texture
-
-    func _set_texture(value):
-        # If the texture variable is modified externally,
-        # this callback is called.
-        texture = value  # Texture was changed.
-        queue_redraw()  # Trigger a redraw of the node.
+    @export var texture: Texture:
+        set(value):
+            # Trigger a redraw of the node when texture is set.
+            texture = value
+            queue_redraw()
 
     func _draw():
         draw_texture(texture, Vector2())

--- a/tutorials/best_practices/data_preferences.rst
+++ b/tutorials/best_practices/data_preferences.rst
@@ -237,7 +237,7 @@ tree structures.
     class_name TreeNode
 
     var _parent : TreeNode = null
-    var _children : = [] setget
+    var _children := []
 
     func _notification(p_what):
         match p_what:

--- a/tutorials/best_practices/godot_interfaces.rst
+++ b/tutorials/best_practices/godot_interfaces.rst
@@ -55,7 +55,9 @@ access.
     tool # Must place at top of file.
 
     # Must configure from the editor, defaults to null.
-    export(Script) var const_script setget set_const_script
+    @export var const_script: Script = null:
+        set = set_const_script
+
     func set_const_script(value):
         if Engine.is_editor_hint():
             const_script = value

--- a/tutorials/best_practices/godot_notifications.rst
+++ b/tutorials/best_practices/godot_notifications.rst
@@ -156,7 +156,8 @@ instantiation:
     # "one" is an "initialized value". These DO NOT trigger the setter.
     # If someone set the value as "two" from the Inspector, this would be an
     # "exported value". These DO trigger the setter.
-    export(String) var test = "one" setget set_test
+    @export var test: String = "one":
+        set = set_test
 
     func _init():
         # "three" is an "init assignment value".

--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -181,8 +181,8 @@ run the game, it will spin counter-clockwise.
 Editing variables
 -----------------
 
-Add and export a variable speed to the script. The function set_speed after
-``setget`` is executed with your input to change the variable. Modify
+Add and export a variable speed to the script. Use a custom property ``set``
+method to reset the rotation to zero when speed is assigned a value.  Modify
 ``_process()`` to include the rotation speed.
 
 .. tabs::

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1556,8 +1556,7 @@ won't generate infinite recursion and saves you from explicitly declaring anothe
 This backing member variable is not created if you don't use it.
 
 .. note::
-
-    Unlike ``setget`` in previous Godot versions, the properties setter and getter are **always** called,
+    Unlike ``setget`` in previous Godot versions, ``set`` and ``get`` methods are **always** called,
     even when accessed inside the same class (with or without prefixing with ``self.``). This makes the behavior
     consistent. If you need direct access to the value, use another variable for direct access and make the property
     code use that name.

--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -35,10 +35,13 @@ Here is a complete class example based on these guidelines:
 
     signal state_changed(previous, new)
 
-    export var initial_state = NodePath()
-    var is_active = true setget set_is_active
+    @export var initial_state = NodePath()
+    var is_active = true:
+        set = set_is_active
 
-    @onready var _state = get_node(initial_state) setget set_state
+    @onready var _state = get_node(initial_state):
+        set = set_state
+
     @onready var _state_name = _state.name
 
 
@@ -764,12 +767,11 @@ variables, in that order.
 
    const MAX_LIVES = 3
 
-   export(Jobs) var job = Jobs.KNIGHT
-   export var max_health = 50
-   export var attack = 5
+   @export var job: Jobs = Jobs.KNIGHT
+   @export var max_health = 50
+   @export var attack = 5
 
-   var health = max_health setget set_health
-
+   var health = max_health
    var _speed = 300.0
 
    @onready var sword = get_node("Sword")
@@ -778,7 +780,7 @@ variables, in that order.
 
 .. note::
 
-   The GDScript compiler evaluates onready variables right before the ``_ready``
+   The GDScript compiler evaluates @onready variables right before the ``_ready``
    callback. You can use that to cache node dependencies, that is to say, to get
    child nodes in the scene that your class relies on. This is what the example
    above shows.


### PR DESCRIPTION
Fixes old setget method for tutorials to new set/get in Godot4. 
Addresses issue: https://github.com/godotengine/godot-docs/issues/6265