### PR TITLE
Specify the "it"s in Viewport class reference and ViewportContainer class reference

### DIFF
--- a/classes/class_viewport.rst
+++ b/classes/class_viewport.rst
@@ -21,7 +21,7 @@ A Viewport creates a different view into the screen, or a sub-view inside anothe
 
 Optionally, a viewport can have its own 2D or 3D world, so they don't share what they draw with other viewports.
 
-If a viewport is a child of a :ref:`ViewportContainer<class_ViewportContainer>`, it will automatically take up its size, otherwise it must be set manually.
+If a viewport is a child of a :ref:`ViewportContainer<class_ViewportContainer>`, the viewport will automatically take up the viewportcontainer's size, otherwise it must be set manually.
 
 Viewports can also choose to be audio listeners, so they generate positional audio depending on a 2D or 3D camera child of it.
 

--- a/classes/class_viewportcontainer.rst
+++ b/classes/class_viewportcontainer.rst
@@ -17,7 +17,7 @@ Control for holding :ref:`Viewport<class_Viewport>`\ s.
 Description
 -----------
 
-A :ref:`Container<class_Container>` node that holds a :ref:`Viewport<class_Viewport>`, automatically setting its size.
+A :ref:`Container<class_Container>` node that holds a :ref:`Viewport<class_Viewport>`, automatically setting viewport's size.
 
 \ **Note:** Changing a ViewportContainer's :ref:`Control.rect_scale<class_Control_property_rect_scale>` will cause its contents to appear distorted. To change its visual size without causing distortion, adjust the node's margins instead (if it's not already in a container).
 


### PR DESCRIPTION
reference issue: #6743 
changed the "it"s in the description of Viewport and ViewportContainer
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
