### PR TITLE
Add note about removing new_game() _ready() in 2D tut

### DIFF
--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -387,8 +387,8 @@ In ``game_over()`` we need to call the corresponding ``HUD`` function:
 
         _hud->show_game_over();
 
-We also don't want to start the new game automatically, so remove the call to
-``new_game()`` in ``_ready()``.
+Just a reminder: we don't want to start the new game automatically, so
+remove the call to ``new_game()`` in ``_ready()`` if you haven't yet.
 
 Finally, add this to ``_on_ScoreTimer_timeout()`` to keep the display in sync
 with the changing score:

--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -387,6 +387,9 @@ In ``game_over()`` we need to call the corresponding ``HUD`` function:
 
         _hud->show_game_over();
 
+We also don't want to start the new game automatically, so remove the call to
+``new_game()`` in ``_ready()``.
+
 Finally, add this to ``_on_ScoreTimer_timeout()`` to keep the display in sync
 with the changing score:
 


### PR DESCRIPTION
The Start button handles calling `new_game()` so without removing the `_ready()` function that called `new_game()`, the game will automatically start on launch.

I've been going through: https://docs.godotengine.org/en/latest/getting_started/first_2d_game/06.heads_up_display.html and noticed this little issue.

Happy to adjust the language in any way that I can to make it better. Let me know if I'm missing anything!