### PR TITLE
VS Code: remove duplicate code block

### DIFF
--- a/contributing/development/configuring_an_ide/visual_studio_code.rst
+++ b/contributing/development/configuring_an_ide/visual_studio_code.rst
@@ -35,8 +35,7 @@ Importing the project
 
 - Within the ``tasks.json`` file find the ``"tasks"`` array and add a new section to it:
 
-.. tabs::
-  .. code-tab:: js LinuxBSD
+  .. code-block:: js
 
     {
       "label": "build",
@@ -45,19 +44,6 @@ Importing the project
       "command": "scons",
       "args": [
         // enable for debugging with breakpoints
-        "dev_build=yes",
-      ],
-      "problemMatcher": "$msCompile"
-    }
-
-  .. code-tab:: js Windows
-
-    {
-      "label": "build",
-      "group": "build",
-      "type": "shell",
-      "command": "scons",
-      "args": [
         "dev_build=yes",
       ],
       "problemMatcher": "$msCompile"


### PR DESCRIPTION
This removes a duplicate code block in the VS Code configuration page.

The code blocks were once different and thus two tabs, but in modern Godot 4.0, they are the same on both platforms.