### PR TITLE
Add a warning that docs are WIP and a status flag for articles

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -936,11 +936,24 @@ code,
 }
 
 /* Admonition tweaks */
+.rst-content .admonition-grid {
+    display: grid;
+    grid-template-columns: 4fr 5fr;
+    gap: 20px;
+}
+@media screen and (max-width: 1020px) {
+    .rst-content .admonition-grid {
+        grid-template-columns: 1fr;
+        gap: 12px;
+    }
+}
 
 .rst-content .admonition,
 .rst-content .admonition.note,
 .rst-content .admonition.seealso {
     background-color: var(--admonition-note-background-color);
+    border-radius: 4px;
+    box-shadow: 0px 3px 9px 0px rgb(0 0 0 / 29%);
     color: var(--admonition-note-color);
 }
 
@@ -948,7 +961,17 @@ code,
 .rst-content .admonition.note .admonition-title,
 .rst-content .admonition.seealso .admonition-title {
     background-color: var(--admonition-note-title-background-color);
+    border-radius: 4px 4px 0 0;
     color: var(--admonition-note-title-color);
+    font-weight: 600;
+    font-size: 105%;
+    line-height: 120%;
+    padding: 6px 16px;
+    text-align: right;
+}
+
+.rst-content .admonition .admonition-title:before {
+    margin-right: 9px;
 }
 
 .rst-content .admonition.attention,
@@ -985,6 +1008,10 @@ code,
 .rst-content .admonition.important .admonition-title {
     background-color: var(--admonition-tip-title-background-color);
     color: var(--admonition-tip-title-color);
+}
+
+.article-status strong {
+    color: var(--body-color);
 }
 
 /* Keyboard shortcuts tweaks */

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -26,17 +26,41 @@
 
 {%- block document %}
 <div itemprop="articleBody">
-  {% if godot_is_latest %}
-  <div class="admonition attention latest-notice">
-    <p class="first admonition-title">Attention</p>
-    <p>
-      You are reading the <code class="docutils literal notranslate"><span class="pre">latest</span></code>
-      (unstable) version of this documentation, which may document features not available
-      or compatible with Godot 3.x.
-    </p>
-    <p class="last latest-notice-link">
-      Checking the stable version of the documentation...
-    </p>
+  {% if godot_is_latest or godot_show_article_status %}
+  <div class="admonition-grid">
+    {% if godot_is_latest %}
+    <div class="admonition attention latest-notice">
+      <p class="first admonition-title">Attention</p>
+      <p>
+        You are reading the <code class="docutils literal notranslate"><span class="pre">latest</span></code>
+        (unstable) version of this documentation, which may document features not available
+        or compatible with Godot 3.x.
+      </p>
+      <p class="last latest-notice-link">
+        Checking the stable version of the documentation...
+      </p>
+    </div>
+    {% endif %}
+
+    {% if godot_show_article_status %}
+    <div class="admonition tip article-status">
+      <p class="first admonition-title">Work in progress</p>
+      <p>
+        Godot documentation is being updated to reflect the latest changes in version
+        <code class="docutils literal notranslate">{{ godot_version }}</code>. Some documentation pages may
+        still state outdated information. This banner will tell you if you're reading one of such pages.
+      </p>
+      <p>
+        {% if meta and meta.get('article_outdated') == 'True' %}
+          The contents of this page can be <strong>outdated</strong>. If you know how to improve this page or you can confirm
+          that it's up to date, feel free to <a href="https://github.com/godotengine/godot-docs">open a pull request</a>.
+        {% else %}
+          The contents of this page are <strong>up to date</strong>. If you can still find outdated information, please
+          <a href="https://github.com/godotengine/godot-docs">open an issue</a>.
+        {% endif %}
+      </p>
+    </div>
+    {% endif %}
   </div>
   {% endif %}
 

--- a/about/docs_changelog.rst
+++ b/about/docs_changelog.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_docs_changelog:
 
 Documentation changelog

--- a/about/release_policy.rst
+++ b/about/release_policy.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_release_policy:
 
 Godot release policy

--- a/about/troubleshooting.rst
+++ b/about/troubleshooting.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_troubleshooting:
 
 Troubleshooting

--- a/conf.py
+++ b/conf.py
@@ -178,6 +178,9 @@ html_context = {
     # Set this to `True` when in the `latest` branch to clearly indicate to the reader
     # that they are not reading the `stable` documentation.
     "godot_is_latest": True,
+    "godot_version": "4.0",
+    # Enables a banner that displays the up-to-date status of each article.
+    "godot_show_article_status": True,
 }
 
 html_logo = "img/docs_logo.svg"
