### PR TITLE
Update Sublime Text external editor arguments

### DIFF
--- a/tutorials/editor/external_editor.rst
+++ b/tutorials/editor/external_editor.rst
@@ -35,7 +35,7 @@ Some example Exec Flags for various editors include:
 +=====================+=====================================================+
 | Geany/Kate          | ``{file} --line {line} --column {col}``             |
 +---------------------+-----------------------------------------------------+
-| Atom/Sublime Text   | ``{file}:{line}``                                   |
+| Atom                | ``{file}:{line}``                                   |
 +---------------------+-----------------------------------------------------+
 | JetBrains Rider     | ``{project} --line {line} {file}``                  |
 +---------------------+-----------------------------------------------------+
@@ -44,6 +44,8 @@ Some example Exec Flags for various editors include:
 | Vim (gVim)          | ``"+call cursor({line}, {col})" {file}``            |
 +---------------------+-----------------------------------------------------+
 | Emacs               | ``emacs +{line}:{col} {file}``                      |
++---------------------+-----------------------------------------------------+
+| Sublime Text        | ``{project} {file}:{line}:{column}``                |
 +---------------------+-----------------------------------------------------+
 
 .. note:: For Visual Studio Code on Windows, you will have to point to the ``code.cmd``


### PR DESCRIPTION
Sublime Text now supports expanded command line arguments for opening project/files.

Sublime docs: https://www.sublimetext.com/docs/command_line.html

I have tested these arguments using Godot Mono 4.0 beta 14 and Sublime Text 4143.