### PR TITLE
[ci] use Makefile

### DIFF
--- a/.github/workflows/build_offline_docs.yml
+++ b/.github/workflows/build_offline_docs.yml
@@ -15,8 +15,7 @@ jobs:
           - master
           - stable
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           ref: ${{ matrix.branch }}
 
@@ -25,10 +24,8 @@ jobs:
           sudo pip3 install -r requirements.txt
           sudo pip3 install codespell
 
-      # Build the HTML to upload it.
-      - name: Sphinx build
-        run: |
-          sphinx-build --color -d _build/doctrees . _build/html
+      - name: Sphinx build HTML
+        run: make SPHINXOPTS='--color' html
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,4 @@ jobs:
 
       # Use dummy builder to improve performance as we don't need the generated HTML in this workflow.
       - name: Sphinx build
-        run: |
-          sphinx-build --color -b dummy -d _build/doctrees -W . _build/html
+        run: make SPHINXOPTS='--color -W' dummy


### PR DESCRIPTION
~This PR is based on #7068 and it will be kept as a draft until that's merged.~

Instead of hardcoding the sphinx-build commands in CI workflows, this PR uses `make dummy` and `make html`. That allows to test that the procedure recommended to users/contributors does work.