@@ -192,14 +195,14 @@ html_extra_path = ["robots.txt"]
 html_css_files = [
     'css/algolia.css',
     'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css',
-    "css/custom.css?7", # Increment the number at the end when the file changes to bust the cache.
+    "css/custom.css?8", # Increment the number at the end when the file changes to bust the cache.
 ]
 
 if not on_rtd:
     html_css_files.append("css/dev.css")
 
 html_js_files = [
-    "js/custom.js?4", # Increment the number at the end when the file changes to bust the cache.
+    "js/custom.js?5", # Increment the number at the end when the file changes to bust the cache.
     ('https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js', {'defer': 'defer'}),
     ('js/algolia.js', {'defer': 'defer'})
 ]

--- a/contributing/development/file_formats/gdscript_grammar.rst
+++ b/contributing/development/file_formats/gdscript_grammar.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_gdscript_grammar:
 
 GDScript grammar

--- a/contributing/development/file_formats/tscn.rst
+++ b/contributing/development/file_formats/tscn.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_tscn_file_format:
 
 TSCN file format

--- a/getting_started/introduction/godot_design_philosophy.rst
+++ b/getting_started/introduction/godot_design_philosophy.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_godot_design_philosophy:
 
 Godot's design philosophy

--- a/getting_started/introduction/index.rst
+++ b/getting_started/introduction/index.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. Intention: provide the necessary information to make the most of the getting
    started series, answering questions like "do I want to learn Godot?", "how
    does it look and feel?", "how does it work?", and "how do I best learn it?".

--- a/getting_started/introduction/introduction_to_godot.rst
+++ b/getting_started/introduction/introduction_to_godot.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_introduction_to_godot:
 
 Introduction to Godot

--- a/getting_started/introduction/key_concepts_overview.rst
+++ b/getting_started/introduction/key_concepts_overview.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. Intention: introduce only a handful of key concepts and avoid a big cognitive
    load. Readers will then be reminded of the concepts further in the getting
    started series, reinforcing their learning.

--- a/getting_started/introduction/learning_new_features.rst
+++ b/getting_started/introduction/learning_new_features.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. Keep this page short and sweet! We want users to read it to the end, so they
    know where to find information, how to get help, and how to maximize chances
    of getting answers.

--- a/getting_started/step_by_step/index.rst
+++ b/getting_started/step_by_step/index.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 Step by step
 ============
 

--- a/getting_started/step_by_step/instancing.rst
+++ b/getting_started/step_by_step/instancing.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_instancing:
 
 Creating instances

--- a/getting_started/step_by_step/nodes_and_scenes.rst
+++ b/getting_started/step_by_step/nodes_and_scenes.rst
@@ -1,4 +1,7 @@
-.. The goal of this page is to explain more than doc_key_concepts_overview about nodes and scenes, get the user to create their first concrete scene.
+:article_outdated: True
+
+.. The goal of this page is to explain more than doc_key_concepts_overview about nodes and scenes,
+   get the user to create their first concrete scene.
 
 .. _doc_nodes_and_scenes:
 

--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 ..
     Intention:
 

--- a/getting_started/step_by_step/scripting_languages.rst
+++ b/getting_started/step_by_step/scripting_languages.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. Intention: only introduce what a script does in general and options for
    scripting languages.
 

--- a/getting_started/step_by_step/scripting_player_input.rst
+++ b/getting_started/step_by_step/scripting_player_input.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. Intention: only introduce one necessary input method at this point. The
    Inputs section of the docs should provide more guides comparing the various
    tools you have to manage the complexity of user input.

--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. Intention: give the user a first taste of signals. We should write more
    documentation in the scripting/ section.
 .. Note: GDScript snippets use one line return instead of two because they're

--- a/tutorials/2d/2d_meshes.rst
+++ b/tutorials/2d/2d_meshes.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_2d_meshes:
 
 2D meshes

--- a/tutorials/2d/2d_transforms.rst
+++ b/tutorials/2d/2d_transforms.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_viewport_and_canvas_transforms:
 
 Viewport and canvas transforms

--- a/tutorials/2d/particle_systems_2d.rst
+++ b/tutorials/2d/particle_systems_2d.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_particle_systems_2d:
 
 Particle systems (2D)

--- a/tutorials/2d/using_tilemaps.rst
+++ b/tutorials/2d/using_tilemaps.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_using_tilemaps:
 
 Using TileMaps

