### PR TITLE
Clarify ternary operator in the style guide

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -318,7 +318,7 @@ The only exception to that rule is the ternary operator:
 
 ::
 
-   next_state = "fall" if not is_on_floor() else "idle"
+   next_state = "idle" if is_on_floor() else "fall"
 
 Format multiline statements for readability
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
In the current style guide, the example for ternary operators includes a `not` in the conditional which is the same text color as the preceding `if` giving the impression that the format for a ternary operation is `[some_value] if not [condition] else [other_value]` which is incorrect, and may be confusing to figure out. I'm new to Godot and I've never used python (which I understand GDScript is based on). My only experience is with c# which I don't believe has a `not` keyword so I was quite confused by this.

This change would remove `not` from the condition to eliminate confusion, and rearrange the values to keep the meaning of the example code the same. Any alternative that removes the `not` would also work.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
