### PR TITLE
Fix link to Rust GDExtension repository

### DIFF
--- a/tutorials/scripting/gdextension/what_is_gdextension.rst
+++ b/tutorials/scripting/gdextension/what_is_gdextension.rst
@@ -76,7 +76,7 @@ The bindings below are developed and maintained by the community:
 .. Binding developers: Feel free to open a pull request to add your binding if it's well-developed enough to be used in a project.
 .. Please keep languages sorted in alphabetical order.
 
-- `Rust <https://github.com/godot-rust/godot-rust>`__
+- `Rust <https://github.com/godot-rust/gdextension>`__
 
 .. note::
 


### PR DESCRIPTION
The previous link was pointing to the Godot 3.5 Rust GDNative repo.
The new link is pointing to the current/upcoming GDExtension repo.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
