### PR TITLE
Add a page on Godot system requirements

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -14,24 +14,30 @@ This page aims to list **all** features currently supported by Godot.
 Platforms
 ---------
 
+.. seealso::
+
+    See :ref:`doc_system_requirements` for hardware and software version requirements.
+
 **Can run both the editor and exported projects:**
 
-- Windows 7 and later (64-bit and 32-bit).
-- macOS 10.12 and later (64-bit, x86 and ARM).
-- Linux (64-bit, x86 and ARM).
+- Windows (x86, 64-bit and 32-bit).
+- macOS (x86 and ARM, 64-bit only).
+- Linux (x86 and ARM, 64-bit and 32-bit).
 
    - Binaries are statically linked and can run on any distribution if compiled
      on an old enough base distribution.
-   - Official binaries are compiled on Ubuntu 14.04.
-   - 32-bit binaries can be compiled from source.
+   - Official binaries are compiled using the
+     `Godot Engine buildroot <https://github.com/godotengine/buildroot>`__,
+     allowing for binaries that work across common Linux distributions
+     (including LTS variants).
 
-- Android 6.0 and later (editor support is experimental).
+- Android (editor support is experimental).
 - :ref:`Web browsers <doc_using_the_web_editor>`. Experimental in 4.0,
   using Godot 3.x is recommended instead when targeting HTML5.
 
 **Runs exported projects:**
 
-- iOS 11.0 and later.
+- iOS.
 - :ref:`Consoles <doc_consoles>`.
 
 Godot aims to be as platform-independent as possible and can be

