### PR TITLE
Update Python version requirements on Compiling pages

### DIFF
--- a/contributing/development/code_style_guidelines.rst
+++ b/contributing/development/code_style_guidelines.rst
@@ -263,8 +263,7 @@ Blacken your Python changes using `Black <https://pypi.org/project/black/>`__.
 Using black locally
 ~~~~~~~~~~~~~~~~~~~
 
-First of all, you will need to install black. Black requires Python 3.6.0+
-to run.
+First of all, you will need to install Black. Black requires Python 3.7+ to run.
 
 Installation
 ^^^^^^^^^^^^

--- a/contributing/development/compiling/compiling_for_android.rst
+++ b/contributing/development/compiling/compiling_for_android.rst
@@ -26,19 +26,19 @@ Requirements
 
 For compiling under Windows, Linux or macOS, the following is required:
 
--  `Python 3.5+ <https://www.python.org/downloads/>`_.
--  `SCons 3.0+ <https://scons.org/pages/download.html>`_ build system.
--  `Android SDK <https://developer.android.com/studio/#command-tools>`_
-   (command-line tools are sufficient).
+- `Python 3.6+ <https://www.python.org/downloads/>`_.
+- `SCons 3.0+ <https://scons.org/pages/download.html>`_ build system.
+- `Android SDK <https://developer.android.com/studio/#command-tools>`_
+  (command-line tools are sufficient).
 
-   -  Required SDK components will be automatically installed.
-   -  On Linux,
+   - Required SDK components will be automatically installed.
+   - On Linux,
       **do not use an Android SDK provided by your distribution's repositories as it will often be outdated**.
 
--  Gradle (will be downloaded and installed automatically if missing).
--  JDK 11 (either OpenJDK or Oracle JDK).
+- Gradle (will be downloaded and installed automatically if missing).
+- JDK 11 (either OpenJDK or Oracle JDK).
 
-   -  You can download a build from `ojdkbuild <https://github.com/ojdkbuild/ojdkbuild>`_.
+   - You can download a build from `ojdkbuild <https://github.com/ojdkbuild/ojdkbuild>`_.
 
 .. seealso:: To get the Godot source code for compiling, see
              :ref:`doc_getting_source`.

--- a/contributing/development/compiling/compiling_for_ios.rst
+++ b/contributing/development/compiling/compiling_for_ios.rst
@@ -13,15 +13,29 @@ Compiling for iOS
 Requirements
 ------------
 
--  SCons 3.0+ (you can install it via `Homebrew <https://brew.sh/>`_ or
-   `MacPorts <https://www.macports.org/>`_, you should be able
-   to run ``scons`` in a terminal when installed).
--  Xcode 11.0 (or later) with the iOS (13.0) SDK and the command line tools.
+- `Python 3.6+ <https://www.python.org/downloads/macos/>`_.
+- `SCons 3.0+ <https://scons.org/pages/download.html>`_ build system.
+- `Xcode <https://apps.apple.com/us/app/xcode/id497799835>`_
+  (or the more lightweight Command Line Tools for Xcode).
 
 If you are building the ``master`` branch:
 
 -  Download and follow README instructions to build a static ``.xcframework``
    from the `MoltenVK SDK <https://github.com/KhronosGroup/MoltenVK#fetching-moltenvk-source-code>`__.
+
+.. note:: If you have `Homebrew <https://brew.sh/>`_ installed, you can easily
+          install SCons using the following command::
+
+              brew install scons
+
+          Installing Homebrew will also fetch the Command Line Tools
+          for Xcode automatically if you don't have them already.
+
+          Similarly, if you have `MacPorts <https://www.macports.org/>`_
+          installed, you can easily install SCons using the
+          following command::
+
+              sudo port install scons
 
 .. seealso:: To get the Godot source code for compiling, see
              :ref:`doc_getting_source`.

--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -16,19 +16,19 @@ Requirements
 For compiling under Linux or other Unix variants, the following is
 required:
 
--  GCC 7+ or Clang 6+.
--  Python 3.5+.
--  SCons 3.0+ build system. If your distribution uses Python 2 by default,
-   or you are using a version of SCons prior to 3.1.2, you will need to change
-   the version of Python that SCons uses by changing the shebang (the first line)
-   of the SCons script file to ``#! /usr/bin/python3``.
-   Use the command ``which scons`` to find the location of the SCons script file.
--  pkg-config (used to detect the dependencies below).
--  X11, Xcursor, Xinerama, Xi and XRandR development libraries.
--  MesaGL development libraries.
--  ALSA development libraries.
--  PulseAudio development libraries.
--  *Optional* - libudev (build with ``udev=yes``).
+- GCC 7+ or Clang 6+.
+- Python 3.6+ <https://www.python.org/downloads/>`_.
+- `SCons 3.0+ <https://scons.org/pages/download.html>`_ build system. If your distribution uses Python 2 by default,
+  or you are using a version of SCons prior to 3.1.2, you will need to change
+  the version of Python that SCons uses by changing the shebang (the first line)
+  of the SCons script file to ``#! /usr/bin/python3``.
+  Use the command ``which scons`` to find the location of the SCons script file.
+- pkg-config (used to detect the dependencies below).
+- X11, Xcursor, Xinerama, Xi and XRandR development libraries.
+- MesaGL development libraries.
+- ALSA development libraries.
+- PulseAudio development libraries.
+- *Optional* - libudev (build with ``udev=yes``).
 
 .. seealso:: To get the Godot source code for compiling, see
              :ref:`doc_getting_source`.

