### PR TITLE
step_by_step/instancing.rst: Add macOS shortcuts

### DIFF
--- a/getting_started/step_by_step/instancing.rst
+++ b/getting_started/step_by_step/instancing.rst
@@ -45,7 +45,7 @@ you to download the ball's sample project we prepared for you:
 :download:`instancing.zip <files/instancing.zip>`.
 
 Extract the archive on your computer. To import it, you need the Project Manager.
-The Project Manager is accessed by opening Godot, or if you already have Godot opened, click on *Project -> Quit to Project List* (:kbd:`Ctrl + Shift + Q`)
+The Project Manager is accessed by opening Godot, or if you already have Godot opened, click on *Project -> Quit to Project List* (:kbd:`Ctrl + Shift + Q`, :kbd:`Ctrl + Option + Cmd + B` on macOS)
 
 In the Project Manager, click the *Import* button to import the project.
 
@@ -88,7 +88,7 @@ Click on it and drag it towards the center of the view.
 
 .. image:: img/instancing_ball_moved.png
 
-Play the game by pressing F5. You should see it fall.
+Play the game by pressing :kbd:`F5` (:kbd:`Cmd + B` on macOS). You should see it fall.
 
 Now, we want to create more instances of the Ball node. With the ball still
 selected, press :kbd:`Ctrl-D` (:kbd:`Cmd-D` on macOS) to call the duplicate


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

There were 2 instances where the default windows shortcut was used, but not the macOS shortcut, so I added them. I also let Godot convert the example `instancing.zip` project to be Godot 4 compatible (it prompted to do this when opening the project in Godot 4), then rezipped it.
