### PR TITLE
Mention the "Pick" button when connecting signals

### DIFF
--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -349,9 +349,10 @@ Now we need to connect the ``HUD`` functionality to our ``Main`` script. This
 requires a few additions to the ``Main`` scene:
 
 In the Node tab, connect the HUD's ``start_game`` signal to the ``new_game()``
-function of the Main node by typing "new_game" in the "Receiver Method" in the
-"Connect a Signal" window. Verify that the green connection icon now appears
-next to ``func new_game()`` in the script.
+function of the Main node by clicking the "Pick" button in the "Connect a Signal"
+window and selecting the ``new_game()`` method or type "new_game" below "Receiver Method"
+in the window. Verify that the green connection icon now appears next to
+``func new_game()`` in the script.
 
 In ``new_game()``, update the score display and show the "Get Ready" message:
 


### PR DESCRIPTION
With the addition of the useful Pick button in the "Connect a Signal" window, I thought it would be useful to mention it here.