### PR TITLE
Fix file-path strings in C# for plugin tutorial

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -246,8 +246,8 @@ dialog. For that, change the ``custom_node.gd`` script to the following:
         {
             // Initialization of the plugin goes here.
             // Add the new type with a name, a parent type, a script and an icon.
-            var script = GD.Load<Script>("MyButton.cs");
-            var texture = GD.Load<Texture2D>("icon.png");
+            var script = GD.Load<Script>("res://addons/my_custom_node/MyButton.cs");
+            var texture = GD.Load<Texture2D>("res://addons/my_custom_node/icon.png");
             AddCustomType("MyButton", "Button", script, texture);
         }
 


### PR DESCRIPTION
Resolves errors when activating the docs' example C# plugin, by updating the example code to use absolute, not relative, paths.

The [tutorial on creating plugins](https://docs.godotengine.org/en/stable/tutorials/plugins/editor/making_plugins.html) directs users to create an `addons/my_custom_node` subdirectory in the containing project, and to place a custom icon and a script extending the `Button` class in it. The example code loads the script and the icon using relative (not fully-qualified) paths, as in the GDScript example:

```
var script = GD.Load<Script>("MyButton.cs");
var texture = GD.Load<Texture2D>("icon.png");
```

The equivalent GDScript example seems to work fine. However, using this path structure causes errors when enabling a C# plugin, even after building, as Godot will attempt to load the resources from the project root:

```
Cannot open file 'res://MyButton.cs'.
Failed to read file: 'res://MyButton.cs'.
Cannot load C# script file 'res://MyButton.cs'.
Failed loading resource: res://MyButton.cs. Make sure resources have been imported by opening the project in the editor at least once.
Error loading resource: 'MyButton.cs'.
Resource file not found: res://icon.png.
It's not a reference to a valid Script object.
```

This PR updates the C# example code to use the qualified path to the addons plugin directory, `res://addons/my_custom_node`, which resolves the errors.