### PR TITLE
[contributing/documentation/building_the_manual] use tabs and admonitions

### DIFF
--- a/contributing/documentation/building_the_manual.rst
+++ b/contributing/documentation/building_the_manual.rst
@@ -7,11 +7,12 @@ This page explains how to build a local copy of the Godot manual using the
 Sphinx docs engine. This allows you to have local HTML files and build the
 documentation as a PDF, EPUB, or LaTeX file, for example.
 
-Before you get started, make sure that you have:
-
-- `Git <https://git-scm.com/>`_
-- `make <https://www.gnu.org/software/make/>`_ (unless you’re using Windows)
-- `Python <https://www.python.org/>`_ 3
+.. important::
+    Before you get started, make sure that you have
+    `Git <https://git-scm.com/>`_,
+    `Python 3 <https://www.python.org/>`_,
+    and, unless you are using Windows,
+    `make <https://www.gnu.org/software/make/>`_.
 
 .. note:: Python 3 should come with the ``pip3`` command. You may need to write
     ``python3 -m pip`` (Unix) or  ``py -m pip`` (Windows) instead of ``pip3``.
@@ -24,18 +25,51 @@ Before you get started, make sure that you have:
 
     a.  Create the virtual environment:
 
-        - On Windows, run ``py -m venv godot-docs-venv``
-        - On other platforms, run ``python3 -m venv godot-docs-venv``
+        .. tabs::
+
+            .. group-tab:: Windows
+
+                .. code:: pwsh
+
+                    py -m venv godot-docs-venv
+
+            .. group-tab:: Other platforms
+
+                .. code:: sh
+
+                    python3 -m venv godot-docs-venv
 
     b.  Activate the virtual environment:
 
-        - On Windows, run ``godot-docs-venv\Scripts\activate.bat``
-        - On other platforms, run ``source godot-docs-venv/bin/activate``
+        .. tabs::
+
+            .. group-tab:: Windows
+
+                .. code:: pwsh
+
+                    godot-docs-venv\Scripts\activate.bat
+
+            .. group-tab:: Other platforms
+
+                .. code:: sh
+
+                    source godot-docs-venv/bin/activate
 
     c.  *(Optional)* Update pre-installed packages:
 
-        - On Windows, run ``py -m pip install --upgrade pip setuptools``
-        - On other platforms, run ``pip3 install --upgrade pip setuptools``
+        .. tabs::
+
+            .. group-tab:: Windows
+
+                .. code:: pwsh
+
+                    py -m pip install --upgrade pip setuptools
+
+            .. group-tab:: Other platforms
+
+                .. code:: sh
+
+                    pip3 install --upgrade pip setuptools
 
 2.  Clone the docs repo:
 
@@ -61,42 +95,61 @@ Before you get started, make sure that you have:
 
         make html
 
-.. note:: On Windows, that command will run ``make.bat`` instead of GNU Make (or
-          an alternative).
-
-If you run into errors, you may try the following command:
-
-.. code:: sh
-
-    make SPHINXBUILD=~/.local/bin/sphinx-build html
-
-Building the documentation requires at least 8 GB of RAM to run without disk
-swapping, which slows it down. If you have at least 16 GB of RAM, you can speed
-up compilation by running:
-
-.. code:: sh
-
-    # On Linux/macOS
-    make html SPHINXOPTS=-j2
-
-    # On Windows
-    set SPHINXOPTS=-j2 && make html
+    .. note::
+        On Windows, that command will run ``make.bat`` instead of GNU Make (or an alternative).
 
 The compilation will take some time as the ``classes/`` folder contains hundreds
 of files.
 
+.. tip::
+
+    Building the documentation requires at least 8 GB of RAM to run without disk
+    swapping, which slows it down. If you have at least 16 GB of RAM, you can speed
+    up compilation by running:
+
+    .. tabs::
+
+        .. group-tab:: Windows
+
+            .. code:: pwsh
+
+                set SPHINXOPTS=-j2 && make html
+
+        .. group-tab:: Other platforms
+
+            .. code:: sh
+
+                make html SPHINXOPTS=-j2
+
+.. tip::
+
+    You can specify a list of files to build, which can geatly speed up compilation:
+
+    .. code:: sh
+
+        make FILELIST='classes/class_node.rst classes/class_resource.rst' html
+
 You can then browse the documentation by opening ``_build/html/index.html`` in
 your web browser.
 
