### PR TITLE
Display Godot version more clearly

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1601,6 +1601,7 @@ p + .classref-constant {
     overflow-y: auto;
     overflow-x: hidden;
     max-height: calc(100% - 348px);
+    padding-bottom: 24px;
 }
 @media screen and (max-width: 768px) {
     .wy-nav-side {

--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -13,11 +13,11 @@ const registerOnScrollEvent = (function(){
   // The number of pixels the user must scroll by before the logo is completely hidden.
   const scrollTopPixels = 84;
   // The target margin to be applied to the navigation bar when the logo is hidden.
-  const menuTopMargin = 88;
+  const menuTopMargin = 70;
   // The max-height offset when the logo is completely visible.
-  const menuHeightOffset_default = 180;
+  const menuHeightOffset_default = 162;
   // The max-height offset when the logo is completely hidden.
-  const menuHeightOffset_fixed = 98;
+  const menuHeightOffset_fixed = 80;
   // The distance between the two max-height offset values above; used for intermediate values.
   const menuHeightOffset_diff = (menuHeightOffset_default - menuHeightOffset_fixed);
 

--- a/_templates/breadcrumbs.html
+++ b/_templates/breadcrumbs.html
@@ -1,25 +1,40 @@
 {%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
 
+{% block breadcrumbs %}
+<li>
+	<div style="font-size: 105%;font-weight: 600;">
+		{{ godot_docs_title | replace("%s", godot_version) }}
+	</div>
+	<ul class="wy-breadcrumbs">
+		{{ super() }}
+	</ul>
+</li>
+{% endblock %}
+
 {% block breadcrumbs_aside %}
 {% if not meta or meta.get('github_url') != 'hide' %}
-{{ super() }}
+<li style="float: right; text-align: right;">
+	<ul>
+		{{ super() }}
+	</ul>
 
-<style>
-	.godot-edit-guidelines {
-		font-size: 14px;
-		float: right;
-		clear: both;
-		padding-top: 4px;
-	}
-
-	@media screen and (max-width: 480px) {
+	<style>
 		.godot-edit-guidelines {
-			display: none;
+			font-size: 14px;
+			float: right;
+			clear: both;
+			padding-top: 4px;
 		}
-	}
-</style>
-<a class="godot-edit-guidelines" href="https://docs.godotengine.org/en/latest/contributing/documentation/index.html#writing-documentation">
-	Learn how to contribute!
-</a>
+
+		@media screen and (max-width: 480px) {
+			.godot-edit-guidelines {
+				display: none;
+			}
+		}
+	</style>
+	<a class="godot-edit-guidelines" href="https://docs.godotengine.org/en/latest/contributing/documentation/index.html#writing-documentation">
+		Learn how to contribute!
+	</a>
+</li>
 {% endif %}
 {% endblock %}

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,4 +1,5 @@
 {% extends "!layout.html" -%}
+{# Refer to https://github.com/readthedocs/sphinx_rtd_theme/blob/master/sphinx_rtd_theme/layout.html #}
 
 {% block htmltitle -%}
 <title>{{ godot_title_prefix }}{{ title|striptags|e }}{{ titlesuffix }}</title>

--- a/_templates/versions.html
+++ b/_templates/versions.html
@@ -13,7 +13,7 @@
 <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
   <span class="rst-current-version" data-toggle="rst-current-version">
     <span class="fa fa-book"> Read the Docs</span>
-    v: {{ display_version }}
+    v: {{ display_version }}{% if display_version != godot_version %} ({{ godot_version }}){% endif %}
     <span class="fa fa-caret-down"></span>
   </span>
   <div class="rst-other-versions">

--- a/conf.py
+++ b/conf.py
@@ -97,20 +97,20 @@ if env_tags is not None:
 # Language / i18n
 
 supported_languages = {
-    "en": "Godot Engine (%s) documentation in English",
-    "de": "Godot Engine (%s) Dokumentation auf Deutsch",
-    "es": "Documentación de Godot Engine (%s) en español",
-    "fr": "Documentation de Godot Engine (%s) en français",
-    "fi": "Godot Engine (%s) dokumentaatio suomeksi",
-    "it": "Godot Engine (%s) documentazione in italiano",
-    "ja": "Godot Engine (%s)の日本語のドキュメント",
-    "ko": "Godot Engine (%s) 문서 (한국어)",
-    "pl": "Dokumentacja Godot Engine (%s) w języku polskim",
-    "pt_BR": "Documentação da Godot Engine (%s) em Português Brasileiro",
-    "ru": "Документация Godot Engine (%s) на русском языке",
-    "uk": "Документація до Godot Engine (%s) українською мовою",
-    "zh_CN": "Godot Engine (%s) 简体中文文档",
-    "zh_TW": "Godot Engine (%s) 正體中文 (台灣) 文件",
+    "en": "Godot Engine %s documentation in English",
+    "de": "Godot Engine %s Dokumentation auf Deutsch",
+    "es": "Documentación de Godot Engine %s en español",
+    "fr": "Documentation de Godot Engine %s en français",
+    "fi": "Godot Engine %s dokumentaatio suomeksi",
+    "it": "Godot Engine %s documentazione in italiano",
+    "ja": "Godot Engine %sの日本語のドキュメント",
+    "ko": "Godot Engine %s 문서 (한국어)",
+    "pl": "Dokumentacja Godot Engine %s w języku polskim",
+    "pt_BR": "Documentação da Godot Engine %s em Português Brasileiro",
+    "ru": "Документация Godot Engine %s на русском языке",
+    "uk": "Документація до Godot Engine %s українською мовою",
+    "zh_CN": "Godot Engine %s 简体中文文档",
+    "zh_TW": "Godot Engine %s 正體中文 (台灣) 文件",
 }
 
 language = os.getenv("READTHEDOCS_LANGUAGE", "en")
@@ -155,9 +155,11 @@ html_theme_options = {
     "logo_only": True,
     # Collapse navigation (False makes it tree-like)
     "collapse_navigation": False,
+    # Hide the documentation version name/number under the logo
+    "display_version": False,
 }
 
-html_title = supported_languages[language] % version
+html_title = supported_languages[language] % ( "(" + version + ")" )
 
 # VCS options: https://docs.readthedocs.io/en/latest/vcs.html#github
 html_context = {
@@ -168,6 +170,7 @@ html_context = {
     "conf_py_path": "/",  # Path in the checkout to the docs root
     "godot_inject_language_links": True,
     "godot_docs_supported_languages": list(supported_languages.keys()),
+    "godot_docs_title": supported_languages[language],
     "godot_docs_basepath": "https://docs.godotengine.org/",
     "godot_docs_suffix": ".html",
     "godot_default_lang": "en",
@@ -195,14 +198,14 @@ html_extra_path = ["robots.txt"]
 html_css_files = [
     'css/algolia.css',
     'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css',
-    "css/custom.css?9", # Increment the number at the end when the file changes to bust the cache.
+    "css/custom.css?10", # Increment the number at the end when the file changes to bust the cache.
 ]
 
 if not on_rtd:
     html_css_files.append("css/dev.css")
 
 html_js_files = [
-    "js/custom.js?5", # Increment the number at the end when the file changes to bust the cache.
+    "js/custom.js?6", # Increment the number at the end when the file changes to bust the cache.
     ('https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js', {'defer': 'defer'}),
     ('js/algolia.js', {'defer': 'defer'})
 ]


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-docs/issues/6866.

We have evergreen versions, stable and latest, where the version of Godot is not clear. While we only had Godot 3 docs this was mostly okay, but now that we have two stable branches, this leads to a lot of confusion. Personally, I also didn't quite like having that docs branch version written under the logo, as it was lacking context and relevance for users.

So here's an attempt to address these issues:

* Remove the version text from under the logo;
* Add Godot version to the ReadTheDocs panel in the sidebar;
  * Unfortunately, in the unfolded form, in the list of versions, it will still state "stable" and "latest". We have no control over that list, at least not in the layout.
* Add a small title to the top navigation block, similar to the page's title but with Godot version stated instead.
  * I'm stealing the same string used for page titles, so it also states the language, but that's also not bad.

![chrome_2023-03-02_20-18-11](https://user-images.githubusercontent.com/11782833/222530785-59c8eccb-914d-4288-859a-2da219420e3f.png)

And here's how it looks now, for comparison:

![chrome_2023-03-02_20-11-07](https://user-images.githubusercontent.com/11782833/222531574-eb28d995-cdbe-4087-9714-bd2d8fda26d5.png)

-----

PS. We should probably mark latest as 4.1 at some point, but perhaps later.