### PR TITLE
Update compiling_for_android.rst

### DIFF
--- a/contributing/development/compiling/compiling_for_android.rst
+++ b/contributing/development/compiling/compiling_for_android.rst
@@ -62,13 +62,13 @@ Setting up the buildsystem
 
     ::
 
-        tools/bin/sdkmanager --sdk_root=<android_sdk_path> --licenses
+        cmdline-tools/latest/bin/sdkmanager --sdk_root=<android_sdk_path> --licenses
 
     -  Complete setup by running the following command where ``android_sdk_path`` is the path to the Android SDK.
 
     ::
 
-        tools/bin/sdkmanager --sdk_root=<android_sdk_path> "platform-tools" "build-tools;30.0.3" "platforms;android-29" "cmdline-tools;latest" "cmake;3.10.2.4988404"
+        cmdline-tools/latest/bin/sdkmanager --sdk_root=<android_sdk_path> "platform-tools" "build-tools;30.0.3" "platforms;android-29" "cmdline-tools;latest" "cmake;3.10.2.4988404"
 
 .. seealso::   To set the environment variable on Windows, press :kbd:`Windows + R`, type
             "control system", then click on **Advanced system settings** in the left


### PR DESCRIPTION
```
Godot Version: 4.0.2 (Steam)
Godot CPP version: 4.0.2
OS: Windows 11
```

I was trying to compile the engine for Android exports using the Android SDK installed via Android Studio.  
I was failing the part accepting Android SDK licenses due to an exception thrown by the `tools/bin/sdkmanager` bat:
```java
Exception in thread "main" java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlSchema
        at com.android.repository.api.SchemaModule$SchemaModuleVersion.<init>(SchemaModule.java:156)
        at com.android.repository.api.SchemaModule.<init>(SchemaModule.java:75)
        at com.android.sdklib.repository.AndroidSdkHandler.<clinit>(AndroidSdkHandler.java:81)
        at com.android.sdklib.tool.sdkmanager.SdkManagerCli.main(SdkManagerCli.java:73)
        at com.android.sdklib.tool.sdkmanager.SdkManagerCli.main(SdkManagerCli.java:48)
Caused by: java.lang.ClassNotFoundException: javax.xml.bind.annotation.XmlSchema
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        ... 5 more
```
Looks like the `tools` folder has been deprecated and replaced with the `cmdline-tools` folder instead. [Reference](https://developer.android.com/tools/releases/sdk-tools).  
Indeed using the new command line tools it works.
```powershell
~\AppData\Local\Android                                                                                     
➜ .\Sdk\cmdline-tools\latest\bin\sdkmanager.bat "--sdk_root=C:\Users\nsant\AppData\Local\Android\Sdk" --licenses
All SDK package licenses accepted.======] 100% Computing updates...
```
