### PR TITLE
Update Mono references to .NET

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -412,11 +412,11 @@ Scripting
 :ref:`C#: <toc-learn-scripting-C#>`
 
 - Packaged in a separate binary to keep file sizes and dependencies down.
-- Uses Mono 6.x.
+- Uses .NET 6.
 
-   - Full support for the C# 8.0 syntax and features.
+   - Full support for the C# 10.0 syntax and features.
 
-- Supports all platforms.
+- Supports Windows, Linux and macOS.
 - Using an external editor is recommended to benefit from IDE functionality.
 
 **GDExtension (C, C++, Rust, D, ...):**

--- a/contributing/workflow/bug_triage_guidelines.rst
+++ b/contributing/workflow/bug_triage_guidelines.rst
@@ -172,7 +172,7 @@ use the following labels:
    merge conflicts and its author is not active anymore. However, it can still
    be picked up by an external contributor to bring it to a mergeable state.
    To do so, you need to open a new pull request based on the original pull request.
--  *Topic:Mono*: the issue is about C# support in Godot.
+-  *Topic:Dotnet*: the issue is about C# support in Godot.
 -  *Topic:Website*: the issue relates to the Sphinx/Read the Docs frontend or backend,
    not the documentation contents.
 

--- a/getting_started/step_by_step/scripting_languages.rst
+++ b/getting_started/step_by_step/scripting_languages.rst
@@ -109,14 +109,14 @@ thanks to a generous donation from Microsoft.
 C# offers a good tradeoff between performance and ease of use, although you
 should be aware of its garbage collector.
 
-.. note:: You must use the Mono edition of the Godot editor to script in C#. You
+.. note:: You must use the .NET edition of the Godot editor to script in C#. You
           can download it on the Godot website's `download
           <https://godotengine.org/download/>`_ page.
 
-Since Godot uses the `Mono <https://mono-project.com>`_ .NET runtime, in theory,
-you can use any third-party .NET library or framework in Godot, as well as any
-Common Language Infrastructure-compliant programming language, such as F#, Boo,
-or ClojureCLR. However, C# is the only officially supported .NET option.
+Since Godot uses .NET 6, in theory, you can use any third-party .NET library or
+framework in Godot, as well as any Common Language Infrastructure-compliant
+programming language, such as F#, Boo, or ClojureCLR. However, C# is the only
+officially supported .NET option.
 
 .. note:: GDScript code itself doesn't execute as fast as compiled C# or C++.
           However, most script code calls functions written with fast algorithms


### PR DESCRIPTION
Replaces mono with .NET, changes the C# version to 10 on the list of features page. Changes supported platforms from "all platforms" to "Windows, Linux and macOS"

@paulloz is this a good way to phrase that we use .NET 6? I know you can use the 7 SDK but it's limited to .NET 6 features