### PR TITLE
Corrected virtual function name in "Custom GUI Controls"

### DIFF
--- a/tutorials/ui/custom_gui_controls.rst
+++ b/tutorials/ui/custom_gui_controls.rst
@@ -79,13 +79,13 @@ the minimum size will make sure your custom control is not squished by
 the other controls in the container.
 
 To provide this callback, just override
-:ref:`Control.get_minimum_size() <class_Control_method_get_minimum_size>`,
+:ref:`Control._get_minimum_size() <class_Control_method__get_minimum_size>`,
 for example:
 
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    func get_minimum_size():
+    func _get_minimum_size():
         return Vector2(30, 30)
 
  .. code-tab:: csharp


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

It is not possible to directly override non-virtual native methods (like `get_minimum_size`), so we have to override `_get_minimum_size` (the virtual variant) instead. Attempting the former produces an error in Godot 4, indicating that the method override will have no effect. I'm not sure if this is new to Godot 4 or applies to 3.x as well.

**Bugsquad note for cherrypicking:** verify whether this applies to `3.x` before cherrypicking.