### PR TITLE
Remove most mentions of SCons `-j` parameter as it's now set automatically

### DIFF
--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -107,25 +107,7 @@ Start a terminal, go to the root dir of the engine source code and type:
 
 ::
 
-    scons -j8 platform=linuxbsd
-
-A good rule of thumb for the ``-j`` (*jobs*) flag, is to have at least as many
-threads compiling Godot as you have cores in your CPU, if not one or two more.
-Feel free to add the ``-j`` option to any SCons command you see below.
-
-You can automatically use all available CPU cores with command substitution.
-
-On Linux, you can use ``nproc``:
-
-::
-
-    scons -j$(nproc)
-
-On \*BSD, you can use ``sysctl -n hw.ncpu``:
-
-::
-
-    scons -j$(sysctl -n hw.ncpu)
+    scons platform=linuxbsd
 
 .. note::
 
@@ -169,7 +151,7 @@ Running a headless/server build
 To run in *headless* mode which provides editor functionality to export
 projects in an automated manner, use the normal build::
 
-    scons -j8 platform=linuxbsd target=editor
+    scons platform=linuxbsd target=editor
 
 And then use the ``--headless`` command line argument::
 
@@ -178,12 +160,12 @@ And then use the ``--headless`` command line argument::
 To compile a debug *server* build which can be used with
 :ref:`remote debugging tools <doc_command_line_tutorial>`, use::
 
-    scons -j8 platform=linuxbsd target=template_debug
+    scons platform=linuxbsd target=template_debug
 
 To compile a *server* build which is optimized to run dedicated game servers,
 use::
 
-    scons -j8 platform=linuxbsd target=template_release production=yes
+    scons platform=linuxbsd target=template_release production=yes
 
 Building export templates
 -------------------------

--- a/contributing/development/compiling/compiling_for_macos.rst
+++ b/contributing/development/compiling/compiling_for_macos.rst
@@ -54,11 +54,11 @@ Start a terminal, go to the root directory of the engine source code.
 
 To compile for Intel (x86-64) powered Macs, use::
 
-    scons platform=macos arch=x86_64 --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=macos arch=x86_64
 
 To compile for Apple Silicon (ARM64) powered Macs, use::
 
-    scons platform=macos arch=arm64 --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=macos arch=arm64
 
 To support both architectures in a single "Universal 2" binary, run the above two commands and then use ``lipo`` to bundle them together::
 
@@ -100,7 +100,7 @@ Running a headless/server build
 To run in *headless* mode which provides editor functionality to export
 projects in an automated manner, use the normal build::
 
-    scons platform=macos target=editor --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=macos target=editor
 
 And then use the ``--headless`` command line argument::
 
@@ -109,12 +109,12 @@ And then use the ``--headless`` command line argument::
 To compile a debug *server* build which can be used with
 :ref:`remote debugging tools <doc_command_line_tutorial>`, use::
 
-    scons platform=macos target=template_debug --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=macos target=template_debug
 
 To compile a release *server* build which is optimized to run dedicated game servers,
 use::
 
-    scons platform=macos target=template_release production=yes --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=macos target=template_release production=yes
 
 Building export templates
 -------------------------
@@ -129,13 +129,13 @@ of those two architectures by leaving out the ``lipo`` step below.
 
 - For Intel x86_64::
 
-    scons platform=macos target=template_release arch=x86_64 --jobs=$(sysctl -n hw.logicalcpu)
-    scons platform=macos target=template_debug arch=x86_64 --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=macos target=template_release arch=x86_64
+    scons platform=macos target=template_debug arch=x86_64
 
 - For ARM64 (Apple M1)::
 
-    scons platform=macos target=template_release arch=arm64 --jobs=$(sysctl -n hw.logicalcpu)
-    scons platform=macos target=template_debug arch=arm64 --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=macos target=template_release arch=arm64
+    scons platform=macos target=template_debug arch=arm64
 
 To support both architectures in a single "Universal 2" binary, run the above
 two commands blocks and then use ``lipo`` to bundle them together::

--- a/contributing/development/compiling/compiling_for_windows.rst
+++ b/contributing/development/compiling/compiling_for_windows.rst
@@ -136,14 +136,6 @@ the engine source code (using ``cd``) and type::
 
     C:\godot> scons platform=windows
 
