### PR TITLE
Replace setget with set() and get(), and export with @export

### DIFF
--- a/tutorials/2d/custom_drawing_in_2d.rst
+++ b/tutorials/2d/custom_drawing_in_2d.rst
@@ -69,7 +69,7 @@ redrawn if modified:
 
     extends Node2D
 
-    export (Texture) var texture setget _set_texture
+    @export(Texture) var texture: set(_set_texture)
 
     func _set_texture(value):
         # If the texture variable is modified externally,

--- a/tutorials/2d/custom_drawing_in_2d.rst
+++ b/tutorials/2d/custom_drawing_in_2d.rst
@@ -69,7 +69,7 @@ redrawn if modified:
 
     extends Node2D
 
-    @export(Texture) var texture: set(_set_texture)
+    @export(Texture) var texture: set = _set_texture
 
     func _set_texture(value):
         # If the texture variable is modified externally,

--- a/tutorials/best_practices/data_preferences.rst
+++ b/tutorials/best_practices/data_preferences.rst
@@ -239,7 +239,7 @@ tree structures.
     class_name TreeNode
 
     var _parent: TreeNode = null
-    var _children: = [] setget
+    var _children: = []
 
     func _notification(p_what):
         match p_what:
@@ -282,7 +282,7 @@ Enumerations: int vs. string
 
 Most languages offer an enumeration type option. GDScript is no different, but
 unlike most other languages, it allows one to use either integers or strings for
-the enum values (the latter only when using the ``export`` keyword in GDScript).
+the enum values (the latter only when using the ``@export`` annotation in GDScript).
 The question then arises, "which should one use?"
 
 The short answer is, "whichever you are more comfortable with." This

--- a/tutorials/best_practices/godot_interfaces.rst
+++ b/tutorials/best_practices/godot_interfaces.rst
@@ -50,14 +50,14 @@ access.
     const MyScript : = preload("my_script.gd") as Script
 
     # This type's value varies, i.e. it is a variable, so it uses snake_case.
-    export(Script) var script_type: Script
+    @export var script_type: Script
 
-    # If need an "export const var" (which doesn't exist), use a conditional
+    # If need an "@export const var" (which doesn't exist), use a conditional
     # setter for a tool script that checks if it's executing in the editor.
     tool # Must place at top of file.
 
     # Must configure from the editor, defaults to null.
-    export(Script) var const_script setget set_const_script
+    @export(Script) var const_script: set(set_const_script)
     func set_const_script(value):
         if Engine.is_editor_hint():
             const_script = value

--- a/tutorials/best_practices/godot_interfaces.rst
+++ b/tutorials/best_practices/godot_interfaces.rst
@@ -57,7 +57,7 @@ access.
     tool # Must place at top of file.
 
     # Must configure from the editor, defaults to null.
-    @export(Script) var const_script: set(set_const_script)
+    @export(Script) var const_script: set = set_const_script
     func set_const_script(value):
         if Engine.is_editor_hint():
             const_script = value

--- a/tutorials/best_practices/godot_notifications.rst
+++ b/tutorials/best_practices/godot_notifications.rst
@@ -158,7 +158,7 @@ instantiation:
     # "one" is an "initialized value". These DO NOT trigger the setter.
     # If someone set the value as "two" from the Inspector, this would be an
     # "exported value". These DO trigger the setter.
-    export(String) var test = "one" setget set_test
+    @export(String) var test = "one": set(set_test)
 
     func _init():
         # "three" is an "init assignment value".

--- a/tutorials/best_practices/godot_notifications.rst
+++ b/tutorials/best_practices/godot_notifications.rst
@@ -158,7 +158,7 @@ instantiation:
     # "one" is an "initialized value". These DO NOT trigger the setter.
     # If someone set the value as "two" from the Inspector, this would be an
     # "exported value". These DO trigger the setter.
-    @export(String) var test = "one": set(set_test)
+    @export(String) var test = "one": set = set_test
 
     func _init():
         # "three" is an "init assignment value".

--- a/tutorials/best_practices/logic_preferences.rst
+++ b/tutorials/best_practices/logic_preferences.rst
@@ -72,7 +72,7 @@ either? Let's see an example:
     #
     # 4. It is when one instantiates this script on its own with .new() that
     #    one will load "office.tscn" rather than the exported value.
-    export(PackedScene) var a_building = preload("office.tscn")
+    @export(PackedScene) var a_building = preload("office.tscn")
 
     # Uh oh! This results in an error!
     # One must assign constant values to constants. Because `load` performs a
@@ -121,7 +121,7 @@ consider:
    in exceptional cases, one may wish not to do this:
 
    1. If the 'imported' class is liable to change, then it should be a property
-      instead, initialized either using an ``export`` or a ``load`` (and
+      instead, initialized either using an ``@export`` or a ``load`` (and
       perhaps not even initialized until later).
 
    2. If the script requires a great many dependencies, and one does not wish

--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -180,8 +180,7 @@ run the game, it will spin counter-clockwise.
 Editing variables
 -----------------
 
-Add and export a variable speed to the script. The function set_speed after
-``setget`` is executed with your input to change the variable. Modify
+Add and export a variable speed to the script. The code inside ``set()`` is executed with your input to change the variable. Modify
 ``_process()`` to include the rotation speed.
 
 .. tabs::

--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -35,10 +35,10 @@ Here is a complete class example based on these guidelines:
 
     signal state_changed(previous, new)
 
-    export var initial_state = NodePath()
-    var is_active = true setget set_is_active
+    @export var initial_state = NodePath()
+    var is_active = true: set(set_is_active)
 
-    @onready var _state = get_node(initial_state) setget set_state
+    @onready var _state = get_node(initial_state): set(set_state)
     @onready var _state_name = _state.name
 
 
@@ -780,11 +780,11 @@ variables, in that order.
 
    const MAX_LIVES = 3
 
-   export(Jobs) var job = Jobs.KNIGHT
-   export var max_health = 50
-   export var attack = 5
+   @export(Jobs) var job = Jobs.KNIGHT
+   @export var max_health = 50
+   @export var attack = 5
 
-   var health = max_health setget set_health
+   var health = max_health: set(set_health)
 
    var _speed = 300.0
 

--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -36,9 +36,9 @@ Here is a complete class example based on these guidelines:
     signal state_changed(previous, new)
 
     @export var initial_state = NodePath()
-    var is_active = true: set(set_is_active)
+    var is_active = true: set = set_is_active
 
-    @onready var _state = get_node(initial_state): set(set_state)
+    @onready var _state = get_node(initial_state): set = set_state
     @onready var _state_name = _state.name
 
 
@@ -784,7 +784,7 @@ variables, in that order.
    @export var max_health = 50
    @export var attack = 5
 
-   var health = max_health: set(set_health)
+   var health = max_health: set = set_health
 
    var _speed = 300.0
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

This pull request fixes old `setget` and `export` usages. I used a grep to find them, so there might be more.