### PR TITLE
Update release policy for 4.0 release

### DIFF
--- a/about/release_policy.rst
+++ b/about/release_policy.rst
@@ -21,7 +21,7 @@ term adapted to the complexity of a game engine:
   which imply significant porting work to move projects from one major version
   to another.
 
-  For example, porting Godot projects from Godot 2.1 to Godot 3.0 required
+  For example, porting Godot projects from Godot 3.x to Godot 4.x requires
   running the project through a conversion tool, and then performing a number
   of further adjustments manually for what the tool could not do automatically.
 
@@ -40,7 +40,7 @@ term adapted to the complexity of a game engine:
 
     Upgrading to a new minor version is therefore recommended for all users,
     but some testing is necessary to ensure that your project still behaves as
-    expected in a new minor version.
+    expected.
 
 - The ``patch`` version is incremented for maintenance releases which focus on
   fixing bugs and security issues, implementing new requirements for platform
@@ -58,15 +58,8 @@ term adapted to the complexity of a game engine:
 We call ``major.minor`` combinations *stable branches*. Each stable branch
 starts with a ``major.minor`` release (without the ``0`` for ``patch``) and is
 further developed for maintenance releases in a Git branch of the same name
-(for example patch updates for the 3.3 stable branch are developed in the
-``3.3`` Git branch).
-
-.. note::
-
-    As mentioned in the introduction, Godot's release policy is evolving, and
-    earlier Godot releases may not have followed the above rules to the letter.
-    In particular, the 3.2 stable branch received a number of new features in
-    3.2.2 that would have warranted a ``minor`` version increment.
+(for example patch updates for the 4.0 stable branch are developed in the
+``4.0`` Git branch).
 
 Release support timeline
 ------------------------
@@ -79,8 +72,8 @@ who need maintenance updates.
 Whenever a new major version is released, we make the previous stable branch a
 long-term supported release, and do our best to provide fixes for issues
 encountered by users of that branch who cannot port complex projects to the new
-major version. This was the case for the 2.1 branch, and will be the case for
-the latest 3.x stable branch by the time Godot 4.0 is released.
+major version. This was the case for the 2.1 branch, and is the case for the
+3.6 branch.
 
 In a given minor release series, only the latest patch release receives support.
 If you experience an issue using an older patch release, please upgrade to the
@@ -90,17 +83,22 @@ on GitHub.
 +-------------+----------------------+--------------------------------------------------------------------------+
 | **Version** | **Release date**     | **Support level**                                                        |
 +-------------+----------------------+--------------------------------------------------------------------------+
-| Godot 4.0   | Q1 2023 (estimate)   | |unstable| *Beta.* Current focus of development (unstable).              |
+| Godot 4.1   | Q2-Q3 2023 (estimate)| |unstable| *Development.* Receives new features as well as bug fixes     |
+| (`master`)  |                      | while under development.                                                 |
 +-------------+----------------------+--------------------------------------------------------------------------+
-| Godot 3.6   | Q1-Q2 2023 (estimate)| |supported| *Beta.* Receives new features as well as bug fixes while     |
-| (LTS)       |                      | under development. Will be released *after* 4.0.                         |
+| Godot 4.0   | March 2023           | |supported| Receives fixes for bugs, security and platform support       |
+|             |                      | issues, as well as backwards-compatible usability enhancements.          |
++-------------+----------------------+--------------------------------------------------------------------------+
+| Godot 3.6   | Q2-Q3 2023 (estimate)| |supported| *Beta.* Receives new features as well as bug fixes while     |
+| (`3.x`, LTS)|                      | under development. Will be released *after* 4.0.                         |
 +-------------+----------------------+--------------------------------------------------------------------------+
 | Godot 3.5   | August 2022          | |supported| Receives fixes for bugs, security and platform support       |
 |             |                      | issues, as well as backwards-compatible usability enhancements.          |
 +-------------+----------------------+--------------------------------------------------------------------------+
-| Godot 3.4   | November 2021        | |partial| Receives fixes for security and platform support issues only.  |
+| Godot 3.4   | November 2021        | |eol| No longer supported, as fully superseded by the compatible 3.5     |
+|             |                      | release (last update: 3.4.5).                                            |
 +-------------+----------------------+--------------------------------------------------------------------------+
-| Godot 3.3   | April 2021           | |eol| No longer supported as fully superseded by the compatible 3.4      |
+| Godot 3.3   | April 2021           | |eol| No longer supported, as fully superseded by the compatible 3.4     |
 |             |                      | release (last update: 3.3.4).                                            |
 +-------------+----------------------+--------------------------------------------------------------------------+
 | Godot 3.2   | January 2020         | |eol| No longer supported (last update: 3.2.3).                          |
@@ -134,7 +132,8 @@ provided for testing purposes only.
 
 .. seealso::
 
-    See :ref:`doc_upgrading_to_godot_4` for instructions on migrating a project.
+    See :ref:`doc_upgrading_to_godot_4` for instructions on migrating a project
+    from Godot 3.x to 4.x.
 
 .. _doc_release_policy_when_is_next_release_out:
 
@@ -142,13 +141,23 @@ When is the next release out?
 -----------------------------
 
 While Godot contributors aren't working under any deadlines, we strive to
-publish minor releases relatively frequently, with an average of two 3.x minor
-releases per year since Godot 3.3.
+publish minor releases relatively frequently.
+
+In particular, after the very length release cycle for 4.0, we are pivoting to
+a faster paced development workflow, with the 4.1 release expected within late
+Q2 / early Q3 2023.
+
+Frequent minor releases will enable us to ship new features faster (possibly
+as experimental), get user feedback quickly, and iterate to improve those
+features and their usability. Likewise, the general user experience will be
+improved more steadily with a faster path to the end users.
 
 Maintenance (patch) releases are released as needed with potentially very
 short development cycles, to provide users of the current stable branch with
 the latest bug fixes for their production needs.
 
-As for the upcoming Godot 4.0, as of December 2022, we are well into the *beta*
-phase, and are aiming for a stable release in Q1 2023.
-`Follow the Godot blog <https://godotengine.org/news>`__ for the latest updates.
+The 3.6 release is still planned and should be the last stable branch of Godot
+3.x. It will be a Long-Term Support (LTS) release, which we plan to support for
+as long as users still need it (due to missing features in Godot 4.x, or
+having published games which they need to keep updating for platform
+requirements).


### PR DESCRIPTION
- Add estimate for 4.1 release.
- Update estimate for 3.6.
- Mark 3.4 as EOL.
- Update section on our future releases.