### PR TITLE
Update/Clarify gdextension docs

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -35,10 +35,12 @@ of Godot. GDExtensions will not work in older versions of Godot (only Godot 4 an
 .. note::
 
     To use `GDExtension <https://godotengine.org/article/introducing-gd-extensions>`__
-    you need to use the ``master`` branch of godot-cpp,
-    which is only compatible with Godot 4.0 and follow this example.
+    you need to use the ``4.0`` branch of godot-cpp,
+    which is only compatible with Godot 4.0 and being used here as an example.
+    The ``master`` branch is the development branch and is being updated 
+    regularly to work with godot's ``master`` branch.
 
-If you are versioning your project using Git, it is a good idea to add it as
+If you are versioning your project using Git, it is recommended to add it as
 a Git submodule:
 
 .. code-block:: none
@@ -46,11 +48,11 @@ a Git submodule:
     mkdir gdextension_cpp_example
     cd gdextension_cpp_example
     git init
-    git submodule add -b master https://github.com/godotengine/godot-cpp
+    git submodule add -b 4.0 https://github.com/godotengine/godot-cpp
     cd godot-cpp
     git submodule update --init
 
-Do make sure you clone recursively to pull in both repositories:
+Alternatively, you can also clone it to the project folder:
 
 .. code-block:: none
 


### PR DESCRIPTION
This PR clarifies the GDExtension docs that you either add `godot-cpp` as a submodule OR clone it to your project folder.
It also updates the branch version being used to `4.0` instead of `master` before since 4.0 is stable and master isn't always compatible with the latest master build of Godot itself.