### PR TITLE
fix: 3d tutorial squash code

### DIFF
--- a/getting_started/first_3d_game/06.jump_and_squash.rst
+++ b/getting_started/first_3d_game/06.jump_and_squash.rst
@@ -233,7 +233,7 @@ With this code, if no collisions occurred on a given frame, the loop won't run.
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-   func _physics_process(delta):
+    func _physics_process(delta):
        #...
 
        # Iterate through all collisions that occurred this frame

--- a/getting_started/first_3d_game/06.jump_and_squash.rst
+++ b/getting_started/first_3d_game/06.jump_and_squash.rst
@@ -234,25 +234,25 @@ With this code, if no collisions occurred on a given frame, the loop won't run.
  .. code-tab:: gdscript GDScript
 
    func _physics_process(delta):
-        #...
+       #...
 
-        # Iterate through all collisions that occurred this frame
-        for index in range(get_slide_collision_count()):
-            # We get one of the collisions with the player
-            var collision = get_slide_collision(index)
+       # Iterate through all collisions that occurred this frame
+       for index in range(get_slide_collision_count()):
+           # We get one of the collisions with the player
+           var collision = get_slide_collision(index)
 
-            # If the collision is with ground
-            if (collision.get_collider() == null):
-                continue
+           # If the collision is with ground
+           if (collision.get_collider() == null):
+               continue
 
-            # If the collider is with a mob
-            if collision.get_collider().is_in_group("mob"):
-                var mob = collision.get_collider()
-                # we check that we are hitting it from above.
-                if Vector3.UP.dot(collision.get_normal()) > 0.1:
-                    # If so, we squash it and bounce.
-                    mob.squash()
-                    target_velocity.y = bounce_impulse
+           # If the collider is with a mob
+           if collision.get_collider().is_in_group("mob"):
+               var mob = collision.get_collider()
+               # we check that we are hitting it from above.
+               if Vector3.UP.dot(collision.get_normal()) > 0.1:
+                   # If so, we squash it and bounce.
+                   mob.squash()
+                   target_velocity.y = bounce_impulse
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
The code block was indented 5 spaces and not 4. This caused it to get pasted in as one tab with one extra space in the script editor.

This of course broke indentation and made the syntax highlighter have show an error on the whole block since it had the wrong indentation.