### PR TITLE
3.6 branch: Git ignore .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ logo.h
 # Output of list-unused-images.sh tool
 tmp-unused-images
 tmp-unused-images-history
+*.env


### PR DESCRIPTION
Adds `*.env` files to `.gitignore`, which we may use (e.g. for ReadTheDocs). This is already done on the `master` branch.