### PR TITLE
.net windows editor build uses backslashes

### DIFF
--- a/contributing/development/compiling/compiling_with_dotnet.rst
+++ b/contributing/development/compiling/compiling_with_dotnet.rst
@@ -149,7 +149,7 @@ Example (Windows)
     scons p=windows target=template_release module_mono_enabled=yes
     
     # Generate glue sources
-    bin/godot.windows.editor.x86_64.mono --generate-mono-glue modules/mono/glue
+    bin\godot.windows.editor.x86_64.mono --generate-mono-glue modules/mono/glue
     # Build .NET assemblies
     ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=windows
 


### PR DESCRIPTION
Using the slash command in the windows console will report an error
![QQ截图20230227120054](https://user-images.githubusercontent.com/17066147/221471392-5b577eca-b906-47f7-a1bf-126e5b97a69e.png)


