### PR TITLE
Fix Autoload capitalization inconsistency

### DIFF
--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -233,7 +233,7 @@ Add and export a variable speed to the script. The function set_speed after
     Code from other nodes doesn't run in the editor. Your access to other nodes
     is limited. You can access the tree and nodes, and their default properties,
     but you can't access user variables. If you want to do so, other nodes have
-    to run in the editor too. AutoLoad nodes cannot be accessed in the editor at
+    to run in the editor too. Autoload nodes cannot be accessed in the editor at
     all.
 
 Reporting node configuration warnings

--- a/tutorials/scripting/scene_unique_nodes.rst
+++ b/tutorials/scripting/scene_unique_nodes.rst
@@ -85,7 +85,7 @@ some situations where other techniques may be better.
 A :ref:`Group <doc_groups>` allows locating a node (or a group of many nodes)
 from any other node, no matter what scene the two nodes are located in.
 
-A :ref:`Singleton (AutoLoad) <doc_singletons_autoload>` is an always loaded node
+A :ref:`Singleton (Autoload) <doc_singletons_autoload>` is an always loaded node
 that can be accessed directly by any node regardless of the scene. These are useful
 when some data or functionality is shared globally.
 

--- a/tutorials/scripting/singletons_autoload.rst
+++ b/tutorials/scripting/singletons_autoload.rst
@@ -1,6 +1,6 @@
 .. _doc_singletons_autoload:
 
-Singletons (AutoLoad)
+Singletons (Autoload)
 =====================
 
 Introduction
@@ -37,7 +37,7 @@ Autoloading nodes and scripts can give us these characteristics.
 
 .. note::
 
-    Godot won't make an AutoLoad a "true" singleton as per the singleton design
+    Godot won't make an Autoload a "true" singleton as per the singleton design
     pattern. It may still be instanced more than once by the user if desired.
 
 .. tip::
@@ -46,10 +46,10 @@ Autoloading nodes and scripts can give us these characteristics.
     :ref:`registering it automatically in the Project Settings <doc_making_plugins_autoload>`
     when the plugin is enabled.
 
-AutoLoad
+Autoload
 --------
 
-You can create an AutoLoad to load a scene or a script that inherits from
+You can create an Autoload to load a scene or a script that inherits from
 :ref:`class_Node`.
 
 .. note::
@@ -61,7 +61,7 @@ You can create an AutoLoad to load a scene or a script that inherits from
 .. image:: img/singleton.png
 
 To autoload a scene or script, select **Project > Project Settings** from the
-menu and switch to the **AutoLoad** tab.
+menu and switch to the **Autoload** tab.
 
 .. image:: img/autoload_tab.png
 
@@ -136,7 +136,7 @@ Make sure it inherits from ``Node``:
 .. image:: img/autoload_script.png
 
 The next step is to add this script to the autoLoad list. Open
-**Project > Project Settings** from the menu, switch to the **AutoLoad** tab and
+**Project > Project Settings** from the menu, switch to the **Autoload** tab and
 select the script by clicking the browse button or typing its path:
 ``res://Global.gd``. Press **Add** to add it to the autoload list:
 


### PR DESCRIPTION
All `AutoLoad` were changed to `Autoload` in the engine, see https://github.com/godotengine/godot/pull/58920.