-If you get a ``MemoryError`` or ``EOFError``, you can remove the
-``classes/`` folder and run ``make`` again. This will drop the class references
-from the final HTML documentation but will keep the rest intact.
+.. hint::
+    If you run into errors, you may try the following command:
 
-.. note:: If you delete the ``classes/`` folder, do not use ``git add .`` when
-          working on a pull request or the whole ``classes/`` folder will be
-          removed when you commit. See `#3157
-          <https://github.com/godotengine/godot-docs/issues/3157>`__ for more
-          detail.
+    .. code:: sh
+
+        make SPHINXBUILD=~/.local/bin/sphinx-build html
+
+.. hint::
+    If you get a ``MemoryError`` or ``EOFError``, you can remove the ``classes/``
+    folder and run ``make`` again.
+    This will drop the class references from the final HTML documentation but will
+    keep the rest intact.
+
+.. note::
+    If you delete the ``classes/`` folder, do not use ``git add .`` when working on
+    a pull request or the whole ``classes/`` folder will be removed when you commit.
+    See `#3157 <https://github.com/godotengine/godot-docs/issues/3157>`__ for more
+    detail.
 
 Alternatively, you can build the documentation by running the sphinx-build
 program manually:
@@ -104,9 +157,3 @@ program manually:
 .. code:: sh
 
    sphinx-build -b html ./ _build/html
-
-You can also specify a list of files to build, which can greatly speed up compilation:
-
-.. code:: sh
-
-  sphinx-build -b html ./ _build/html classes/class_node.rst classes/class_resource.rst

--- a/contributing/documentation/building_the_manual.rst
+++ b/contributing/documentation/building_the_manual.rst
@@ -1,18 +1,17 @@
 .. _doc_building_the_manual:
 
 Building the manual with Sphinx
-###############################
+===============================
 
 This page explains how to build a local copy of the Godot manual using the
 Sphinx docs engine. This allows you to have local HTML files and build the
 documentation as a PDF, EPUB, or LaTeX file, for example.
 
-.. important::
-    Before you get started, make sure that you have
-    `Git <https://git-scm.com/>`_,
-    `Python 3 <https://www.python.org/>`_,
-    and, unless you are using Windows,
-    `make <https://www.gnu.org/software/make/>`_.
+Before you get started, make sure that you have:
+
+- `Git <https://git-scm.com/>`_
+- `make <https://www.gnu.org/software/make/>`_ (unless you’re using Windows)
+- `Python <https://www.python.org/>`_ 3
 
 .. note:: Python 3 should come with the ``pip3`` command. You may need to write
     ``python3 -m pip`` (Unix) or  ``py -m pip`` (Windows) instead of ``pip3``.

--- a/contributing/documentation/building_the_manual.rst
+++ b/contributing/documentation/building_the_manual.rst
@@ -1,7 +1,7 @@
 .. _doc_building_the_manual:
 
 Building the manual with Sphinx
-===============================
+###############################
 
 This page explains how to build a local copy of the Godot manual using the
 Sphinx docs engine. This allows you to have local HTML files and build the
@@ -98,62 +98,68 @@ documentation as a PDF, EPUB, or LaTeX file, for example.
     .. note::
         On Windows, that command will run ``make.bat`` instead of GNU Make (or an alternative).
 
