### PR TITLE
Convert some things from 3.x to 4.x

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -35,10 +35,10 @@ Here is a complete class example based on these guidelines:
 
     signal state_changed(previous, new)
 
-    export var initial_state = NodePath()
-    var is_active = true setget set_is_active
+    @export var initial_state = NodePath()
+    var is_active = true : set = set_is_active
 
-    @onready var _state = get_node(initial_state) setget set_state
+    @onready var _state = get_node(initial_state) : set = set_state
     @onready var _state_name = _state.name
 
 
@@ -780,9 +780,9 @@ variables, in that order.
 
    const MAX_LIVES = 3
 
-   export(Jobs) var job = Jobs.KNIGHT
-   export var max_health = 50
-   export var attack = 5
+   @export var job : Jobs = Jobs.KNIGHT
+   @export var max_health = 50
+   @export var attack = 5
 
    var health = max_health setget set_health
 


### PR DESCRIPTION
Few things are still 3.x for example `setget`, `export`, so have converted those to 4.x. Not everything is converted and fully checked, just a few things that I could see from scanning through
