### PR TITLE
Corrected directory for HTML documentation output

### DIFF
--- a/contributing/documentation/building_the_manual.rst
+++ b/contributing/documentation/building_the_manual.rst
@@ -103,10 +103,10 @@ program manually:
 
 .. code:: sh
 
-   sphinx-build -b html ./ _build
+   sphinx-build -b html ./ _build/html
 
 You can also specify a list of files to build, which can greatly speed up compilation:
 
 .. code:: sh
 
-  sphinx-build -b html ./ _build classes/class_node.rst classes/class_resource.rst
+  sphinx-build -b html ./ _build/html classes/class_node.rst classes/class_resource.rst


### PR DESCRIPTION
Updated the examples for manually invoking `sphinx-build` in the  [tutorial page on building godot-docs](https://docs.godotengine.org/en/latest/contributing/documentation/building_the_manual.html), changing the output directory from `_build` to `_build/html`, to match the Makefile's output directory from the `make html` command.