### PR TITLE
Add C# type test example (pattern matching)

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_features.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_features.rst
@@ -81,11 +81,8 @@ otherwise it returns true. Note that using the ``is`` operator against ``null`` 
         // This block can never happen.
     }
 
-**Type test with variable declaration**
-
-You can use `Pattern Matching <https://docs.microsoft.com/en-us/dotnet/csharp/pattern-matching>`_
-to check if the node can be cast to Sprite2D, and if so, store the result in a
-new variable.
+You can add a variable declaration to conditionally store the result of the cast
+if the ``is`` operator returns true.
 
 .. code-block:: csharp
 
@@ -94,6 +91,9 @@ new variable.
         // The mySprite variable only exists inside this block, and it's never null.
         mySprite.SetFrame(0);
     }
+
+For more advanced type checking, you can look into `Pattern Matching <https://docs.microsoft.com/en-us/dotnet/csharp/pattern-matching>`_.
+
 
 Preprocessor defines
 --------------------

--- a/tutorials/scripting/c_sharp/c_sharp_features.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_features.rst
@@ -81,8 +81,8 @@ otherwise it returns true. Note that using the ``is`` operator against ``null`` 
         // This block can never happen.
     }
 
-You can add a variable declaration to conditionally store the result of the cast
-if the ``is`` operator returns true.
+You can also declare a new variable to conditionally store the result of the cast
+if the ``is`` operator returns ``true``.
 
 .. code-block:: csharp
 

--- a/tutorials/scripting/c_sharp/c_sharp_features.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_features.rst
@@ -81,8 +81,19 @@ otherwise it returns true. Note that using the ``is`` operator against ``null`` 
         // This block can never happen.
     }
 
-For more advanced type checking, you can look into `Pattern Matching <https://docs.microsoft.com/en-us/dotnet/csharp/pattern-matching>`_.
+**Type test with variable declaration**
 
+You can use `Pattern Matching <https://docs.microsoft.com/en-us/dotnet/csharp/pattern-matching>`_
+to check if the node can be cast to Sprite2D, and if so, store the result in a
+new variable.
+
+.. code-block:: csharp
+
+    if (GetNode("MySprite") is Sprite2D mySprite)
+    {
+        // The mySprite variable only exists inside this block, and it's never null.
+        mySprite.SetFrame(0);
+    }
 
 Preprocessor defines
 --------------------


### PR DESCRIPTION
Add a simple example, `GetNode("MySprite") is Sprite2D mySprite`. This is a very common suggestion in the C# Discord channel and quite popular in modern C#, and adding it to the doc makes the doc much more useful as a reference.

It happens a lot that someone sends a link to this page, but also has to mention "and if you use `is Foo f`, then it's even better for this situation!"

There's more text that could be added to this section explaining how it works, maybe analogizing to `as`+`if not null` or explicitly describing how it relates to the `is` section earlier. But I think it's good enough to have a brief description, an example, and keep the C# doc link to point anyone who wants more info in the right direction.