### PR TITLE
Change capitalization of Project Manager

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -76,7 +76,7 @@ Editor
 - :ref:`Create your own plugins <doc_making_plugins>` using GDScript to add new
   features or speed up your workflow.
 - :ref:`Download projects from the asset library <doc_using_assetlib_editor>`
-  in the project manager and import them directly.
+  in the Project Manager and import them directly.
 
 Rendering
 ---------

--- a/about/troubleshooting.rst
+++ b/about/troubleshooting.rst
@@ -12,7 +12,7 @@ This page lists common issues encountered when using Godot and possible solution
     See :ref:`doc_using_the_web_editor` for caveats specific to the HTML5 version
     of the Godot editor.
 
-Everything I do in the editor or project manager appears delayed by one frame
+Everything I do in the editor or Project Manager appears delayed by one frame
 -----------------------------------------------------------------------------
 
 This is a `known bug <https://github.com/godotengine/godot/issues/23069>`__ on
@@ -100,7 +100,7 @@ the system console. Godot cannot override this system-specific behavior.
 To solve this, select the system console window and press Enter to leave
 selection mode.
 
-Some text such as "NO DC" appears in the top-left corner of the project manager and editor window
+Some text such as "NO DC" appears in the top-left corner of the Project Manager and editor window
 -------------------------------------------------------------------------------------------------
 
 This is caused by the NVIDIA graphics driver injecting an overlay to display information.

--- a/about/troubleshooting.rst
+++ b/about/troubleshooting.rst
@@ -12,17 +12,6 @@ This page lists common issues encountered when using Godot and possible solution
     See :ref:`doc_using_the_web_editor` for caveats specific to the HTML5 version
     of the Godot editor.
 
-Everything I do in the editor or Project Manager appears delayed by one frame
------------------------------------------------------------------------------
-
-This is a `known bug <https://github.com/godotengine/godot/issues/23069>`__ on
-Intel graphics drivers on Windows. Updating to the latest graphics driver
-version *provided by Intel* should fix the issue.
-
-You should use the graphics driver provided by Intel rather than the one
-provided by your desktop or laptop's manufacturer because their version is often
-outdated.
-
 The editor runs slowly and uses all my CPU and GPU resources, making my computer noisy
 --------------------------------------------------------------------------------------
 

--- a/community/asset_library/using_assetlib.rst
+++ b/community/asset_library/using_assetlib.rst
@@ -109,10 +109,10 @@ In the editor
 .. note::
 
     The editor will display different categories of assets depending on whether
-    you're browsing the project manager's **Asset Library Projects** tab or the editor's
+    you're browsing the Project Manager's **Asset Library Projects** tab or the editor's
     **AssetLib** tab.
 
-    The project manager's **Asset Library Projects** tab will only display assets that are
+    The Project Manager's **Asset Library Projects** tab will only display assets that are
     standalone projects by themselves. This is denoted on the asset library with
     the *Templates*, *Demos* and *Projects* categories.
 

--- a/community/asset_library/what_is_assetlib.rst
+++ b/community/asset_library/what_is_assetlib.rst
@@ -31,7 +31,7 @@ Types of assets
 Be aware that there are, broadly, two different types of assets you can post.
 
 * Assets labeled as "Templates", "Projects", or "Demos" appear under
-  the "Asset Library Projects" tab in the Godot project manager. These assets are
+  the "Asset Library Projects" tab in the Godot Project Manager. These assets are
   standalone Godot projects that can run by themselves.
 
 * Other assets show up inside of the Godot editor under the "AssetLib"

--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -117,8 +117,8 @@ Start a terminal, go to the root dir of the engine source code and type:
 
 If all goes well, the resulting binary executable will be placed in the
 "bin" subdirectory. This executable file contains the whole engine and
-runs without any dependencies. Executing it will bring up the project
-manager.
+runs without any dependencies. Executing it will bring up the Project
+Manager.
 
 .. note::
 

--- a/contributing/development/compiling/compiling_for_macos.rst
+++ b/contributing/development/compiling/compiling_for_macos.rst
@@ -66,8 +66,8 @@ To support both architectures in a single "Universal 2" binary, run the above tw
 
 If all goes well, the resulting binary executable will be placed in the
 ``bin/`` subdirectory. This executable file contains the whole engine and
