### PR TITLE
fix paths used in gdextension example

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -349,9 +349,9 @@ loaded for each platform and the entry function for the module. It is called ``g
 
     [libraries]
 
-    linux.64="res://demo/bin/libgdexample.linux.64.so"
-    windows.x86_64="res://demo/bin/libgdexample.windows.x86_64.dll"
-    macos="res://demo/bin/libgdexample.macos.framework"
+    linux.64="res://bin/libgdexample.linux.64.so"
+    windows.x86_64="res://bin/libgdexample.windows.x86_64.dll"
+    macos="res://bin/libgdexample.macos.framework"
 
 This file contains a ``configuration`` section that controls the entry function of the module.
 


### PR DESCRIPTION
fixes godotengine#7044

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
