### PR TITLE
Fix wrong registration method names for 3D gizmo plugins

### DIFF
--- a/tutorials/plugins/editor/3d_gizmos.rst
+++ b/tutorials/plugins/editor/3d_gizmos.rst
@@ -49,11 +49,11 @@ This would be a basic setup:
 
 
     func _enter_tree():
-        add_node3d_gizmo_plugin(gizmo_plugin)
+        add_node_3d_gizmo_plugin(gizmo_plugin)
 
 
     func _exit_tree():
-        remove_node3d_gizmo_plugin(gizmo_plugin)
+        remove_node_3d_gizmo_plugin(gizmo_plugin)
 
 
 For simple gizmos, inheriting :ref:`EditorNode3DGizmoPlugin <class_EditorNode3DGizmoPlugin>`


### PR DESCRIPTION
As mentioned here https://github.com/godotengine/godot-docs/issues/6716 add/remove_node3d_gizmo_plugin is the wrong method name. But i'm not sure if it intentionally changed to add/remove_node_3d_gizmo_plugin. Here are the adjustments anway in case it is intentional and going to stay that way.

_Closes https://github.com/godotengine/godot-docs/issues/6716_
