### PR TITLE
Corrected the GDScript and C# examples for the MeshDataTool documentation

### DIFF
--- a/classes/class_meshdatatool.rst
+++ b/classes/class_meshdatatool.rst
@@ -60,7 +60,7 @@ Below is an example of how MeshDataTool may be used.
         // Save your change.
         mdt.SetVertex(i, vertex);
     }
-    mesh.SurfaceRemove(0);
+    mesh.ClearSurfaces();
     mdt.CommitToSurface(mesh);
     var mi = new MeshInstance();
     mi.Mesh = mesh;

--- a/classes/class_meshdatatool.rst
+++ b/classes/class_meshdatatool.rst
@@ -40,7 +40,7 @@ Below is an example of how MeshDataTool may be used.
         vertex += mdt.get_vertex_normal(i)
         # Save your change.
         mdt.set_vertex(i, vertex)
-    mesh.clear_surfaces(0)
+    mesh.clear_surfaces()
     mdt.commit_to_surface(mesh)
     var mi = MeshInstance.new()
     mi.mesh = mesh

--- a/classes/class_meshdatatool.rst
+++ b/classes/class_meshdatatool.rst
@@ -40,7 +40,7 @@ Below is an example of how MeshDataTool may be used.
         vertex += mdt.get_vertex_normal(i)
         # Save your change.
         mdt.set_vertex(i, vertex)
-    mesh.surface_remove(0)
+    mesh.clear_surfaces(0)
     mdt.commit_to_surface(mesh)
     var mi = MeshInstance.new()
     mi.mesh = mesh


### PR DESCRIPTION
Fixes: #7176 

These changes simply correct the GDScript and C# code examples within the MeshDataTool documentation. The GDScript example was using `mesh.surface_remove(0)` and the C# example was using `mesh.SurfaceRemove(0)`. This method does not exist under the ArrayMesh documentation. Under the advice of @clayjohn in issue #7176, I have changed the GDScript example to use `mesh.clear_surfaces()` and the C# example to use `mesh.ClearSurfaces()`.
