### PR TITLE
Fix typo 'adominitions' in Comment Style Guide

### DIFF
--- a/contributing/development/code_style_guidelines.rst
+++ b/contributing/development/code_style_guidelines.rst
@@ -321,7 +321,7 @@ Godot's codebase.
   always end them with a period.
 - Reference variable/function names and values using backticks.
 - Wrap comments to ~100 characters.
-- You can use ``TODO:``, ``FIXME:``, ``NOTE:``, or ``HACK:`` as adominitions
+- You can use ``TODO:``, ``FIXME:``, ``NOTE:``, or ``HACK:`` as admonitions
   when needed.
 
 **Example:**


### PR DESCRIPTION
A Google search returns <300 hits for this spelling, with the top hit being a typo itself, so I'm pretty sure the use here is also a typo for 'admonitions.'

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
