### PR TITLE
fix: link to animation tree tutorial

### DIFF
--- a/tutorials/animation/introduction.rst
+++ b/tutorials/animation/introduction.rst
@@ -366,4 +366,4 @@ create a RESET track when using the keyframe icon next to a property in the insp
 This does not apply on tracks created with Godot versions prior to 3.4,
 as the animation reset track feature was added in 3.4.
 
-.. note:: RESET tracks is also used as a reference value for blending. See also `For better blending <../tutorials/animation/animation_tree.html#for-better-blending>`__.
+.. note:: RESET tracks is also used as a reference value for blending. See also `For better blending <../animation/animation_tree.html#for-better-blending>`__.


### PR DESCRIPTION
The link to the animation tree tutorial is wrong: 

```
SHOULD BE:
https://docs.godotengine.org/en/stable/tutorials/animation/animation_tree.html#for-better-blending

IS CURRENTLY:
https://docs.godotengine.org/en/stable/tutorials/tutorials/animation/animation_tree.html#for-better-blending
```
Note the duplicate "tutorials/tutorials" in the path.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
