### PR TITLE
Clarified hiDPI setting in docs

### DIFF
--- a/getting_started/step_by_step/nodes_and_scenes.rst
+++ b/getting_started/step_by_step/nodes_and_scenes.rst
@@ -163,7 +163,7 @@ Close the window or press :kbd:`F8` (:kbd:`Cmd + .` on macOS) to quit the runnin
 
     If this doesn't immediately work and you have a hiDPI display on at least
     one of your monitors, go to Project -> Project Settings -> Display ->
-    Window then enable Allow Hidpi under Dpi.
+    Window then, making sure Advancesd Settings is on, enable Allow hiDPI, under DPI.
 
 Setting the main scene
 ----------------------


### PR DESCRIPTION
Small fix. The "Enable hiDPI" setting can't be found, unless Advanced Settings is on (which is not the default case)
