### PR TITLE
Fix gdscript_exports @export_node_path example by adding quotes

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_exports.rst
+++ b/tutorials/scripting/gdscript/gdscript_exports.rst
@@ -224,7 +224,7 @@ annotation:
 
 ::
 
-    @export_node_path(Button, TouchScreenButton) var some_button
+    @export_node_path("Button", "TouchScreenButton") var some_button
 
 Resources
 ---------


### PR DESCRIPTION
… around class names to pass strings

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
