### PR TITLE
Remove duplicate text from GDExtension doc

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -28,7 +28,7 @@ There are a few prerequisites you'll need:
 See also :ref:`Compiling <toc-devel-compiling>` as the build tools are identical
 to the ones you need to compile Godot from source.
 
-You can download this repository from GitHub or let Git do the work for you.
+You can download the `godot-cpp repository <https://github.com/godotengine/godot-cpp>`__ from GitHub or let Git do the work for you.
 Note that this repository has different branches for different versions
 of Godot. GDExtensions will not work in older versions of Godot (only Godot 4 and up) and vice versa, so make sure you download the correct branch.
 
@@ -49,11 +49,6 @@ a Git submodule:
     git submodule add -b master https://github.com/godotengine/godot-cpp
     cd godot-cpp
     git submodule update --init
-
-If you decide to just download the repositories or clone them into your project
-folder, make sure to keep the folder layout identical to the one described here,
-as much of the code we'll be showcasing here assumes the project follows this
-layout.
 
 Do make sure you clone recursively to pull in both repositories:
 


### PR DESCRIPTION
2 changes :
- Make the link to godot-cpp more explicit. The phrase `See also Compiling as the build` breaks the flow, and thus the link should be mentioned again

![2023-02-28_01-22](https://user-images.githubusercontent.com/3624853/221719868-cd35ffc5-0eb3-4a90-a675-68d16eefa1fc.png)

- Remove duplicate block of text : `If you decide to download the repository ...` which is repeated in the next `Note` block

![2023-02-28_01-15](https://user-images.githubusercontent.com/3624853/221719907-ec7ffafb-0487-4c56-9099-e20360fbd58d.png)
