### PR TITLE
Mention maximum recommended size of 128×128 in Customizing the mouse cursor

### DIFF
--- a/tutorials/inputs/custom_mouse_cursor.rst
+++ b/tutorials/inputs/custom_mouse_cursor.rst
@@ -3,7 +3,9 @@
 Customizing the mouse cursor
 ============================
 
-You might want to change the appearance of the mouse cursor in your game in order to suit the overall design. There are two ways to customize the mouse cursor:
+You might want to change the appearance of the mouse cursor in your game in
+order to suit the overall design. There are two ways to customize the mouse
+cursor:
 
 1. Using project settings
 2. Using a script
@@ -14,8 +16,8 @@ The second way is more customizable, but involves scripting:
 .. note::
 
     You could display a "software" mouse cursor by hiding the mouse cursor and
-    moving a Sprite2D to the cursor position in a ``_process`` method, but this
-    will add at least one frame of latency compared to an "hardware" mouse
+    moving a Sprite2D to the cursor position in a ``_process()`` method, but
+    this will add at least one frame of latency compared to an "hardware" mouse
     cursor. Therefore, it's recommended to use the approach described here
     whenever possible.
 
@@ -32,7 +34,12 @@ Open project settings, go to Display>Mouse Cursor. You will see Custom Image and
 Custom Image is the desired image that you would like to set as the mouse cursor.
 Custom Hotspot is the point in the image that you would like to use as the cursor's detection point.
 
-.. note:: The custom image **must** be less than 256x256.
+.. warning::
+
+    The custom image **must** be 256×256 pixels at most. To avoid rendering
+    issues, sizes lower than or equal to 128×128 are recommended.
+
+    On the web platform, the maximum allowed cursor image size is 128×128.
 
 Using a script
 --------------
@@ -74,9 +81,10 @@ Create a Node and attach the following script.
         Input.SetCustomMouseCursor(beam, Input.CursorShape.Ibeam);
     }
 
-.. note::
-    Check :ref:`Input.set_custom_mouse_cursor() <class_Input_method_set_custom_mouse_cursor>`.
+.. seealso::
 
+    Check :ref:`Input.set_custom_mouse_cursor() <class_Input_method_set_custom_mouse_cursor>`'s
+    documentation for more information on usage and platform-specific caveats.
 
 Demo project
 ------------
@@ -87,4 +95,6 @@ https://github.com/guilhermefelipecgs/custom_hardware_cursor
 Cursor list
 -----------
 
-As documented in the :ref:`Input <class_Input>` class (see the **CursorShape** enum), there are multiple mouse cursors you can define. Which ones you want to use depends on your use case.
+As documented in the :ref:`Input <class_Input>` class (see the **CursorShape**
+enum), there are multiple mouse cursors you can define. Which ones you want to
+use depends on your use case.


### PR DESCRIPTION
Sizes larger than 128×128 are not supported in web exports and can exhibit rendering issues on desktop platforms.

- This closes https://github.com/godotengine/godot-docs/issues/4554.
