### PR TITLE
Clarify return value

### DIFF
--- a/classes/class_inputevent.rst
+++ b/classes/class_inputevent.rst
@@ -215,7 +215,7 @@ Returns ``true`` if this input event's type is one that can be assigned to an in
 
 :ref:`bool<class_bool>` **is_echo** **(** **)** |const|
 
-Returns ``true`` if this input event is an echo event (only for events of type :ref:`InputEventKey<class_InputEventKey>`).
+Returns ``true`` if this input event is an echo event (only for events of type :ref:`InputEventKey<class_InputEventKey>`). Any other event type returns false.
 
 .. rst-class:: classref-item-separator
 


### PR DESCRIPTION
I didn't look at other documentation to see whether they write the "default" return value or not. While it might be "obvious", I don't think the user should need to assume what the default value should probably be.
And while it might be irrelevant for other event types, IMO this one is useful in cases like

```cs
if (e.IsActionPressed("main_action") && !e.IsEcho())
{ ... }
```

where `main_action` might not be a key and `e` might not be an InputEventKey