### PR TITLE
Fix the wrong hyperlink to XR Tools.

### DIFF
--- a/tutorials/xr/introducing_xr_tools.rst
+++ b/tutorials/xr/introducing_xr_tools.rst
@@ -7,7 +7,8 @@ Out of the box Godot gives you all the basic support to setup an XR project.
 XR specific game mechanics however need to be implemented on top of this foundation.
 While Godot makes this relatively easy this can still be a daunting task.
 
-For this reason Godot has developed a toolkit called `Godot XR Tools <https://github/GodotVR/godot-xr-tools>`_ that implements many of the basic mechanics found in XR games, from locomotion to object interaction to UI interaction. 
+For this reason Godot has developed a toolkit called `Godot XR Tools <https://github.com/GodotVR/godot-xr-tools>`_
+that implements many of the basic mechanics found in XR games, from locomotion to object interaction to UI interaction. 
 
 This toolkit is designed to work with both OpenXR and WebXR runtimes.
 We'll be using this as a base for our documentation here.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Fix #6908.