### PR TITLE
Update references to "Mono" menu item to "Dotnet"

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -66,7 +66,7 @@ external IDE or editor, such as  `Visual Studio Code <https://code.visualstudio.
 or MonoDevelop. These provide autocompletion, debugging, and other
 useful features for C#. To select an external editor in Godot,
 click on **Editor → Editor Settings** and scroll down to
-**Mono**. Under **Mono**, click on **Editor**, and select your
+**Dotnet**. Under **Dotnet**, click on **Editor**, and select your
 external editor of choice. Godot currently supports the following
 external editors:
 
@@ -87,7 +87,7 @@ After reading the "Prerequisites" section, you can download and install
 
 In Godot's **Editor → Editor Settings** menu:
 
-- Set **Mono** -> **Editor** -> **External Editor** to **JetBrains Rider**.
+- Set **Dotnet** -> **Editor** -> **External Editor** to **JetBrains Rider**.
 
 In Rider:
 
@@ -102,7 +102,7 @@ After reading the "Prerequisites" section, you can download and install
 
 In Godot's **Editor → Editor Settings** menu:
 
-- Set **Mono** -> **Editor** -> **External Editor** to **Visual Studio Code**.
+- Set **Dotnet** -> **Editor** -> **External Editor** to **Visual Studio Code**.
 
 In Visual Studio Code:
 
@@ -138,7 +138,7 @@ While installing Visual Studio, select these workloads:
 
 In Godot's **Editor → Editor Settings** menu:
 
-- Set **Mono** -> **Editor** -> **External Editor** to **Visual Studio**.
+- Set **Dotnet** -> **Editor** -> **External Editor** to **Visual Studio**.
 
 Next, you can download the Godot Visual Studio extension from github
 `here <https://github.com/godotengine/godot-csharp-visualstudio/releases>`__.


### PR DESCRIPTION
Update references to "Mono" menu item to "Dotnet" in the text of the C Sharp Basics tutorial to match the actual menus as of Godot 4 RC5

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
