### PR TITLE
add missing line to json parsing example

### DIFF
--- a/classes/class_json.rst
+++ b/classes/class_json.rst
@@ -34,6 +34,7 @@ The **JSON** enables all data types to be converted to and from a JSON string. T
     # Save data
     # ...
     # Retrieve data
+    var json = JSON.new()
     var error = json.parse(json_string)
     if error == OK:
         var data_received = json.data


### PR DESCRIPTION
```gdscript
var json = JSON.new()
```
was missing, It was quite confusing for me until I found https://godotengine.org/qa/118343/godot-4-0-how-to-get-a-dictionary-from-a-json-type