### PR TITLE
Fix Python link typo in Compiling for Linux

### DIFF
--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -17,7 +17,7 @@ For compiling under Linux or other Unix variants, the following is
 required:
 
 - GCC 7+ or Clang 6+.
-- Python 3.6+ <https://www.python.org/downloads/>`_.
+- `Python 3.6+ <https://www.python.org/downloads/>`_.
 - `SCons 3.0+ <https://scons.org/pages/download.html>`_ build system. If your distribution uses Python 2 by default,
   or you are using a version of SCons prior to 3.1.2, you will need to change
   the version of Python that SCons uses by changing the shebang (the first line)


### PR DESCRIPTION
It breaks the formatting of that link.