### PR TITLE
Document using Pyston-lite for faster builds on macOS

### DIFF
--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -284,3 +284,10 @@ to get even faster builds.
 
 If you can't run ``pyston-scons`` after creating the symbolic link,
 make sure ``$HOME/.local/bin/`` is part of your user's ``PATH`` environment variable.
+
+.. note::
+
+    Alternatively, you can run ``python -m pip install pyston_lite_autoload``
+    then run SCons as usual. This will automatically load a subset of Pyston's
+    optimizations in any Python program you run. However, this won't bring as
+    much of a performance improvement compared to installing "full" Pyston.

--- a/contributing/development/compiling/compiling_for_macos.rst
+++ b/contributing/development/compiling/compiling_for_macos.rst
@@ -172,6 +172,22 @@ template from the official Godot distribution::
 
     zip -q -9 -r macos.zip macos_template.app
 
+Using Pyston for faster development
+-----------------------------------
+
+You can use `Pyston <https://www.pyston.org/>`__ to run SCons. Pyston is a
+JIT-enabled implementation of the Python language (which SCons is written in).
+Its "full" version is currently only compatible with Linux, but Pyston-lite is
+also compatible with macOS (both x86 and ARM). Pyston can speed up incremental
+builds significantly, often by a factor between 1.5× and 2×. Pyston can be
+combined with alternative likers such as LLD or Mold to get even faster builds.
+
+To install Pyston-lite, run ``python -m pip install pyston_lite_autoload`` then
+run SCons as usual. This will automatically load a subset of Pyston's
+optimizations in any Python program you run. However, this won't bring as much
+of a performance improvement compared to installing "full" Pyston (which
+currently can't be done on macOS).
+
 Cross-compiling for macOS from Linux
 ------------------------------------
 


### PR DESCRIPTION
I've tested this on a 2020 Mac mini (M1) and can confirm it works.

See https://github.com/pyston/pyston/issues/16.
