### PR TITLE
Fix Mob's initial rotation remain untilted

### DIFF
--- a/getting_started/first_3d_game/04.mob_scene.rst
+++ b/getting_started/first_3d_game/04.mob_scene.rst
@@ -160,7 +160,7 @@ between ``-PI / 4`` radians and ``PI / 4`` radians.
     func initialize(start_position, player_position):
         # We position the mob by placing it at start_position
         # and rotate it towards player_position, so it looks at the player.
-        look_at_from_position(start_position, player_position, Vector3.UP)
+        look_at_from_position(start_position, Vector3(player_position.x, 0, player_position.z), Vector3.UP)
         # Rotate this mob randomly within range of -90 and +90 degrees,
         # so that it doesn't move directly towards the player.
         rotate_y(randf_range(-PI / 4, PI / 4))
@@ -172,11 +172,18 @@ between ``-PI / 4`` radians and ``PI / 4`` radians.
     {
         // We position the mob by placing it at startPosition
         // and rotate it towards playerPosition, so it looks at the player.
-        LookAtFromPosition(startPosition, playerPosition, Vector3.Up);
+        LookAtFromPosition(startPosition, Vector3(playerPosition.x, 0, playerPosition.z), Vector3.Up);
         // Rotate this mob randomly within range of -90 and +90 degrees,
         // so that it doesn't move directly towards the player.
         RotateY((float)GD.RandRange(-Mathf.Pi / 4.0, Mathf.Pi / 4.0));
     }
+
+.. note::
+
+    0 for the Vector3's Y parameter ensures ``Mobs`` don't tilt up when 
+    ``Player`` jumps changing the Y coordinate. When ``Mob``'s ``initialize`` 
+    method is called they won't be fooled by the ``Player``'s Y position 
+    and look forward as expected of them.
 
 We got a random position, now we need a ``random_speed``. ``randi_range()`` will be useful as it gives random int values, and we will use ``min_speed`` and ``max_speed``.
 ``random_speed`` is just an integer, and we just use it to multiply our ``CharacterBody3D.velocity``. After ``random_speed`` is applied, we rotate ``CharacterBody3D.velocity`` Vector3 towards the player.


### PR DESCRIPTION
Fixes the following issue: https://github.com/godotengine/godot-docs/issues/7121

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