--- a/contributing/development/compiling/compiling_for_macos.rst
+++ b/contributing/development/compiling/compiling_for_macos.rst
@@ -15,8 +15,8 @@ Requirements
 
 For compiling under macOS, the following is required:
 
-- `Python 3.5+ <https://www.python.org>`_.
-- `SCons 3.0+ <https://www.scons.org>`_ build system.
+- `Python 3.6+ <https://www.python.org/downloads/macos/>`_.
+- `SCons 3.0+ <https://scons.org/pages/download.html>`_ build system.
 - `Xcode <https://apps.apple.com/us/app/xcode/id497799835>`_
   (or the more lightweight Command Line Tools for Xcode).
 

--- a/contributing/development/compiling/compiling_for_uwp.rst
+++ b/contributing/development/compiling/compiling_for_uwp.rst
@@ -13,13 +13,15 @@ Compiling for Universal Windows Platform
 Requirements
 ------------
 
--  SCons 3.0+ (see :ref:`doc_compiling_for_windows` for more details).
--  Visual Studio 2017 or later. See :ref:`doc_compiling_for_windows` about the
-   caveats of installing it and the various prompts.
--  Windows 10 SDK (can be selected in Visual Studio installation).
--  `ANGLE source <https://github.com/Microsoft/angle>`__. Use the
-   ``ms_master`` (default) branch. Keep it in a path without spaces to
-   avoid problems.
+- `Python 3.6+ <https://www.python.org/downloads/windows/>`_.
+  **Make sure to enable the option to add Python to the ``PATH`` in the installer.**
+- `SCons 3.0+ <https://scons.org/pages/download.html>`_ build system. Using the
+  latest release is recommended, especially for proper support of recent Visual
+  Studio releases.
+- Windows 10 SDK (can be selected in Visual Studio installation).
+- `ANGLE source <https://github.com/Microsoft/angle>`__. Use the
+  ``ms_master`` (default) branch. Keep it in a path without spaces to
+  avoid problems.
 
 .. note:: The ANGLE repo by Microsoft has been discontinued and the
           ``ms_master`` branch has been cleared out.

--- a/contributing/development/compiling/compiling_for_web.rst
+++ b/contributing/development/compiling/compiling_for_web.rst
@@ -15,9 +15,9 @@ Requirements
 
 To compile export templates for the Web, the following is required:
 
--  `Emscripten 1.39.9+ <https://emscripten.org>`__.
--  `Python 3.5+ <https://www.python.org/>`__.
--  `SCons 3.0+ <https://www.scons.org>`__ build system.
+- `Emscripten 1.39.9+ <https://emscripten.org>`__.
+- `Python 3.6+ <https://www.python.org/>`__.
+- `SCons 3.0+ <https://scons.org/pages/download.html>`__ build system.
 
 .. seealso:: To get the Godot source code for compiling, see
              :ref:`doc_getting_source`.

--- a/contributing/development/compiling/compiling_for_windows.rst
+++ b/contributing/development/compiling/compiling_for_windows.rst
@@ -22,10 +22,11 @@ For compiling under Windows, the following is required:
 - `MinGW-w64 <http://mingw-w64.org/>`_ with GCC can be used as an alternative to
   Visual Studio. Be sure to install/configure it to use the ``posix`` thread model.
   **Important:** When using MinGW to compile the ``master`` branch, you need GCC 9 or later.
-- `Python 3.5+ <https://www.python.org/downloads/windows/>`_.
+- `Python 3.6+ <https://www.python.org/downloads/windows/>`_.
   **Make sure to enable the option to add Python to the ``PATH`` in the installer.**
-- `SCons <https://www.scons.org/>`_ build system. Using the latest release is
-  recommended, especially for proper support of recent Visual Studio releases.
+- `SCons 3.0+ <https://scons.org/pages/download.html>`_ build system. Using the
+  latest release is recommended, especially for proper support of recent Visual
+  Studio releases.
 
 .. note:: If you have `Scoop <https://scoop.sh/>`_ installed, you can easily
           install MinGW and other dependencies using the following command::


### PR DESCRIPTION
The `master` branch has required Python 3.6 to be compiled for a few years now.

This also makes the text more consistent across platforms.
