### PR TITLE
Update matrices_and_transforms.rst

### DIFF
--- a/tutorials/math/matrices_and_transforms.rst
+++ b/tutorials/math/matrices_and_transforms.rst
@@ -606,6 +606,9 @@ this project which has colored lines and cubes to help visualize the
 :ref:`class_Basis` vectors and the origin in both 2D and 3D:
 https://github.com/godotengine/godot-demo-projects/tree/master/misc/matrix_transform
 
+.. note:: You cannot edit Node2D's transform matrix directly in Godot 4.0's
+          inspector. This may be changed in a future release of Godot.
+
 If you would like additional explanation, you should check out
 3Blue1Brown's excellent video about 3D linear transformations:
 https://www.youtube.com/watch?v=rHLEWRxRGiM

--- a/tutorials/math/matrices_and_transforms.rst
+++ b/tutorials/math/matrices_and_transforms.rst
@@ -606,14 +606,6 @@ this project which has colored lines and cubes to help visualize the
 :ref:`class_Basis` vectors and the origin in both 2D and 3D:
 https://github.com/godotengine/godot-demo-projects/tree/master/misc/matrix_transform
 
-.. note:: Spatial's "Matrix" section in Godot 3.2's inspector
-          displays the matrix as transposed, with the columns
-          horizontal and the rows vertical. This may be changed
-          to be less confusing in a future release of Godot.
-
-.. note:: You cannot edit Node2D's transform matrix directly in Godot 3.2's
-          inspector. This may be changed in a future release of Godot.
-
 If you would like additional explanation, you should check out
 3Blue1Brown's excellent video about 3D linear transformations:
 https://www.youtube.com/watch?v=rHLEWRxRGiM


### PR DESCRIPTION
Removed mention of Godot 3.2 in current version of Godot 4. To me the text also assumed that the current version being used is 3.2.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
