### PR TITLE
Build ePubs of the documentation for offline reading

### DIFF
--- a/.github/workflows/build_offline_docs.yml
+++ b/.github/workflows/build_offline_docs.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         branch:
           - master
-          - stable
+          - 3.6
     steps:
       - uses: actions/checkout@v3
         with:
@@ -23,14 +23,38 @@ jobs:
         run: |
           sudo pip3 install -r requirements.txt
           sudo pip3 install codespell
+          sudo apt update
+          sudo apt install parallel libwebp7
 
-      - name: Sphinx build HTML
+      - name: Sphinx - Build HTML
         run: make SPHINXOPTS='--color' html
 
       - uses: actions/upload-artifact@v3
         with:
           name: godot-docs-html-${{ matrix.branch }}
           path: _build/html
+          # Keep the current build and the previous build (in case a scheduled build failed).
+          # This makes it more likely to have at least one successful build available at all times.
+          retention-days: 15
+
+      - name: Sphinx - Build ePub
+        run: |
+          # Convert WebP images to PNG and replace references, so that ePub readers can display those images.
+          # The ePub 3.0 specification has WebP support, but it's not widely supported by apps and e-readers yet.
+          shopt -s globstar nullglob
+          parallel --will-cite convert {} {.}.png ::: {about,community,contributing,getting_started,img,tutorials}/**/*.webp
+          parallel --will-cite sed -i "s/\\.webp$/\\.png/g" ::: {about,community,contributing,getting_started,tutorials}/**/*.rst
+
+          # Remove banners at the top of each page when building `latest`.
+          sed -i 's/"godot_is_latest": True/"godot_is_latest": False/' conf.py
+          sed -i 's/"godot_show_article_status": True/"godot_show_article_status": False/' conf.py
+
+          make SPHINXOPTS='--color' epub
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: godot-docs-epub-${{ matrix.branch }}
+          path: _build/epub/GodotEngine.epub
           # Keep the current build and the previous build (in case a scheduled build failed).
           # This makes it more likely to have at least one successful build available at all times.
           retention-days: 15

--- a/README.md
+++ b/README.md
@@ -6,9 +6,25 @@ They are meant to be parsed with the [Sphinx](https://www.sphinx-doc.org/) docum
 
 ## Download for offline use
 
-You can [download an HTML copy](https://nightly.link/godotengine/godot-docs/workflows/build_offline_docs/master/godot-docs-html-master.zip)
+To browse the documentation offline, you can use the mirror of the documentation
+hosted on [DevDocs](https://devdocs.io/godot/). To enable offline browsing on
+DevDocs, you need to:
+
+- Click the three dots in the top-left corner, choose **Preferences**.
+- Enable the desired version of the Godot documentation by checking the box
+  next to it in the sidebar.
+- Click the three dots in the top-left corner, choose **Offline data**.
+- Click the **Install** link next to the Godot documentation.
+
+You can also
+[download an HTML copy](https://nightly.link/godotengine/godot-docs/workflows/build_offline_docs/master/godot-docs-html-master.zip)
 for offline reading (updated every Monday). Extract the ZIP archive then open
 the top-level `index.html` in a web browser.
+
+For mobile devices or e-readers, you can also
+[download an ePub copy](https://nightly.link/godotengine/godot-docs/workflows/build_offline_docs/master/godot-docs-epub-master.zip)
+for offline reading (updated every Monday). Extract the ZIP archive then open
+the `GodotEngine.epub` file in an e-book reader application.
 
 ## Theming
 

--- a/index.rst
+++ b/index.rst
@@ -65,6 +65,9 @@ You can also `download an HTML copy <https://nightly.link/godotengine/godot-docs
 for offline reading (updated every Monday). Extract the ZIP archive then open
 the top-level ``index.html`` in a web browser.
 
+For mobile devices or e-readers, you can also `download an ePub copy <https://nightly.link/godotengine/godot-docs/workflows/build_offline_docs/master/godot-docs-epub-master.zip>`__
+for offline reading (updated every Monday). Extract the ZIP archive then open
+the ``GodotEngine.epub`` file in an e-book reader application.
 
 .. Below is the main table-of-content tree of the documentation website.
    It is hidden on the page itself, but it makes up the sidebar for navigation.


### PR DESCRIPTION
This format is more suited to mobile devices or e-readers compared to HTML. Note that the generated ePubs are quite large (156 MB for `master`) and may struggle on low-end devices.

PDF builds could also be added, but there isn't as much of an use when you have both HTML and ePub already.

### Outstanding issues

- Table of contents generation appears to be broken (there's only one chapter). I remember it working at some point while working on this branch, but I don't know what broke it.
- The class reference is missing. Like the above issue, it also worked at some point, but I don't know why it's missing now.
  - The lack of a built-in class reference may be desired to make the ePub easier to open though. With the class reference, it's 5,500 pages instead of 2,900 in `master`. You can already read the class reference offline in the editor anyway.
- Formatting could be improved somewhat to make it more "book-like", but I don't know how to customize the ePub output. For example:
  - Give admonitions their usual colored background.
  - Give headings a colored background depending on their level.
  - Add a line below H1 headings.
  - Force `figure` images to be center-aligned and on a new line. Right now, they ignore the `:align: center` option and may appear on the same line as text.
  - Give `figure` captions a different text style (italic, slightly different color).
  - Fix visible blank lines between lines in multiline code blocks.
- The margin on the page's edges is very low, but this may not be a bad idea as it should help with readability on mobile devices.

**Note:** This PR changes the stable branch that is built to `3.6`, so that we have both Godot 3.x and 4.x docs available for download. Stable branches will need to have their URLs updated accordingly. There isn't much use in having both `stable` (4.0) and `latest` (4.1) built right now, since these barely have any differences. In the long term, I'd suggest restoring `stable` builds, but this could be done after 4.1 is released.

___

Example outputs: <sub>(links expire in September 2023)</sub>

- `master`: https://0x0.st/HZs0.zip
- `3.6`: https://0x0.st/HZsU.6.zip