### PR TITLE
Added note to circumvent an error during iOS project export

### DIFF
--- a/tutorials/export/exporting_for_ios.rst
+++ b/tutorials/export/exporting_for_ios.rst
@@ -28,6 +28,12 @@ Export window opens, click **Add..** and select **iOS**.
 The **App Store Team ID** and (Bundle) **Identifier** options in the **Application** category
 are required. Leaving them blank will cause the exporter to throw an error.
 
+.. note:: | If you encounter an error during export similar to
+          | ``JSON text did not start with array or object and option to allow fragments not set``
+          | then it might be due to a malformated **App Store Team ID**!
+          | The exporter expects a (10 characters long) code like ``ABCDE12XYZ`` and not, e.g., your name as Xcode likes to display in the *Signing & Capabilities* tab.
+          | You can find the code over at `developer.apple.com <https://developer.apple.com/account/resources/certificates/list>`_ in next to your name in the top right corner.
+
 After you click **Export Project**, there are still two important options left:
 
   * **Path** is an empty folder that will contain the exported Xcode project files.


### PR DESCRIPTION
During my first trial of exporting a project for iOS and Xcode, I encountered the error:

```2023-03-28 00:19:12.627 xcodebuild[97362:6702242] Error Domain=NSCocoaErrorDomain Code=3840 "JSON text did not start with array or object and option to allow fragments not set. around line 1, column 0." UserInfo={NSDebugDescription=JSON text did not start with array or object and option to allow fragments not set. around line 1, column 0., NSJSONSerializationErrorIndex=0}```

After some investigation, I found that...

1. many users have the same issue
2. the exporter assumes the App Store Team ID to be a 10-character long code, not the Team's name, as it is commonly used in Xcode for native development.

To hint the user towards a possible root cause for this error, I added a **note** box explaining this workaround. I also added a link to the Apple developer account page, where this code can be easily found.

I hope this helps some people.

Cheers,
Martin