### PR TITLE
fix class_node.rst "TranferMode" typo

### DIFF
--- a/classes/class_node.rst
+++ b/classes/class_node.rst
@@ -2124,7 +2124,7 @@ Changes the RPC mode for the given ``method`` with the given ``config`` which sh
 
     {
         rpc_mode = MultiplayerAPI.RPCMode,
-        transfer_mode = MultiplayerPeer.TranferMode,
+        transfer_mode = MultiplayerPeer.TransferMode,
         call_local = false,
         channel = 0,
     }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
