### PR TITLE
Update example to use correct arguments for connect()

### DIFF
--- a/tutorials/networking/http_request_class.rst
+++ b/tutorials/networking/http_request_class.rst
@@ -39,8 +39,8 @@ Below is all the code we need to make it work. The URL points to an online API m
         extends CanvasLayer
 
         func _ready():
-            $HTTPRequest.connect("request_completed", self, "_on_request_completed")
-            $Button.connect("pressed", self, "_on_Button_pressed")
+            $HTTPRequest.connect("request_completed", _on_request_completed)
+            $Button.connect("pressed", _on_Button_pressed)
 
         func _on_Button_pressed():
             $HTTPRequest.request("http://www.mocky.io/v2/5185415ba171ea3a00704eed")


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
In Godot 4, the current expression for connecting a method to a signal won't work. As such I've updated it with an updated set of arguments.