### PR TITLE
Updated 07.finishing-up.rst for looping audio

### DIFF
--- a/getting_started/first_2d_game/07.finishing-up.rst
+++ b/getting_started/first_2d_game/07.finishing-up.rst
@@ -31,7 +31,9 @@ loses.
 Add two :ref:`AudioStreamPlayer <class_AudioStreamPlayer>` nodes as children of
 ``Main``. Name one of them ``Music`` and the other ``DeathSound``. On each one,
 click on the ``Stream`` property, select "Load", and choose the corresponding
-audio file.
+audio file. If you want the music to loop seamlessly, click on the Stream file 
+arrow, select ``Make Unique``, then click on the Stream file and check the 
+``Loop`` box. 
 
 To play the music, add ``$Music.play()`` in the ``new_game()`` function and
 ``$Music.stop()`` in the ``game_over()`` function.


### PR DESCRIPTION
Updated 07.finishing-up.rst to include Godot 4 information about how to loop the ogg AudioStreamPlayer2D

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
