### PR TITLE
Mention Spatial -> Node3D rename in Introduction docs

### DIFF
--- a/getting_started/introduction/key_concepts_overview.rst
+++ b/getting_started/introduction/key_concepts_overview.rst
@@ -46,7 +46,8 @@ It is made of a ``CharacterBody2D`` node named "Character", a ``Sprite2D``, a
 ``Camera2D``, and a ``CollisionShape2D``.
 
 .. note:: The node names end with "2D" because this is a 2D scene. Their 3D
-          counterparts have names that end with "3D".
+          counterparts have names that end with "3D". Be aware that "Spatial"
+          Nodes are now called "Node3D" starting with Godot 4.
 
 Notice how nodes and scenes look the same in the editor. When you save a tree of
 nodes as a scene, it then shows as a single node, with its internal structure

--- a/tutorials/3d/introduction_to_3d.rst
+++ b/tutorials/3d/introduction_to_3d.rst
@@ -24,6 +24,10 @@ Node3D node
 Following this reasoning, the 3D engine uses the :ref:`Node3D <class_Node3D>`
 node for everything 3D.
 
+.. note:: Be aware that "Spatial" Nodes are now called "Node3D"
+   starting with Godot 4. Any Godot 3.x references to "Spatial"
+   Nodes refer to "Node3D" in Godot 4.
+
 .. image:: img/tuto_3d1.png
 
 Node3Ds have a local transform, which is relative to the parent


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-docs/issues/7337

I added the renaming in "introduction to 3D" and "key_concepts_overview"