### PR TITLE
Replace text about migrating preprocessor directives with a short list of supported macros

### DIFF
--- a/tutorials/shaders/converting_glsl_to_godot_shaders.rst
+++ b/tutorials/shaders/converting_glsl_to_godot_shaders.rst
@@ -74,13 +74,11 @@ rename ``main`` to ``fragment``.
 Macros
 ^^^^^^
 
-In keeping with its similarity to C, GLSL lets you use macros. Commonly
-``#define`` is used to define constants or small functions. There is no
-straightforward way to translate defines to Godot's shading language. If it is a
-function that is defined, then replace with a function, and if it is a constant,
-then replace with a uniform. For other macros (``#if``, ``#ifdef``, etc.), there
-is no equivalent because they run during the pre-processing stage of
-compilation.
+The :ref:`Godot shader preprocessor<doc_shader_preprocessor>` supports the following macros:
+* ``#define`` / ``#undef``
+* ``#if``, ``#elif``, ``#else``, ``#endif``, ``defined()``, ``#ifdef``, ``#ifndef``
+* ``#include`` (only ``.gdshaderinc`` files and with a maximum depth of 25)
+* ``#pragma disable_preprocessor``, which disables preprocessing for the rest of the file
 
 Variables
 ^^^^^^^^^


### PR DESCRIPTION
Closes #7006.

This pull request deletes the text about migrating preprocessor directives, and replaces it with a grouped list of preprocessor directives (define, if, include, and pragma).

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
