### PR TITLE
Update Making Main Screen Plugins page

### DIFF
--- a/tutorials/plugins/editor/making_main_screen_plugins.rst
+++ b/tutorials/plugins/editor/making_main_screen_plugins.rst
@@ -5,6 +5,9 @@
 Making main screen plugins
 ==========================
 
+.. note:: This tutorial assumes you already know how to make generic plugins. If
+          in doubt, refer to the :ref:`doc_making_plugins` page.
+
 What this tutorial covers
 -------------------------
 
@@ -107,10 +110,9 @@ Main screen scene
 -----------------
 
 Create a new scene with a root node derived from ``Control`` (for this
-example plugin, we'll make the root node a ``CenterContainer``).
-Select this root node, and in the viewport, click the ``Layout`` menu
-and select ``Full Rect``. You also need to enable the ``Expand``
-vertical size flag in the inspector.
+example plugin, we'll make the root node a ``CenterContainer``). Select the node,
+and in the inspecter, click the ``Layout`` section and set ``Full Rect``
+as the anchors preset. You also need to enable the ``Expand`` vertical size flag.
 The panel now uses all the space available in the main viewport.
 
 Next, let's add a button to our example main screen plugin.
@@ -124,7 +126,7 @@ Add a script to the button like this:
     extends Button
 
 
-    func _on_PrintHello_pressed():
+    func _on_pressed():
         print("Hello from the main screen plugin!")
 
  .. code-tab:: csharp
@@ -134,15 +136,13 @@ Add a script to the button like this:
     [Tool]
     public partial class PrintHello : Button
     {
-        public void OnPrintHelloPressed()
+        public void OnPressed()
         {
             GD.Print("Hello from the main screen plugin!");
         }
     }
 
-
-Then connect the "pressed" signal to itself. If you need help with signals,
-see the :ref:`doc_signals` article.
+We are connecting the Button's "pressed" signal to itself. If you want to learn more, refer to :ref:`doc_signals`
 
 We are done with the main screen panel. Save the scene as ``main_panel.tscn``.
 


### PR DESCRIPTION
Edited [Making Main Screen Plugins](https://docs.godotengine.org/en/latest/tutorials/plugins/editor/making_main_screen_plugins.html) page:
- Added a note in the beginning, that it assumes you know how to make generic plugins.
- Edited the first paragraph in [Main screen scene](https://docs.godotengine.org/en/latest/tutorials/plugins/editor/making_main_screen_plugins.html#main-screen-scene) to make more sense
- Fixed the button script code (in the same section)
- Changed the sentience after the button code.

I don't know C#, so I'm not sure if the button script will work, I apologize. 

This should make the page totally Godot 4 compatible, but I'm not positive?

Also, the repo that holds the [example project](https://github.com/godotengine/godot-demo-projects/blob/master/plugins/addons/main_screen/print_hello.gd) will need to be updated. 

This is my first ever PR, so please forgive any mistakes :)