### PR TITLE
Fix incorrect auto-generated signal names

### DIFF
--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -246,10 +246,10 @@ the other two timers. ``ScoreTimer`` will increment the score by 1.
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    func _on_ScoreTimer_timeout():
+    func _on_score_timer_timeout():
         score += 1
 
-    func _on_StartTimer_timeout():
+    func _on_start_timer_timeout():
         $MobTimer.start()
         $ScoreTimer.start()
 
@@ -302,7 +302,7 @@ Note that a new instance must be added to the scene using ``add_child()``.
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    func _on_MobTimer_timeout():
+    func _on_mob_timer_timeout():
         # Create a new instance of the Mob scene.
         var mob = mob_scene.instantiate()
 

--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -297,11 +297,11 @@ signal of ``StartButton``, and add the following code to the new functions:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    func _on_StartButton_pressed():
+    func _on_start_button_pressed():
         $StartButton.hide()
         start_game.emit()
 
-    func _on_MessageTimer_timeout():
+    func _on_message_timer_timeout():
         $Message.hide()
 
  .. code-tab:: csharp


### PR DESCRIPTION
In https://github.com/godotengine/godot-docs/issues/7028 it is noted that the autogenerated signal names for "Your first 2D game" are in the wrong case. They are PascalCase in the docs but in the engine they are snake_case in the latest stable 4.0.

fixes #7028

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
