### PR TITLE
Update Invalid References 

### DIFF
--- a/contributing/documentation/docs_image_guidelines.rst
+++ b/contributing/documentation/docs_image_guidelines.rst
@@ -41,8 +41,7 @@ Linux programs will support saving screenshots in this format, macOS and the
 Snip & Sketch program on Windows do not. For images that don't need editing,
 such as precise cropping or adding outlines, Squoosh can be used.
 `Squoosh <https://squoosh.app/>`_ is a converter developed by Google, is open
-source, and doesn't give Google any image rights by using it. There is also a
-experimental CLI version which can be found `here <https://github.com/GoogleChromeLabs/squoosh/tree/dev/cli>`_.
+source, and doesn't give Google any image rights by using it.
 
 If you already have an image editor such as GIMP, Krita or Photoshop installed
 it may have the ability to open an image then save it as a WebP file.
@@ -61,7 +60,7 @@ have cropping built in it's not always easy to get something precise. And while
 Krita is designed as a painting program the cropping tool gives you pixel precision
 by default. Of course, feel free to use a different program you are familiar with.
 
-If you've never used Krita before download it from the `official website <https://krita.org/en/download/krita-desktop/>`_,
+If you've never used Krita before download it from the `official Krita website <https://krita.org/en/download/krita-desktop/>`_,
 on Linux you may also be able to download it from your distributions repository,
 flathub is also an option. Once it's installed on your computer open Krita then
 open the image you want to crop. This button on the left panel is the crop tool.
@@ -108,7 +107,7 @@ Outlines arrows and text
 Sometimes an image needs something extra to properly direct the readers
 attention, or make something clear. Outlines and arrows can be used
 for this purpose. For these types of edits Inkscape is the recommended open
-source program, it can be downloaded `here <https://inkscape.org/release/inkscape-1.2.1/>`_.
+source program, it can be downloaded from the `official Inkscape website <https://inkscape.org/release/inkscape-1.2.1/>`_.
 Like Krita, if you're on linux you can also check your distributions repository
 or get it from Flathub.
 

--- a/tutorials/assets_pipeline/importing_scenes.rst
+++ b/tutorials/assets_pipeline/importing_scenes.rst
@@ -137,7 +137,7 @@ There are 2 ways to use OBJ meshes in Godot:
   expects as mesh (such as GPUParticles3D). This is the default mode.
 - Change their import mode to **OBJ as Scene** in the Import dock then restart
   the editor. This allows you to use the same import options as glTF or Collada
-  scenes, such as unwrapping UV2 on import (for :ref:`doc_baked_lightmaps`).
+  scenes, such as unwrapping UV2 on import (for :ref:`doc_using_lightmap_gi`).
 
 .. note::
 

--- a/tutorials/scripting/c_sharp/c_sharp_differences.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_differences.rst
@@ -567,7 +567,7 @@ GDScript              C#
 ====================  ==============================================================
 
 The ``Signal`` type implements the awaitable pattern which means it can be used with
-the ``await`` keyword. See :ref:`_doc_c_sharp_differences_await`.
+the ``await`` keyword. See :ref:`doc_c_sharp_differences_await`.
 
 Instead of using the ``Signal`` type, the recommended way to use Godot signals in C# is
 to use the generated C# events. See :ref:`doc_c_sharp_signals`.


### PR DESCRIPTION
`tutorials/scripting/c_sharp/c_sharp_differences.rst:569: WARNING: undefined label:_ doc_c_sharp_differences_await`
leading `_` removed.

`tutorials/assets_pipeline/importing_scenes.rst:138: WARNING: undefined label: doc_baked_lightmaps`
the page was removed and replaced in [commit](https://github.com/godotengine/godot-docs/commit/6e453527b1582bd5a4d5c9af1a71ec2944c9be3a).

`contributing/documentation/docs_image_guidelines.rst:4: WARNING: Duplicate explicit target name: "here".`
looks like there can't be links with the same name and different target.
renamed link and removed the cli for squoosh because of [this :(](https://github.com/GoogleChromeLabs/squoosh/pull/1321)