### PR TITLE
gdexample.gdextension file not recognized

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -351,9 +351,22 @@ loaded for each platform and the entry function for the module. It is called ``g
 
     [libraries]
 
-    linux.64="res://bin/libgdexample.linux.64.so"
-    windows.x86_64="res://bin/libgdexample.windows.x86_64.dll"
-    macos="res://bin/libgdexample.macos.framework"
+    macos.debug = "res://bin/libgdexample.macos.template_debug.framework"
+    macos.release = "res://bin/libgdexample.macos.template_release.framework"
+    windows.debug.x86_32 = "res://bin/libgdexample.windows.template_debug.x86_32.dll"
+    windows.release.x86_32 = "res://bin/libgdexample.windows.template_release.x86_32.dll"
+    windows.debug.x86_64 = "res://bin/libgdexample.windows.template_debug.x86_64.dll"
+    windows.release.x86_64 = "res://bin/libgdexample.windows.template_release.x86_64.dll"
+    linux.debug.x86_64 = "res://bin/libgdexample.linux.template_debug.x86_64.so"
+    linux.release.x86_64 = "res://bin/libgdexample.linux.template_release.x86_64.so"
+    linux.debug.arm64 = "res://bin/libgdexample.linux.template_debug.arm64.so"
+    linux.release.arm64 = "res://bin/libgdexample.linux.template_release.arm64.so"
+    linux.debug.rv64 = "res://bin/libgdexample.linux.template_debug.rv64.so"
+    linux.release.rv64 = "res://bin/libgdexample.linux.template_release.rv64.so"
+    android.debug.x86_64 = "res://bin/libgdexample.android.template_debug.x86_64.so"
+    android.release.x86_64 = "res://bin/libgdexample.android.template_release.x86_64.so"
+    android.debug.arm64 = "res://bin/libgdexample.android.template_debug.arm64.so"
+    android.release.arm64 = "res://bin/libgdexample.android.template_release.arm64.so"
 
 This file contains a ``configuration`` section that controls the entry function of the module.
 


### PR DESCRIPTION
Using Windows 10 and Godot 4.0.2 Mono

The gdexample.gdextension file used in the example project is not being recognized by my version of Godot. I don't know the exact reason but I'm guessing it is because it doesn't specify whether or not it is supposed to be a debug or release file.

My changed .gdextension file is the same as the one that is available under godot-cpp\test\demo\example.gdextension. With this one it worked with no problems.