-You can specify a number of CPU threads to use to speed up the build::
-
-    C:\godot> scons -j6 platform=windows
-
-In general, it is OK to have at least as many threads compiling Godot as you
-have cores in your CPU, if not one or two more. Feel free to add the ``-j``
-option to any SCons command you see below.
-
 .. note:: When compiling with multiple CPU threads, SCons may warn about
           pywin32 being missing. You can safely ignore this warning.
 

--- a/contributing/development/compiling/introduction_to_the_buildsystem.rst
+++ b/contributing/development/compiling/introduction_to_the_buildsystem.rst
@@ -81,16 +81,17 @@ To build for a platform (for example, ``linuxbsd``), run with the ``platform=``
 
     scons platform=linuxbsd
 
-This will start the build process, which will take a while. If you want
-SCons to build faster, use the ``-j <cores>`` parameter to specify how many
-cores will be used for the build. Or leave it using one core, so you
-can use your computer for something else :)
+This will start the build process, which will take a while. By default, Godot's
+SCons setup is configured to use all CPU threads but one (to keep the system
+responsive during compilation). If you want to adjust how many CPU threads SCons
+will use, use the ``-j <threads>`` parameter to specify how many threads will be
+used for the build.
 
-Example for using 4 cores:
+Example for using 4 threads:
 
 ::
 
-    scons platform=linuxbsd -j 4
+    scons platform=linuxbsd -j4
 
 .. _doc_introduction_to_the_buildsystem_resulting_binary:
 
@@ -291,8 +292,8 @@ Using the SCONSFLAGS
 ``SCONSFLAGS`` is an environment variable which is used by the SCons to set the
 options automatically without having to supply them via the command line.
 
-For instance, you may want to build Godot in parallel with the aforementioned
-``-j`` option for all the future builds:
+For instance, you may want to force a number of CPU threads with the
+aforementioned ``-j`` option for all future builds:
 
 .. tabs::
  .. code-tab:: bash Linux/macOS

--- a/contributing/development/configuring_an_ide/clion.rst
+++ b/contributing/development/configuring_an_ide/clion.rst
@@ -45,7 +45,7 @@ To add a custom build target that invokes SCons for compilation:
 
 - Give the tool a name, e.g. ``Build Godot debug``, set **Program** to ``scons``, set **Arguments** to the compilation settings you want (see :ref:`compiling Godot <toc-devel-compiling>`), and set the **Working directory** to ``$ProjectFileDir$``, which equals the Godot root directory. Click **OK** to create the tool.
 
-   .. note:: CLion does not expand shell commands like ``scons -j$(nproc)``. Use concrete values instead, e.g. ``scons -j8``
+   .. note:: CLion does not expand shell commands like ``scons -j$(nproc)``. Use concrete values instead, e.g. ``scons -j8``.
 
 .. figure:: img/clion-create-build-tool.png
    :align: center

--- a/contributing/development/configuring_an_ide/visual_studio_code.rst
+++ b/contributing/development/configuring_an_ide/visual_studio_code.rst
@@ -30,7 +30,7 @@ Importing the project
 
 .. figure:: img/vscode_create_tasksjson_others.png
    :align: center
- 
+
 - If there is no such option as **Create tasks.json file from template** available, either delete the file if it already exists in your folder or create a ``.vscode/tasks.json`` file manually. See `Tasks in Visual Studio Code <https://code.visualstudio.com/docs/editor/tasks#_custom-tasks>`_ for more details on tasks.
 
 - Within the ``tasks.json`` file find the ``"tasks"`` array and add a new section to it:
@@ -44,8 +44,6 @@ Importing the project
       "type": "shell",
       "command": "scons",
       "args": [
-        "-j",
-        "$(nproc)",
         // enable for debugging with breakpoints
         "dev_build=yes",
       ],
@@ -60,10 +58,6 @@ Importing the project
       "type": "shell",
       "command": "scons",
       "args": [
-        // Use this when your default shell is Command Prompt (cmd.exe).
-        "-j %NUMBER_OF_PROCESSORS%",
-        // Use this when your default shell is PowerShell.
-        "-j $env:NUMBER_OF_PROCESSORS",
         "dev_build=yes",
       ],
       "problemMatcher": "$msCompile"


### PR DESCRIPTION
The Introduction to the buildsystem page still mentions this parameter
in case it needs to be changed, but in most situations, the default
value of `(number of CPU threads) - 1` does a good job.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
