### PR TITLE
Add C# Examples for ArrayMesh Tutorial

### DIFF
--- a/tutorials/3d/procedural_geometry/arraymesh.rst
+++ b/tutorials/3d/procedural_geometry/arraymesh.rst
@@ -140,7 +140,8 @@ by adding each array to ``surface_array`` and then committing to the mesh.
     surface_array[Mesh.ARRAY_NORMAL] = normals
     surface_array[Mesh.ARRAY_INDEX] = indices
 
-    mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, surface_array) # No blendshapes, lods, or compression used.
+    # No blendshapes, lods, or compression used.
+    mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, surface_array)
 
  .. code-tab:: csharp C#
 
@@ -157,7 +158,8 @@ by adding each array to ``surface_array`` and then committing to the mesh.
     var arrMesh = Mesh as ArrayMesh;
     if (arrMesh != null)
     {
-        arrMesh.AddSurfaceFromArrays(Mesh.PrimitiveType.Triangles, surfaceArray); // No blendshapes, lods, or compression used.
+        // No blendshapes, lods, or compression used.
+        arrMesh.AddSurfaceFromArrays(Mesh.PrimitiveType.Triangles, surfaceArray); 
     }
 
 .. note:: In this example, we used ``Mesh.PRIMITIVE_TRIANGLES``, but you can use any primitive type
@@ -191,7 +193,8 @@ Put together, the full code looks like:
         surface_array[Mesh.ARRAY_INDEX] = indices
 
         # Create mesh surface from mesh array.
-        mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, surface_array) # No blendshapes, lods, or compression used.
+        # No blendshapes, lods, or compression used.
+        mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, surface_array)
 
  .. code-tab:: csharp C#
 
@@ -228,7 +231,8 @@ Put together, the full code looks like:
             if (arrMesh != null)
             {
                 // Create mesh surface from mesh array
-                arrMesh.AddSurfaceFromArrays(Mesh.PrimitiveType.Triangles, surfaceArray); // No blendshapes, lods, or compression used.
+                // No blendshapes, lods, or compression used.
+                arrMesh.AddSurfaceFromArrays(Mesh.PrimitiveType.Triangles, surfaceArray);
             }
         }
     }

--- a/tutorials/3d/procedural_geometry/arraymesh.rst
+++ b/tutorials/3d/procedural_geometry/arraymesh.rst
@@ -247,7 +247,6 @@ that you find online.
 
     var rings = 50
     var radial_segments = 50
-    var height = 1
     var radius = 1
 
     func _ready():
@@ -310,7 +309,6 @@ that you find online.
 
             var rings = 50;
             var radialSegments = 50;
-            var height = 1;
             var radius = 1;
 
             // Vertex indices.

