### PR TITLE
Configuring node import options fix

### DIFF
--- a/tutorials/assets_pipeline/importing_scenes.rst
+++ b/tutorials/assets_pipeline/importing_scenes.rst
@@ -380,7 +380,7 @@ This exposes several per-node import options:
   will keep the original mesh visible, while **NavMesh Only** will only import
   the navigation mesh (without a visual representation). **NavMesh Only** is
   meant to be used when you've manually authored a simplified mesh for navigation.
-- **Generate > NavMesh:** If checked, generates an OccluderInstance3D *sibling*
+- **Generate > Occluder:** If checked, generates an OccluderInstance3D *sibling*
   node for :ref:`occlusion culling <doc_occlusion_culling>` using the mesh's
   geometry as a basis for the occluder's shape. **Mesh + Occluder** will keep
   the original mesh visible, while **Occluder Only** will only import the


### PR DESCRIPTION
Changed NavMesh to Occluder as meant by the documentation and the image above it.

Here is the original page: https://docs.godotengine.org/en/latest/tutorials/assets_pipeline/importing_scenes.html

Here is the issue where this was mentioned: https://github.com/godotengine/godot-docs/issues/6201#issuecomment-1371629067

Additionally, I would break the parent issue above into check boxes to make them more easily trackable. That, and separate the proposals for improvements from actual issues where things are not documented. So the actual issue can be worked on more easily and closed.


 Irrelevant to this PR but, I've noticed a lot of Github issues where the issue is no longer valid since either the documentation has changed so much or a fix was already merged. Can I send you a list @YuriSizov ? We could stream line things and make it easier for first time contributors to actually find something valid to work on.
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
