### PR TITLE
Update paths in preload call in making_plugins.rst

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -226,7 +226,7 @@ dialog. For that, change the ``custom_node.gd`` script to the following:
     func _enter_tree():
         # Initialization of the plugin goes here.
         # Add the new type with a name, a parent type, a script and an icon.
-        add_custom_type("MyButton", "Button", preload("my_button.gd"), preload("icon.png"))
+        add_custom_type("MyButton", "Button", preload("res://addons/my_custom_node/my_button.gd"), preload("res://addons/my_custom_node/icon.png"))
 
 
     func _exit_tree():

--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -246,8 +246,8 @@ dialog. For that, change the ``custom_node.gd`` script to the following:
         {
             // Initialization of the plugin goes here.
             // Add the new type with a name, a parent type, a script and an icon.
-            var script = GD.Load<Script>("MyButton.cs");
-            var texture = GD.Load<Texture2D>("icon.png");
+            var script = GD.Load<Script>("addons/my_custom_node/MyButton.cs");
+            var texture = GD.Load<Texture2D>("addons/my_custom_node/icon.png");
             AddCustomType("MyButton", "Button", script, texture);
         }
 


### PR DESCRIPTION
If not using the the full path Godot will fail to initialize the plugin and show an error message.