### PR TITLE
Removed outdated documentation in C# Basics Page

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -98,7 +98,6 @@ After reading the "Prerequisites" section, you can download and install
 In Godot's **Editor → Editor Settings** menu:
 
 - Set **Mono** -> **Editor** -> **External Editor** to **JetBrains Rider**.
-- Set **Mono** -> **Builds** -> **Build Tool** to **dotnet CLI**.
 
 In Rider:
 
@@ -114,7 +113,6 @@ After reading the "Prerequisites" section, you can download and install
 In Godot's **Editor → Editor Settings** menu:
 
 - Set **Mono** -> **Editor** -> **External Editor** to **Visual Studio Code**.
-- Set **Mono** -> **Builds** -> **Build Tool** to **dotnet CLI**.
 
 In Visual Studio Code:
 
@@ -150,7 +148,6 @@ While installing Visual Studio, select these workloads:
 In Godot's **Editor → Editor Settings** menu:
 
 - Set **Mono** -> **Editor** -> **External Editor** to **Visual Studio**.
-- Set **Mono** -> **Builds** -> **Build Tool** to **dotnet CLI**.
 
 Next, you can download the Godot Visual Studio extension from github
 `here <https://github.com/godotengine/godot-csharp-visualstudio/releases>`__.


### PR DESCRIPTION
Resolves #6610 

Removed the _"Set Mono -> Builds -> Build Tool to dotnet CLI"_  lines since there is no _build tool_ setting in Godot 4.0

Page Updated: https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/c_sharp_basics.html

