### PR TITLE
Enable error reporting on the CI and address the remaining errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,4 @@ jobs:
       # Use dummy builder to improve performance as we don't need the generated HTML in this workflow.
       - name: Sphinx build
         run: |
-          sphinx-build --color -b dummy -d _build/doctrees . _build/html
+          sphinx-build --color -b dummy -d _build/doctrees -W . _build/html

--- a/tutorials/networking/websocket.rst
+++ b/tutorials/networking/websocket.rst
@@ -18,7 +18,7 @@ Godot supports WebSocket in both native and HTML5 exports.
 Using WebSocket in Godot
 ------------------------
 
-WebSocket is implemented in Godot via three main classes :ref:`WebSocketClient <class_WebSocketClient>`, :ref:`WebSocketServer <class_WebSocketServer>`, and :ref:`WebSocketPeer <class_WebSocketPeer>`. The WebSocket implementation is compatible with the High Level Multiplayer. See section on :ref:`high-level multiplayer <doc_high_level_multiplayer>` for more details.
+WebSocket is implemented in Godot via :ref:`WebSocketPeer <class_WebSocketPeer>`. The WebSocket implementation is compatible with the High Level Multiplayer. See section on :ref:`high-level multiplayer <doc_high_level_multiplayer>` for more details.
 
 .. warning::
 

--- a/tutorials/shaders/shader_reference/shader_preprocessor.rst
+++ b/tutorials/shaders/shader_reference/shader_preprocessor.rst
@@ -61,7 +61,8 @@ anywhere within the shader (including in uniform hints).
 ``#define`` can also be used to insert arbitrary shader code at any location,
 while constants can't do that.
 
-.. code-block:: glsl
+.. FIXME: An upstream bug (https://github.com/pygments/pygments/pull/2350), fixed but not published yet.
+.. code-block:: none
 
     shader_type spatial;
 

--- a/tutorials/shaders/shaders_style_guide.rst
+++ b/tutorials/shaders/shaders_style_guide.rst
@@ -344,7 +344,8 @@ the console, extra indentation should **not** be added within ``#if``,
 
 **Bad**:
 
-.. code-block:: glsl
+.. FIXME: An upstream bug in Pygment related to #ifdef.
+.. code-block:: none
 
     #define heightmap_enabled
 

--- a/tutorials/xr/xr_action_map.rst
+++ b/tutorials/xr/xr_action_map.rst
@@ -287,7 +287,7 @@ Some runtimes might even permit users to edit the bindings themselves.
 
 A common approach for a runtime is to look for a matching interaction profile first.
 If this is not found it will check the most common profiles such as that of the "Touch controller" and do a conversion.
-If all else fails, it will check the generic :ref:`"Simple controller"<The simple controller>`.
+If all else fails, it will check the generic :ref:`"Simple controller" <doc_xr_action_map_simple>`.
 
 .. note::
   There is an important conclusion to be made here:
@@ -357,6 +357,8 @@ As mentioned before OpenXR will do conversions between the two, but do read the 
   It is important to note that only a select number of XR controllers support touch sensors or have click features on thumbsticks.
   Keep that in mind when designing your game/application. 
   Make sure these are used for optional features of your game/application.
+
+.. _doc_xr_action_map_simple:
 
 The simple controller
 ---------------------


### PR DESCRIPTION
Reverts us to the state before https://github.com/godotengine/godot-docs/commit/6952796767163494f24cd2a9269565d30902b5c5.

We had a couple of issues for a long time now, hoping to improve related articles or for related bugs to be fixed, but at this point disabling error reporting for their sake makes us miss obvious bugs in new PRs. So I think it's time.

- Shader syntax highlighter is disabled for those couple samples that have issues with Pygments 2.14;
- Invalid node references removed from the networking documentation (it's pending rework, and removing them doesn't break the flow of the article anyway);
- Invalid internal reference in a recent XR article is fixed.