### PR TITLE
Update sync_with_audio.rst for Godot 4

### DIFF
--- a/tutorials/audio/sync_with_audio.rst
+++ b/tutorials/audio/sync_with_audio.rst
@@ -42,14 +42,14 @@ Add these two and it's possible to guess almost exactly when sound or music will
 
 
     func _ready():
-        time_begin = OS.get_ticks_usec()
+        time_begin = Time.get_ticks_usec()
         time_delay = AudioServer.get_time_to_next_mix() + AudioServer.get_output_latency()
         $Player.play()
 
 
     func _process(delta):
         # Obtain from ticks.
-        var time = (OS.get_ticks_usec() - time_begin) / 1000000.0
+        var time = (Time.get_ticks_usec() - time_begin) / 1000000.0
         # Compensate for latency.
         time -= time_delay
         # May be below 0 (did not begin yet).
@@ -63,14 +63,14 @@ Add these two and it's possible to guess almost exactly when sound or music will
 
     public override void _Ready()
     {
-        _timeBegin = OS.GetTicksUsec();
+        _timeBegin = Time.GetTicksUsec();
         _timeDelay = AudioServer.GetTimeToNextMix() + AudioServer.GetOutputLatency();
         GetNode<AudioStreamPlayer>("Player").Play();
     }
 
     public override void _Process(float _delta)
     {
-        double time = (OS.GetTicksUsec() - _timeBegin) / 1000000.0d;
+        double time = (Time.GetTicksUsec() - _timeBegin) / 1000000.0d;
         time = Math.Max(0.0d, time - _timeDelay);
         GD.Print(string.Format("Time is: {0}", time));
     }


### PR DESCRIPTION
Godot 4.0 moved the time-related functions to the Time class from the OS one.