### PR TITLE
Added `mingw` to the scoop install instructions

### DIFF
--- a/contributing/development/compiling/compiling_for_windows.rst
+++ b/contributing/development/compiling/compiling_for_windows.rst
@@ -31,7 +31,7 @@ For compiling under Windows, the following is required:
 .. note:: If you have `Scoop <https://scoop.sh/>`_ installed, you can easily
           install MinGW and other dependencies using the following command::
 
-              scoop install gcc python scons make
+              scoop install gcc python scons make mingw
 
 .. note:: If you have `MSYS2 <https://www.msys2.org/>`_ installed, you can easily
           install MinGW and other dependencies using the following command::


### PR DESCRIPTION
Added the missing `mingw` text to the scoop installation instructions in the Compiling for Windows tutorial. The text implies that the provided command will install MinGW, but MinGW is absent from the command and may not be recognized by the later compilation commands if the user does not manually add it or install it separately.

This is my first ever pull request to a public repo so proofreading and pointers are highly appreciated.