### PR TITLE
Remove outdated HiDPI note from nodes and scenes

### DIFF
--- a/getting_started/step_by_step/nodes_and_scenes.rst
+++ b/getting_started/step_by_step/nodes_and_scenes.rst
@@ -159,12 +159,6 @@ The application should open in a new window and display the text "Hello World".
 
 Close the window or press :kbd:`F8` (:kbd:`Cmd + .` on macOS) to quit the running scene.
 
-.. note::
-
-    If this doesn't immediately work and you have a hiDPI display on at least
-    one of your monitors, go to Project -> Project Settings -> Display ->
-    Window then enable Allow Hidpi under Dpi.
-
 Setting the main scene
 ----------------------
 


### PR DESCRIPTION
The note is no longer necessary as HiDPI is turned on for projects by default in Godot 4. This note was made for Godot 3 where it was off by default. Supersedes #7202.