-runs without any dependencies. Executing it will bring up the project
-manager.
+runs without any dependencies. Executing it will bring up the Project
+Manager.
 
 .. note:: If you want to use separate editor settings for your own Godot builds
           and official releases, you can enable

--- a/contributing/development/compiling/introduction_to_the_buildsystem.rst
+++ b/contributing/development/compiling/introduction_to_the_buildsystem.rst
@@ -118,7 +118,7 @@ A Windows binary with the same configuration will look like this:
     C:\godot> dir bin/
     godot.windows.editor.64.exe
 
-Copy that binary to any location you like, as it contains the project manager,
+Copy that binary to any location you like, as it contains the Project Manager,
 editor and all means to execute the game. However, it lacks the data to export
 it to the different platforms. For that the export templates are needed (which
 can be either downloaded from `godotengine.org <https://godotengine.org/>`__, or
@@ -141,7 +141,7 @@ All builds are optimized. Each mode means:
 
 The editor is enabled by default in all PC targets (Linux, Windows, macOS),
 disabled for everything else. Disabling the editor produces a binary that can
-run projects but that does not include the editor or the project manager.
+run projects but that does not include the editor or the Project Manager.
 
 ::
 

--- a/contributing/development/configuring_an_ide/clion.rst
+++ b/contributing/development/configuring_an_ide/clion.rst
@@ -70,7 +70,7 @@ To add a custom build target that invokes SCons for compilation:
 .. figure:: img/clion-add-custom-build-application.png
    :align: center
 
-- Give the run/debug configuration a name, e.g. ``Godot debug``, select the ``Godot debug`` custom build target as the **Target**. Select the Godot executable in the ``bin/`` folder as the **Executable**, and set the **Program arguments** to ``--editor --path path-to-your-project/``, where ``path-to-your-project/`` should be a path pointing to an existing Godot project. If you omit the ``--path`` argument, you will only be able to debug the Godot project manager window. Click **OK** to create the run/debug configuration.
+- Give the run/debug configuration a name, e.g. ``Godot debug``, select the ``Godot debug`` custom build target as the **Target**. Select the Godot executable in the ``bin/`` folder as the **Executable**, and set the **Program arguments** to ``--editor --path path-to-your-project/``, where ``path-to-your-project/`` should be a path pointing to an existing Godot project. If you omit the ``--path`` argument, you will only be able to debug the Godot Project Manager window. Click **OK** to create the run/debug configuration.
 
 .. figure:: img/clion-run-configuration.png
    :align: center

--- a/contributing/development/configuring_an_ide/visual_studio.rst
+++ b/contributing/development/configuring_an_ide/visual_studio.rst
@@ -34,9 +34,9 @@ source code, stop at specific points in the code, inspect the current execution 
 and make live changes to the codebase.
 
 You can launch the project with the debugger attached using the **Debug > Start Debugging**
-option from the top menu. However, unless you want to debug the project manager specifically,
+option from the top menu. However, unless you want to debug the Project Manager specifically,
 you'd need to configure debugging options first. This is due to the fact that when the Godot
-project manager opens a project, the initial process is terminated and the debugger gets detached.
+Project Manager opens a project, the initial process is terminated and the debugger gets detached.
 
 - To configure the launch options to use with the debugger use **Project > Properties**
   from the top menu:
@@ -45,7 +45,7 @@ project manager opens a project, the initial process is terminated and the debug
    :align: center
 
 - Open the **Debugging** section and under **Command Arguments** add two new arguments:
-  the ``-e`` flag opens the editor instead of the project manager, and the ``--path`` argument
+  the ``-e`` flag opens the editor instead of the Project Manager, and the ``--path`` argument
   tells the executable to open the specified project (must be provided as an *absolute* path
   to the project root, not the ``project.godot`` file).
 

--- a/contributing/development/configuring_an_ide/xcode.rst
+++ b/contributing/development/configuring_an_ide/xcode.rst
@@ -99,7 +99,7 @@ To enable debugging support you need to edit the external build target's build a
 - Set the **Executable** to the file you linked in your post-build action script.
 - Check **Debug executable**.
 - You can add two arguments on the **Arguments** tab:
-  the ``-e`` flag opens the editor instead of the project manager, and the ``--path`` argument
+  the ``-e`` flag opens the editor instead of the Project Manager, and the ``--path`` argument
   tells the executable to open the specified project (must be provided as an *absolute* path
   to the project root, not the ``project.godot`` file).
 

--- a/contributing/development/debugging/index.rst
+++ b/contributing/development/debugging/index.rst
@@ -16,8 +16,8 @@ Debugging the editor
 --------------------
 
 When working on the Godot editor keep in mind that by default the executable
-will start in the project manager mode. Opening a project from the project
-manager spawns a new process, which stops the debugging session. To avoid that
+will start in the Project Manager mode. Opening a project from the Project
+Manager spawns a new process, which stops the debugging session. To avoid that
 you should launch directly into the project using ``-e`` and ``--path`` launch
 options.
 

--- a/contributing/development/debugging/using_cpp_profilers.rst
+++ b/contributing/development/debugging/using_cpp_profilers.rst
@@ -68,8 +68,8 @@ VerySleepy
 ^^^^^^^^^^
 
 - Start the Godot editor or your project first.
-  If you start the project manager, make sure to edit or run a project first.
-  Otherwise, the profiler will not track the child process since the project manager
+  If you start the Project Manager, make sure to edit or run a project first.
+  Otherwise, the profiler will not track the child process since the Project Manager
   will spawn a child process for every project edited or run.
 - Open VerySleepy and select the Godot executable in the list of processes on the left:
 

--- a/contributing/development/editor/introduction_to_editor_development.rst
+++ b/contributing/development/editor/introduction_to_editor_development.rst
@@ -47,7 +47,7 @@ Some important files in the editor are:
 - `editor/editor_node.cpp <https://github.com/godotengine/godot/blob/master/editor/editor_node.cpp>`__:
   Main editor initialization file. Effectively the "main scene" of the editor.
 - `editor/project_manager.cpp <https://github.com/godotengine/godot/blob/master/editor/project_manager.cpp>`__:
-  Main project manager initialization file. Effectively the "main scene" of the project manager.
+  Main Project Manager initialization file. Effectively the "main scene" of the Project Manager.
 - `editor/plugins/canvas_item_editor_plugin.cpp <https://github.com/godotengine/godot/blob/master/editor/plugins/canvas_item_editor_plugin.cpp>`__:
   The 2D editor viewport and related functionality (toolbar at the top, editing modes, overlaid helpers/panels, …).
 - `editor/plugins/node_3d_editor_plugin.cpp <https://github.com/godotengine/godot/blob/master/editor/plugins/node_3d_editor_plugin.cpp>`__:
@@ -84,5 +84,5 @@ Development tips
 
 To iterate quickly on the editor, we recommend to set up a test project and
 :ref:`open it from the command line <doc_command_line_tutorial>` after compiling
-the editor. This way, you don't have to go through the project manager every
+the editor. This way, you don't have to go through the Project Manager every
 time you start Godot.

--- a/contributing/workflow/pr_workflow.rst
+++ b/contributing/workflow/pr_workflow.rst
@@ -136,7 +136,7 @@ metadata is hidden in its ``.git`` subfolder).
           working in Git.
 
 In the following, we will assume as an example that you want to implement a feature in
