### PR TITLE
Information about the need to download v. 4.72 of .Net

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -50,6 +50,8 @@ version of Godot.
 Download and install the latest stable version of the SDK from the
 `.NET download page <https://dotnet.microsoft.com/download>`__.
 
+Additionally, as of 02.2023, you will need to download `The Developer pack for The 4.7.2 version of .NET Framework <https://dotnet.microsoft.com/en-us/download/dotnet-framework/net472>`__.
+
 .. important::
 
     Be sure to install the 64-bit version of the SDK(s)


### PR DESCRIPTION
I had a problem with OmniSharp in VS code getting an "Error: The reference assemblies for .NETFramework,Version=v4.7.2 were not found. To resolve this, install the Developer Pack (SDK/Targeting Pack) for this framework version or retarget your application. You can download .NET Framework Developer Packs at...". I see that Godot should download it automatically (https://github.com/godotengine/godot/issues/40546) but It evidently stopped doing that, or sometimes fails to do that. That's why I'm adding this information for anyone, so that when they will get the same error and get flustrated, then they won't quit because of it.
