### PR TITLE
Replace legacy setget in tool tutorial

### DIFF
--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -180,7 +180,8 @@ run the game, it will spin counter-clockwise.
 Editing variables
 -----------------
 
-Add and export a variable speed to the script. To update the speed and also reset the rotation angle add a setter ``set(new_speed)`` which is executed with the input from the inspector. Modify
+Add and export a variable speed to the script. To update the speed and also reset the rotation
+angle add a setter ``set(new_speed)`` which is executed with the input from the inspector. Modify
 ``_process()`` to include the rotation speed.
 
 .. tabs::

--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -180,8 +180,7 @@ run the game, it will spin counter-clockwise.
 Editing variables
 -----------------
 
-Add and export a variable speed to the script. The function set_speed after
-``setget`` is executed with your input to change the variable. Modify
+Add and export a variable speed to the script. To update the speed and also reset the rotation angle add a setter ``set(new_speed)`` which is executed with the input from the inspector. Modify
 ``_process()`` to include the rotation speed.
 
 .. tabs::


### PR DESCRIPTION
Replace reference to legacy setget keyword and replace it with the new setter style in the "Running Code in the Editor" tutorial.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
