### PR TITLE
Remove obsolete and confusing tip re: move_and_slide()

### DIFF
--- a/tutorials/physics/using_character_body_2d.rst
+++ b/tutorials/physics/using_character_body_2d.rst
@@ -70,10 +70,6 @@ The ``move_and_slide()`` method is intended to simplify the collision
 response in the common case where you want one body to slide along the other.
 It is especially useful in platformers or top-down games, for example.
 
-.. tip:: ``move_and_slide()`` automatically calculates frame-based movement
-         using ``delta``. Do *not* multiply your velocity vector by ``delta``
-         before passing it to ``move_and_slide()``.
-
 When calling ``move_and_slide()``, the function uses a number of node properties
 to calculate its slide behavior. These properties can be found in the Inspector,
 or set in code.


### PR DESCRIPTION
Since we no longer pass a velocity to `move_and_slide()`, the mention of `delta` here is no longer relevant, and probably misleading. It was originally needed to distinguish between the very similar-looking calls to `move_and_collide()`.