### PR TITLE
Update 05.the_main_game_scene.rst

### DIFF
--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -289,7 +289,7 @@ the other two timers. ``ScoreTimer`` will increment the score by 1.
         godot::register_property("mob_scene", &Main::mob_scene, (godot::Ref<godot::PackedScene>)nullptr);
     }
 
-In ``_on_MobTimer_timeout()``, we will create a mob instance, pick a random
+In ``_on_mob_timer_timeout()``, we will create a mob instance, pick a random
 starting location along the ``Path2D``, and set the mob in motion. The
 ``PathFollow2D`` node will automatically rotate as it follows the path, so we
 will use that to select the mob's direction as well as its position.


### PR DESCRIPTION
Main body refers to function as `on_MobTimer_timeout`. This is the C++ name for that function. For consistency should this use the GDScript name?

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