--- a/tutorials/3d/procedural_geometry/arraymesh.rst
+++ b/tutorials/3d/procedural_geometry/arraymesh.rst
@@ -303,13 +303,13 @@ that you find online.
 
     public partial class MyMeshInstance3D : MeshInstance3D
     {
+        private int _rings = 50;
+        private int _radialSegments = 50;
+        private float _radius = 1;
+
         public override void _Ready()
         {
             // Insert setting up the surface array and lists here.
-
-            var rings = 50;
-            var radialSegments = 50;
-            var radius = 1;
 
             // Vertex indices.
             var thisRow = 0;
@@ -317,19 +317,19 @@ that you find online.
             var point = 0;
 
             // Loop over rings.
-            for (var i = 0; i < rings + 1; i++)
+            for (var i = 0; i < _rings + 1; i++)
             {
-                var v = ((float)i) / rings;
+                var v = ((float)i) / _rings;
                 var w = Mathf.Sin(Mathf.Pi * v);
                 var y = Mathf.Cos(Mathf.Pi * v);
 
                 // Loop over segments in ring.
-                for (var j = 0; j < radialSegments; j++)
+                for (var j = 0; j < _radialSegments; j++)
                 {
-                    var u = ((float)j) / radialSegments;
+                    var u = ((float)j) / _radialSegments;
                     var x = Mathf.Sin(u * Mathf.Pi * 2);
                     var z = Mathf.Cos(u * Mathf.Pi * 2);
-                    var vert = new Vector3(x * radius * w, y, z * radius * w);
+                    var vert = new Vector3(x * _radius * w, y, z * _radius * w);
                     verts.Add(vert);
                     normals.Add(vert.Normalized());
                     uvs.Add(new Vector2(u, v));
@@ -350,13 +350,13 @@ that you find online.
 
                 if (i > 0)
                 {
-                    indices.Add(prevRow + radialSegments - 1);
+                    indices.Add(prevRow + _radialSegments - 1);
                     indices.Add(prevRow);
-                    indices.Add(thisRow + radialSegments - 1);
+                    indices.Add(thisRow + _radialSegments - 1);
 
                     indices.Add(prevRow);
-                    indices.Add(prevRow + radialSegments);
-                    indices.Add(thisRow + radialSegments - 1);
+                    indices.Add(prevRow + _radialSegments);
+                    indices.Add(thisRow + _radialSegments - 1);
                 }
 
                 prevRow = thisRow;

--- a/tutorials/3d/procedural_geometry/arraymesh.rst
+++ b/tutorials/3d/procedural_geometry/arraymesh.rst
@@ -124,10 +124,10 @@ Next create the arrays for each data type you will use.
 
  .. code-tab:: csharp C#
 
-    var verts = new Vector3[] { };
-    var uvs = new Vector2[] { };
-    var normals = new Vector3[] { };
-    var indices = new int[] { };
+    var vertList = new List<Vector3>();
+    var uvList = new List<Vector2>();
+    var normalList = new List<Vector3>();
+    var indexList = new List<int>();
 
 Once you have filled your data arrays with your geometry you can create a mesh
 by adding each array to ``surface_array`` and then committing to the mesh.
@@ -144,6 +144,11 @@ by adding each array to ``surface_array`` and then committing to the mesh.
 
  .. code-tab:: csharp C#
 
+    var verts = vertList.ToArray();
+    var uvs = uvList.ToArray();
+    var normals = normalList.ToArray();
+    var indices = indexList.ToArray();
+    
     surfaceArray[(int)Mesh.ArrayType.Vertex] = verts;
     surfaceArray[(int)Mesh.ArrayType.TexUV] = uvs;
     surfaceArray[(int)Mesh.ArrayType.Normal] = normals;
@@ -197,15 +202,21 @@ Put together, the full code looks like:
             var surfaceArray = new Godot.Collections.Array();
             surfaceArray.Resize((int)Mesh.ArrayType.Max);
 
-            // Arrays for mesh construction
-            var verts = new Vector3[] { };
-            var uvs = new Vector2[] { };
-            var normals = new Vector3[] { };
-            var indices = new int[] { };
+            // C# arrays cannot be resized or expanded, so use Lists to create geometry.
+            var vertList = new List<Vector3>();
+            var uvList = new List<Vector2>();
+            var normalList = new List<Vector3>();
+            var indexList = new List<int>();
 
             /***********************************
-              * Insert code here to generate mesh
-              * *********************************/
+            * Insert code here to generate mesh.
+            * *********************************/
+
+            // Convert lists to arrays for mesh construction.
+            var verts = vertList.ToArray();
+            var uvs = uvList.ToArray();
+            var normals = normalList.ToArray();
+            var indices = indexList.ToArray();
 
             // Assign arrays to surface array
             surfaceArray[(int)Mesh.ArrayType.Vertex] = verts;
@@ -302,12 +313,7 @@ that you find online.
     {
         public override void _Ready()
         {
-            // Insert setting up the surface array here.
-
-            var vertList = new List<Vector3>();
-            var uvList = new List<Vector2>();
-            var normalList = new List<Vector3>();
-            var indexList = new List<int>();
+            // Insert setting up the surface array and lists here.
 
             var rings = 50;
             var radialSegments = 50;
@@ -365,16 +371,6 @@ that you find online.
                 prevRow = thisRow;
                 thisRow = point;
             }
-
-            var verts = vertList.ToArray();
-            var uvs = uvList.ToArray();
-            var normals = normalList.ToArray();
-            var indices = indexList.ToArray();
-
-            surfaceArray[(int)Mesh.ArrayType.Vertex] = verts;
-            surfaceArray[(int)Mesh.ArrayType.TexUV] = uvs;
-            surfaceArray[(int)Mesh.ArrayType.Normal] = normals;
-            surfaceArray[(int)Mesh.ArrayType.Index] = indices;
 
             // Insert committing to the ArrayMesh here.
         }

--- a/tutorials/3d/procedural_geometry/arraymesh.rst
+++ b/tutorials/3d/procedural_geometry/arraymesh.rst
@@ -193,7 +193,7 @@ Put together, the full code looks like:
 
  .. code-tab:: csharp C#
 
-    public partial class ArrayMeshInstance : MeshInstance3D
+    public partial class MyMeshInstance3D : MeshInstance3D
     {
         public override void _Ready()
         {
@@ -301,7 +301,7 @@ that you find online.
 
  .. code-tab:: csharp C#
 
-    public partial class ArrayMeshInstance : MeshInstance3D
+    public partial class MyMeshInstance3D : MeshInstance3D
     {
         public override void _Ready()
         {

--- a/tutorials/3d/procedural_geometry/arraymesh.rst
+++ b/tutorials/3d/procedural_geometry/arraymesh.rst
@@ -124,10 +124,10 @@ Next create the arrays for each data type you will use.
 
  .. code-tab:: csharp C#
 
-    var vertList = new List<Vector3>();
-    var uvList = new List<Vector2>();
-    var normalList = new List<Vector3>();
-    var indexList = new List<int>();
+    var verts = new List<Vector3>();
+    var uvs = new List<Vector2>();
+    var normals = new List<Vector3>();
+    var indices = new List<int>();
 
 Once you have filled your data arrays with your geometry you can create a mesh
 by adding each array to ``surface_array`` and then committing to the mesh.
@@ -145,15 +145,10 @@ by adding each array to ``surface_array`` and then committing to the mesh.
 
  .. code-tab:: csharp C#
 
-    var verts = vertList.ToArray();
-    var uvs = uvList.ToArray();
-    var normals = normalList.ToArray();
-    var indices = indexList.ToArray();
-    
-    surfaceArray[(int)Mesh.ArrayType.Vertex] = verts;
-    surfaceArray[(int)Mesh.ArrayType.TexUV] = uvs;
-    surfaceArray[(int)Mesh.ArrayType.Normal] = normals;
-    surfaceArray[(int)Mesh.ArrayType.Index] = indices;
+    surfaceArray[(int)Mesh.ArrayType.Vertex] = verts.ToArray();
+    surfaceArray[(int)Mesh.ArrayType.TexUV] = uvs.ToArray();
+    surfaceArray[(int)Mesh.ArrayType.Normal] = normals.ToArray();
+    surfaceArray[(int)Mesh.ArrayType.Index] = indices.ToArray()
 
     var arrMesh = Mesh as ArrayMesh;
     if (arrMesh != null)
@@ -206,26 +201,20 @@ Put together, the full code looks like:
             surfaceArray.Resize((int)Mesh.ArrayType.Max);
 
             // C# arrays cannot be resized or expanded, so use Lists to create geometry.
-            var vertList = new List<Vector3>();
-            var uvList = new List<Vector2>();
-            var normalList = new List<Vector3>();
-            var indexList = new List<int>();
+            var verts = new List<Vector3>();
+            var uvs = new List<Vector2>();
+            var normals = new List<Vector3>();
+            var indices = new List<int>();
 
             /***********************************
             * Insert code here to generate mesh.
             * *********************************/
 
-            // Convert lists to arrays for mesh construction.
-            var verts = vertList.ToArray();
-            var uvs = uvList.ToArray();
-            var normals = normalList.ToArray();
-            var indices = indexList.ToArray();
-
-            // Assign arrays to surface array
-            surfaceArray[(int)Mesh.ArrayType.Vertex] = verts;
-            surfaceArray[(int)Mesh.ArrayType.TexUV] = uvs;
-            surfaceArray[(int)Mesh.ArrayType.Normal] = normals;
-            surfaceArray[(int)Mesh.ArrayType.Index] = indices;
+            // Convert Lists to arrays and assign to surface array
+            surfaceArray[(int)Mesh.ArrayType.Vertex] = verts.ToArray();
+            surfaceArray[(int)Mesh.ArrayType.TexUV] = uvs.ToArray();
+            surfaceArray[(int)Mesh.ArrayType.Normal] = normals.ToArray();
+            surfaceArray[(int)Mesh.ArrayType.Index] = indices.ToArray()
 
             var arrMesh = Mesh as ArrayMesh;
             if (arrMesh != null)
@@ -343,33 +332,33 @@ that you find online.
                     var x = Mathf.Sin(u * Mathf.Pi * 2);
                     var z = Mathf.Cos(u * Mathf.Pi * 2);
                     var vert = new Vector3(x * radius * w, y, z * radius * w);
-                    vertList.Add(vert);
-                    normalList.Add(vert.Normalized());
-                    uvList.Add(new Vector2(u, v));
+                    verts.Add(vert);
+                    normals.Add(vert.Normalized());
+                    uvs.Add(new Vector2(u, v));
                     point += 1;
 
                     // Create triangles in ring using indices.
                     if (i > 0 && j > 0)
                     {
-                        indexList.Add(prevRow + j - 1);
-                        indexList.Add(prevRow + j);
-                        indexList.Add(thisRow + j - 1);
+                        indices.Add(prevRow + j - 1);
+                        indices.Add(prevRow + j);
+                        indices.Add(thisRow + j - 1);
 
-                        indexList.Add(prevRow + j);
-                        indexList.Add(thisRow + j);
-                        indexList.Add(thisRow + j - 1);
+                        indices.Add(prevRow + j);
+                        indices.Add(thisRow + j);
+                        indices.Add(thisRow + j - 1);
                     }
                 }
 
                 if (i > 0)
                 {
-                    indexList.Add(prevRow + radialSegments - 1);
-                    indexList.Add(prevRow);
-                    indexList.Add(thisRow + radialSegments - 1);
+                    indices.Add(prevRow + radialSegments - 1);
+                    indices.Add(prevRow);
+                    indices.Add(thisRow + radialSegments - 1);
 
-                    indexList.Add(prevRow);
-                    indexList.Add(prevRow + radialSegments);
-                    indexList.Add(thisRow + radialSegments - 1);
+                    indices.Add(prevRow);
+                    indices.Add(prevRow + radialSegments);
+                    indices.Add(thisRow + radialSegments - 1);
                 }
 
                 prevRow = thisRow;

--- a/tutorials/3d/procedural_geometry/arraymesh.rst
+++ b/tutorials/3d/procedural_geometry/arraymesh.rst
@@ -92,6 +92,10 @@ Under ``_ready()``, create a new Array.
   .. code-tab:: gdscript GDScript
 
     var surface_array = []
+  
+  .. code-tab:: csharp C#
+
+    var surfaceArray = new Godot.Collections.Array();
 
 This will be the array that we keep our surface information in - it will hold
 all the arrays of data that the surface needs. Godot will expect it to be of
@@ -102,6 +106,11 @@ size ``Mesh.ARRAY_MAX``, so resize it accordingly.
 
     var surface_array = []
     surface_array.resize(Mesh.ARRAY_MAX)
+  
+ .. code-tab:: csharp C#
+
+    var surfaceArray = new Godot.Collections.Array();
+    surfaceArray.Resize((int)Mesh.ArrayType.Max);
 
 Next create the arrays for each data type you will use.
 
@@ -112,6 +121,13 @@ Next create the arrays for each data type you will use.
     var uvs = PackedVector2Array()
     var normals = PackedVector3Array()
     var indices = PackedInt32Array()
+
+ .. code-tab:: csharp C#
+
+    var verts = new Vector3[] { };
+    var uvs = new Vector2[] { };
+    var normals = new Vector3[] { };
+    var indices = new int[] { };
 
 Once you have filled your data arrays with your geometry you can create a mesh
 by adding each array to ``surface_array`` and then committing to the mesh.
@@ -125,6 +141,19 @@ by adding each array to ``surface_array`` and then committing to the mesh.
     surface_array[Mesh.ARRAY_INDEX] = indices
 
     mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, surface_array) # No blendshapes, lods, or compression used.
+
+ .. code-tab:: csharp C#
+
+    surfaceArray[(int)Mesh.ArrayType.Vertex] = verts;
+    surfaceArray[(int)Mesh.ArrayType.TexUV] = uvs;
+    surfaceArray[(int)Mesh.ArrayType.Normal] = normals;
+    surfaceArray[(int)Mesh.ArrayType.Index] = indices;
+
+    var arrMesh = Mesh as ArrayMesh;
+    if (arrMesh != null)
+    {
+        arrMesh.AddSurfaceFromArrays(Mesh.PrimitiveType.Triangles, surfaceArray); // No blendshapes, lods, or compression used.
+    }
 
 .. note:: In this example, we used ``Mesh.PRIMITIVE_TRIANGLES``, but you can use any primitive type
           available from mesh.
@@ -158,6 +187,40 @@ Put together, the full code looks like:
 
         # Create mesh surface from mesh array.
         mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, surface_array) # No blendshapes, lods, or compression used.
+
+ .. code-tab:: csharp C#
+
+    public partial class ArrayMeshInstance : MeshInstance3D
+    {
+        public override void _Ready()
+        {
+            var surfaceArray = new Godot.Collections.Array();
+            surfaceArray.Resize((int)Mesh.ArrayType.Max);
+
+            // Arrays for mesh construction
+            var verts = new Vector3[] { };
+            var uvs = new Vector2[] { };
+            var normals = new Vector3[] { };
+            var indices = new int[] { };
+
+            /***********************************
+              * Insert code here to generate mesh
+              * *********************************/
+
+            // Assign arrays to surface array
+            surfaceArray[(int)Mesh.ArrayType.Vertex] = verts;
+            surfaceArray[(int)Mesh.ArrayType.TexUV] = uvs;
+            surfaceArray[(int)Mesh.ArrayType.Normal] = normals;
+            surfaceArray[(int)Mesh.ArrayType.Index] = indices;
+
+            var arrMesh = Mesh as ArrayMesh;
+            if (arrMesh != null)
+            {
+                // Create mesh surface from mesh array
+                arrMesh.AddSurfaceFromArrays(Mesh.PrimitiveType.Triangles, surfaceArray); // No blendshapes, lods, or compression used.
+            }
+        }
+    }
 
 
 The code that goes in the middle can be whatever you want. Below we will present some
@@ -233,6 +296,90 @@ that you find online.
 
       # Insert committing to the ArrayMesh here.
 
+ .. code-tab:: csharp C#
+
+    public partial class ArrayMeshInstance : MeshInstance3D
+    {
+        public override void _Ready()
+        {
+            // Insert setting up the surface array here.
+
+            var vertList = new List<Vector3>();
+            var uvList = new List<Vector2>();
+            var normalList = new List<Vector3>();
+            var indexList = new List<int>();
+
+            var rings = 50;
+            var radialSegments = 50;
+            var height = 1;
+            var radius = 1;
+
+            // Vertex indices.
+            var thisRow = 0;
+            var prevRow = 0;
+            var point = 0;
+
+            // Loop over rings.
+            for (var i = 0; i < rings + 1; i++)
+            {
+                var v = ((float)i) / rings;
+                var w = Mathf.Sin(Mathf.Pi * v);
+                var y = Mathf.Cos(Mathf.Pi * v);
+
+                // Loop over segments in ring.
+                for (var j = 0; j < radialSegments; j++)
+                {
+                    var u = ((float)j) / radialSegments;
+                    var x = Mathf.Sin(u * Mathf.Pi * 2);
+                    var z = Mathf.Cos(u * Mathf.Pi * 2);
+                    var vert = new Vector3(x * radius * w, y, z * radius * w);
+                    vertList.Add(vert);
+                    normalList.Add(vert.Normalized());
+                    uvList.Add(new Vector2(u, v));
+                    point += 1;
+
+                    // Create triangles in ring using indices.
+                    if (i > 0 && j > 0)
+                    {
+                        indexList.Add(prevRow + j - 1);
+                        indexList.Add(prevRow + j);
+                        indexList.Add(thisRow + j - 1);
+
+                        indexList.Add(prevRow + j);
+                        indexList.Add(thisRow + j);
+                        indexList.Add(thisRow + j - 1);
+                    }
+                }
+
+                if (i > 0)
+                {
+                    indexList.Add(prevRow + radialSegments - 1);
+                    indexList.Add(prevRow);
+                    indexList.Add(thisRow + radialSegments - 1);
+
+                    indexList.Add(prevRow);
+                    indexList.Add(prevRow + radialSegments);
+                    indexList.Add(thisRow + radialSegments - 1);
+                }
+
+                prevRow = thisRow;
+                thisRow = point;
+            }
+
+            var verts = vertList.ToArray();
+            var uvs = uvList.ToArray();
+            var normals = normalList.ToArray();
+            var indices = indexList.ToArray();
+
+            surfaceArray[(int)Mesh.ArrayType.Vertex] = verts;
+            surfaceArray[(int)Mesh.ArrayType.TexUV] = uvs;
+            surfaceArray[(int)Mesh.ArrayType.Normal] = normals;
+            surfaceArray[(int)Mesh.ArrayType.Index] = indices;
+
+            // Insert committing to the ArrayMesh here.
+        }
+    }
+
 Saving
 ------
 
@@ -244,3 +391,8 @@ This is useful when you want to generate a mesh and then use it later without ha
 
     # Saves mesh to a .tres file with compression enabled.
     ResourceSaver.save(mesh, "res://sphere.tres", ResourceSaver.FLAG_COMPRESS)
+
+ .. code-tab:: csharp C#
+
+    // Saves mesh to a .tres file with compression enabled.
+    ResourceSaver.Save(Mesh, "res://sphere.tres", ResourceSaver.SaverFlags.Compress);

--- a/tutorials/3d/procedural_geometry/arraymesh.rst
+++ b/tutorials/3d/procedural_geometry/arraymesh.rst
@@ -148,7 +148,7 @@ by adding each array to ``surface_array`` and then committing to the mesh.
     surfaceArray[(int)Mesh.ArrayType.Vertex] = verts.ToArray();
     surfaceArray[(int)Mesh.ArrayType.TexUV] = uvs.ToArray();
     surfaceArray[(int)Mesh.ArrayType.Normal] = normals.ToArray();
-    surfaceArray[(int)Mesh.ArrayType.Index] = indices.ToArray()
+    surfaceArray[(int)Mesh.ArrayType.Index] = indices.ToArray();
 
     var arrMesh = Mesh as ArrayMesh;
     if (arrMesh != null)
@@ -214,7 +214,7 @@ Put together, the full code looks like:
             surfaceArray[(int)Mesh.ArrayType.Vertex] = verts.ToArray();
             surfaceArray[(int)Mesh.ArrayType.TexUV] = uvs.ToArray();
             surfaceArray[(int)Mesh.ArrayType.Normal] = normals.ToArray();
-            surfaceArray[(int)Mesh.ArrayType.Index] = indices.ToArray()
+            surfaceArray[(int)Mesh.ArrayType.Index] = indices.ToArray();
 
             var arrMesh = Mesh as ArrayMesh;
             if (arrMesh != null)


### PR DESCRIPTION
Resolves #6714. Although the equivalent C# type to GDScript's PackedVector\*Array is Vector\*[], I've used List<Vector\*> and converted with ToArray(), since the arrays have to resize dynamically as mesh data is added. Happy to revise this if there's any objection to that.