### PR TITLE
Update GitHub issue URL for encapsulation violations in Editor development

### DIFF
--- a/contributing/development/editor/introduction_to_editor_development.rst
+++ b/contributing/development/editor/introduction_to_editor_development.rst
@@ -77,7 +77,7 @@ from ``servers/`` and ``core/``, it cannot depend on includes from ``editor/``.
 
 Currently, there are some dependencies to ``editor/`` includes in ``scene/``
 files, but
-`they are in the process of being removed <https://github.com/godotengine/godot/issues/29730>`__.
+`they are in the process of being removed <https://github.com/godotengine/godot/issues/53295>`__.
 
 Development tips
 ----------------


### PR DESCRIPTION
The previously linked issue is now closed.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
