### PR TITLE
Add macOS shortcut for closing Scene window

### DIFF
--- a/getting_started/step_by_step/nodes_and_scenes.rst
+++ b/getting_started/step_by_step/nodes_and_scenes.rst
@@ -157,7 +157,7 @@ The application should open in a new window and display the text "Hello World".
 
 .. image:: img/nodes_and_scenes_11_final_result.webp
 
-Close the window or press :kbd:`F8` to quit the running scene.
+Close the window or press :kbd:`F8` (:kbd:`Cmd + .` on macOS) to quit the running scene.
 
 .. note::
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->


This PR adds the macOS shortcut to the documentation. This was the only macOS shortcut that was missing on this page.