### PR TITLE
Specify `Input Devices` as an Advanced Setting in Project Settings

### DIFF
--- a/tutorials/inputs/input_examples.rst
+++ b/tutorials/inputs/input_examples.rst
@@ -395,6 +395,7 @@ a mouse click event, and :ref:`InputEventScreenDrag <class_InputEventScreenDrag>
 works much the same as mouse motion.
 
 .. tip:: To test your touch events on a non-touchscreen device, open Project
-        Settings and go to the "Input Devices/Pointing" section. Enable "Emulate
-        Touch From Mouse" and your project will interpret mouse clicks and
+        Settings, go to the "General" tab, turn the "Advanced Settings" toggle 
+        in the top right of the window on, and go to the "Input Devices/Pointing" 
+        section. Enable "Emulate Touch From Mouse" and your project will interpret mouse clicks and
         motion as touch events.


### PR DESCRIPTION
After reading this page, I was unable to find the "Input Devices/Pointing" section at first as it's hidden behind the "Advanced Settings" toggle in my version of the editor (version `v4.0.beta14.mono.official [28a24639c]`). This makes it explicit that you need to turn on Advanced settings to access the section.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
