### PR TITLE
Update scenes_versus_scripts.rst minor correction

### DIFF
--- a/tutorials/best_practices/scenes_versus_scripts.rst
+++ b/tutorials/best_practices/scenes_versus_scripts.rst
@@ -11,8 +11,8 @@ declarative code.
 
 Each system's capabilities are different as a result.
 Scenes can define how an extended class initializes, but not what its
-behavior actually is. Scenes are often used in conjunction with a script so
-that the scene acts as an extension of the scripts declarative code.
+behavior actually is. Scenes are often used in conjunction with a script, 
+the scene declaring a composition of nodes, and the script adding behaviour with imperative code.
 
 Anonymous types
 ---------------

--- a/tutorials/best_practices/what_are_godot_classes.rst
+++ b/tutorials/best_practices/what_are_godot_classes.rst
@@ -54,8 +54,8 @@ The behavior of scenes has many similarities to classes, so it can make sense to
 a class. Scenes are reusable, instantiable, and inheritable groups of nodes. Creating a scene is
 similar to having a script that creates nodes and adds them as children using ``add_child()``.
 
-We often pair a scene with a scripted root node that makes use of the scene's nodes. As such, the
-scene is often an extension of the script's declarative code.
+We often pair a scene with a scripted root node that makes use of the scene's nodes. As such, 
+the script extends the scene by adding behavior through imperative code.
 
 The content of a scene helps to define:
 


### PR DESCRIPTION
Swap mention of scene and script that mistakes scripts as declarative.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
