### PR TITLE
Less intrusive 4.0 update state info

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -28,7 +28,7 @@
 {%- block document %}
 <div itemprop="articleBody">
   {% if godot_is_latest or godot_show_article_status %}
-  <div class="admonition-grid {% if godot_is_latest and godot_show_article_status %}admonition-grid-2x{% endif %}">
+  <div class="admonition-grid">
     {% if godot_is_latest %}
     <div class="admonition attention latest-notice">
       <p class="first admonition-title">Attention: Here be dragons</p>

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -31,11 +31,11 @@
   <div class="admonition-grid {% if godot_is_latest and godot_show_article_status %}admonition-grid-2x{% endif %}">
     {% if godot_is_latest %}
     <div class="admonition attention latest-notice">
-      <p class="first admonition-title">Attention</p>
+      <p class="first admonition-title">Attention: Here be dragons</p>
       <p>
-        You are reading the <code class="docutils literal notranslate"><span class="pre">latest</span></code>
-        (unstable) version of this documentation, which may document features not available
-        or compatible with Godot 3.x.
+        This is the <code class="docutils literal notranslate"><span class="pre">latest</span></code>
+        (unstable) version of this documentation, which may be outdated or
+        document features not available in or compatible with released stable versions of Godot.
       </p>
       <p class="last latest-notice-link">
         Checking the stable version of the documentation...
@@ -43,23 +43,23 @@
     </div>
     {% endif %}
 
-    {% if godot_show_article_status %}
+    {% if godot_show_article_status and not godot_is_latest %}
     <div class="admonition tip article-status">
+      {% if meta and meta.get('article_outdated') == 'True' %}
       <p class="first admonition-title">Work in progress</p>
       <p>
-        Godot documentation is being updated to reflect the latest changes in version
-        <code class="docutils literal notranslate">{{ godot_version }}</code>. Some documentation pages may
-        still state outdated information. This banner will tell you if you're reading one of such pages.
+        The content of this page was not yet updated for Godot
+        <code class="docutils literal notranslate">{{ godot_version }}</code>
+        and may be <strong>outdated</strong>. If you know how to improve this page or you can confirm
+        that it's up to date, feel free to <a href="https://github.com/godotengine/godot-docs">open a pull request</a>.
       </p>
+      {% else %}
+      <p class="first admonition-title">Up to date</p>
       <p>
-        {% if meta and meta.get('article_outdated') == 'True' %}
-          The contents of this page can be <strong>outdated</strong>. If you know how to improve this page or you can confirm
-          that it's up to date, feel free to <a href="https://github.com/godotengine/godot-docs">open a pull request</a>.
-        {% else %}
-          The contents of this page are <strong>up to date</strong>. If you can still find outdated information, please
-          <a href="https://github.com/godotengine/godot-docs">open an issue</a>.
-        {% endif %}
+        This page is <strong>up to date</strong> for Godot <code class="docutils literal notranslate">{{ godot_version }}</code>.
+        If you still find outdated information, please <a href="https://github.com/godotengine/godot-docs">open an issue</a>.
       </p>
+      {% endif %}
     </div>
     {% endif %}
   </div>

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -34,8 +34,8 @@
       <p class="first admonition-title">Attention: Here be dragons</p>
       <p>
         This is the <code class="docutils literal notranslate"><span class="pre">latest</span></code>
-        (unstable) version of this documentation, which may be outdated or
-        document features not available in or compatible with released stable versions of Godot.
+        (unstable) version of this documentation, which may document features
+        not available in or compatible with released stable versions of Godot.
       </p>
       <p class="last latest-notice-link">
         Checking the stable version of the documentation...


### PR DESCRIPTION
Now that Godot 4.0 has been out a bit and we're on the road to Godot 4.0.2, I'm growing a bit tired of that giant admonition at the top. This is an attempt to make it a bit smaller while retaining the information and also being easier to discvern at a glance by changing the title.

# New

![popup-wip](https://user-images.githubusercontent.com/1654763/229178131-0de45a40-cbea-44cf-bdb7-5c3574194bef.PNG)

![popup-uptodate](https://user-images.githubusercontent.com/1654763/229178139-bd457edf-c61a-4e14-80f5-565bafdce55f.PNG)

# Old

![old-wip](https://user-images.githubusercontent.com/1654763/229178450-da0f0d69-7fa5-49f1-94b4-d9b6afb9aecd.PNG)

![old-up](https://user-images.githubusercontent.com/1654763/229178460-a786f567-bc19-490e-9e40-70c3ee352bb7.PNG)
