### PR TITLE
Update SFC to Godot Foundation, old URLs

### DIFF
--- a/about/introduction.rst
+++ b/about/introduction.rst
@@ -46,8 +46,8 @@ if you need a quick write-up about Godot Engine.
     license. No strings attached, no royalties, nothing. Users' games are
     theirs, down to the last line of engine code. Godot's development is fully
     independent and community-driven, empowering users to help shape their
-    engine to match their expectations. It is supported by the `Software
-    Freedom Conservancy <https://sfconservancy.org>`_ not-for-profit.
+    engine to match their expectations. It is supported by the `Godot
+    Foundation <https://godot.foundation/>`_ not-for-profit.
 
 For a more in-depth view of the engine, you are encouraged to read this
 documentation further, especially the :ref:`Getting Started <sec-learn>` series.
@@ -57,9 +57,9 @@ About the documentation
 
 This documentation is continuously written, corrected, edited, and revamped by
 members of the Godot Engine community. It is edited via text files in the
-`reStructuredText <http://www.sphinx-doc.org/en/stable/rest.html>`_ markup
+`reStructuredText <https://www.sphinx-doc.org/en/stable/rest.html>`_ markup
 language and then compiled into a static website/offline document using the
-open source `Sphinx <http://www.sphinx-doc.org>`_ and `ReadTheDocs
+open source `Sphinx <https://www.sphinx-doc.org>`_ and `ReadTheDocs
 <https://readthedocs.org/>`_ tools.
 
 .. note:: You can contribute to Godot's documentation by opening issue tickets

--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -48,7 +48,7 @@ Video tutorials
 Text tutorials
 --------------
 
-- `FinepointCGI website by Mitch <http://finepointcgi.io/>`__
+- `FinepointCGI website by Mitch <https://finepointcgi.io/>`__
 - `GDScript website by Andrew Wilkes <https://gdscript.com>`__
 - `Godot Recipes by KidsCanCode <https://kidscancode.org/godot_recipes/4.x/>`__
 - `Steincodes <https://steincodes.tumblr.com>`__

--- a/contributing/development/code_style_guidelines.rst
+++ b/contributing/development/code_style_guidelines.rst
@@ -15,7 +15,7 @@ C++ and Objective-C
 -------------------
 
 There are no written guidelines, but the code style agreed upon by the
-developers is enforced via the `clang-format <http://clang.llvm.org/docs/ClangFormat.html>`__
+developers is enforced via the `clang-format <https://clang.llvm.org/docs/ClangFormat.html>`__
 code beautifier, which takes care for you of all our conventions.
 To name a few:
 
@@ -69,10 +69,10 @@ Here's how to install clang-format:
 - Linux: It will usually be available out-of-the-box with the clang toolchain
   packaged by your distribution. If your distro version is not the required one,
   you can download a pre-compiled version from the
-  `LLVM website <http://releases.llvm.org/download.html>`__, or if you are on
-  a Debian derivative, use the `upstream repos <http://apt.llvm.org/>`__.
+  `LLVM website <https://releases.llvm.org/download.html>`__, or if you are on
+  a Debian derivative, use the `upstream repos <https://apt.llvm.org/>`__.
 - macOS and Windows: You can download precompiled binaries from the
-  `LLVM website <http://releases.llvm.org/download.html>`__. You may need to add
+  `LLVM website <https://releases.llvm.org/download.html>`__. You may need to add
   the path to the binary's folder to your system's ``PATH`` environment
   variable to be able to call ``clang-format`` out of the box.
 
@@ -118,7 +118,7 @@ clang-format automatically, for example each time you save a file.
 
 Here is a non-exhaustive list of beautifier plugins for some IDEs:
 
-- Qt Creator: `Beautifier plugin <http://doc.qt.io/qtcreator/creator-beautifier.html>`__
+- Qt Creator: `Beautifier plugin <https://doc.qt.io/qtcreator/creator-beautifier.html>`__
 - Visual Studio Code: `Clang-Format <https://marketplace.visualstudio.com/items?itemName=xaver.clang-format>`__
 - Visual Studio: `ClangFormat <https://marketplace.visualstudio.com/items?itemName=LLVMExtensions.ClangFormat>`__
 - vim: `vim-clang-format <https://github.com/rhysd/vim-clang-format>`__

