### PR TITLE
Fix formatting of pluralization code examples

### DIFF
--- a/tutorials/i18n/internationalizing_games.rst
+++ b/tutorials/i18n/internationalizing_games.rst
@@ -153,12 +153,14 @@ singular and plural don't clearly apply.
 ::
 
     var num_apples = 5
-	label.text = tr_n("There is %d apple", "There are %d apples", num_apples) % num_apples
+    label.text = tr_n("There is %d apple", "There are %d apples", num_apples) % num_apples
 
 This can be combined with a context if needed:
 
+::
+
     var num_jobs = 1
-	label.text = tr_n("%d job", "%d jobs", num_jobs, "Task Manager") % num_jobs
+    label.text = tr_n("%d job", "%d jobs", num_jobs, "Task Manager") % num_jobs
 
 .. note::
 


### PR DESCRIPTION
The code examples of [pluralization in the localization tutorial](https://docs.godotengine.org/en/stable/tutorials/i18n/internationalizing_games.html#pluralization) were incorrectly formatted. They used inconsistent indentation and the second one wasn't rendered as code.

This change fixes that.