### PR TITLE
Full Rect option in Background section

### DIFF
--- a/getting_started/first_2d_game/07.finishing-up.rst
+++ b/getting_started/first_2d_game/07.finishing-up.rst
@@ -15,7 +15,7 @@ The default gray background is not very appealing, so let's change its color.
 One way to do this is to use a :ref:`ColorRect <class_ColorRect>` node. Make it
 the first node under ``Main`` so that it will be drawn behind the other nodes.
 ``ColorRect`` only has one property: ``Color``. Choose a color you like and
-select "Layout" -> "Full Rect" so that it covers the screen.
+select "Layout" -> "Anchors Preset" -> "Full Rect" so that it covers the screen.
 
 You could also add a background image, if you have one, by using a
 ``TextureRect`` node instead.

--- a/getting_started/first_2d_game/07.finishing-up.rst
+++ b/getting_started/first_2d_game/07.finishing-up.rst
@@ -15,7 +15,7 @@ The default gray background is not very appealing, so let's change its color.
 One way to do this is to use a :ref:`ColorRect <class_ColorRect>` node. Make it
 the first node under ``Main`` so that it will be drawn behind the other nodes.
 ``ColorRect`` only has one property: ``Color``. Choose a color you like and
-select "Layout" -> "Anchors Preset" -> "Full Rect" so that it covers the screen.
+select "Layout" -> "Anchors Preset" -> "Full Rect" either in the toolbar at the top of the viewport or in the inspector so that it covers the screen.
 
 You could also add a background image, if you have one, by using a
 ``TextureRect`` node instead.


### PR DESCRIPTION
Corrected the "Full Rect" option location in Background section because it was wrong in Godot 4.
