### PR TITLE
Fix in MultiMesh example

### DIFF
--- a/tutorials/performance/using_multimesh.rst
+++ b/tutorials/performance/using_multimesh.rst
@@ -63,8 +63,6 @@ efficient for millions of objects, but for a few thousands, GDScript should be f
         multimesh = MultiMesh.new()
         # Set the format first.
         multimesh.transform_format = MultiMesh.TRANSFORM_3D
-        multimesh.color_format = MultiMesh.COLOR_NONE
-        multimesh.custom_data_format = MultiMesh.CUSTOM_DATA_NONE
         # Then resize (otherwise, changing the format is not allowed).
         multimesh.instance_count = 10000
         # Maybe not all of them should be visible at first.
@@ -86,8 +84,6 @@ efficient for millions of objects, but for a few thousands, GDScript should be f
             Multimesh = new MultiMesh();
             // Set the format first.
             Multimesh.TransformFormat = MultiMesh.TransformFormatEnum.Transform3D;
-            Multimesh.ColorFormat = MultiMesh.ColorFormatEnum.None;
-            Multimesh.CustomDataFormat = MultiMesh.CustomDataFormatEnum.None;
             // Then resize (otherwise, changing the format is not allowed)
             Multimesh.InstanceCount = 1000;
             // Maybe not all of them should be visible at first.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

## What I did 

- Removed out of date lines of codes from `tutorials/performance/using_multimesh.rst` file, it was necessary because the [`MultiMesh` class](https://docs.godotengine.org/en/stable/classes/class_multimesh.html) has updated and does not has anymore some properties and enums used in the code.

### Fixes: #6998 