-Godot's project manager, which is coded in the ``editor/project_manager.cpp``
+Godot's Project Manager, which is coded in the ``editor/project_manager.cpp``
 file.
 
 Branching
@@ -298,7 +298,7 @@ Here's how the shell history could look like on our example:
     # It's nice to know where you're starting from
     $ git log
 
-    # Do changes to the project manager with the nano text editor
+    # Do changes to the Project Manager with the nano text editor
     $ nano editor/project_manager.cpp
 
     # Find an unrelated bug in Control and fix it
@@ -320,7 +320,7 @@ Here's how the shell history could look like on our example:
 
     # Make our second commit
     $ git add editor/project_manager.cpp
-    $ git commit -m "Add a pretty banner to the project manager"
+    $ git commit -m "Add a pretty banner to the Project Manager"
     $ git log
 
 With this, we should have two new commits in our ``better-project-manager``
@@ -476,7 +476,7 @@ to configure your favorite one) with something which may look like this:
 
 .. code-block:: text
 
-    pick 1b4aad7 Add a pretty banner to the project manager
+    pick 1b4aad7 Add a pretty banner to the Project Manager
     pick e07077e Fix a typo in the banner's title
 
 The editor will also show instructions regarding how you can act on those
@@ -489,7 +489,7 @@ so we use:
 
 .. code-block:: text
 
