### PR TITLE
Addresses minor grammar issue

### DIFF
--- a/getting_started/introduction/godot_design_philosophy.rst
+++ b/getting_started/introduction/godot_design_philosophy.rst
@@ -81,9 +81,9 @@ user experience. You can still work with external programs as long as
 there is an import plugin for it. Or you can create one, like the `Tiled
 Map Importer <https://github.com/vnen/godot-tiled-importer>`__.
 
-That is also partly why Godot offers its own programming languages
-GDScript and, along with C#. They're designed for the needs
-of game developers and game designers, and they're tightly integrated in
+That is also partly why Godot offers its own programming language
+GDScript along with C#. GDScript is designed for the needs
+of game developers and game designers, and is tightly integrated in
 the engine and the editor.
 
 GDScript lets you write code using an indentation-based syntax,


### PR DESCRIPTION
Grammar issue accidentally left in when references to Visual Script were removed. https://github.com/godotengine/godot-docs/pull/6111

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