--- a/about/system_requirements.rst
+++ b/about/system_requirements.rst
@@ -1,0 +1,369 @@
+.. _doc_system_requirements:
+
+System requirements
+===================
+
+This page contains system requirements for the editor and exported projects.
+These specifications are given for informative purposes only, but they can be
+referred to if you're looking to build or upgrade a system to use Godot on.
+
+Godot editor
+------------
+
+These are the **minimum** specifications required to run the Godot editor and work
+on a simple 2D or 3D project:
+
+Desktop or laptop PC - Minimum
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. When adjusting specifications, make sure to only mention hardware that can run the required OS version.
+.. For example, the x86 CPU requirement for macOS is set after the MacBook Air 11" (late 2010 model),
+.. which can run up to macOS 10.13.
+
++----------------------+-----------------------------------------------------------------------------------------+
+| **CPU**              | - **Windows:** x86_32 CPU with SSE2 instructions, or any x86_64 CPU                     |
+|                      |                                                                                         |
+|                      |   - *Example: Intel Core 2 Duo E8200, AMD Athlon XE BE-2300*                            |
+|                      |                                                                                         |
+|                      | - **macOS:** x86_64 or ARM CPU (Apple Silicon)                                          |
+|                      |                                                                                         |
+|                      |   - *Example: Intel Core 2 Duo SU9400, Apple M1*                                        |
+|                      |                                                                                         |
+|                      | - **Linux:** x86_32 CPU with SSE2 instructions, x86_64 CPU, ARMv7 or ARMv8 CPU          |
+|                      |                                                                                         |
+|                      |   - *Example: Intel Core 2 Duo E8200, AMD Athlon XE BE-2300, Raspberry Pi 4*            |
++----------------------+-----------------------------------------------------------------------------------------+
+| **GPU**              | - **Forward+ rendering method:** Integrated graphics with full Vulkan 1.0 support       |
+|                      |                                                                                         |
+|                      |   - *Example: Intel HD Graphics 5500 (Broadwell), AMD Radeon R5 Graphics (Kaveri)*      |
+|                      |                                                                                         |
+|                      | - **Mobile rendering method:** Integrated graphics with full Vulkan 1.0 support         |
+|                      |                                                                                         |
+|                      |   - *Example: Intel HD Graphics 5500 (Broadwell), AMD Radeon R5 Graphics (Kaveri)*      |
+|                      |                                                                                         |
+|                      | - **Compatibility rendering method:** Integrated graphics with full OpenGL 3.3 support  |
+|                      |                                                                                         |
+|                      |   - *Example: Intel HD Graphics 2500 (Ivy Bridge), AMD Radeon R5 Graphics (Kaveri)*     |
++----------------------+-----------------------------------------------------------------------------------------+
+| **RAM**              | - **Native editor:** 4 GB                                                               |
+|                      | - **Web editor:** 8 GB                                                                  |
++----------------------+-----------------------------------------------------------------------------------------+
+| **Storage**          | 200 MB (used for the executable, project files and cache).                              |
+|                      | Exporting projects requires downloading export templates separately                     |
+|                      | (1.3 GB after installation).                                                            |
++----------------------+-----------------------------------------------------------------------------------------+
+| **Operating system** | - **Native editor:** Windows 7, macOS 10.13 (Compatibility) or                          |
+|                      |   macOS 10.15 (Forward+/Mobile), Linux distribution released after 2016                 |
+|                      | - **Web editor:** Firefox 79, Chrome 68, Edge 79, Safari 15.2, Opera 64                 |
++----------------------+-----------------------------------------------------------------------------------------+
+
+.. note::
+
+    Windows 7/8/8.1 are supported on a best-effort basis. These versions are not
+    regularly tested and some features may be missing (such as colored
+    :ref:`print_rich <class_@GlobalScope_method_print_rich>` console output).
+    Support for Windows 7/8/8.1 may be removed in a
+    :ref:`future Godot 4.x release <doc_release_policy>`.
+
+    Vulkan drivers for these Windows versions are known to have issues with
+    memory leaks. As a result, it's recommended to stick to the Compatibility
+    rendering method when running Godot on an Windows version older than 10.
+
+Mobile device (smartphone/tablet) - Minimum
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++----------------------+-----------------------------------------------------------------------------------------+
+| **CPU**              | - **Android:** SoC with any 32-bit or 64-bit ARM or x86 CPU                             |
+|                      |                                                                                         |
+|                      |    - *Example: Qualcomm Snapdragon 430, Samsung Exynos 5 Octa 5430*                     |
+|                      |                                                                                         |
+|                      | - **iOS:** *Cannot run the editor*                                                      |
++----------------------+-----------------------------------------------------------------------------------------+
+| **GPU**              | - **Forward+ rendering method:** SoC featuring GPU with full Vulkan 1.0 support         |
+|                      |                                                                                         |
+|                      |   - *Example: Qualcomm Adreno 505, Mali-G71 MP2*                                        |
+|                      |                                                                                         |
+|                      | - **Mobile rendering method:** SoC featuring GPU with full Vulkan 1.0 support           |
+|                      |                                                                                         |
+|                      |   - *Example: Qualcomm Adreno 505, Mali-G71 MP2*                                        |
+|                      |                                                                                         |
+|                      | - **Compatibility rendering method:** SoC featuring GPU with full OpenGL ES 3.0 support |
+|                      |                                                                                         |
+|                      |   - *Example: Qualcomm Adreno 306, Mali-T628 MP6*                                       |
++----------------------+-----------------------------------------------------------------------------------------+
+| **RAM**              | - **Native editor:** 3 GB                                                               |
+|                      | - **Web editor:** 6 GB                                                                  |
++----------------------+-----------------------------------------------------------------------------------------+
+| **Storage**          | 200 MB (used for the executable, project files and cache).                              |
+|                      | Exporting projects requires downloading export templates separately                     |
+|                      | (1.3 GB after installation).                                                            |
++----------------------+-----------------------------------------------------------------------------------------+
+| **Operating system** | - **Native editor:** Android 6.0 (Compatibility) or Android 9.0 (Forward+/Mobile),      |
+|                      |   iOS 11.0                                                                              |
+|                      | - **Web editor:** Firefox 79, Chrome 88, Edge 79, Safari 15.2, Opera 64,                |
+|                      |   Samsung Internet 15                                                                   |
++----------------------+-----------------------------------------------------------------------------------------+
+
+These are the **recommended** specifications to get a smooth experience with the
+Godot editor on a simple 2D or 3D project:
+
+Desktop or laptop PC - Recommended
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++----------------------+-----------------------------------------------------------------------------------------+
+| **CPU**              | - **Windows:** x86_64 CPU with SSE4.2 instructions, with 4 physical cores or more       |
+|                      |                                                                                         |
+|                      |   - *Example: Intel Core i5-6600K, AMD Ryzen 5 1600*                                    |
+|                      |                                                                                         |
+|                      | - **macOS:** x86_64 or ARM CPU (Apple Silicon)                                          |
+|                      |                                                                                         |
+|                      |   - *Example: Intel Core i5-8500, Apple M1*                                             |
+|                      |                                                                                         |
+|                      | - **Linux:** x86_32 CPU with SSE2 instructions, x86_64 CPU, ARMv7 or ARMv8 CPU          |
+|                      |                                                                                         |
+|                      |   - *Example: Intel Core i5-6600K, AMD Ryzen 5 1600, Raspberry Pi 5 with overclocking*  |
++----------------------+-----------------------------------------------------------------------------------------+
+| **GPU**              | - **Forward+ rendering method:** Dedicated graphics with full Vulkan 1.2 support        |
+|                      |                                                                                         |
+|                      |   - *Example: NVIDIA GeForce GTX 1050 (Pascal), AMD Radeon RX 460 (GCN 4.0)*            |
+|                      |                                                                                         |
+|                      | - **Mobile rendering method:** Dedicated graphics with full Vulkan 1.2 support          |
+|                      |                                                                                         |
+|                      |   - *Example: NVIDIA GeForce GTX 1050 (Pascal), AMD Radeon RX 460 (GCN 4.0)*            |
+|                      |                                                                                         |
+|                      | - **Compatibility rendering method:** Dedicated graphics with full OpenGL 4.6 support   |
+|                      |                                                                                         |
+|                      |   - *Example: NVIDIA GeForce GTX 650 (Kepler), AMD Radeon HD 7750 (GCN 1.0)*            |
++----------------------+-----------------------------------------------------------------------------------------+
+| **RAM**              | - **Native editor:** 8 GB                                                               |
+|                      | - **Web editor:** 12 GB                                                                 |
++----------------------+-----------------------------------------------------------------------------------------+
+| **Storage**          | 1.5 GB (used for the executable, project files, all export templates and cache)         |
++----------------------+-----------------------------------------------------------------------------------------+
+| **Operating system** | - **Native editor:** Windows 10, macOS 10.15,                                           |
+|                      |   Linux distribution released after 2020                                                |
+|                      | - **Web editor:** Latest version of Firefox, Chrome, Edge, Safari, Opera                |
++----------------------+-----------------------------------------------------------------------------------------+
+
+Mobile device (smartphone/tablet) - Recommended
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++----------------------+-----------------------------------------------------------------------------------------+
+| **CPU**              | - **Android:** SoC with 64-bit ARM or x86 CPU, with 3 "performance" cores or more       |
+|                      |                                                                                         |
+|                      |   - *Example: Qualcomm Snapdragon 845, Samsung Exynos 9810*                             |
+|                      |                                                                                         |
+|                      | - **iOS:** *Cannot run the editor*                                                      |
++----------------------+-----------------------------------------------------------------------------------------+
+| **GPU**              | - **Forward+ rendering method:** SoC featuring GPU with full Vulkan 1.2 support         |
+|                      |                                                                                         |
+|                      |   - *Example: Qualcomm Adreno 630, Mali-G72 MP18*                                       |
+|                      |                                                                                         |
+|                      | - **Mobile rendering method:** SoC featuring GPU with full Vulkan 1.2 support           |
+|                      |                                                                                         |
+|                      |   - *Example: Qualcomm Adreno 630, Mali-G72 MP18*                                       |
+|                      |                                                                                         |
+|                      | - **Compatibility rendering method:** SoC featuring GPU with full OpenGL ES 3.2 support |
+|                      |                                                                                         |
+|                      |   - *Example: Qualcomm Adreno 630, Mali-G72 MP18*                                       |
++----------------------+-----------------------------------------------------------------------------------------+
+| **RAM**              | - **Native editor:** 6 GB                                                               |
+|                      | - **Web editor:** 8 GB                                                                  |
++----------------------+-----------------------------------------------------------------------------------------+
+| **Storage**          | 1.5 GB (used for the executable, project files, all export templates and cache)         |
++----------------------+-----------------------------------------------------------------------------------------+
+| **Operating system** | - **Native editor:** Android 9.0 or iOS 11.0                                            |
+|                      | - **Web editor:** Latest version of Firefox, Chrome, Edge, Safari, Opera,               |
+|                      |   Samsung Internet                                                                      |
++----------------------+-----------------------------------------------------------------------------------------+
+
+Exported Godot project
+----------------------
+
+.. warning::
+
+    The requirements below are a baseline for a **simple** 2D or 3D project,
+    with basic scripting and few visual flourishes. CPU, GPU, RAM and
+    storage requirements will heavily vary depending on your project's scope,
+    its rendering method, viewport resolution and graphics settings chosen.
+    Other programs running on the system while the project is running
+    will also compete for resources, including RAM and video RAM.
+
+    It is strongly recommended to do your own testing on low-end hardware to
+    make sure your project runs at the desired speed. To provide scalability for
+    low-end hardware, you will also need to introduce a
+    `graphics options menu <https://github.com/godotengine/godot-demo-projects/tree/master/3d/graphics_settings>`__
+    to your project.
+
+These are the **minimum** specifications required to run a simple 2D or 3D
+project exported with Godot:
+
+Desktop or laptop PC - Minimum
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. When adjusting specifications, make sure to only mention hardware that can run the required OS version.
+.. For example, the x86 CPU requirement for macOS is set after the MacBook Air 11" (late 2010 model),
+.. which can run up to macOS 10.13.
+
++----------------------+-----------------------------------------------------------------------------------------+
+| **CPU**              | - **Windows:** x86_32 CPU with SSE2 instructions, or any x86_64 CPU                     |
+|                      |                                                                                         |
+|                      |  - *Example: Intel Core 2 Duo E8200, AMD Athlon XE BE-2300*                             |
+|                      |                                                                                         |
+|                      | - **macOS:** x86_64 or ARM CPU (Apple Silicon)                                          |
+|                      |                                                                                         |
+|                      |  - *Example: Intel Core 2 Duo SU9400, Apple M1*                                         |
+|                      |                                                                                         |
+|                      | - **Linux:** x86_32 CPU with SSE2 instructions, x86_64 CPU, ARMv7 or ARMv8 CPU          |
+|                      |                                                                                         |
+|                      |  - *Example: Intel Core 2 Duo E8200, AMD Athlon XE BE-2300, Raspberry Pi 4*             |
++----------------------+-----------------------------------------------------------------------------------------+
+| **GPU**              | - **Forward+ rendering method:** Integrated graphics with full Vulkan 1.0 support       |
+|                      |                                                                                         |
+|                      |   - *Example: Intel HD Graphics 5500 (Broadwell), AMD Radeon R5 Graphics (Kaveri)*      |
+|                      |                                                                                         |
+|                      | - **Mobile rendering method:** Integrated graphics with full Vulkan 1.0 support         |
+|                      |                                                                                         |
+|                      |   - *Example: Intel HD Graphics 5500 (Broadwell), AMD Radeon R5 Graphics (Kaveri)*      |
+|                      |                                                                                         |
+|                      | - **Compatibility rendering method:** Integrated graphics with full OpenGL 3.3 support  |
+|                      |                                                                                         |
+|                      |   - *Example: Intel HD Graphics 2500 (Ivy Bridge), AMD Radeon R5 Graphics (Kaveri)*     |
++----------------------+-----------------------------------------------------------------------------------------+
+| **RAM**              | - **For native exports:** 2 GB                                                          |
+|                      | - **For web exports:** 4 GB                                                             |
++----------------------+-----------------------------------------------------------------------------------------+
+| **Storage**          | 150 MB (used for the executable, project files and cache)                               |
++----------------------+-----------------------------------------------------------------------------------------+
+| **Operating system** | - **For native exports:** Windows 7, macOS 10.13 (Compatibility) or                     |
+|                      |   macOS 10.15 (Forward+/Mobile), Linux distribution released after 2016                 |
+|                      | - **For web exports:** Firefox 79, Chrome 68, Edge 79, Safari 15.2, Opera 64            |
++----------------------+-----------------------------------------------------------------------------------------+
+
+.. note::
+
+    Windows 7/8/8.1 are supported on a best-effort basis. These versions are not
+    regularly tested and some features may be missing (such as colored
+    :ref:`print_rich <class_@GlobalScope_method_print_rich>` console output).
+    Support for Windows 7/8/8.1 may be removed in a
+    :ref:`future Godot 4.x release <doc_release_policy>`.
+
+    Vulkan drivers for these Windows versions are known to have issues with
+    memory leaks. As a result, it's recommended to stick to the Compatibility
+    rendering method when running Godot on an Windows version older than 10.
+
+Mobile device (smartphone/tablet) - Minimum
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++----------------------+-----------------------------------------------------------------------------------------+
+| **CPU**              | - **Android:** SoC with any 32-bit or 64-bit ARM or x86 CPU                             |
+|                      |                                                                                         |
+|                      |   - *Example: Qualcomm Snapdragon 430, Samsung Exynos 5 Octa 5430*                      |
+|                      |                                                                                         |
+|                      | - **iOS:** SoC with any 64-bit ARM CPU                                                  |
+|                      |                                                                                         |
+|                      |   - *Example: Apple A7 (iPhone 5S)*                                                     |
++----------------------+-----------------------------------------------------------------------------------------+
+| **GPU**              | - **Forward+ rendering method:** SoC featuring GPU with full Vulkan 1.0 support         |
+|                      |                                                                                         |
+|                      |   - *Example: Qualcomm Adreno 505, Mali-G71 MP2, PowerVR G6430 (iPhone 6S/iPhone SE 1)* |
+|                      |                                                                                         |
+|                      | - **Mobile rendering method:** SoC featuring GPU with full Vulkan 1.0 support           |
+|                      |                                                                                         |
+|                      |   - *Example: Qualcomm Adreno 505, Mali-G71 MP2, PowerVR G6430 (iPhone 6S/iPhone SE 1)* |
+|                      |                                                                                         |
+|                      | - **Compatibility rendering method:** SoC featuring GPU with full OpenGL ES 3.0 support |
+|                      |                                                                                         |
+|                      |   - *Example: Qualcomm Adreno 306, Mali-T628 MP6, PowerVR G6430 (iPhone 5S)*            |
++----------------------+-----------------------------------------------------------------------------------------+
+| **RAM**              | - **For native exports:** 1 GB                                                          |
+|                      | - **For web exports:** 2 GB                                                             |
++----------------------+-----------------------------------------------------------------------------------------+
+| **Storage**          | 150 MB (used for the executable, project files and cache)                               |
++----------------------+-----------------------------------------------------------------------------------------+
+| **Operating system** | - **For native exports:** Android 6.0 (Compatibility) or Android 9.0 (Forward+/Mobile), |
+|                      |   iOS 11.0                                                                              |
+|                      | - **For web exports:** Firefox 79, Chrome 88, Edge 79, Safari 15.2, Opera 64,           |
+|                      |   Samsung Internet 15                                                                   |
++----------------------+-----------------------------------------------------------------------------------------+
+
+These are the **recommended** specifications to get a smooth experience with a
+simple 2D or 3D project exported with Godot:
+
+Desktop or laptop PC - Recommended
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++----------------------+-----------------------------------------------------------------------------------------+
+| **CPU**              | - **Windows:** x86_64 CPU with SSE4.2 instructions, with 4 physical cores or more       |
+|                      |                                                                                         |
+|                      |  - *Example: Intel Core i5-6600K, AMD Ryzen 5 1600*                                     |
+|                      |                                                                                         |
+|                      | - **macOS:** x86_64 or ARM CPU (Apple Silicon)                                          |
+|                      |                                                                                         |
+|                      |  - *Example: Intel Core i5-8500, Apple M1*                                              |
+|                      |                                                                                         |
+|                      | - **Linux:** x86_32 CPU with SSE2 instructions, x86_64 CPU, ARMv7 or ARMv8 CPU          |
+|                      |                                                                                         |
+|                      |  - *Example: Intel Core i5-6600K, AMD Ryzen 5 1600, Raspberry Pi 5 with overclocking*   |
++----------------------+-----------------------------------------------------------------------------------------+
+| **GPU**              | - **Forward+ rendering method:** Dedicated graphics with full Vulkan 1.2 support        |
+|                      |                                                                                         |
+|                      |   - *Example: NVIDIA GeForce GTX 1050 (Pascal), AMD Radeon RX 460 (GCN 4.0)*            |
+|                      |                                                                                         |
+|                      | - **Mobile rendering method:** Dedicated graphics with full Vulkan 1.2 support          |
+|                      |                                                                                         |
+|                      |   - *Example: NVIDIA GeForce GTX 1050 (Pascal), AMD Radeon RX 460 (GCN 4.0)*            |
+|                      |                                                                                         |
+|                      | - **Compatibility rendering method:** Dedicated graphics with full OpenGL 4.6 support   |
+|                      |                                                                                         |
+|                      |   - *Example: NVIDIA GeForce GTX 650 (Kepler), AMD Radeon HD 7750 (GCN 1.0)*            |
++----------------------+-----------------------------------------------------------------------------------------+
+| **RAM**              | - **For native exports:** 4 GB                                                          |
+|                      | - **For web exports:** 8 GB                                                             |
++----------------------+-----------------------------------------------------------------------------------------+
+| **Storage**          | 150 MB (used for the executable, project files and cache)                               |
++----------------------+-----------------------------------------------------------------------------------------+
+| **Operating system** | - **For native exports:** Windows 10, macOS 10.15,                                      |
+|                      |   Linux distribution released after 2020                                                |
+|                      | - **For web exports:** Latest version of Firefox, Chrome, Edge, Safari, Opera           |
++----------------------+-----------------------------------------------------------------------------------------+
+
+Mobile device (smartphone/tablet) - Recommended
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
++----------------------+-----------------------------------------------------------------------------------------+
+| **CPU**              | - **Android:** SoC with 64-bit ARM or x86 CPU, with 3 "performance" cores or more       |
+|                      |                                                                                         |
+|                      |   - *Example: Qualcomm Snapdragon 845, Samsung Exynos 9810*                             |
+|                      |                                                                                         |
+|                      | - **iOS:** SoC with 64-bit ARM CPU                                                      |
+|                      |                                                                                         |
+|                      |   - *Example: Apple A11 (iPhone XS/XR)*                                                 |
++----------------------+-----------------------------------------------------------------------------------------+
+| **GPU**              | - **Forward+ rendering method:** SoC featuring GPU with full Vulkan 1.2 support         |
+|                      |                                                                                         |
+|                      |   - *Example: Qualcomm Adreno 630, Mali-G72 MP18, Apple G11P (iPhone XR/XS)*            |
+|                      |                                                                                         |
+|                      | - **Mobile rendering method:** SoC featuring GPU with full Vulkan 1.2 support           |
+|                      |                                                                                         |
+|                      |   - *Example: Qualcomm Adreno 630, Mali-G72 MP18, Apple G11P (iPhone XR/XS)*            |
+|                      |                                                                                         |
+|                      | - **Compatibility rendering method:** SoC featuring GPU with full OpenGL ES 3.2 support |
+|                      |                                                                                         |
+|                      |   - *Example: Qualcomm Adreno 630, Mali-G72 MP18, Apple G11P (iPhone XR/XS)*            |
++----------------------+-----------------------------------------------------------------------------------------+
+| **RAM**              | - **For native exports:** 2 GB                                                          |
+|                      | - **For web exports:** 4 GB                                                             |
++----------------------+-----------------------------------------------------------------------------------------+
+| **Storage**          | 150 MB (used for the executable, project files and cache)                               |
++----------------------+-----------------------------------------------------------------------------------------+
+| **Operating system** | - **For native exports:** Android 9.0 or iOS 11.0                                       |
+|                      | - **For web exports:** Latest version of Firefox, Chrome, Edge, Safari, Opera,          |
+|                      |   Samsung Internet                                                                      |
++----------------------+-----------------------------------------------------------------------------------------+
+
+.. note::
+
+    Godot doesn't use OpenGL/OpenGL ES extensions introduced after OpenGL
+    3.3/OpenGL ES 3.0, but GPUs supporting newer OpenGL/OpenGL ES versions
+    generally have fewer driver issues.

