### PR TITLE
Update high_level_multiplayer.rst

### DIFF
--- a/tutorials/networking/high_level_multiplayer.rst
+++ b/tutorials/networking/high_level_multiplayer.rst
@@ -317,14 +317,14 @@ every peer and RPC will work great! Here is an example:
         # Load my player
         var my_player = preload("res://player.tscn").instantiate()
         my_player.set_name(str(selfPeerID))
-        my_player.set_network_master(selfPeerID) # Will be explained later
+        my_player.set_multiplayer_authority(selfPeerID) # Will be explained later
         get_node("/root/world/players").add_child(my_player)
 
         # Load other players
         for p in player_info:
             var player = preload("res://player.tscn").instantiate()
             player.set_name(str(p))
-            player.set_network_master(p) # Will be explained later
+            player.set_multiplayer_authority(p) # Will be explained later
             get_node("/root/world/players").add_child(player)
 
         # Tell server (remember, server is always ID=1) that this peer is done pre-configuring.
@@ -384,7 +384,7 @@ The network master of a node is the peer that has the ultimate authority over it
 When not explicitly set, the network master is inherited from the parent node, which if not changed, is always going to be the server (ID 1). Thus the server has authority over all nodes by default.
 
 The network master can be set
-with the function :ref:``Node.set_network_master(id, recursive)`` (recursive is ``true`` by default and means the network master is recursively set on all child nodes of the node as well).
+with the function :ref:``Node.set_multiplayer_authority(id, recursive)`` (recursive is ``true`` by default and means the network master is recursively set on all child nodes of the node as well).
 
 Checking that a specific node instance on a peer is the network master for this node for all connected peers is done by calling ``Node.is_network_master()``. This will return ``true`` when executed on the server and ``false`` on all client peers.
 
@@ -396,14 +396,14 @@ If you have paid attention to the previous example, it's possible you noticed th
         # Load my player
         var my_player = preload("res://player.tscn").instantiate()
         my_player.set_name(str(selfPeerID))
-        my_player.set_network_master(selfPeerID) # The player belongs to this peer; it has the authority.
+        my_player.set_multiplayer_authority(selfPeerID) # The player belongs to this peer; it has the authority.
         get_node("/root/world/players").add_child(my_player)
 
         # Load other players
         for p in player_info:
             var player = preload("res://player.tscn").instantiate()
             player.set_name(str(p))
-            player.set_network_master(p) # Each other connected peer has authority over their own player.
+            player.set_multiplayer_authority(p) # Each other connected peer has authority over their own player.
             get_node("/root/world/players").add_child(player)
         [...]
 


### PR DESCRIPTION
Old documentation used set_network_master instead of new method set_multiplayer_authority. Making this small update since rest of documentation for this page looks correct, but it took me a while to figure out why the old method wasn't working.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
