### PR TITLE
clarify importance of naming files

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -629,6 +629,13 @@ This is consistent with how C++ files are named in Godot's source code. This
 also avoids case sensitivity issues that can crop up when exporting a project
 from Windows to other platforms.
 
+.. note:: Godot does not require class names and file names to match exactly like many other languages.
+          ⚠ Do not make them match exactly! Follow the above advice please.
+          This can cause errors like:
+          `SCRIPT ERROR: Invalid call. Nonexistent function 'init' in base 'Area2D'.`
+          `SCRIPT ERROR: Parse Error: Could not find type "SomeClass" in the current scope.`
+          `SCRIPT ERROR: Parse Error: Identifier "SomeOtherClass" not declared in the current scope.`
+
 Classes and nodes
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
godot does not require file and class names to match exactly, but this is different than many other languages

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