--- a/tutorials/3d/csg_tools.rst
+++ b/tutorials/3d/csg_tools.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_csg_tools:
 
 Prototyping levels with CSG

--- a/tutorials/3d/high_dynamic_range.rst
+++ b/tutorials/3d/high_dynamic_range.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_high_dynamic_range:
 
 High dynamic range lighting

--- a/tutorials/3d/using_multi_mesh_instance.rst
+++ b/tutorials/3d/using_multi_mesh_instance.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_using_multi_mesh_instance:
 
 Using MultiMeshInstance3D

--- a/tutorials/animation/animation_track_types.rst
+++ b/tutorials/animation/animation_track_types.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_animation_track_types:
 
 Animation Track types

--- a/tutorials/audio/audio_buses.rst
+++ b/tutorials/audio/audio_buses.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_audio_buses:
 
 Audio buses

--- a/tutorials/audio/audio_effects.rst
+++ b/tutorials/audio/audio_effects.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_audio_effects:
 
 Audio effects

--- a/tutorials/audio/audio_streams.rst
+++ b/tutorials/audio/audio_streams.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_audio_streams:
 
 Audio streams

--- a/tutorials/audio/index.rst
+++ b/tutorials/audio/index.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 Audio
 =====
 

--- a/tutorials/audio/recording_with_microphone.rst
+++ b/tutorials/audio/recording_with_microphone.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_recording_with_microphone:
 
 Recording with microphone

--- a/tutorials/audio/sync_with_audio.rst
+++ b/tutorials/audio/sync_with_audio.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_sync_with_audio:
 
 Sync the gameplay with audio and music

--- a/tutorials/best_practices/autoloads_versus_internal_nodes.rst
+++ b/tutorials/best_practices/autoloads_versus_internal_nodes.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_autoloads_versus_internal_nodes:
 
 Autoloads versus regular nodes

--- a/tutorials/best_practices/data_preferences.rst
+++ b/tutorials/best_practices/data_preferences.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_data_preferences:
 
 Data preferences

--- a/tutorials/best_practices/godot_interfaces.rst
+++ b/tutorials/best_practices/godot_interfaces.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_godot_interfaces:
 
 Godot interfaces

--- a/tutorials/best_practices/godot_notifications.rst
+++ b/tutorials/best_practices/godot_notifications.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_godot_notifications:
 
 Godot notifications

--- a/tutorials/best_practices/index.rst
+++ b/tutorials/best_practices/index.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 Best practices
 ==============
 

--- a/tutorials/best_practices/introduction_best_practices.rst
+++ b/tutorials/best_practices/introduction_best_practices.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_introduction_best_practices:
 
 Introduction

--- a/tutorials/best_practices/logic_preferences.rst
+++ b/tutorials/best_practices/logic_preferences.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_logic_preferences:
 
 Logic preferences

--- a/tutorials/best_practices/node_alternatives.rst
+++ b/tutorials/best_practices/node_alternatives.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_node_alternatives:
 
 When and how to avoid using nodes for everything

--- a/tutorials/best_practices/scene_organization.rst
+++ b/tutorials/best_practices/scene_organization.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_scene_organization:
 
 Scene organization

--- a/tutorials/best_practices/scenes_versus_scripts.rst
+++ b/tutorials/best_practices/scenes_versus_scripts.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_scenes_versus_scripts:
 
 When to use scenes versus scripts

--- a/tutorials/best_practices/version_control_systems.rst
+++ b/tutorials/best_practices/version_control_systems.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_version_control_systems:
 
 Version Control Systems

--- a/tutorials/best_practices/what_are_godot_classes.rst
+++ b/tutorials/best_practices/what_are_godot_classes.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_what_are_godot_classes:
 
 Applying object-oriented principles in Godot

--- a/tutorials/editor/command_line_tutorial.rst
+++ b/tutorials/editor/command_line_tutorial.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_command_line_tutorial:
 
 Command line tutorial

--- a/tutorials/editor/customizing_editor.rst
+++ b/tutorials/editor/customizing_editor.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_customizing_editor:
 
 Customizing the interface

--- a/tutorials/editor/default_key_mapping.rst
+++ b/tutorials/editor/default_key_mapping.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. meta::
     :keywords: cheatsheet, cheat sheet, shortcut
 

--- a/tutorials/editor/external_editor.rst
+++ b/tutorials/editor/external_editor.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_external_editor:
 
 Using an external text editor

--- a/tutorials/editor/index.rst
+++ b/tutorials/editor/index.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 Editor introduction
 ===================
 

