### PR TITLE
Clarify OpenEXR limitations in export templates in Importing images

### DIFF
--- a/tutorials/assets_pipeline/importing_images.rst
+++ b/tutorials/assets_pipeline/importing_images.rst
@@ -15,6 +15,9 @@ Godot can import the following image formats:
   This can be used to achieve effects using custom mipmaps.
 - OpenEXR (``.exr``)
   - Supports HDR (highly recommended for panorama skies).
+  Can only be loaded and saved within the editor. In export templates,
+  this format is disabled unless custom export templates are compiled
+  with the ``tinyexr_export_templates=yes`` SCons option.
 - Radiance HDR (``.hdr``)
   - Supports HDR (highly recommended for panorama skies).
 - JPEG (``.jpg``, ``.jpeg``)


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/73003 (should be merged **after** that PR).
