### PR TITLE
Fix typo in inputevent.rst

### DIFF
--- a/tutorials/inputs/inputevent.rst
+++ b/tutorials/inputs/inputevent.rst
@@ -133,7 +133,7 @@ methods has to be used:
 1. Use a :ref:`SubViewportContainer <class_SubViewportContainer>`, which automatically
    sends events to its child :ref:`SubViewports <class_SubViewport>` during
    :ref:`Node._input() <class_Node_method__input>` and :ref:`Node._unhandled_input() <class_Node_method__unhandled_input>`.
-2. Implement event propagation based on the indivitual requirements.
+2. Implement event propagation based on the individual requirements.
 
 GUI events also travel up the scene tree but, since these events target
 specific Controls, only direct ancestors of the targeted Control node receive the event.


### PR DESCRIPTION
Indivitual was changed to Individual

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
