### PR TITLE
docs: add script templates example

### DIFF
--- a/tutorials/scripting/creating_script_templates.rst
+++ b/tutorials/scripting/creating_script_templates.rst
@@ -67,6 +67,11 @@ where:
 
 * ``extension``: will indicate which language the template will apply to (it should be ``gd`` for GDScript or ``cs`` for C#)
 
+For example:
+
+-  ``template_scripts/Node/smooth_camera.gd``
+-  ``template_scripts/CharacterBody3D/platformer_movement.gd``
+
 
 Default behaviour and overriding it
 -----------------------------------


### PR DESCRIPTION
First of all, thanks much for all the work on such an amazing engine and docs site! :tada: 

I ran into the new script template style today - the docs are solid, but could use an actual example to confirm what they imply. Using a node name as a directory name is kind of odd - this would have helped me figure it out at a glance.