### PR TITLE
Updated Object's set_meta documentation to indicate metadata's name must be a valid identifier

### DIFF
--- a/classes/class_object.rst
+++ b/classes/class_object.rst
@@ -1190,6 +1190,8 @@ Returns ``true`` if a metadata entry is found with the given ``name``. See also 
 
 \ **Note:** Metadata that has a ``name`` starting with an underscore (``_``) is considered editor-only. Editor-only metadata is not displayed in the Inspector and should not be edited, although it can still be found by this method.
 
+\ **Note:** A metadata’s ``name`` must be a valid identifier. A valid identifier cannot start with a number.
+
 .. rst-class:: classref-item-separator
 
 ----


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/70141

It looks like the original cause of the issue has been fixed by https://github.com/godotengine/godot/pull/70386, but no one had added this information to the method's documentation and the issue is still open. Thus, I figured this change would be an excellent first issue to tackle. This change simply adds another **Note:** under the documentation of Object's set_meta(String name, Variant value) method that indicates the "name" argument must be a valid identifier (i.e., the String cannot begin with a number).
