### PR TITLE
Fix in methods names used in Using ImmediateMesh 3d tutorial

### DIFF
--- a/tutorials/3d/procedural_geometry/immediatemesh.rst
+++ b/tutorials/3d/procedural_geometry/immediatemesh.rst
@@ -10,30 +10,30 @@ API like SurfaceTool, but it's actually designed to create meshes on the fly.
 Generating complex geometry (several thousand vertices) with this node is inefficient, even if it's
 done only once. Instead, it is designed to generate simple geometry that changes every frame.
 
-Before starting, you should clear the geometry by calling ``clear()``. This ensures that
+Before starting, you should clear the geometry by calling ``clear_surfaces()``. This ensures that
 you are not building upon the geometry from the previous frame. If you want to keep geometry between frames, do
-not call ``clear()``.
+not call ``clear_surfaces()``.
 
-To begin generating geometry you must call ``begin()``. ``begin()`` takes a ``PrimitiveType`` as an argument.
+To begin generating geometry you must call ``surface_begin()``. ``surface_begin()`` takes a ``PrimitiveType`` as an argument.
 ``PrimitiveType`` is an OpenGL concept that instructs the GPU how to arrange the primitive based on the
 vertices given whether it is triangles, lines, points, etc. A complete list can be found under
 the :ref:`Mesh <class_mesh>` class reference page.
 
-Once you have called ``begin()`` you are ready to start adding vertices. You add vertices one at a time.
-First you add vertex specific attributes such as normals or UVs using ``set_****()`` (e.g. ``set_normal()``).
-Then you call ``add_vertex()`` to add a vertex with those attributes. For example:
+Once you have called ``surface_begin()`` you are ready to start adding vertices. You add vertices one at a time.
+First you add vertex specific attributes such as normals or UVs using ``surface_set_****()`` (e.g. ``surface_set_normal()``).
+Then you call ``surface_add_vertex()`` to add a vertex with those attributes. For example:
 
 .. tabs::
   .. code-tab:: gdscript GDScript
 
     # Add a vertex with normal and uv.
-    set_normal(Vector3(0, 1, 0))
-    set_uv(Vector2(1, 1))
-    add_vertex(Vector3(0, 0, 1))
+    surface_set_normal(Vector3(0, 1, 0))
+    surface_set_uv(Vector2(1, 1))
+    surface_add_vertex(Vector3(0, 0, 1))
 
-Only attributes added before the call to ``add_vertex()`` will be included in that vertex.
+Only attributes added before the call to ``surface_add_vertex()`` will be included in that vertex.
 
-Finally, once you have added all your vertices call ``end()`` to signal that you have finished generating the mesh.
+Finally, once you have added all your vertices call ``surface_end()`` to signal that you have finished generating the mesh.
 
 The example code below draws a single triangle.
 
@@ -44,24 +44,24 @@ The example code below draws a single triangle.
 
     func _process(_delta):
         # Clean up before drawing.
-        clear()
+        clear_surfaces()
 
         # Begin draw.
-        begin(Mesh.PRIMITIVE_TRIANGLES)
+        surface_begin(Mesh.PRIMITIVE_TRIANGLES)
 
-        # Prepare attributes for add_vertex.
-        set_normal(Vector3(0, 0, 1))
-        set_uv(Vector2(0, 0))
+        # Prepare attributes for surface_add_vertex.
+        surface_set_normal(Vector3(0, 0, 1))
+        surface_set_uv(Vector2(0, 0))
         # Call last for each vertex, adds the above attributes.
-        add_vertex(Vector3(-1, -1, 0))
+        surface_add_vertex(Vector3(-1, -1, 0))
 
-        set_normal(Vector3(0, 0, 1))
-        set_uv(Vector2(0, 1))
-        add_vertex(Vector3(-1, 1, 0))
+        surface_set_normal(Vector3(0, 0, 1))
+        surface_set_uv(Vector2(0, 1))
+        surface_add_vertex(Vector3(-1, 1, 0))
 
-        set_normal(Vector3(0, 0, 1))
-        set_uv(Vector2(1, 1))
-        add_vertex(Vector3(1, 1, 0))
+        surface_set_normal(Vector3(0, 0, 1))
+        surface_set_uv(Vector2(1, 1))
+        surface_add_vertex(Vector3(1, 1, 0))
 
         # End drawing.
-        end()
+        surface_end()


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

## What I did 

- Adjusted methods names used in `tutorials/3d/procedural_geometry/immediatemesh.rst` file ([**Using ImmediateMesh**](https://docs.godotengine.org/en/stable/tutorials/3d/procedural_geometry/immediatemesh.html) 3d tutorial), now the methods names are up to date with [ImmediateMesh class](https://docs.godotengine.org/en/stable/classes/class_immediatemesh.html) info.

### Fixes: #7067 