### PR TITLE
C#: Lowercase titles for exports and signals pages

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_exports.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_exports.rst
@@ -1,6 +1,6 @@
 .. _doc_c_sharp_exports:
 
-C# Exports
+C# exports
 ==========
 
 Introduction to exports

--- a/tutorials/scripting/c_sharp/c_sharp_signals.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_signals.rst
@@ -1,6 +1,6 @@
 .. _doc_c_sharp_signals:
 
-C# Signals
+C# signals
 ==========
 
 For a detailed explanation of signals in general, see the :ref:`doc_signals` section in the step


### PR DESCRIPTION
Fixes a minor inconsistency noticeable in the toctree:

![image](https://user-images.githubusercontent.com/331300/216794976-cb981e46-bfe1-4a2c-9f5a-07ff8c431888.png)
