### PR TITLE
small c# fix in the "Arc polygon function" section

### DIFF
--- a/tutorials/2d/custom_drawing_in_2d.rst
+++ b/tutorials/2d/custom_drawing_in_2d.rst
@@ -336,7 +336,7 @@ the same as before, except that we draw a polygon instead of lines:
         var colors = PackedColorArray([color])
 
         for i in range(nb_points + 1):
-            var angle_point = deg2rad(angle_from + i * (angle_to - angle_from) / nb_points - 90)
+            var angle_point = deg_to_rad(angle_from + i * (angle_to - angle_from) / nb_points - 90)
             points_arc.push_back(center + Vector2(cos(angle_point), sin(angle_point)) * radius)
         draw_polygon(points_arc, colors)
 
@@ -345,14 +345,14 @@ the same as before, except that we draw a polygon instead of lines:
     public void DrawCircleArcPoly(Vector2 center, float radius, float angleFrom, float angleTo, Color color)
     {
         int nbPoints = 32;
-        var pointsArc = new Vector2[nbPoints + 1];
+        var pointsArc = new Vector2[nbPoints + 2];
         pointsArc[0] = center;
         var colors = new Color[] { color };
 
         for (int i = 1; i <= nbPoints; i++)
         {
-            float anglePoint = Mathf.Deg2Rad(angleFrom + i * (angleTo - angleFrom) / nbPoints - 90);
-            pointsArc[i] = center + new Vector2(Mathf.Cos(anglePoint), Mathf.Sin(anglePoint)) * radius;
+            float anglePoint = Mathf.DegToRad(angleFrom + i * (angleTo - angleFrom) / nbPoints - 90);
+            pointsArc[i+1] = center + new Vector2(Mathf.Cos(anglePoint), Mathf.Sin(anglePoint)) * radius;
         }
 
         DrawPolygon(pointsArc, colors);

--- a/tutorials/2d/custom_drawing_in_2d.rst
+++ b/tutorials/2d/custom_drawing_in_2d.rst
@@ -349,7 +349,7 @@ the same as before, except that we draw a polygon instead of lines:
         pointsArc[0] = center;
         var colors = new Color[] { color };
 
-        for (int i = 0; i <= nbPoints; i++)
+        for (int i = 1; i <= nbPoints; i++)
         {
             float anglePoint = Mathf.Deg2Rad(angleFrom + i * (angleTo - angleFrom) / nbPoints - 90);
             pointsArc[i] = center + new Vector2(Mathf.Cos(anglePoint), Mathf.Sin(anglePoint)) * radius;

--- a/tutorials/2d/custom_drawing_in_2d.rst
+++ b/tutorials/2d/custom_drawing_in_2d.rst
@@ -352,7 +352,7 @@ the same as before, except that we draw a polygon instead of lines:
         for (int i = 0; i <= nbPoints; i++)
         {
             float anglePoint = Mathf.DegToRad(angleFrom + i * (angleTo - angleFrom) / nbPoints - 90);
-            pointsArc[i+1] = center + new Vector2(Mathf.Cos(anglePoint), Mathf.Sin(anglePoint)) * radius;
+            pointsArc[i + 1] = center + new Vector2(Mathf.Cos(anglePoint), Mathf.Sin(anglePoint)) * radius;
         }
 
         DrawPolygon(pointsArc, colors);

--- a/tutorials/2d/custom_drawing_in_2d.rst
+++ b/tutorials/2d/custom_drawing_in_2d.rst
@@ -349,7 +349,7 @@ the same as before, except that we draw a polygon instead of lines:
         pointsArc[0] = center;
         var colors = new Color[] { color };
 
-        for (int i = 1; i <= nbPoints; i++)
+        for (int i = 0; i <= nbPoints; i++)
         {
             float anglePoint = Mathf.DegToRad(angleFrom + i * (angleTo - angleFrom) / nbPoints - 90);
             pointsArc[i+1] = center + new Vector2(Mathf.Cos(anglePoint), Mathf.Sin(anglePoint)) * radius;


### PR DESCRIPTION
i needs to start at 1 so "pointsArc[0] = center;" is not overridden

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
