### PR TITLE
Fix small typo in the GDExtension C++ example

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -412,7 +412,7 @@ GDScript allows you to add properties to your script using the ``export``
 keyword. In GDExtension you have to register the properties with a getter and
 setter function or directly implement the ``_get_property_list``, ``_get`` and
 ``_set`` methods of an object (but that goes far beyond the scope of this
-tutorial.
+tutorial)
 
 Lets add a property that allows us to control the amplitude of our wave.
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

I noticed a bracket wasn't closed. So I closed it.
