### PR TITLE
Remove outdated notices about GDScript debugger not supporting threads

### DIFF
--- a/tutorials/performance/cpu_optimization.rst
+++ b/tutorials/performance/cpu_optimization.rst
@@ -216,9 +216,7 @@ CPU core operates independently, they can end up trying to access the same
 memory at the same time. One thread can be reading to a variable while another
 is writing: this is called a *race condition*. Before you use threads, make sure
 you understand the dangers and how to try and prevent these race conditions.
-
-Threads can also make debugging considerably more difficult. The GDScript
-debugger doesn't support setting up breakpoints in threads yet.
+Threads can make debugging considerably more difficult.
 
 For more information on threads, see :ref:`doc_using_multiple_threads`.
 

--- a/tutorials/scripting/debug/debugger_panel.rst
+++ b/tutorials/scripting/debug/debugger_panel.rst
@@ -48,14 +48,6 @@ You can use the buttons in the top-right corner to:
 - **Break**. This button pauses the game's execution.
 - **Continue**. This button resumes the game after a breakpoint or pause.
 
-
-
-.. warning::
-
-    Breakpoints won't break on code if it's
-    :ref:`running in a thread <doc_using_multiple_threads>`.
-    This is a current limitation of the GDScript debugger.
-
 Errors
 ------
 

--- a/tutorials/scripting/debug/overview_of_debugging_tools.rst
+++ b/tutorials/scripting/debug/overview_of_debugging_tools.rst
@@ -111,12 +111,6 @@ When the debugger breaks on a breakpoint, a green triangle arrow is visible in
 the script editor's gutter. This arrow indicates the line of code the debugger
 broke on.
 
-.. warning::
-
-    Breakpoints won't break on code if it's
-    :ref:`running in a thread <doc_using_multiple_threads>`.
-    This is a current limitation of the GDScript debugger.
-
 Debug project settings
 ----------------------
 


### PR DESCRIPTION
This will be supported in Godot once https://github.com/godotengine/godot/pull/76582 is merged.
