### PR TITLE
Fix Getting State Machine Example for Godot 4

### DIFF
--- a/tutorials/animation/animation_tree.rst
+++ b/tutorials/animation/animation_tree.rst
@@ -312,7 +312,7 @@ object from the ``AnimationTree`` node (it is exported as a property).
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    var state_machine = anim_tree["parameters/playback"]
+    var state_machine = anim_tree["parameters/StateMachine/playback"]
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
Really small fix but I've changed line 315 to work with Godot 4

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
