### PR TITLE
Link to the Multiple resolutions demo in the relevant page (3.6)

### DIFF
--- a/tutorials/rendering/multiple_resolutions.rst
+++ b/tutorials/rendering/multiple_resolutions.rst
@@ -48,6 +48,11 @@ handle scaling for different sizes and aspect ratios.
 
 Godot provides several useful tools to do this easily.
 
+.. seealso::
+
+    You can see how Godot's support for multiple resolutions works in action using the
+    `Multiple Resolutions and Aspect Ratios demo project <https://github.com/godotengine/godot-demo-projects/tree/3.x/gui/multiple_resolutions>`__.
+
 Base size
 ---------
 


### PR DESCRIPTION
This demo provides a lot of helpful guidance for setting up a project that supports multiple resolutions and aspect ratios. It's available for both 3.x and 4.x.

This is a subset of https://github.com/godotengine/godot-docs/pull/7136 with the demo link changed to point to the `3.x` branch of the demo.