--- a/tutorials/editor/inspector_dock.rst
+++ b/tutorials/editor/inspector_dock.rst
@@ -1,3 +1,4 @@
+:article_outdated: True
 
 .. _doc_editor_inspector_dock:
 

--- a/tutorials/editor/managing_editor_features.rst
+++ b/tutorials/editor/managing_editor_features.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_managing_editor_features:
 
 Managing editor features

--- a/tutorials/editor/project_manager.rst
+++ b/tutorials/editor/project_manager.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_project_manager:
 
 Using the Project manager

--- a/tutorials/editor/project_settings.rst
+++ b/tutorials/editor/project_settings.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_project_settings:
 
 Project Settings

--- a/tutorials/editor/using_the_web_editor.rst
+++ b/tutorials/editor/using_the_web_editor.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_using_the_web_editor:
 
 Using the Web editor

--- a/tutorials/export/exporting_for_dedicated_servers.rst
+++ b/tutorials/export/exporting_for_dedicated_servers.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_exporting_for_dedicated_servers:
 
 Exporting for dedicated servers

--- a/tutorials/export/exporting_for_uwp.rst
+++ b/tutorials/export/exporting_for_uwp.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_exporting_for_uwp:
 
 Exporting for Universal Windows Platform

--- a/tutorials/export/exporting_projects.rst
+++ b/tutorials/export/exporting_projects.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_exporting_projects:
 
 Exporting projects

--- a/tutorials/io/background_loading.rst
+++ b/tutorials/io/background_loading.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_background_loading:
 
 Background loading

--- a/tutorials/io/binary_serialization_api.rst
+++ b/tutorials/io/binary_serialization_api.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_binary_serialization_api:
 
 Binary serialization API

--- a/tutorials/networking/high_level_multiplayer.rst
+++ b/tutorials/networking/high_level_multiplayer.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_high_level_multiplayer:
 
 High-level multiplayer

--- a/tutorials/networking/http_client_class.rst
+++ b/tutorials/networking/http_client_class.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_http_client_class:
 
 HTTP client class

--- a/tutorials/networking/http_request_class.rst
+++ b/tutorials/networking/http_request_class.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_http_request_class:
 
 Making HTTP requests

--- a/tutorials/networking/index.rst
+++ b/tutorials/networking/index.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 Networking
 ==========
 

--- a/tutorials/networking/ssl_certificates.rst
+++ b/tutorials/networking/ssl_certificates.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_ssl_certificates:
 
 SSL certificates

--- a/tutorials/networking/webrtc.rst
+++ b/tutorials/networking/webrtc.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_webrtc:
 
 WebRTC

--- a/tutorials/networking/websocket.rst
+++ b/tutorials/networking/websocket.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_websocket:
 
 WebSocket

--- a/tutorials/performance/cpu_optimization.rst
+++ b/tutorials/performance/cpu_optimization.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_cpu_optimization:
 
 CPU optimization

--- a/tutorials/performance/general_optimization.rst
+++ b/tutorials/performance/general_optimization.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_general_optimization:
 
 General optimization tips

--- a/tutorials/performance/gpu_optimization.rst
+++ b/tutorials/performance/gpu_optimization.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_gpu_optimization:
 
 GPU optimization

--- a/tutorials/performance/index.rst
+++ b/tutorials/performance/index.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_performance:
 
 Performance

--- a/tutorials/performance/optimizing_3d_performance.rst
+++ b/tutorials/performance/optimizing_3d_performance.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. meta::
     :keywords: optimization
 

--- a/tutorials/performance/thread_safe_apis.rst
+++ b/tutorials/performance/thread_safe_apis.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_thread_safe_apis:
 
 Thread-safe APIs

--- a/tutorials/performance/using_multimesh.rst
+++ b/tutorials/performance/using_multimesh.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_using_multimesh:
 
 Optimization using MultiMeshes

--- a/tutorials/performance/using_multiple_threads.rst
+++ b/tutorials/performance/using_multiple_threads.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_using_multiple_threads:
 
 Using multiple threads

--- a/tutorials/performance/using_servers.rst
+++ b/tutorials/performance/using_servers.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_using_servers:
 
 Optimization using Servers

--- a/tutorials/performance/vertex_animation/animating_thousands_of_fish.rst
+++ b/tutorials/performance/vertex_animation/animating_thousands_of_fish.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_animating_thousands_of_fish:
 
 Animating thousands of fish with MultiMeshInstance3D

