### PR TITLE
Updated method name in GDScript example

### DIFF
--- a/getting_started/first_3d_game/04.mob_scene.rst
+++ b/getting_started/first_3d_game/04.mob_scene.rst
@@ -237,7 +237,7 @@ method. This function destroy the instance it's called on.
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-   func _on_VisibilityNotifier_screen_exited():
+   func _on_visible_on_screen_notifier_3d_screen_exited():
        queue_free()
 
  .. code-tab:: csharp


### PR DESCRIPTION
_on_visible_on_screen_notifier_3d_screen_exited is the default name for the method created in GDScript, and is how the function is referred to elsewhere in the instructions
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
