### PR TITLE
Add NavigationAgent.is_navigation_finished() early return to script examples to avoid in-place jitter

### DIFF
--- a/tutorials/navigation/navigation_introduction_2d.rst
+++ b/tutorials/navigation/navigation_introduction_2d.rst
@@ -123,7 +123,7 @@ NavigationServer2D and a NavigationAgent2D for path movement.
         navigation_agent.set_target_location(movement_target)
 
     func _physics_process(delta):
-        if navigation_agent.is_target_reached():
+        if navigation_agent.is_navigation_finished():
             return
 
         var current_agent_position : Vector2 = global_transform.origin
@@ -173,7 +173,7 @@ NavigationServer2D and a NavigationAgent2D for path movement.
         {
             base._PhysicsProcess(delta);
 
-            if (_navigationAgent.IsTargetReached())
+            if (_navigationAgent.IsNavigationFinished())
             {
                 return;
             }

--- a/tutorials/navigation/navigation_introduction_3d.rst
+++ b/tutorials/navigation/navigation_introduction_3d.rst
@@ -131,7 +131,7 @@ a NavigationAgent3D for path movement.
         navigation_agent.set_target_position(movement_target)
 
     func _physics_process(delta):
-        if navigation_agent.is_target_reached():
+        if navigation_agent.is_navigation_finished():
             return
 
         var current_agent_position : Vector3 = global_transform.origin
@@ -180,7 +180,7 @@ a NavigationAgent3D for path movement.
         {
             base._PhysicsProcess(delta);
 
-            if (_navigationAgent.IsTargetReached())
+            if (_navigationAgent.IsNavigationFinished())
             {
                 return;
             }

--- a/tutorials/navigation/navigation_using_navigationagents.rst
+++ b/tutorials/navigation/navigation_using_navigationagents.rst
@@ -167,6 +167,8 @@ This script adds basic navigation movement to a Node3D with a NavigationAgent3D 
         navigation_agent.set_target_position(movement_target)
 
     func _physics_process(delta):
+        if navigation_agent.is_navigation_finished():
+            return
 
         movement_delta = movement_speed * delta
         var next_path_position : Vector3 = navigation_agent.get_next_path_position()
@@ -197,6 +199,8 @@ This script adds basic navigation movement to a CharacterBody3D with a Navigatio
         navigation_agent.set_target_position(movement_target)
 
     func _physics_process(delta):
+        if navigation_agent.is_navigation_finished():
+            return
 
         movement_delta = movement_speed * delta
         var next_path_position : Vector3 = navigation_agent.get_next_path_position()
@@ -226,6 +230,8 @@ This script adds basic navigation movement to a RigidBody3D with a NavigationAge
         navigation_agent.set_target_position(movement_target)
 
     func _physics_process(delta):
+        if navigation_agent.is_navigation_finished():
+            return
 
         var next_path_position : Vector3 = navigation_agent.get_next_path_position()
         var current_agent_position : Vector3 = global_transform.origin


### PR DESCRIPTION
Adds early return to script examples for `NavigationAgent` path following when `NavigationAgent.is_navigation_finished(`) is `true`.

Related to https://github.com/godotengine/godot-docs/issues/6776.


The old examples had no guards or used `is_target_reached()` which is an unreliable check for this as it only checks the distance to the final target. The `is_navigation_finished()` checks if the actual path following and path array has reached the end.

Without such a check the path following gets processed every frame which can make agent jitter in place when the path is finished due to precision problems, especially in 2D that uses a far larger scale.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
