### PR TITLE
Fix typo at 2d_movenet.rst

### DIFF
--- a/tutorials/2d/2d_movement.rst
+++ b/tutorials/2d/2d_movement.rst
@@ -261,7 +261,7 @@ on the screen will cause the player to move to the target location.
 
         public override void _PhysicsProcess(double delta)
         {
-            velocity = Position.DirectionTo(_target) * Speed;
+            Velocity = Position.DirectionTo(_target) * Speed;
             // LookAt(target);
             if (Position.DistanceTo(_target) > 10)
             {


### PR DESCRIPTION
There is a typo with variable "velocity" for c# script, it should be "Velocity".