### PR TITLE
Link to 3.5 version of the doc in List of features

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -7,9 +7,9 @@ This page aims to list **all** features currently supported by Godot.
 
 .. note::
 
-    This page lists features supported by the current development version of
-    Godot (4.0.rc). Some of these features may not be available in the
-    `current stable release series (3.x) <https://docs.godotengine.org/en/stable/about/list_of_features.html>`__.
+    This page lists features supported by the current stable version of
+    Godot (4.0). Some of these features may not be available in the
+    `LTS release series (3.x) <https://docs.godotengine.org/en/3.5/about/list_of_features.html>`__.
 
 Platforms
 ---------


### PR DESCRIPTION
Fixes #6853.
I opted to link to the 3.5 version of the doc for now, as 3.6 is not out yet. I also changed the wording to refer to 4.0 as "stable" and 3.5 as "LTS".
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
