### PR TITLE
Add `--print-filenames` option to GDScript unit testing

### DIFF
--- a/contributing/development/core_and_modules/unit_testing.rst
+++ b/contributing/development/core_and_modules/unit_testing.rst
@@ -336,7 +336,7 @@ the crash and debug from there.
 
        ./bin/<godot_binary> --test --test-suite="*GDScript*"
 
-Also accepts the ``--print-filenames`` option. See above.
+This also accepts the ``--print-filenames`` option (see above).
 
 If no errors are printed and everything goes well, you're done!
 

--- a/contributing/development/core_and_modules/unit_testing.rst
+++ b/contributing/development/core_and_modules/unit_testing.rst
@@ -325,11 +325,18 @@ Therefore, the process of writing integration tests for GDScript is the followin
 
        ./bin/<godot_binary> --gdscript-generate-tests godot-source/modules/gdscript/tests/scripts
 
+You may add the ``--print-filenames`` option to see filenames as their test
+outputs are generated. If you are working on a new feature that is causing
+hard crashes, you can use this option to quickly find which test file causes
+the crash and debug from there.
+
 4. Run GDScript tests with:
 
    .. code-block:: shell
 
        ./bin/<godot_binary> --test --test-suite="*GDScript*"
+
+Also accepts the ``--print-filenames`` option. See above.
 
 If no errors are printed and everything goes well, you're done!
 


### PR DESCRIPTION
Added documentation for the `--print-filenames` option in GDScript unit testing from https://github.com/godotengine/godot/pull/72212.

Haven't done .rst before so hopefully this checks out :)

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
