### PR TITLE
Update code to 4.0+ for screenshotting the viewport tutorial

### DIFF
--- a/tutorials/rendering/viewports.rst
+++ b/tutorials/rendering/viewports.rst
@@ -138,14 +138,13 @@ following code:
 
 ::
 
-   # Retrieve the captured Image using get_data().
-   var img = get_viewport().get_texture().get_data()
+   # Retrieve the captured Image using get_image().
+   var img = get_viewport().get_texture().get_image()
    # Flip on the Y axis.
    # You can also set "V Flip" to true if not on the root Viewport.
    img.flip_y()
    # Convert Image to ImageTexture.
-   var tex = ImageTexture.new()
-   tex.create_from_image(img)
+   var tex = ImageTexture.create_from_image(img)
    # Set sprite texture.
    $sprite.texture = tex
 


### PR DESCRIPTION
The viewport tutorial:
https://docs.godotengine.org/en/latest/tutorials/rendering/viewports.html

did not work for Godot 4- as instead of get_data() from Texture one should use get_image() from Texture2D.

Also setting a texture didn't work as documented, fixed too. Tested by using the code on a simple scene with a sprite.

This should be backported to 4.0 branch, but not previous ones.

Fixes #7162