### PR TITLE
Update godot_design_philosophy.rst

### DIFF
--- a/getting_started/introduction/godot_design_philosophy.rst
+++ b/getting_started/introduction/godot_design_philosophy.rst
@@ -44,7 +44,9 @@ except you're free to design it by using the editor, using only the
 code, or mixing and matching the two.
 
 It's different from prefabs you find in several 3D engines, as you can
-then inherit from and extend those scenes. You may create a Magician
+then inherit from and extend those scenes. Normally, prefabs in other 3d engines 
+does not allow you to extend them with new features but require you to create new prefabs
+with the desired features and functions.  In Godot you may create a Magician
 that extends your Character. Modify the Character in the editor and the Magician
 will update as well. It helps you build your projects so that their
 structure matches the game's design.


### PR DESCRIPTION
It was not clear to me whether or not other 3d engines also uses scenes.  The update aims to make a more clear distinction between prefab behaviour in other engines vs the behaviour of scenes in Godot.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
