### PR TITLE
Add a CI action to sync up the class reference

### DIFF
--- a/.github/workflows/sync_class_ref.yml
+++ b/.github/workflows/sync_class_ref.yml
@@ -1,0 +1,68 @@
+name: Sync Class Reference
+
+on:
+  workflow_dispatch:
+  # Scheduled updates are only enabled for in-dev branches.
+  schedule:
+    # Run it at night (European time) every Saturday.
+    # The offset is there to try and avoid the high load times.
+    - cron: '15 3 * * 6'
+
+# Make sure jobs cannot overlap.
+concurrency:
+  group: classref-sync-ci
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Update class reference files based on the engine revision
+    runs-on: ubuntu-latest
+    env:
+      engine_rev: 'master'
+
+    steps:
+      - name: Checkout the documentation repository
+        uses: actions/checkout@v3
+
+      - name: Checkout the engine repository
+        uses: actions/checkout@v3
+        with:
+          repository: 'godotengine/godot'
+          # Use the appropriate branch for the documentation version.
+          ref: ${{ env.engine_rev }}
+          path: './.engine-src'
+
+      - name: Store the engine revision
+        id: 'engine'
+        run: |
+          cd ./.engine-src
+          hash=$(git rev-parse HEAD)
+          hash_short=$(git rev-parse --short HEAD)
+          echo "Checked out godotengine/godot at $hash"
+          echo "rev_hash=$hash" >> $GITHUB_OUTPUT
+          echo "rev_hash_short=$hash_short" >> $GITHUB_OUTPUT
+
+      - name: Remove old documentation
+        run: |
+          rm ./classes/class_*.rst
+
+      - name: Build new documentation
+        run: |
+          ./.engine-src/doc/tools/make_rst.py --color -o ./classes -l en ./.engine-src/doc/classes ./.engine-src/modules
+
+      - name: Submit a pull-request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: 'classref: Sync with current ${{ env.engine_rev }} branch (${{ steps.engine.outputs.rev_hash_short }})'
+          branch: 'classref/sync-${{ steps.engine.outputs.rev_hash_short }}'
+          add-paths: './classes'
+          delete-branch: true
+
+          # Configure the commit author.
+          author: 'Godot Organization <noreply@godotengine.org>'
+          committer: 'Godot Organization <noreply@godotengine.org>'
+
+          # Configure the pull-request.
+          title: 'classref: Sync with current ${{ env.engine_rev }} branch (${{ steps.engine.outputs.rev_hash_short }})'
+          body: 'Update Godot API online class reference to match the engine at https://github.com/godotengine/godot/commit/${{ steps.engine.outputs.rev_hash }} (`${{ env.engine_rev }}`).'
+          labels: 'area:class reference,bug,enhancement'


### PR DESCRIPTION
Let's reduce manual labor :)

This adds a workflow that can be triggered on demand, and also runs on a schedule once a week. It checks out the target version of the main repo, generates new RSTs, and submits a PR for us to approve and merge. I opted to go through a PR to stay on a safer side, though we can also commit directly if we want to.

Here's an example of a PR it creates: https://github.com/YuriSizov/godot-docs/pull/38 _(contains extra commits that temporary appeared in the master, look for the last one)_
And here's an example of a workflow run: https://github.com/YuriSizov/godot-docs/actions/runs/4700847275/jobs/8336065111

-----

I only tested this with the master branch. When you want to run a workflow, you can select any branch you want, but it will not work correctly. We need to map versions of docs to versions of the engine for it to work. Initially I wanted to commit a modified version of this workflow to each branch, but I don't think it will work. I think workflows that are triggered manually need to exist on the master branch and are triggered based on the script from that branch. I will test further what happens with other branches once we merge this.

Another point to consider is automatic runs. I set this up to run once a week, on Saturday night European time. But this is only relevant for the in-dev versions, such as `master` and `3.6`, as of now. For stable branches I want to only keep the manual trigger. So I also need to see how to achieve that with other branches.