### PR TITLE
Added restated text

### DIFF
--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -354,6 +354,9 @@ window and selecting the ``new_game()`` method or type "new_game" below "Receive
 in the window. Verify that the green connection icon now appears next to
 ``func new_game()`` in the script.
 
+Remember to remove the call to ``new_game()`` from
+``_ready()``.
+
 In ``new_game()``, update the score display and show the "Get Ready" message:
 
 .. tabs::


### PR DESCRIPTION
A copy of https://github.com/godotengine/godot-docs/pull/6470#issue-1487793995 with the change that was requested. This way this PR and that one can be closed.

I am unsure however of if this text should be restated. Users will run into errors constantly; they have to get used to troubleshooting and making sure they read through the documentation correctly. I think this change is superfluous. 

If needed this PR and the linked can be closed and if not, they also can be closed.

Thank you!

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
