### PR TITLE
Best practices godot notifications

### DIFF
--- a/tutorials/best_practices/godot_notifications.rst
+++ b/tutorials/best_practices/godot_notifications.rst
@@ -158,18 +158,16 @@ instantiation:
     # "one" is an "initialized value". These DO NOT trigger the setter.
     # If someone set the value as "two" from the Inspector, this would be an
     # "exported value". These DO trigger the setter.
-    export(String) var test = "one" setget set_test
+    @export var test: String = "one":
+        set(value):
+            test = value
+            print("Setting: ", test)
 
     func _init():
         # "three" is an "init assignment value".
-        # These DO NOT trigger the setter, but...
+        # These DO trigger the setter
         test = "three"
-        # These DO trigger the setter. Note the `self` prefix.
-        self.test = "three"
-
-    func set_test(value):
-        test = value
-        print("Setting: ", test)
+        self.test = "four"
 
   .. code-tab:: csharp
 

--- a/tutorials/best_practices/godot_notifications.rst
+++ b/tutorials/best_practices/godot_notifications.rst
@@ -164,7 +164,7 @@ instantiation:
             print("Setting: ", test)
 
     func _init():
-        # "three" is an "init assignment value".
+        # "three" and "four" are both "init assignment value".
         # These DO trigger the setter
         test = "three"
         self.test = "four"


### PR DESCRIPTION
Update one code block in [Godot Notifications](https://docs.godotengine.org/en/latest/tutorials/best_practices/godot_notifications.html#init-vs-initialization-vs-export)

Setter are always triggered (except in "initialized value").  
Reference: [Properties (setters and getters) note](https://docs.godotengine.org/en/latest/tutorials/scripting/gdscript/gdscript_basics.html#properties-setters-and-getters)  

Tested with Godot 4.0-rc6
```gdscript
extends Node2D


# Setted "two" in the Inspector
@export var test: String = "one":
	set(value):
		test = value
		print("Setting: ", test)

func _init():
	test = "three"
	self.test = "four"

func _ready():
	test = "five"
	self.test = "six"
```
```
Setting: three
Setting: four
Setting: two
Setting: five
Setting: six
```

I don't know if the rest of this section still up to date.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
