### PR TITLE
Changed admonition-title alignment from 'right' to 'left'.

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -967,7 +967,7 @@ code,
     font-size: 105%;
     line-height: 120%;
     padding: 6px 16px;
-    text-align: right;
+    text-align: left;
 }
 
 .rst-content .admonition .admonition-title:before {


### PR DESCRIPTION
Currently, all admonition titles are aligned to the **right**.  This is unintuitive and as all other admonitions [that I'm aware of](https://f5-rtd-howto.readthedocs.io/en/dev/resources/resources_rtd-admonitions.html) align to the **left**, I can only assume that this right alignment is not intended.  This PR simply changes the alignment from the right to the left as seen in the before and after images below.

![image](https://user-images.githubusercontent.com/1691061/221774642-88672c20-552a-4897-ad5d-881cd73eb4f2.png)

![image](https://user-images.githubusercontent.com/1691061/221775080-974e5649-bed4-4a74-9d8f-9980dac6f74b.png)

The change that caused the right alignment appears to have been committed yesterday in https://github.com/godotengine/godot-docs/commit/ff4f111677f523892817b0c6efe0be1692263dac by @YuriSizov.
Though, I'm not sure if it was already right aligned before that as I hadn't noticed until now.