### PR TITLE
Update usages of obsolete rad2deg() and deg2rad() in docs

### DIFF
--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -392,8 +392,8 @@ Note that a new instance must be added to the scene using ``add_child()``.
                not degrees. Pi represents a half turn in radians, about
                ``3.1415`` (there is also ``TAU`` which is equal to ``2 * PI``).
                If you're more comfortable working with degrees, you'll need to
-               use the ``deg2rad()`` and ``rad2deg()`` functions to convert
-               between the two.
+               use the ``deg_to_rad()`` and ``rad_to_deg()`` functions to
+               convert between the two.
 
 Testing the scene
 ~~~~~~~~~~~~~~~~~

--- a/tutorials/2d/custom_drawing_in_2d.rst
+++ b/tutorials/2d/custom_drawing_in_2d.rst
@@ -227,7 +227,7 @@ In our example, we will simply use a fixed number of points, no matter the radiu
         var points_arc = PackedVector2Array()
 
         for i in range(nb_points + 1):
-            var angle_point = deg2rad(angle_from + i * (angle_to-angle_from) / nb_points - 90)
+            var angle_point = deg_to_rad(angle_from + i * (angle_to-angle_from) / nb_points - 90)
             points_arc.push_back(center + Vector2(cos(angle_point), sin(angle_point)) * radius)
 
         for index_point in range(nb_points):
@@ -242,7 +242,7 @@ In our example, we will simply use a fixed number of points, no matter the radiu
 
         for (int i = 0; i <= nbPoints; i++)
         {
-            float anglePoint = Mathf.Deg2Rad(angleFrom + i * (angleTo - angleFrom) / nbPoints - 90f);
+            float anglePoint = Mathf.DegToRad(angleFrom + i * (angleTo - angleFrom) / nbPoints - 90f);
             pointsArc[i] = center + new Vector2(Mathf.Cos(anglePoint), Mathf.Sin(anglePoint)) * radius;
         }
 

--- a/tutorials/performance/using_servers.rst
+++ b/tutorials/performance/using_servers.rst
@@ -116,7 +116,7 @@ This is an example of how to create a sprite from code and move it using the low
         # Add it, centered.
         RenderingServer.canvas_item_add_texture_rect(ci_rid, Rect2(texture.get_size() / 2, texture.get_size()), texture)
         # Add the item, rotated 45 degrees and translated.
-        var xform = Transform2D().rotated(deg2rad(45)).translated(Vector2(20, 30))
+        var xform = Transform2D().rotated(deg_to_rad(45)).translated(Vector2(20, 30))
         RenderingServer.canvas_item_set_transform(ci_rid, xform)
 
 The Canvas Item API in the server allows you to add draw primitives to it. Once added, they can't be modified.

--- a/tutorials/scripting/evaluating_expressions.rst
+++ b/tutorials/scripting/evaluating_expressions.rst
@@ -8,7 +8,7 @@ Godot provides an :ref:`class_Expression` class you can use to evaluate expressi
 An expression can be:
 
 - A mathematical expression such as ``(2 + 4) * 16/4.0``.
-- A built-in method call like ``deg2rad(90)``.
+- A built-in method call like ``deg_to_rad(90)``.
 - A method call on an user-provided script like ``update_health()``,
   if ``base_instance`` is set to a value other than ``null`` when calling
   :ref:`Expression.execute() <class_Expression_method_execute>`.
@@ -145,8 +145,8 @@ The script below demonstrates what the Expression class is capable of::
         # Math expression with variables.
         evaluate("x + y", ["x", "y"], [60, 100])
 
-        # Call built-in method (hardcoded in the Expression class).
-        evaluate("deg2rad(90)")
+        # Call built-in method (built-in math function call).
+        evaluate("deg_to_rad(90)")
 
         # Call user method (defined in the script).
         # We can do this because the expression execution is bound to `self`
@@ -182,7 +182,7 @@ The output from the script will be::
 
     4
     160
-    1.570796
+    1.5707963267949
 
     You called 'call_me()' in the expression text.
     1365


### PR DESCRIPTION
There were 4 pages documentation pages still using deg2rad(), which have been substituted by deg_to_rad() and the examples tested against 4.0.X.

There was 1 usage of C# Deg2Rad(), now DegToRad().

Some dependent comments and output have been updated accordingly: (deg_to_rad() is implemented in the Math core functions, not in the Expressions class), plus some float precission fixes, at least on my architecture.

Only one mention of rad2deg() was found in all docs.

Fixes #7247

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
