### PR TITLE
Updated "Reporting node configuration warnings"

### DIFF
--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -268,14 +268,16 @@ By default, the warning only updates when closing and reopening the scene.
 
 
     func _get_configuration_warnings():
-        var warning = []
-        if title == "":
-            warning.append("Please set `title` to a non-empty value.")
-        if description.length() >= 100:
-            warning.append("`description` should be less than 100 characters long.")
+        var warnings = []
 
-        # Returning an empty string means "no warning".
-        return warning
+        if title == "":
+            warnings.append("Please set `title` to a non-empty value.")
+
+        if description.length() >= 100:
+            warnings.append("`description` should be less than 100 characters long.")
+
+        # Returning an empty array means "no warning".
+        return warnings
 
 Instancing scenes
 -----------------


### PR DESCRIPTION
- Replaced `func _get_configuration_warning():` by `func _get_configuration_warnings():`
- Replaced `string` with `PackedStringArray` as the former doesn't work anymore.
- Removed the line breaks that were added to the String to visually separate warnings, as it is no longer required.
- Replaced the "empty string" with "empty array" in the comment about how to report no errors.
- Renamed `warning` variable to `warnings` to indicate that it can contain multiple warnings.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
