### PR TITLE
Update PR Workflow documentation to include updated information about GitHub's account verification via HTTPS

### DIFF
--- a/contributing/workflow/pr_workflow.rst
+++ b/contributing/workflow/pr_workflow.rst
@@ -351,8 +351,8 @@ Git will ask you for your username and password. For your password, enter your
 GitHub Personal Access Token (PAT). If you do not have a GitHub Personal Access
 Token, or do not have one with the correct permissions for your newly forked
 repository, you will need to create one. Follow this link to create your Personal
-Access Token: Creating a personal access token
-<https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>
+Access Token: `Creating a personal access token
+<https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_
 
 After you have successfully verified your account using your PAT, the changes
 will be sent to your remote repository. If you check the fork's page on GitHub,

--- a/contributing/workflow/pr_workflow.rst
+++ b/contributing/workflow/pr_workflow.rst
@@ -352,7 +352,7 @@ GitHub Personal Access Token (PAT). If you do not have a GitHub Personal Access
 Token, or do not have one with the correct permissions for your newly forked
 repository, you will need to create one. Follow this link to create your Personal
 Access Token: `Creating a personal access token
-<https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_
+<https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_.
 
 After you have successfully verified your account using your PAT, the changes
 will be sent to your remote repository. If you check the fork's page on GitHub,

--- a/contributing/workflow/pr_workflow.rst
+++ b/contributing/workflow/pr_workflow.rst
@@ -347,9 +347,16 @@ do:
 
     $ git push origin better-project-manager
 
-Git will ask you for your username and password, and the changes will be sent
-to your remote. If you check the fork's page on GitHub, you should see a new
-branch with your added commits.
+Git will ask you for your username and password. For your password, enter your
+GitHub Personal Access Token (PAT). If you do not have a GitHub Personal Access
+Token, or do not have one with the correct permissions for your newly forked
+repository, you will need to create one. Follow this link to create your Personal
+Access Token: Creating a personal access token
+<https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>
+
+After you have successfully verified your account using your PAT, the changes
+will be sent to your remote repository. If you check the fork's page on GitHub,
+you should see a new branch with your added commits.
 
 Issuing a pull request
 ----------------------


### PR DESCRIPTION
Resolves: https://github.com/godotengine/godot-docs/issues/7273

To preface, I am not sure that I have edited the correct file to resolve the issue. While I found that most of the RST files in Godot's documentation are automatically generated, this seems to only occur within the class reference documentation. Furthermore, this file did not have a warning comment at its beginning. Thus, I have gone ahead and attempted to resolve the issue by directly editing the RST file.

These changes simply update the [documentation](https://docs.godotengine.org/en/stable/contributing/workflow/pr_workflow.html) that currently exists for the PR Workflow to include up-to-date information about GitHub's account verification over HTTPS. This change should remove some possible confusion for new contributors of Godot, which in-turn will promote more community development. If I have made in a mistake in editing this file to resolve this issue, please let me know and I will happily edit the correct file. Thank you! 