### PR TITLE
Makefile: fix check condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LATEXDEPS     = latex dvipng
 FILELIST      =
 
 # User-friendly check for sphinx-build
-ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
+ifneq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 0)
 $(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD make variable to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the executable's directory to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
 endif
 


### PR DESCRIPTION
On MSYS2:

```
# which sphinx-buildx >/dev/null 2>&1

# echo $?
42

# which sphinx-build >/dev/null 2>&1

# echo $?
0
```

This PR changes the check in the Makefile to `neq 0`, instead of `eq 1`.

_Bugsquad note: superseded by https://github.com/godotengine/godot-docs/pull/7068_