### PR TITLE
Fix references to DEPTH_TEXTURE and SCREEN_TEXTURE

### DIFF
--- a/tutorials/3d/environment_and_post_processing.rst
+++ b/tutorials/3d/environment_and_post_processing.rst
@@ -397,7 +397,8 @@ A few user-controlled parameters are available to better tweak the technique:
 
 Keep in mind that screen-space-reflections only work for reflecting opaque
 geometry. Transparent materials won't be reflected, as they don't write to the depth buffer.
-This also applies to shaders that use ``SCREEN_TEXTURE`` or ``DEPTH_TEXTURE``.
+This also applies to shaders that use ``hint_screen_texture`` or ``hint_depth_texture``
+uniforms.
 
 Screen-Space Ambient Occlusion (SSAO)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tutorials/shaders/advanced_postprocessing.rst
+++ b/tutorials/shaders/advanced_postprocessing.rst
@@ -76,19 +76,25 @@ You can also use both options.
 Depth texture
 -------------
 
-To read from the depth texture, perform a texture lookup using ``texture()`` and
-the uniform variable ``DEPTH_TEXTURE``.
+To read from the depth texture, we first need to create a texture uniform set to the depth buffer
+by using ``hint_depth_texture``.
 
 .. code-block:: glsl
 
-  float depth = texture(DEPTH_TEXTURE, SCREEN_UV).x;
+  uniform sampler2D depth_texture : source_color, hint_depth_texture;
+
+Once defined, the depth texture can be read with the ``texture`` function.
+
+.. code-block:: glsl
+
+  float depth = texture(depth_texture, SCREEN_UV).x;
 
 .. note:: Similar to accessing the screen texture, accessing the depth texture is only
           possible when reading from the current viewport. The depth texture cannot be
           accessed from another viewport to which you have rendered.
 
-The values returned by ``DEPTH_TEXTURE`` are between ``0.0`` and ``1.0`` and are nonlinear.
-When displaying depth directly from the ``DEPTH_TEXTURE``, everything will look almost
+The values returned by ``depth_texture`` are between ``0.0`` and ``1.0`` and are nonlinear.
+When displaying depth directly from the ``depth_texture``, everything will look almost
 white unless it is very close. This is because the depth buffer stores objects closer
 to the camera using more bits than those further, so most of the detail in depth
 buffer is found close to the camera. In order to make the depth value align with world or
@@ -111,7 +117,7 @@ the depth value for ``z``.
 .. code-block:: glsl
 
   void fragment() {
-    float depth = texture(DEPTH_TEXTURE, SCREEN_UV).x;
+    float depth = texture(depth_texture, SCREEN_UV).x;
     vec3 ndc = vec3(SCREEN_UV * 2.0 - 1.0, depth);
   }
 

--- a/tutorials/shaders/advanced_postprocessing.rst
+++ b/tutorials/shaders/advanced_postprocessing.rst
@@ -83,7 +83,7 @@ by using ``hint_depth_texture``.
 
   uniform sampler2D depth_texture : source_color, hint_depth_texture;
 
-Once defined, the depth texture can be read with the ``texture`` function.
+Once defined, the depth texture can be read with the ``texture()`` function.
 
 .. code-block:: glsl
 

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -464,7 +464,7 @@ If you want the lights to add together, add the light contribution to ``DIFFUSE_
     for more information and ways to avoid issues.
 
     Transparent materials also cannot cast shadows or appear in
-    ``SCREEN_TEXTURE`` and ``DEPTH_TEXTURE``. This in turn prevents those
+    ``hint_screen_texture`` and ``hint_depth_texture`` uniforms. This in turn prevents those
     materials from appearing in screen-space reflections or refraction.
     :ref:`SDFGI <doc_using_sdfgi>` sharp reflections are not visible on transparent
     materials (only rough reflections are visible on transparent materials).


### PR DESCRIPTION
This updates a couple outdated references to `DEPTH_TEXTURE` to be `hint_depth_texture` instead. It's the tutorial in described in https://github.com/godotengine/godot-docs/issues/7118 and a couple other sites.