### PR TITLE
Fix heading in using_tilesets

### DIFF
--- a/tutorials/2d/using_tilesets.rst
+++ b/tutorials/2d/using_tilesets.rst
@@ -537,7 +537,7 @@ An example configuration for a full tilesheet may look as follows:
 .. _doc_using_tilemaps_assigning_properties_to_multiple_tiles:
 
 Assigning properties to multiple tiles at once
-----------------------------------------------c
+----------------------------------------------
 
 There are two ways to assign properties to multiple tiles at once.
 Depending on your use cases, one method may be faster than the other:


### PR DESCRIPTION
Fixed a heading that had a random c at the end

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
