### PR TITLE
Error in gdexample.cpp

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -442,7 +442,7 @@ show the methods we end up changing, don't remove the lines we're omitting:
         ClassDB::add_property("GDExample", PropertyInfo(Variant::FLOAT, "amplitude"), "set_amplitude", "get_amplitude");
     }
 
-    void GDExample::GDExample() {
+    GDExample::GDExample() {
         // Initialize any variables here.
         time_passed = 0.0;
         amplitude = 10.0;


### PR DESCRIPTION
When adding the getter and setter functions to the example project a void has been added to the constructor  which was not there during the creation of the gdexample.cpp file and is also causing the error C2533: constructors not allowed a return type. Simply removing it again fixes it.

Using Windows 10 and Godot 4.0.2