--- a/contributing/development/compiling/compiling_for_windows.rst
+++ b/contributing/development/compiling/compiling_for_windows.rst
@@ -19,7 +19,7 @@ For compiling under Windows, the following is required:
   version 2017 or later. VS 2019 is recommended.
   **Make sure to read "Installing Visual Studio caveats" below or you
   will have to run/download the installer again.**
-- `MinGW-w64 <http://mingw-w64.org/>`_ with GCC can be used as an alternative to
+- `MinGW-w64 <https://mingw-w64.org/>`_ with GCC can be used as an alternative to
   Visual Studio. Be sure to install/configure it to use the ``posix`` thread model.
   **Important:** When using MinGW to compile the ``master`` branch, you need GCC 9 or later.
 - `Python 3.6+ <https://www.python.org/downloads/windows/>`_.

--- a/contributing/development/compiling/cross-compiling_for_ios_on_linux.rst
+++ b/contributing/development/compiling/cross-compiling_for_ios_on_linux.rst
@@ -15,10 +15,8 @@ Disclaimer
 While it is possible to compile for iOS on a Linux environment, Apple is
 very restrictive about the tools to be used (especially hardware-wise),
 allowing pretty much only their products to be used for development. So
-this is **not official**. However, a `statement from Apple in 2010
-<http://www.apple.com/pr/library/2010/09/09Statement-by-Apple-on-App-Store-Review-Guidelines.html>`__
-says they relaxed some of the `App Store review guidelines
-<https://developer.apple.com/app-store/review/guidelines/>`__
+this is **not official**. However, in 2010 Apple said they relaxed some of the
+`App Store review guidelines <https://developer.apple.com/app-store/review/guidelines/>`__
 to allow any tool to be used, as long as the resulting binary does not
 download any code, which means it should be OK to use the procedure
 described here and cross-compiling the binary.
@@ -28,7 +26,7 @@ Requirements
 
 - `XCode with the iOS SDK <https://developer.apple.com/xcode/download>`__
   (a dmg image, for newer versions a **xip** file is going to be downloaded.)
-- `Clang >= 3.5 <http://clang.llvm.org>`__ for your development
+- `Clang >= 3.5 <https://clang.llvm.org>`__ for your development
   machine installed and in the ``PATH``. It has to be version >= 3.5
   to target ``arm64`` architecture.
 - `Fuse <https://github.com/libfuse/libfuse>`__ for mounting and unmounting

--- a/contributing/development/core_and_modules/binding_to_external_libraries.rst
+++ b/contributing/development/core_and_modules/binding_to_external_libraries.rst
@@ -8,7 +8,7 @@ Modules
 
 The Summator example in :ref:`doc_custom_modules_in_cpp` is great for small,
 custom modules, but what if you want to use a larger, external library?
-Let's look at an example using `Festival <http://www.cstr.ed.ac.uk/projects/festival/>`_,
+Let's look at an example using `Festival <https://www.cstr.ed.ac.uk/projects/festival/>`_,
 a speech synthesis (text-to-speech) library written in C++.
 
 To bind to an external library, set up a module directory similar to the Summator example:

--- a/contributing/development/core_and_modules/custom_resource_format_loaders.rst
+++ b/contributing/development/core_and_modules/custom_resource_format_loaders.rst
@@ -302,8 +302,8 @@ calls into ``std::istream``.
 References
 ~~~~~~~~~~
 
-- `istream <http://www.cplusplus.com/reference/istream/istream/>`_
-- `streambuf <http://www.cplusplus.com/reference/streambuf/streambuf/?kw=streambuf>`_
+- `istream <https://cplusplus.com/reference/istream/istream/>`_
+- `streambuf <https://cplusplus.com/reference/streambuf/streambuf/?kw=streambuf>`_
 - `core/io/file_access.h <https://github.com/godotengine/godot/blob/master/core/os/file_access.h>`_
 
 Registering the new file format

--- a/contributing/documentation/contributing_to_the_documentation.rst
+++ b/contributing/documentation/contributing_to_the_documentation.rst
@@ -146,7 +146,7 @@ Sphinx and reStructuredText syntax
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Check Sphinx’s `reST Primer <https://www.sphinx-doc.org/en/stable/rest.html>`__
-and the `official reference <http://docutils.sourceforge.net/rst.html>`__ for
+and the `official reference <https://docutils.sourceforge.net/rst.html>`__ for
 details on the syntax.
 
 Sphinx uses specific reST comments to do specific operations, like defining the