-    pick 1b4aad7 Add a pretty banner to the project manager
+    pick 1b4aad7 Add a pretty banner to the Project Manager
     fixup e07077e Fix a typo in the banner's title
 
 Upon saving and quitting the editor, the rebase will occur. The second commit
@@ -531,7 +531,7 @@ Git branch for the PR. There won't be issues if you don't delete your branch, bu
 good practice to do so. You'll need to do this twice, once for the local branch and another
 for the remote branch on GitHub.
 
-To delete our better project manager branch locally, use this command:
+To delete our better Project Manager branch locally, use this command:
 
 ::
 

--- a/getting_started/first_3d_game/01.game_setup.rst
+++ b/getting_started/first_3d_game/01.game_setup.rst
@@ -12,7 +12,7 @@ the archive here: `Squash the Creeps assets
 <https://github.com/godotengine/godot-3d-dodge-the-creeps/releases/tag/1.1.0>`__.
 
 Once you downloaded it, extract the .zip archive on your computer. Open the
-Godot project manager and click the *Import* button.
+Godot Project Manager and click the *Import* button.
 
 .. image:: img/01.game_setup/01.import_button.png
 

--- a/getting_started/introduction/first_look_at_the_editor.rst
+++ b/getting_started/introduction/first_look_at_the_editor.rst
@@ -1,8 +1,8 @@
 .. This page is only here to introduce the interface to the user broadly. To
    cover individual areas in greater detail, write the corresponding pages in
    the most appropriate section, and link them. E.g. the animation editor goes
-   to the animation section. General pages, for instance, about the project
-   manager, should go in the editor manual.
+   to the animation section. General pages, for instance, about the Project
+   Manager, should go in the editor manual.
 
 .. _doc_intro_to_the_editor_interface:
 
@@ -15,7 +15,7 @@ look at the different main screens and docks to help you situate yourself.
 .. seealso:: For a comprehensive breakdown of the editor's interface and how to
              use it, see the :ref:`Editor manual <toc-learn-editor>`.
 
-The Project manager
+The Project Manager
 -------------------
 
 When you launch Godot, the first window you see is the Project Manager. In the
@@ -28,7 +28,7 @@ At the top of the window, there is another tab named "Asset Library Projects". Y
 for demo projects in the open source asset library, which includes many projects
 developed by the community.
 
-.. seealso:: To learn the project manager's ins and outs, read
+.. seealso:: To learn the Project Manager's ins and outs, read
              :ref:`doc_project_manager`.
 
 .. image:: img/editor_intro_project_templates.webp

--- a/getting_started/step_by_step/instancing.rst
+++ b/getting_started/step_by_step/instancing.rst
@@ -44,10 +44,10 @@ Let's use instancing in practice to see how it works in Godot. We invite
 you to download the ball's sample project we prepared for you:
 :download:`instancing.zip <files/instancing.zip>`.
 
-Extract the archive on your computer. To import it, you need the project manager.
-The project manager is accessed by opening Godot, or if you already have Godot opened, click on *Project -> Quit to Project List* (:kbd:`Ctrl + Shift + Q`)
+Extract the archive on your computer. To import it, you need the Project Manager.
+The Project Manager is accessed by opening Godot, or if you already have Godot opened, click on *Project -> Quit to Project List* (:kbd:`Ctrl + Shift + Q`)
 
-In the project manager, click the *Import* button to import the project.
+In the Project Manager, click the *Import* button to import the project.
 
 .. image:: img/instancing_import_button.png
 