--- a/index.rst
+++ b/index.rst
@@ -80,10 +80,11 @@ the ``GodotEngine.epub`` file in an e-book reader application.
 
    about/introduction
    about/list_of_features
+   about/system_requirements
    about/faq
    about/complying_with_licenses
    about/release_policy
-   about/docs_changelog 
+   about/docs_changelog
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
Let me know if the format is good and I'll complete the TODO items :slightly_smiling_face:

I'm not sure if we should feature two separate sets of minimum/recommended specs for exported projects (one for simple projects, one for more complex projects), as a project's complexity is a subjective topic.

I also don't know if we should feature a 3rd tier such as "optimal" (e.g. for a smooth 4K 60 FPS experience). This something a lot of AAA games have been doing recently ([example](https://user-images.githubusercontent.com/180032/233505125-c7eb3053-ca9b-4d3e-9d2f-97373c527eeb.png)), but I feel it would introduce too many combinations to check and maintain.

This also adds a note about Windows 7/8/8.1 support being done on a best-effort basis. This closes https://github.com/godotengine/godot/issues/77304.

Once we agree on a final design, I can work on a 3.x version of this page.

- This closes https://github.com/godotengine/godot-docs/issues/6497.

## TODO

- [x] Add editor system requirements.
- [x] Add recommended requirements for exported projects.
