### PR TITLE
Fix small typos in the particle shader doc

### DIFF
--- a/tutorials/shaders/shader_reference/particle_shader.rst
+++ b/tutorials/shaders/shader_reference/particle_shader.rst
@@ -14,7 +14,7 @@ CanvasItem of Spatial shader. They contain two processor functions: ``start()``
 and ``process()``.
 
 Unlike other shader types, particle shaders keep the data that was output the
-previous frame. Therefore, particle shaders ca be used for complex effects that
+previous frame. Therefore, particle shaders can be used for complex effects that
 take place over multiple frames.
 
 .. note::
@@ -85,7 +85,7 @@ Start and Process built-ins
 +---------------------------------+--------------------------------------------------------------------------------+
 | in uint **RANDOM_SEED**         | Random seed used as base for random.                                           |
 +---------------------------------+--------------------------------------------------------------------------------+
-| inout bool **ACTIVE**           | ``true`` when Particle is active, can be set ``false``.                        |
+| inout bool **ACTIVE**           | ``true`` when the particle is active, can be set ``false``.                    |
 +---------------------------------+--------------------------------------------------------------------------------+
 | inout vec4 **COLOR**            | Particle color, can be written to and accessed in mesh's vertex function.      |
 +---------------------------------+--------------------------------------------------------------------------------+


### PR DESCRIPTION
A word was missing a letter and a description had a wrongly capitalized word. Now it matches the rest of the document.

I thought that maybe that capitalization was made on purpose (like talking about "Particle" as an object), but in other parts of the document it does not do it like that. For example in `Process built-ins`, so I think it is a typo after all and fixed it.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
