### PR TITLE
Fix C# typos

### DIFF
--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -101,7 +101,7 @@ the following line of code:
 
     using Godot;
 
-    public partial class Sprite : Sprite2D
+    public partial class Sprite2D : Godot.Sprite2D
     {
     }
 
@@ -327,7 +327,7 @@ Here is the complete ``Sprite2D.gd`` file for reference.
 
     using Godot;
 
-    public partial class Sprite : Sprite2D
+    public partial class Sprite2D : Godot.Sprite2D
     {
         private int Speed = 400;
         private float AngularSpeed = Mathf.Pi;


### PR DESCRIPTION
**Your Godot version:**
v4.0.1.mono.stable

**Issue description:**
![Attach node script](https://docs.godotengine.org/en/stable/_images/scripting_first_script_attach_node_script.webp)

We expect the user to have a filename Sprite2D.gd / Sprite2D.cs

However in the code example the class name is ```Sprite``` instead of ```Sprite2D```

More details : https://github.com/godotengine/godot-docs/issues/7128