-The compilation will take some time as the ``classes/`` folder contains hundreds
-of files.
-
-.. tip::
-
-    Building the documentation requires at least 8 GB of RAM to run without disk
-    swapping, which slows it down. If you have at least 16 GB of RAM, you can speed
-    up compilation by running:
-
-    .. tabs::
-
-        .. group-tab:: Windows
-
-            .. code:: pwsh
-
-                set SPHINXOPTS=-j2 && make html
-
-        .. group-tab:: Other platforms
-
-            .. code:: sh
-
-                make html SPHINXOPTS=-j2
-
-.. tip::
-
-    You can specify a list of files to build, which can geatly speed up compilation:
+    Alternatively, you can build the documentation by running the sphinx-build program manually:
 
     .. code:: sh
 
-        make FILELIST='classes/class_node.rst classes/class_resource.rst' html
+        sphinx-build -b html ./ _build/html
+
+The compilation will take some time as the ``classes/`` folder contains hundreds of files.
+See :ref:`doc_building_the_manual:performance`.
 
 You can then browse the documentation by opening ``_build/html/index.html`` in
 your web browser.
 
-.. hint::
-    If you run into errors, you may try the following command:
+Dealing with errors
+===================
 
-    .. code:: sh
-
-        make SPHINXBUILD=~/.local/bin/sphinx-build html
-
-.. hint::
-    If you get a ``MemoryError`` or ``EOFError``, you can remove the ``classes/``
-    folder and run ``make`` again.
-    This will drop the class references from the final HTML documentation but will
-    keep the rest intact.
-
-.. note::
-    If you delete the ``classes/`` folder, do not use ``git add .`` when working on
-    a pull request or the whole ``classes/`` folder will be removed when you commit.
-    See `#3157 <https://github.com/godotengine/godot-docs/issues/3157>`__ for more
-    detail.
-
-Alternatively, you can build the documentation by running the sphinx-build
-program manually:
+If you run into errors, you may try the following command:
 
 .. code:: sh
 
-   sphinx-build -b html ./ _build/html
+    make SPHINXBUILD=~/.local/bin/sphinx-build html
+
+If you get a ``MemoryError`` or ``EOFError``, you can remove the ``classes/`` folder and
+run ``make`` again.
+This will drop the class references from the final HTML documentation but will keep the
+rest intact.
+
+.. important::
+    If you delete the ``classes/`` folder, do not use ``git add .`` when working on a pull
+    request or the whole ``classes/`` folder will be removed when you commit.
+    See `#3157 <https://github.com/godotengine/godot-docs/issues/3157>`__ for more detail.
+
+.. _doc_building_the_manual:performance:
+
+Hints for performance
+=====================
+
+RAM usage
+---------
+
+Building the documentation requires at least 8 GB of RAM to run without disk swapping,
+which slows it down.
+If you have at least 16 GB of RAM, you can speed up compilation by running:
+
+.. tabs::
+
+    .. group-tab:: Windows
+
+        .. code:: pwsh
+
+            set SPHINXOPTS=-j2 && make html
+
+    .. group-tab:: Other platforms
+
+        .. code:: sh
+
+            make html SPHINXOPTS=-j2
+
+Specifying a list of files
+--------------------------
+
+You can specify a list of files to build, which can geatly speed up compilation:
+
+.. code:: sh
+
+    make FILELIST='classes/class_node.rst classes/class_resource.rst' html

--- a/contributing/documentation/building_the_manual.rst
+++ b/contributing/documentation/building_the_manual.rst
@@ -158,7 +158,7 @@ If you have at least 16 GB of RAM, you can speed up compilation by running:
 Specifying a list of files
 --------------------------
 
-You can specify a list of files to build, which can geatly speed up compilation:
+You can specify a list of files to build, which can greatly speed up compilation:
 
 .. code:: sh
 


### PR DESCRIPTION
This PR updates https://docs.godotengine.org/en/stable/contributing/documentation/building_the_manual.html.

- Group tabs are used to show the steps with variants for Windows or other platforms.
- Some clarifications/comments are moved into admonitions (hint, tip or important).
- The example providing a filelist is changed to be based on the make call (see https://github.com/godotengine/godot-docs/commit/e7c7cf1510600a5295f573eaa481e60b0d3b2eb9) instead of explaining it with the explicit call to sphinx-build.
