### PR TITLE
Document SDFGI sharp reflections only working on opaque materials

### DIFF
--- a/tutorials/3d/global_illumination/using_sdfgi.rst
+++ b/tutorials/3d/global_illumination/using_sdfgi.rst
@@ -227,3 +227,7 @@ illumination appearance will be correct once the camera gets closer. However, if
 a nearby object with a bake mode set to **Static** or **Dynamic** is moved (such
 as a door), the global illumination will appear incorrect until the camera moves
 away from the object.
+
+SDFGI's sharp reflections are only visible on opaque materials. Transparent
+materials will only use rough reflections, even if the material's roughness is
+lower than 0.2.

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -466,3 +466,5 @@ If you want the lights to add together, add the light contribution to ``DIFFUSE_
     Transparent materials also cannot cast shadows or appear in
     ``SCREEN_TEXTURE`` and ``DEPTH_TEXTURE``. This in turn prevents those
     materials from appearing in screen-space reflections or refraction.
+    :ref:`SDFGI <doc_using_sdfgi>` sharp reflections are not visible on transparent
+    materials (only rough reflections are visible on transparent materials).


### PR DESCRIPTION
Transparent materials only use rough reflections, likely for performance reasons.

- This closes https://github.com/godotengine/godot/issues/54176.
