### PR TITLE
Fix CameraPivot rotation in Moving the player with code

### DIFF
--- a/getting_started/first_3d_game/03.player_movement_code.rst
+++ b/getting_started/first_3d_game/03.player_movement_code.rst
@@ -375,7 +375,7 @@ one).
 
 |image7|
 
-Here's where the magic happens. Select the *CameraPivot* and rotate it ``45``
+Here's where the magic happens. Select the *CameraPivot* and rotate it ``-45``
 degrees around the X axis (using the red circle). You'll see the camera move as
 if it was attached to a crane.
 


### PR DESCRIPTION
CameraPivot should be rotated -45 degrees instead of 45 degrees in order to produce the results demonstrated in the screenshots. Otherwise, the camera will be pointing upwards instead of downwards.

Change has already been made in the [master branch](https://github.com/godotengine/godot-docs/blob/master/getting_started/first_3d_game/03.player_movement_code.rst).
