### PR TITLE
Alter a word in "inputevent.rst"

### DIFF
--- a/tutorials/inputs/inputevent.rst
+++ b/tutorials/inputs/inputevent.rst
@@ -117,7 +117,7 @@ received input, in order:
    not. This can be configured through :ref:`Area3D <class_Area3D>` properties).
    In the case of a 2D scene, conceptually the same happens with :ref:`CollisionObject2D._input_event() <class_CollisionObject2D_method__input_event>`.
 
-When sending events to its child and descencand nodes, the viewport will do so, as depicted in
+When sending events to its child and descendant nodes, the viewport will do so, as depicted in
 the following graphic, in a reverse depth-first order, starting with the node at the bottom of
 the scene tree, and ending at the root node. Excluded from this process are embedded Windows
 and SubViewports.


### PR DESCRIPTION
A samll spelling mistake.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
