### PR TITLE
Document compiledb generation.

### DIFF
--- a/contributing/development/configuring_an_ide/index.rst
+++ b/contributing/development/configuring_an_ide/index.rst
@@ -24,3 +24,15 @@ Development Environment), here are setup instructions for some popular ones:
    xcode
 
 It is possible to use other IDEs, but their setup is not documented yet.
+
+If your editor supports the `language server protocol <https://microsoft.github.io/language-server-protocol/>`__,
+you can use `clangd <https://clangd.llvm.org>`__ for completion, diagnostics, and more.
+You can generate a compilation database for use with clangd one of two ways:
+
+.. code-block:: shell
+
+   # Generate compile_commands.json while compiling
+   scons compiledb=yes
+
+   # Generate compile_commands.json without compiling
+   scons compiledb=yes compile_commands.json


### PR DESCRIPTION
The compiledb=yes flag is only documented in the vscode and clion sections, but is relevant to any LSP-based editor.

In addition, nothing mentioned the ability to generate a compilation database without compiling, referenced here:

https://github.com/godotengine/godot/issues/39883#issuecomment-924423857

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
