### PR TITLE
Remove most mentions of SCons `-j` parameter as it's now set automatically

### DIFF
--- a/development/compiling/compiling_for_osx.rst
+++ b/development/compiling/compiling_for_osx.rst
@@ -48,11 +48,11 @@ Start a terminal, go to the root directory of the engine source code.
 
 To compile for Intel (x86-64) powered Macs, use::
 
-    scons platform=osx arch=x86_64 --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=osx arch=x86_64
 
 To compile for Apple Silicon (ARM64) powered Macs, use::
 
-    scons platform=osx arch=arm64 --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=osx arch=arm64
 
 To support both architectures in a single "Universal 2" binary, run the above two commands and then use ``lipo`` to bundle them together::
 
@@ -83,17 +83,17 @@ Compiling a headless/server build
 To compile a *headless* build which provides editor functionality to export
 projects in an automated manner, use::
 
-    scons platform=server tools=yes target=release_debug --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=server tools=yes target=release_debug
 
 To compile a debug *server* build which can be used with
 :ref:`remote debugging tools <doc_command_line_tutorial>`, use::
 
-    scons platform=server tools=no target=release_debug --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=server tools=no target=release_debug
 
 To compile a release *server* build which is optimized to run dedicated game servers,
 use::
 
-    scons platform=server tools=no target=release --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=server tools=no target=release
 
 Building export templates
 -------------------------
@@ -108,13 +108,13 @@ of those two architectures by leaving out the ``lipo`` step below.
 
 - For Intel x86_64::
 
-    scons platform=osx tools=no target=release arch=x86_64 --jobs=$(sysctl -n hw.logicalcpu)
-    scons platform=osx tools=no target=release_debug arch=x86_64 --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=osx tools=no target=release arch=x86_64
+    scons platform=osx tools=no target=release_debug arch=x86_64
 
 - For ARM64 (Apple M1)::
 
-    scons platform=osx tools=no target=release arch=arm64 --jobs=$(sysctl -n hw.logicalcpu)
-    scons platform=osx tools=no target=release_debug arch=arm64 --jobs=$(sysctl -n hw.logicalcpu)
+    scons platform=osx tools=no target=release arch=arm64
+    scons platform=osx tools=no target=release_debug arch=arm64
 
 To support both architectures in a single "Universal 2" binary, run the above
 two commands blocks and then use ``lipo`` to bundle them together::

--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -134,14 +134,6 @@ the engine source code (using ``cd``) and type::
 
     C:\godot> scons platform=windows
 
-You can specify a number of CPU threads to use to speed up the build::
-
-    C:\godot> scons -j6 platform=windows
-
-In general, it is OK to have at least as many threads compiling Godot as you
-have cores in your CPU, if not one or two more. Feel free to add the ``-j``
-option to any SCons command you see below.
-
 .. note:: When compiling with multiple CPU threads, SCons may warn about
           pywin32 being missing. You can safely ignore this warning.
 

--- a/development/compiling/compiling_for_x11.rst
+++ b/development/compiling/compiling_for_x11.rst
@@ -106,11 +106,7 @@ Start a terminal, go to the root dir of the engine source code and type:
 
 ::
 
-    scons -j8 platform=x11
-
-A good rule of thumb for the ``-j`` (*jobs*) flag, is to have at least as many
-threads compiling Godot as you have cores in your CPU, if not one or two more.
-Feel free to add the ``-j`` option to any SCons command you see below.
+    scons platform=x11
 
 If all goes well, the resulting binary executable will be placed in the
 "bin" subdirectory. This executable file contains the whole engine and
@@ -148,17 +144,17 @@ Compiling a headless/server build
 To compile a *headless* build which provides editor functionality to export
 projects in an automated manner, use::
 
-    scons -j8 platform=server tools=yes target=release_debug
+    scons platform=server tools=yes target=release_debug
 
 To compile a debug *server* build which can be used with
 :ref:`remote debugging tools <doc_command_line_tutorial>`, use::
 
-    scons -j8 platform=server tools=no target=release_debug
+    scons platform=server tools=no target=release_debug
 
 To compile a *server* build which is optimized to run dedicated game servers,
 use::
 
-    scons -j8 platform=server tools=no target=release
+    scons platform=server tools=no target=release
 
 Building export templates
 -------------------------

--- a/development/compiling/introduction_to_the_buildsystem.rst
+++ b/development/compiling/introduction_to_the_buildsystem.rst
@@ -81,12 +81,13 @@ To build for a platform (for example, x11), run with the ``platform=`` (or
 
     scons platform=x11
 
-This will start the build process, which will take a while. If you want
-SCons to build faster, use the ``-j <cores>`` parameter to specify how many
-cores will be used for the build. Or leave it using one core, so you
-can use your computer for something else :)
+This will start the build process, which will take a while. By default, Godot's
+SCons setup is configured to use all CPU threads but one (to keep the system
+responsive during compilation). If you want to adjust how many CPU threads SCons
+will use, use the ``-j <threads>`` parameter to specify how many threads will be
+used for the build.
 
-Example for using 4 cores:
+Example for using 4 threads:
 
 ::
 
@@ -294,8 +295,8 @@ Using the SCONSFLAGS
 ``SCONSFLAGS`` is an environment variable which is used by the SCons to set the
 options automatically without having to supply them via the command line.
 
-For instance, you may want to build Godot in parallel with the aforementioned
-``-j`` option for all the future builds:
+For instance, you may want to force a number of CPU threads with the
+aforementioned ``-j`` option for all future builds:
 
 .. tabs::
  .. code-tab:: bash Linux/macOS

--- a/development/cpp/configuring_an_ide/visual_studio_code.rst
+++ b/development/cpp/configuring_an_ide/visual_studio_code.rst
@@ -33,33 +33,13 @@ Importing the project
 
 - Within the ``tasks.json`` file find the ``"tasks"`` array and add a new section to it:
 
-.. tabs::
-  .. code-tab:: js Linux/X11
+.. code-block:: js
 
     {
       "label": "build",
       "group": "build",
       "type": "shell",
       "command": "scons",
-      "args": [
-        "-j $(nproc)"
-      ],
-      "problemMatcher": "$msCompile"
-    }
-
-  .. code-tab:: js Windows
-
-    {
-      "label": "build",
-      "group": "build",
-      "type": "shell",
-      "command": "scons",
-      "args": [
-        // Use this when your default shell is Command Prompt (cmd.exe).
-        "-j %NUMBER_OF_PROCESSORS%",
-        // Use this when your default shell is PowerShell.
-        "-j $env:NUMBER_OF_PROCESSORS"
-      ],
       "problemMatcher": "$msCompile"
     }
 


### PR DESCRIPTION
`3.6` version of https://github.com/godotengine/godot-docs/pull/6658.

The Introduction to the buildsystem page still mentions this parameter in case it needs to be changed, but in most situations, the default value of `(number of CPU threads) - 1` does a good job.
