### PR TITLE
Remove duplicate C# comment from GDscript codeblock

### DIFF
--- a/getting_started/first_3d_game/06.jump_and_squash.rst
+++ b/getting_started/first_3d_game/06.jump_and_squash.rst
@@ -237,7 +237,6 @@ With this code, if no collisions occurred on a given frame, the loop won't run.
         #...
 
         # Iterate through all collisions that occurred this frame
-        # in C this would be for(int i = 0; i < collisions.Count; i++)
         for index in range(get_slide_collision_count()):
             # We get one of the collisions with the player
             var collision = get_slide_collision(index)


### PR DESCRIPTION
There's no need for C# comment to remain in the GDScript codeblock. That line is already a part of the C# example that's in a second tab. 
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
