### PR TITLE
Update `class_name` in Static typing in GDScript to follow style guide

### DIFF
--- a/tutorials/scripting/gdscript/static_typing.rst
+++ b/tutorials/scripting/gdscript/static_typing.rst
@@ -131,8 +131,8 @@ For the example above, your Rifle.gd would look like this:
 
 ::
 
-    extends Node2D
     class_name Rifle
+    extends Node2D
 
 If you use ``class_name``, Godot registers the Rifle type globally in
 the editor, and you can use it anywhere, without having to preload it


### PR DESCRIPTION
In the style guide one page before it was suggested to put the class_name first

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
