### PR TITLE
C#: Add table with equivalent Dictionary methods

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_differences.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_differences.rst
@@ -506,6 +506,7 @@ values                   Values
 operator !=              !RecursiveEqual
 operator ==              RecursiveEqual
 operator []              Dictionary[Variant] indexer, Add or TryGetValue
+======================= ==============================================================
 
 Variant
 -------

--- a/tutorials/scripting/c_sharp/c_sharp_differences.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_differences.rst
@@ -506,7 +506,7 @@ values                   Values
 operator !=              !RecursiveEqual
 operator ==              RecursiveEqual
 operator []              Dictionary[Variant] indexer, Add or TryGetValue
-======================= ==============================================================
+=======================  ==============================================================
 
 Variant
 -------

--- a/tutorials/scripting/c_sharp/c_sharp_differences.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_differences.rst
@@ -483,6 +483,30 @@ Use ``Godot.Collections.Dictionary``.
 ``Godot.Collections.Dictionary<T>`` is a type-safe wrapper around ``Godot.Collections.Dictionary``.
 Use the ``Godot.Collections.Dictionary<T>(Godot.Collections.Dictionary)`` constructor to create one.
 
+List of Godot's Dictionary methods and their equivalent in C#:
+
+=======================  ==============================================================
+GDScript                 C#
+=======================  ==============================================================
+clear                    Clear
+duplicate                Duplicate
+erase                    Remove
+find_key                 N/A
+get                      Dictionary[Variant] indexer or TryGetValue
+has                      ContainsKey
+has_all                  N/A
+hash                     GD.Hash
+is_empty                 Use ``Count == 0``
+is_read_only             IsReadOnly
+keys                     Keys
+make_read_only           MakeReadOnly
+merge                    Merge
+size                     Count
+values                   Values
+operator !=              !RecursiveEqual
+operator ==              RecursiveEqual
+operator []              Dictionary[Variant] indexer, Add or TryGetValue
+
 Variant
 -------
 


### PR DESCRIPTION
- Follow up to https://github.com/godotengine/godot/pull/71984.
- Adds a table with the list of C# methods that are equivalent to the methods in Godot's Dictionary to make it easier to users to port from GDScript and find which APIs are available.