### PR TITLE
Update "reporting node..." segment

### DIFF
--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -254,17 +254,17 @@ By default, the warning only updates when closing and reopening the scene.
  .. code-tab:: gdscript GDScript
 
     # Use setters to update the configuration warning automatically.
-    export var title = "":
+    @export var title = "":
         set(p_title):
             if p_title != title:
                 title = p_title
-                update_configuration_warning()
+                update_configuration_warnings()
 
-    export var description = "":
+    @export var description = "":
         set(p_description):
             if p_description != description:
                 description = p_description
-                update_configuration_warning()
+                update_configuration_warnings()
 
 
     func _get_configuration_warning():


### PR DESCRIPTION
Current code in the "Reporting node configuration warnings" segment doesn't work with Godot 4.0

I added @ to export variables and changed update_configuration_warning() to new update_configuration_warnings().

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
