### PR TITLE
Mention the need for Flip Faces when using QuadMesh for post-processing

### DIFF
--- a/tutorials/shaders/advanced_postprocessing.rst
+++ b/tutorials/shaders/advanced_postprocessing.rst
@@ -33,13 +33,14 @@ shader and to access the depth texture of the scene. Next, use a vertex shader
 to make the quad cover the screen at all times so that the post-processing
 effect will be applied at all times, including in the editor.
 
-First, create a new MeshInstance3D and set its mesh to a QuadMesh. This creates a quad
-centered at position ``(0, 0, 0)`` with a width and height of ``1``. Set the width
-and height to ``2``. Right now, the quad occupies a position in world space at the
-origin; however, we want it to move with the camera so that it always covers the
-entire screen. To do this, we will bypass the coordinate transforms that translate
-the vertex positions through the difference coordinate spaces and treat the vertices
-as if they were already in clip space.
+First, create a new MeshInstance3D and set its mesh to a QuadMesh. This creates
+a quad centered at position ``(0, 0, 0)`` with a width and height of ``1``. Set
+the width and height to ``2`` and check off ``flip_faces``. Right now, the quad
+occupies a position in world space at the origin; however, we want it to move
+with the camera so that it always covers the entire screen. To do this, we will
+bypass the coordinate transforms that translate the vertex positions through the
+difference coordinate spaces and treat the vertices as if they were already in
+clip space.
 
 The vertex shader expects coordinates to be output in clip space, which are coordinates
 ranging from ``-1`` at the left and bottom of the screen to ``1`` at the top and right

--- a/tutorials/shaders/advanced_postprocessing.rst
+++ b/tutorials/shaders/advanced_postprocessing.rst
@@ -35,8 +35,8 @@ effect will be applied at all times, including in the editor.
 
 First, create a new MeshInstance3D and set its mesh to a QuadMesh. This creates
 a quad centered at position ``(0, 0, 0)`` with a width and height of ``1``. Set
-the width and height to ``2`` and check off ``flip_faces``. Right now, the quad
-occupies a position in world space at the origin; however, we want it to move
+the width and height to ``2`` and enable **Flip Faces**. Right now, the quad
+occupies a position in world space at the origin. However, we want it to move
 with the camera so that it always covers the entire screen. To do this, we will
 bypass the coordinate transforms that translate the vertex positions through the
 difference coordinate spaces and treat the vertices as if they were already in


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/58337

This just adds the the instruction to check off ``flip_faces`` so that the QuadMesh is oriented the right way