### PR TITLE
C#: Replace "falsy" with "false" in C# "is" doc

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_features.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_features.rst
@@ -67,8 +67,8 @@ Generic methods are also provided to make this type conversion transparent.
 
 To check if the node can be cast to Sprite2D, you can use the ``is`` operator.
 The ``is`` operator returns false if the node cannot be cast to Sprite2D,
-otherwise it returns true. Note that using the ``is`` operator against ``null``
-always returns ``false``.
+otherwise it returns true. Note that when the ``is`` operator is used against ``null``
+the result is always going to be ``false``.
 
 .. code-block:: csharp
 

--- a/tutorials/scripting/c_sharp/c_sharp_features.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_features.rst
@@ -67,7 +67,8 @@ Generic methods are also provided to make this type conversion transparent.
 
 To check if the node can be cast to Sprite2D, you can use the ``is`` operator.
 The ``is`` operator returns false if the node cannot be cast to Sprite2D,
-otherwise it returns true. Note that using the ``is`` operator against ``null`` is always going to be falsy.
+otherwise it returns true. Note that using the ``is`` operator against ``null``
+always returns ``false``.
 
 .. code-block:: csharp
 


### PR DESCRIPTION
We know that the result of `null is Foo` is `false`, not something false-like, so we might as well be specific.

I hadn't seen "falsy" used to describe anything in C# before seeing this doc. I chatted with @paulloz (who added the line) and apparently it's used conversationally, but @paulloz agrees the doc should probably just say `false` here.

(Also minor grammar tweak to make it more direct.)