--- a/make.bat
+++ b/make.bat
@@ -22,7 +22,7 @@ if errorlevel 9009 (
     echo.may add the Sphinx directory to PATH.
     echo.
     echo.If you don't have Sphinx installed, grab it from
-    echo.http://sphinx-doc.org/
+    echo.https://www.sphinx-doc.org/
     exit /b 1
 )
 

--- a/tutorials/3d/3d_rendering_limitations.rst
+++ b/tutorials/3d/3d_rendering_limitations.rst
@@ -64,7 +64,7 @@ There are two main ways to alleviate banding:
 
 .. seealso::
 
-    See `Banding in Games: A Noisy Rant <http://loopit.dk/banding_in_games.pdf>`__
+    See `Banding in Games: A Noisy Rant (PDF) <https://loopit.dk/banding_in_games.pdf>`__
     for more details about banding and ways to combat it.
 
 Depth buffer precision

--- a/tutorials/performance/vertex_animation/animating_thousands_of_fish.rst
+++ b/tutorials/performance/vertex_animation/animating_thousands_of_fish.rst
@@ -26,7 +26,7 @@ Here is the fish we will be using for the example images, you can use any fish m
 
 .. image:: img/fish.png
 
-.. note:: The fish model in this tutorial is made by `QuaterniusDev <http://quaternius.com>`_ and is
+.. note:: The fish model in this tutorial is made by `QuaterniusDev <https://quaternius.com>`_ and is
           shared with a creative commons license. CC0 1.0 Universal (CC0 1.0) Public Domain
           Dedication https://creativecommons.org/publicdomain/zero/1.0/
 

--- a/tutorials/platform/android/android_plugin.rst
+++ b/tutorials/platform/android/android_plugin.rst
@@ -97,7 +97,7 @@ The instructions below assumes that you're using Android Studio.
 
         local=["local_dep1.aar", "local_dep2.aar"]
         remote=["example.plugin.android:remote-dep1:0.0.1", "example.plugin.android:remote-dep2:0.0.1"]
-        custom_maven_repos=["http://repo.mycompany.com/maven2"]
+        custom_maven_repos=["https://repo.mycompany.com/maven2"]
 
     The ``config`` section and fields are required and defined as follow:
 

--- a/tutorials/platform/consoles.rst
+++ b/tutorials/platform/consoles.rst
@@ -66,7 +66,7 @@ your games to various consoles.
 
 Following is the list of providers:
 
-- `Lone Wolf Technology <http://www.lonewolftechnology.com/>`_ offers
+- `Lone Wolf Technology <https://www.lonewolftechnology.com/>`_ offers
   Switch and PS4 porting and publishing of Godot games.
 - `Pineapple Works <https://pineapple.works/>`_ offers
   Switch, Xbox One & Xbox Series X/S (GDK) porting and publishing of Godot games (GDScript/C#).

--- a/tutorials/scripting/gdscript/gdscript_documentation_comments.rst
+++ b/tutorials/scripting/gdscript/gdscript_documentation_comments.rst
@@ -49,8 +49,8 @@ Tags
     ##
     ## A more detailed description of the script.
     ##
-    ## @tutorial:            http://the/tutorial1/url.com
-    ## @tutorial(Tutorial2): http://the/tutorial2/url.com
+    ## @tutorial:            https://the/tutorial1/url.com
+    ## @tutorial(Tutorial2): https://the/tutorial2/url.com
 
 .. warning:: If there is any space in between the tag name and colon, for example
              ``@tutorial  :``, it won't be treated as a valid tag and will be ignored.
@@ -94,8 +94,8 @@ Examples
     ## The description of the script, what it can do,
     ## and any further detail.
     ##
-    ## @tutorial:            http://the/tutorial1/url.com
-    ## @tutorial(Tutorial2): http://the/tutorial2/url.com
+    ## @tutorial:            https://the/tutorial1/url.com
+    ## @tutorial(Tutorial2): https://the/tutorial2/url.com
 
     ## The description of the variable v1.
     var v1
@@ -140,7 +140,7 @@ Examples
     ## The same rules apply apply here. The documentation must
     ## immediately precede the class definition.
     ##
-    ## @tutorial: http://the/tutorial/url.com
+    ## @tutorial: https://the/tutorial/url.com
     class Inner:
 
         ## Inner class variable v4.


### PR DESCRIPTION
- Update mentions of the `Free Software Conservancy` and related links to the `Godot Foundation`
- Update URLs across the docs:
  - Update to `https://` where possible (HTTP networking docs will be updated in a separate PR)
  - Remove a dead Apple link