### PR TITLE
Fix C# issues in inspector-plugin tutorial

### DIFF
--- a/tutorials/plugins/editor/inspector_plugins.rst
+++ b/tutorials/plugins/editor/inspector_plugins.rst
@@ -143,7 +143,7 @@ specifically add :ref:`class_EditorProperty`-based controls.
 
     public partial class MyInspectorPlugin : EditorInspectorPlugin
     {
-        public override bool _CanHandle(Variant @object)
+        public override bool _CanHandle(GodotObject @object)
         {
             // We support all objects in this example.
             return true;

--- a/tutorials/plugins/editor/inspector_plugins.rst
+++ b/tutorials/plugins/editor/inspector_plugins.rst
@@ -285,7 +285,7 @@ followed by ``set_bottom_editor()`` to position it below the name.
             EmitChanged(GetEditedProperty(), _currentValue);
         }
 
-        public override void UpdateProperty()
+        public override void _UpdateProperty()
         {
             // Read the current value from the property.
             var newValue = (int)GetEditedObject().Get(GetEditedProperty());

--- a/tutorials/plugins/editor/inspector_plugins.rst
+++ b/tutorials/plugins/editor/inspector_plugins.rst
@@ -149,15 +149,16 @@ specifically add :ref:`class_EditorProperty`-based controls.
             return true;
         }
 
-        public override bool _ParseProperty(GodotObject @object, int type, string name, 
-            int hintType, string hintString, int usageFlags, bool wide)
+        public override bool _ParseProperty(GodotObject @object, Variant.Type type, 
+            string name, PropertyHint hintType, string hintString, 
+            PropertyUsageFlags usageFlags, bool wide)
         {
             // We handle properties of type integer.
-            if (type == (int)Variant.Type.Int)
+            if (type == Variant.Type.Int)
             {
                 // Create an instance of the custom property editor and register
                 // it to a specific property path.
-                AddPropertyEditor(path, new RandomIntEditor());
+                AddPropertyEditor(name, new RandomIntEditor());
                 // Inform the editor to remove the default property editor for
                 // this property type.
                 return true;

--- a/tutorials/plugins/editor/inspector_plugins.rst
+++ b/tutorials/plugins/editor/inspector_plugins.rst
@@ -149,7 +149,8 @@ specifically add :ref:`class_EditorProperty`-based controls.
             return true;
         }
 
-        public override bool _ParseProperty(GodotObject @object, int type, string name, int hintType, string hintString, int usageFlags, bool wide)
+        public override bool _ParseProperty(GodotObject @object, int type, string name, 
+            int hintType, string hintString, int usageFlags, bool wide)
         {
             // We handle properties of type integer.
             if (type == (int)Variant.Type.Int)


### PR DESCRIPTION
C#'s `EditorInspectorPlugin::_CanHandle()` method takes an argument of type `GodotObject`, but the tutorial page for inspector plugins gave an override example taking type `Variant`.

Additionally, the same page had one C# line that was causing horizontal scroll in the code panel, and I've included a fix for that.