### PR TITLE
"New Animation" --> "Add Animation"

### DIFF
--- a/getting_started/first_2d_game/02.player_scene.rst
+++ b/getting_started/first_2d_game/02.player_scene.rst
@@ -65,7 +65,7 @@ display. To create one, find the ``Sprite Frames`` property in the Inspector and
 
 
 On the left is a list of animations. Click the "default" one and rename it to
-"walk". Then click the "New Animation" button to create a second animation named
+"walk". Then click the "Add Animation" button to create a second animation named
 "up". Find the player images in the "FileSystem" tab - they're in the ``art``
 folder you unzipped earlier. Drag the two images for each animation, named
 ``playerGrey_up[1/2]`` and ``playerGrey_walk[1/2]``, into the "Animation Frames"


### PR DESCRIPTION
As of Godot v4.0 (Editor Language: "en"), the button in question is called "Add Animation" and not "New Animation":

![add_animation](https://user-images.githubusercontent.com/36742246/226098616-04a56eb8-91d9-4d8e-9ddb-3a15646e1796.png)

This small fix mitigates a potential source of confusion for new Godot users.

Cheers.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
