### PR TITLE
Updating the instructions for C# debugging in Visual Studio Code

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -124,7 +124,7 @@ executable. Now, when you start the debugger in Visual Studio Code, your Godot p
 .. note::
 
     There is also a `C# Tools for Godot <https://marketplace.visualstudio.com/items?itemName=neikeq.godot-csharp-vscode>`__ 
-    Visual Studio Code extension, that is meant to make this setup easier and to provid further usefull tools. 
+    Visual Studio Code extension, that is meant to make this setup easier and to provide further useful tools.
     But it is not yet updated to work with Godot 4.
 
 Visual Studio (Windows only)

--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -108,20 +108,24 @@ In Godot's **Editor → Editor Settings** menu:
 In Visual Studio Code:
 
 - Install the `C# <https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp>`__ extension.
-- Install the `Mono Debug <https://marketplace.visualstudio.com/items?itemName=ms-vscode.mono-debug>`__ extension.
-- Install the `C# Tools for Godot <https://marketplace.visualstudio.com/items?itemName=neikeq.godot-csharp-vscode>`__ extension.
 
 .. note::
 
     If you are using Linux you need to install the `Mono SDK <https://www.mono-project.com/download/stable/#download-lin>`__
     for the C# tools plugin to work.
 
-To configure a project for debugging open the Godot project folder in VS Code.
-Go to the Run tab and click on **Add Configuration...**. Select **C# Godot**
-from the dropdown menu. Open the ``tasks.json`` and ``launch.json`` files that
-were created. Change the executable setting in ``launch.json`` and  command
-settings in ``tasks.json`` to your Godot executable path. Now, when you start
-the debugger in VS Code, your Godot project will run.
+To configure a project for debugging, you need a ``tasks.json`` and ``launch.json`` file in 
+the ``.vscode`` folder with the necessary configuration. An example configuration can be 
+found `here <https://github.com/godotengine/godot-csharp-vscode/issues/43#issuecomment-1258321229>`__ . 
+In the ``tasks.json`` file, make sure the ``program`` parameter points to your Godot executable, either by 
+changing it to the path of the executable or by defining a ``GODOT4`` environment variable that points to the
+executable. Now, when you start the debugger in Visual Studio Code, your Godot project will run.
+
+.. note::
+
+    There is also a `C# Tools for Godot <https://marketplace.visualstudio.com/items?itemName=neikeq.godot-csharp-vscode>`__ 
+    Visual Studio Code extension, that is meant to make this setup easier and to provid further usefull tools. 
+    But it is not yet updated to work with Godot 4.
 
 Visual Studio (Windows only)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Edited the instructions needed to make Visual Studio Code debugging work with Godot 4 - .net. Explained the situation with the not yet updated Godot c# extension for Visual Studio Code.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
