### PR TITLE
Update compute_shaders.rst

### DIFF
--- a/tutorials/shaders/compute_shaders.rst
+++ b/tutorials/shaders/compute_shaders.rst
@@ -217,7 +217,7 @@ So let's initialize an array of floats and create a storage buffer:
     Buffer.BlockCopy(input, 0, inputBytes, 0, inputBytes.Length);
 
     // Create a storage buffer that can hold our float values.
-    // Each float has 4 byte (32 bit) so 10 x 4 = 40 bytes
+    // Each float has 4 bytes (32 bit) so 10 x 4 = 40 bytes
     var buffer = rd.StorageBufferCreate((uint)inputBytes.Length, inputBytes);
 
 With the buffer in place we need to tell the rendering device to use this

--- a/tutorials/shaders/compute_shaders.rst
+++ b/tutorials/shaders/compute_shaders.rst
@@ -206,7 +206,7 @@ So let's initialize an array of floats and create a storage buffer:
     var input_bytes := input.to_byte_array()
 
     # Create a storage buffer that can hold our float values.
-    # Each float has 4 byte (32 bit) so 10 x 4 = 40 bytes
+    # Each float has 4 bytes (32 bit) so 10 x 4 = 40 bytes
     var buffer := rd.storage_buffer_create(input_bytes.size(), input_bytes)
 
  .. code-tab:: csharp

--- a/tutorials/shaders/compute_shaders.rst
+++ b/tutorials/shaders/compute_shaders.rst
@@ -206,7 +206,7 @@ So let's initialize an array of floats and create a storage buffer:
     var input_bytes := input.to_byte_array()
 
     # Create a storage buffer that can hold our float values.
-    # Each float has 8 byte (32 bit) so 10 x 8 = 80 bytes
+    # Each float has 4 byte (32 bit) so 10 x 4 = 40 bytes
     var buffer := rd.storage_buffer_create(input_bytes.size(), input_bytes)
 
  .. code-tab:: csharp
@@ -217,7 +217,7 @@ So let's initialize an array of floats and create a storage buffer:
     Buffer.BlockCopy(input, 0, inputBytes, 0, inputBytes.Length);
 
     // Create a storage buffer that can hold our float values.
-    // Each float has 8 byte (32 bit) so 10 x 8 = 80 bytes
+    // Each float has 4 byte (32 bit) so 10 x 4 = 40 bytes
     var buffer = rd.StorageBufferCreate((uint)inputBytes.Length, inputBytes);
 
 With the buffer in place we need to tell the rendering device to use this


### PR DESCRIPTION
32 bit = to 4 bytes not 8 bytes and GLSL floats are 4 bytes.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
