### PR TITLE
Fixed 'Reporting node configuration warnings' code snippet

### DIFF
--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -267,15 +267,12 @@ By default, the warning only updates when closing and reopening the scene.
                 update_configuration_warnings()
 
 
-    func _get_configuration_warning():
-        var warning = ""
+    func _get_configuration_warnings():
+        var warning = []
         if title == "":
-            warning += "Please set `title` to a non-empty value."
-        if description.size() >= 100:
-            # Add a blank line between each warning to distinguish them individually.
-            if warning != "":
-                warning += "\n"
-            warning += "`description` should be less than 100 characters long."
+            warning.append("Please set `title` to a non-empty value.")
+        if description.length() >= 100:
+            warning.append("`description` should be less than 100 characters long.")
 
         # Returning an empty string means "no warning".
         return warning


### PR DESCRIPTION
- Switched .size for .length
- initialized warnings as empty array
- warning.append instead of +=
- deleted new line
- Corrected method name

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
