### PR TITLE
Fix 2D Sprite Animation @onready vars

### DIFF
--- a/tutorials/2d/2d_sprite_animation.rst
+++ b/tutorials/2d/2d_sprite_animation.rst
@@ -78,7 +78,7 @@ released.
 
     extends CharacterBody2D
 
-    onready var _animated_sprite = $AnimatedSprite2D
+    @onready var _animated_sprite = $AnimatedSprite2D
 
     func _process(_delta):
         if Input.is_action_pressed("ui_right"):
@@ -219,7 +219,7 @@ released.
 
     extends CharacterBody2D
 
-    onready var _animation_player = $AnimationPlayer
+    @onready var _animation_player = $AnimationPlayer
 
     func _process(_delta):
         if Input.is_action_pressed("ui_right"):


### PR DESCRIPTION
The syntax changed in Godot 4 for `onready` -> `@onready`