### PR TITLE
Fix grammer in logic_preferences.rst

### DIFF
--- a/tutorials/best_practices/logic_preferences.rst
+++ b/tutorials/best_practices/logic_preferences.rst
@@ -16,7 +16,7 @@ properties such as the node's name or position. A common dilemma is, when
 should you change those values?
 
 It is the best practice to change values on a node before adding it to the
-scene tree. Some property setters have code to update other
+scene tree. Some property's setters have code to update other
 corresponding values, and that code can be slow! For most cases, this code
 has no impact on your game's performance, but in heavy use cases such as
 procedural generation, it can bring your game to a crawl.

--- a/tutorials/best_practices/logic_preferences.rst
+++ b/tutorials/best_practices/logic_preferences.rst
@@ -16,7 +16,7 @@ properties such as the node's name or position. A common dilemma is, when
 should you change those values?
 
 It is the best practice to change values on a node before adding it to the
-scene tree. Some properties setters have code to update other
+scene tree. Some property setters have code to update other
 corresponding values, and that code can be slow! For most cases, this code
 has no impact on your game's performance, but in heavy use cases such as
 procedural generation, it can bring your game to a crawl.


### PR DESCRIPTION
The [documentation](https://docs.godotengine.org/en/stable/tutorials/best_practices/logic_preferences.html) has this sentence:

> Some **properties setters** have code to update other corresponding values...

Which doesn't sound right to me.

This PR changes it to:

> Some **property setters** have code to update other corresponding values...

But it could also possibly be:

> Some **property's setters** have code to update other corresponding values...