### PR TITLE
Fix TTS code example and add C# version

### DIFF
--- a/tutorials/audio/text_to_speech.rst
+++ b/tutorials/audio/text_to_speech.rst
@@ -13,31 +13,46 @@ Basic usage of text-to-speech involves the following one-time steps:
 
 Once you have the voice ID, you can use it to speak some text:
 
-::
+.. tabs::
+ .. code-tab:: gdscript GDScript
 
-    # One-time steps
-    var voices:Array = DisplayServer.tts_get_voices()
+    # One-time steps.
     # Pick a voice. Here, we arbitrarily pick the first English voice.
-    var voice_data:Dictionary
-    for voice in voices:
-        if "English" in voice["language"]:
-            voice_data = voice
-            break
+    var voices = DisplayServer.tts_get_voices_for_language("en")
+    var voice_id = voices[0]
 
-    # Say "Hello, World!"
-    DisplayServer.tts_speak("Hello, World!", voice_data["id"])
+    # Say "Hello, world!".
+    DisplayServer.tts_speak("Hello, world!", voice_id)
 
     # Say a longer sentence, and then interrupt it.
-    # Note that this method is asynchronous: execution proceeds
-    # to the next line immediately, before the voice finishes speaking.
-    
-    var long_message:String = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur"
+    # Note that this method is asynchronous: execution proceeds to the next line immediately,
+    # before the voice finishes speaking.
+    var long_message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur"
+    DisplayServer.tts_speak(long_message, voice_id)
 
-    DisplayServer.tts_speak(long_message)
-
-    # Immediately stop the current text mid-sentence and say goodbye instead
+    # Immediately stop the current text mid-sentence and say goodbye instead.
     DisplayServer.tts_stop()
-    DisplayServer.tts_speak("Goodbye!")
+    DisplayServer.tts_speak("Goodbye!", voice_id)
+
+ .. code-tab:: csharp
+
+    // One-time steps.
+    // Pick a voice. Here, we arbitrarily pick the first English voice.
+    string[] voices = DisplayServer.TtsGetVoicesForLanguage("en");
+    string voiceId = voices[0];
+
+    // Say "Hello, world!".
+    DisplayServer.TtsSpeak("Hello, world!", voiceId);
+
+    // Say a longer sentence, and then interrupt it.
+    // Note that this method is asynchronous: execution proceeds to the next line immediately,
+    // before the voice finishes speaking.
+    string longMessage = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur";
+    DisplayServer.TtsSpeak(longMessage, voiceId);
+
+    // Immediately stop the current text mid-sentence and say goodbye instead.
+    DisplayServer.TtsStop();
+    DisplayServer.TtsSpeak("Goodbye!", voiceId);
 
 
 Requirements for functionality


### PR DESCRIPTION
- Update GDScript example to follow [typing guidelines](https://docs.godotengine.org/en/latest/contributing/documentation/docs_writing_guidelines.html#dynamic-vs-static-typing)
- Fix the GDScript example (comparing `voice["language"]` to `"English"` would never work, given the format of `voice["language"]`)
- Write the C# equivalent of this example

I don't really like this long string that creates a horizontal scroll, but I'm not sure if there's a better way.

*Bugsquad edit: followup to https://github.com/godotengine/godot-docs/pull/6783*