### PR TITLE
Fix link to the 3.x version of Compiling for Linux

### DIFF
--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -247,7 +247,7 @@ Start a terminal, go to the root dir of the engine source code and type:
 
     Prior to Godot 4.0, the Linux/\*BSD target was called ``x11`` instead of
     ``linuxbsd``. If you are looking to compile Godot 3.x, make sure to use the
-    `stable branch of this documentation <https://docs.godotengine.org/en/stable/development/compiling/compiling_for_x11.html>`__.
+    `3.x branch of this documentation <https://docs.godotengine.org/en/3.6/development/compiling/compiling_for_x11.html>`__.
 
 If all goes well, the resulting binary executable will be placed in the
 "bin" subdirectory. This executable file contains the whole engine and


### PR DESCRIPTION
Since there is no "3.x " branch of the docs, I'm not sure which branch the link should point to instead. I went with the latest 3.x, but maybe 3.0 is better?

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
