### PR TITLE
RTD: Change OS image to Ubuntu 22.04

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@
 version: 2
 
 build:
-  image: latest
+  os: ubuntu-22.04
 
 sphinx:
   configuration: conf.py


### PR DESCRIPTION
This should hopefully fix the recent build errors on ReadTheDocs due to a recent OpenSSL change in urllib3

See:
- https://github.com/urllib3/urllib3/issues/2168
- https://github.com/readthedocs/readthedocs.org/issues/10290