--- a/tutorials/editor/command_line_tutorial.rst
+++ b/tutorials/editor/command_line_tutorial.rst
@@ -52,7 +52,7 @@ Command line reference
 +------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | ``-e``, ``--editor``                     | Start the editor instead of running the scene (:ref:`target=editor <doc_introduction_to_the_buildsystem_target>` must be used).                              |
 +------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| ``-p``, ``--project-manager``            | Start the project manager, even if a project is auto-detected (:ref:`target=editor <doc_introduction_to_the_buildsystem_target>` must be used).              |
+| ``-p``, ``--project-manager``            | Start the Project Manager, even if a project is auto-detected (:ref:`target=editor <doc_introduction_to_the_buildsystem_target>` must be used).              |
 +------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | ``--debug-server <uri>``                 | Start the editor debug server (``<protocol>://<host/IP>[:<port>]``, e.g. ``tcp://127.0.0.1:6007``)                                                           |
 +------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -262,7 +262,7 @@ Running the editor
 
 Running the editor is done by executing Godot with the ``-e`` flag. This
 must be done from within the project directory or a subdirectory,
-otherwise the command is ignored and the project manager appears.
+otherwise the command is ignored and the Project Manager appears.
 
 ::
 

--- a/tutorials/editor/project_manager.rst
+++ b/tutorials/editor/project_manager.rst
@@ -2,7 +2,7 @@
 
 .. _doc_project_manager:
 
-Using the Project manager
+Using the Project Manager
 =========================
 
 When you launch Godot, the first window you see is the Project Manager. It lets
@@ -44,7 +44,7 @@ folder based on your project's name.
 Opening and importing projects
 ------------------------------
 
-The next time you open the project manager, you'll see your new project in the
+The next time you open the Project Manager, you'll see your new project in the
 list. Double click on it to open it in the editor.
 
 .. image:: img/editor_ui_intro_project_manager_06.webp

--- a/tutorials/editor/using_the_web_editor.rst
+++ b/tutorials/editor/using_the_web_editor.rst
@@ -79,7 +79,7 @@ To import an existing project, the current process is as follows:
 - Specify a ZIP file to preload on the HTML5 filesystem using the
   **Preload project ZIP** input.
 - Run the editor by clicking **Start Godot editor**.
-  The Godot project manager should appear after 10-20 seconds.
+  The Godot Project Manager should appear after 10-20 seconds.
   On slower machines or connections, loading may take up to a minute.
 - In the dialog that appears at the middle of the window, specify a name for
   the folder to create then click the **Create Folder** button

--- a/tutorials/migrating/upgrading_to_godot_4.rst
+++ b/tutorials/migrating/upgrading_to_godot_4.rst
@@ -113,12 +113,12 @@ Running the project upgrade tool
     You can backup a project by using version control, or by copying the project
     folder to another location.
 
-Using the project manager
+Using the Project Manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To use the project upgrade tool:
 
-1. Open the Godot 4 project manager.
+1. Open the Godot 4 Project Manager.
 2. Import the Godot 3.x project using the **Import** button, or use the **Scan**
    button to find the project within a folder.
 3. Double-click the imported project (or select the project then choose **Edit**).
@@ -129,7 +129,7 @@ To use the project upgrade tool:
    case the conversion tool fails.
 5. Wait until the project conversion process finishes. This can take up to a few
    minutes for large projects with lots of scenes.
-6. When the project manager interface becomes available again, double-click the
+6. When the Project Manager interface becomes available again, double-click the
    project (or select the project then choose **Edit**) to open it in the
    editor.
 

--- a/tutorials/platform/web/html5_shell_classref.rst
+++ b/tutorials/platform/web/html5_shell_classref.rst
@@ -297,7 +297,7 @@ Properties
 
       A callback function for handling Godot's ``OS.execute`` calls.
 
-      This is for example used in the Web Editor template to switch between project manager and editor, and for running the game.
+      This is for example used in the Web Editor template to switch between Project Manager and editor, and for running the game.
 
       :param string path:
          The path that Godot's wants executed.


### PR DESCRIPTION
I have made the capitalization of Project Manager consistent throughout the documentation.

I hope this sort of blanket commit across the whole of docs is OK. If so, I will likely do similar PRs for "Asset Library" and others.