### PR TITLE
Update exporting_for_dedicated_servers.rst

### DIFF
--- a/tutorials/export/exporting_for_dedicated_servers.rst
+++ b/tutorials/export/exporting_for_dedicated_servers.rst
@@ -11,7 +11,7 @@ have a GPU or display server available, you'll need to use a server build of God
 Platform support
 ----------------
 
-- **Linux:** `Download an official Linux server binary <https://godotengine.org/download/server>`__.
+- **Linux:** `Download an official Linux server binary <https://godotengine.org/download/3.x/server>`__.
   To compile a server binary from source, follow instructions in
   :ref:`doc_compiling_for_linuxbsd`.
 - **macOS:** :ref:`Compile a server binary from source for macOS <doc_compiling_for_macos>`.


### PR DESCRIPTION
Link was dead, made it point to https://godotengine.org/download/3.x/server/.
What should be done for v4 ? We don't have the Linux Server option we had on v3:
![image](https://user-images.githubusercontent.com/16239564/236648904-7132c558-84f7-408f-856d-b67ccba764be.png)


<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
