### PR TITLE
Various fixups

### DIFF
--- a/_extensions/gdscript.py
+++ b/_extensions/gdscript.py
@@ -331,7 +331,6 @@ class GDScriptLexer(RegexLexer):
                         "Color",
                         "RID",
                         "Object",
-                        "NodePath",
                         "Dictionary",
                         "Array",
                         "PackedByteArray",

--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -616,7 +616,7 @@ node. In the **Node** dock, we can find our new signal and link it up by pressin
 the **Connect** button or double-clicking the signal. We've added a script on
 our main node and implemented our signal like this:
 
-.. code-block:: GDScript
+.. code-block:: gdscript
 
     extends Node
 


### PR DESCRIPTION
Remove the duplicate mention of `NodePath` as pointed out in https://github.com/godotengine/godot-docs/issues/4562 and fix a warning due to wrong casing of `gdscript` code language.