--- a/tutorials/performance/vertex_animation/controlling_thousands_of_fish.rst
+++ b/tutorials/performance/vertex_animation/controlling_thousands_of_fish.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_controlling_thousands_of_fish:
 
 Controlling thousands of fish with Particles

--- a/tutorials/performance/vertex_animation/index.rst
+++ b/tutorials/performance/vertex_animation/index.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 Animating thousands of objects
 ==============================
 

--- a/tutorials/platform/android/android_in_app_purchases.rst
+++ b/tutorials/platform/android/android_in_app_purchases.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_android_in_app_purchases:
 
 Android in-app purchases

--- a/tutorials/platform/android/android_plugin.rst
+++ b/tutorials/platform/android/android_plugin.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_android_plugin:
 
 Creating Android plugins

--- a/tutorials/platform/android/index.rst
+++ b/tutorials/platform/android/index.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 Android plugins
 ===============
 

--- a/tutorials/platform/customizing_html5_shell.rst
+++ b/tutorials/platform/customizing_html5_shell.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_customizing_html5_shell:
 
 Custom HTML page for Web export

--- a/tutorials/platform/html5_shell_classref.rst
+++ b/tutorials/platform/html5_shell_classref.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_html5_shell_classref:
 
 HTML5 shell class reference

--- a/tutorials/platform/index.rst
+++ b/tutorials/platform/index.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 Platform-specific
 =================
 

--- a/tutorials/platform/ios/index.rst
+++ b/tutorials/platform/ios/index.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 iOS plugins
 ===========
 

--- a/tutorials/platform/ios/ios_plugin.rst
+++ b/tutorials/platform/ios/ios_plugin.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_ios_plugin:
 
 Creating iOS plugins

--- a/tutorials/platform/ios/plugins_for_ios.rst
+++ b/tutorials/platform/ios/plugins_for_ios.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_plugins_for_ios:
 
 Plugins for iOS

--- a/tutorials/platform/platform_html5.rst
+++ b/tutorials/platform/platform_html5.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_platform_html5:
 
 HTML5

--- a/tutorials/plugins/editor/3d_gizmos.rst
+++ b/tutorials/plugins/editor/3d_gizmos.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_3d_gizmo_plugins:
 
 3D gizmo plugins

--- a/tutorials/plugins/editor/import_plugins.rst
+++ b/tutorials/plugins/editor/import_plugins.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_import_plugins:
 
 Import plugins

--- a/tutorials/plugins/editor/making_main_screen_plugins.rst
+++ b/tutorials/plugins/editor/making_main_screen_plugins.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_making_main_screen_plugins:
 
 Making main screen plugins

--- a/tutorials/rendering/multiple_resolutions.rst
+++ b/tutorials/rendering/multiple_resolutions.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_multiple_resolutions:
 
 Multiple resolutions

--- a/tutorials/ui/custom_gui_controls.rst
+++ b/tutorials/ui/custom_gui_controls.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_custom_gui_controls:
 
 Custom GUI controls

--- a/tutorials/ui/gui_containers.rst
+++ b/tutorials/ui/gui_containers.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_gui_containers:
 
 Using Containers

--- a/tutorials/ui/size_and_anchors.rst
+++ b/tutorials/ui/size_and_anchors.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_size_and_anchors:
 
 Size and anchors


### PR DESCRIPTION
Depends on https://github.com/godotengine/godot-docs/pull/6814.

This PR adds a togglable warning about docs being WIP, advising to pay attention to itself to learn if the page is up to date or not. By default every page is considered outdated. To mark it as up to date, we must add a flag to its metadata (a field at the top of the document), like

```
:article_updated: True
```

See `index.rst` for an example.

-----

Now, obviously, this is a lot of busywork to verify every article, but I think it's better to default to being outdated than to default to being up to date, because that's closer to the true state of the docs. Many articles still need an update pass, even though others have been updated or even rewritten. The outdated banner also has a call to action, so this should hopefully incentivize people to contribute or to at least validate the actuality of the docs.

If we don't agree on this, I can remake the defaults or implement the logic differently.

-----

Here's how it looks (I made some adjustments to the admonition banners in general):

![chrome_2023-02-24_20-37-04](https://user-images.githubusercontent.com/11782833/221278050-bb9880ae-4fd8-4948-ae74-8e8258cd1688.png)
![chrome_2023-02-24_20-36-32](https://user-images.githubusercontent.com/11782833/221278075-10ac9425-43cf-4cd9-9c67-213f421fec9d.png)
