### PR TITLE
Fix broken images in managing_editor_features.rst

### DIFF
--- a/tutorials/editor/managing_editor_features.rst
+++ b/tutorials/editor/managing_editor_features.rst
@@ -27,7 +27,7 @@ will open the **Manage Editor Feature Profiles** window. By default there
 will be no profile. Click on **Create Profile** and give it a name. You will
 then see a list of all the features in the Godot editor.
 
-..img:: img/configure_profile.png
+.. image:: img/configure_profile.png
 
 The first section allows major editor features to be removed, such as the 3D
 editor or scripting editor. Below the main features is every class and node in
@@ -35,7 +35,7 @@ Godot, which can be disabled as well. Click on a node and all of its properties
 and options will be listed in the **Extra Items** box, these can all be
 individually disabled.
 
-..img:: img/node_features.png
+.. image:: img/node_features.png
 
 Sharing a profile
 -----------------


### PR DESCRIPTION
Images are broken on this page: https://docs.godotengine.org/en/stable/tutorials/editor/managing_editor_features.html

![image](https://user-images.githubusercontent.com/2385329/232401908-590fdf40-46e8-4bfe-a1e8-f4fd6a68aaf8.png)
