### PR TITLE
Document Linux + NVIDIA suspend issue in Troubleshooting

### DIFF
--- a/about/troubleshooting.rst
+++ b/about/troubleshooting.rst
@@ -10,8 +10,8 @@ This page lists common issues encountered when using Godot and possible solution
     See :ref:`doc_using_the_web_editor` for caveats specific to the HTML5 version
     of the Godot editor.
 
-Everything I do in the editor or project manager appears delayed by one frame.
-------------------------------------------------------------------------------
+Everything I do in the editor or project manager appears delayed by one frame
+-----------------------------------------------------------------------------
 
 This is a `known bug <https://github.com/godotengine/godot/issues/23069>`__ on
 Intel graphics drivers on Windows. Updating to the latest graphics driver
@@ -21,8 +21,8 @@ You should use the graphics driver provided by Intel rather than the one
 provided by your desktop or laptop's manufacturer because their version is often
 outdated.
 
-The grid disappears and meshes turn black when I rotate the 3D camera in the editor.
-------------------------------------------------------------------------------------
+The grid disappears and meshes turn black when I rotate the 3D camera in the editor
+-----------------------------------------------------------------------------------
 
 This is a `known bug <https://github.com/godotengine/godot/issues/30330>`__ on
 Intel graphics drivers on Windows.
@@ -33,8 +33,8 @@ the renderer in the top-right corner of the editor or the Project Settings.
 If you use a computer allowing you to switch your graphics card, like NVIDIA
 Optimus, you can use the dedicated graphics card to run Godot.
 
-The editor or project takes a very long time to start.
-------------------------------------------------------
+The editor or project takes a very long time to start
+-----------------------------------------------------
 
 This is a `known bug <https://github.com/godotengine/godot/issues/20566>`__ on
 Windows when you have specific USB peripherals connected. In particular,
@@ -43,15 +43,15 @@ peripherals' drivers to their latest version. If the bug persists, you need to
 disconnect the faulty peripherals before opening the editor. You can then
 connect the peripheral again.
 
-Editor tooltips in the Inspector and Node docks blink when they're displayed.
------------------------------------------------------------------------------
+Editor tooltips in the Inspector and Node docks blink when they're displayed
+----------------------------------------------------------------------------
 
 This is a `known issue <https://github.com/godotengine/godot/issues/32990>`__
 caused by the third-party Stardock Fences application on Windows.
 The only known workaround is to disable Stardock Fences while using Godot.
 
-The Godot editor appears frozen after clicking the system console.
-------------------------------------------------------------------
+The Godot editor appears frozen after clicking the system console
+-----------------------------------------------------------------
 
 When running Godot on Windows with the system console enabled, you can
 accidentally enable *selection mode* by clicking inside the command window. This
@@ -61,8 +61,8 @@ the system console. Godot cannot override this system-specific behavior.
 To solve this, select the system console window and press Enter to leave
 selection mode.
 
-Some text such as "NO DC" appears in the top-left corner of the project manager and editor window.
---------------------------------------------------------------------------------------------------
+Some text such as "NO DC" appears in the top-left corner of the project manager and editor window
+-------------------------------------------------------------------------------------------------
 
 This is caused by the NVIDIA graphics driver injecting an overlay to display information.
 
@@ -72,8 +72,8 @@ default values in the NVIDIA Control Panel.
 To disable this overlay on Linux, open ``nvidia-settings``, go to **X Screen 0 >
 OpenGL Settings** then uncheck **Enable Graphics API Visual Indicator**.
 
-The project window appears blurry, unlike the editor.
------------------------------------------------------
+The project window appears blurry, unlike the editor
+----------------------------------------------------
 
 Unlike the editor, the project isn't marked as DPI-aware by default. This is
 done to improve performance, especially on integrated graphics, where rendering
@@ -83,16 +83,30 @@ To resolve this, open **Project > Project Settings** and enable **Display >
 Window > Dpi > Allow Hidpi**. On top of that, make sure your project is
 configured to support :ref:`multiple resolutions <doc_multiple_resolutions>`.
 
-The project window doesn't appear centered when I run the project.
-------------------------------------------------------------------
+The project window doesn't appear centered when I run the project
+-----------------------------------------------------------------
 
 This is a `known bug <https://github.com/godotengine/godot/issues/13017>`__. To
 resolve this, open **Project > Project Settings** and enable **Display > Window
 > Dpi > Allow Hidpi**. On top of that, make sure your project is configured to
 support :ref:`multiple resolutions <doc_multiple_resolutions>`.
 
-The project works when run from the editor, but fails to load some files when running from an exported copy.
-------------------------------------------------------------------------------------------------------------
+The editor/project freezes or displays glitched visuals after resuming the PC from suspend
+------------------------------------------------------------------------------------------
+
+This is a known issue on Linux with NVIDIA graphics when using the proprietary
+driver. There is no definitive fix yet, as suspend on Linux + NVIDIA is often
+buggy when OpenGL is involved.
+
+The NVIDIA driver offers an *experimental*
+`option to preserve video memory after suspend <https://wiki.archlinux.org/title/NVIDIA/Tips_and_tricks#Preserve_video_memory_after_suspend>`__
+which may resolve this issue. This option has been reported to work better with
+more recent NVIDIA driver versions.
+
+To avoid losing work, save scenes in the editor before putting the PC to sleep.
+
+The project works when run from the editor, but fails to load some files when running from an exported copy
+-----------------------------------------------------------------------------------------------------------
 
 This is usually caused by forgetting to specify a filter for non-resource files
 in the Export dialog. By default, Godot will only include actual *resources*


### PR DESCRIPTION
- `3.6` version of https://github.com/godotengine/godot-docs/pull/7305.
- See https://github.com/godotengine/godot/issues/52738.

This issue is less prevalent in `3.x` than it is in `master` since `3.x` only uses OpenGL, but it may still occur (especially for glitched visuals with the script editor minimap).

This also changes headings to match `master`.
