### PR TITLE
Removed all instances of velocity being defined for `CharacterBody2D`

### DIFF
--- a/tutorials/3d/using_transforms.rst
+++ b/tutorials/3d/using_transforms.rst
@@ -293,7 +293,7 @@ Jump:
     if Input.is_action_just_pressed("jump"):
         velocity.y = JUMP_SPEED
 
-    velocity = move_and_slide(velocity)
+    move_and_slide()
 
  .. code-tab:: csharp
 
@@ -301,7 +301,7 @@ Jump:
     if (Input.IsActionJustPressed("jump"))
         velocity.Y = JumpSpeed;
 
-    velocity = MoveAndSlide(velocity);
+    MoveAndSlide();
 
 All common behaviors and logic can be done with just vectors.
 

--- a/tutorials/physics/kinematic_character_2d.rst
+++ b/tutorials/physics/kinematic_character_2d.rst
@@ -149,7 +149,6 @@ little more like a regular game character:
     extends CharacterBody2D
 
     const GRAVITY = 200.0
-    var velocity = Vector2()
 
     func _physics_process(delta):
         velocity.y += delta * GRAVITY
@@ -164,7 +163,6 @@ little more like a regular game character:
     public partial class PhysicsScript : CharacterBody2D
     {
         const float gravity = 200.0f;
-        Vector2 velocity;
 
         public override void _PhysicsProcess(float delta)
         {
@@ -189,8 +187,6 @@ This adds basic support for walking when pressing left and right:
     const GRAVITY = 200.0
     const WALK_SPEED = 200
 
-    var velocity = Vector2()
-
     func _physics_process(delta):
         velocity.y += delta * GRAVITY
 
@@ -201,11 +197,8 @@ This adds basic support for walking when pressing left and right:
         else:
             velocity.x = 0
 
-        # We don't need to multiply velocity by delta because "move_and_slide" already takes delta time into account.
-
-        # The second parameter of "move_and_slide" is the normal pointing up.
-        # In the case of a 2D platformer, in Godot, upward is negative y, which translates to -1 as a normal.
-        move_and_slide(velocity, Vector2(0, -1))
+        # "move_and_slide" takes delta time into account.
+        move_and_slide()
 
  .. code-tab:: csharp
 
@@ -215,8 +208,6 @@ This adds basic support for walking when pressing left and right:
     {
         const float gravity = 200.0f;
         const int walkSpeed = 200;
-
-        Vector2 velocity;
 
         public override void _PhysicsProcess(float delta)
         {
@@ -235,10 +226,7 @@ This adds basic support for walking when pressing left and right:
                 velocity.x = 0;
             }
 
-            // We don't need to multiply velocity by delta because "MoveAndSlide" already takes delta time into account.
-
-            // The second parameter of "MoveAndSlide" is the normal pointing up.
-            // In the case of a 2D platformer, in Godot, upward is negative y, which translates to -1 as a normal.
+            // "MoveAndSlide" already takes delta time into account.
             MoveAndSlide(velocity, new Vector2(0, -1));
         }
     }

--- a/tutorials/physics/kinematic_character_2d.rst
+++ b/tutorials/physics/kinematic_character_2d.rst
@@ -197,7 +197,7 @@ This adds basic support for walking when pressing left and right:
         else:
             velocity.x = 0
 
-        # "move_and_slide" takes delta time into account.
+        # "move_and_slide" already takes delta time into account.
         move_and_slide()
 
  .. code-tab:: csharp

--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -439,8 +439,6 @@ the ground (including slopes) and jump when standing on the ground:
     var jump_speed = -1000
     var gravity = 2500
 
-    var velocity = Vector2()
-
     func get_input():
         velocity.x = 0
         var right = Input.is_action_pressed('ui_right')
@@ -457,7 +455,7 @@ the ground (including slopes) and jump when standing on the ground:
     func _physics_process(delta):
         velocity.y += gravity * delta
         get_input()
-        velocity = move_and_slide(velocity, Vector2(0, -1))
+        move_and_slide()
 
  .. code-tab:: csharp
 
@@ -468,8 +466,6 @@ the ground (including slopes) and jump when standing on the ground:
         private float _runSpeed = 350;
         private float _jumpSpeed = -1000;
         private float _gravity = 2500;
-
-        private Vector2 _velocity = new Vector2();
 
         private void GetInput()
         {
@@ -491,7 +487,7 @@ the ground (including slopes) and jump when standing on the ground:
         {
             _velocity.y += _gravity * delta;
             GetInput();
-            _velocity = MoveAndSlide(_velocity, new Vector2(0,-1));
+            MoveAndSlide();
         }
     }
 


### PR DESCRIPTION
`velocity` is a built-in property of `CharacterBody2D`. There is no need to define it, or use it in move_and_slide(). There is also no need to pass in up direction since that is a built-in property too.

Closes #6860