### PR TITLE
Add missing quotation masks to export_node_path example

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -356,10 +356,10 @@ between parentheses and separated by commas.
 Both of these are the same::
 
     @onready
-    @export_node_path(TextEdit, LineEdit)
+    @export_node_path("TextEdit", "LineEdit")
     var input_field
 
-    @onready @export_node_path(TextEdit, LineEdit) var input_field
+    @onready @export_node_path("TextEdit", "LineEdit") var input_field
 
 .. _doc_gdscript_onready_annotation:
 


### PR DESCRIPTION
This PR adds quotation marks to the values in `@export_node_path`, which are necessary, as those parameters should be strings.
