### PR TITLE
Update submitting_to_assetlib.rst

### DIFF
--- a/community/asset_library/submitting_to_assetlib.rst
+++ b/community/asset_library/submitting_to_assetlib.rst
@@ -60,7 +60,7 @@ if you follow these recommendations, you can help make the asset
 library a better place for all users.
 
 * When creating non-project assets, it is common practice to place your files
-  inside of an **addons/AssetName/** folder. Do this to avoid having your files 
+  inside of an **addons/asset_name/** folder. Do this to avoid having your files 
   clash with other assets, or with the files of users installing your asset. 
   This folder will **not** be automatically generated when a user installs your asset.
 

--- a/community/asset_library/submitting_to_assetlib.rst
+++ b/community/asset_library/submitting_to_assetlib.rst
@@ -59,6 +59,11 @@ These things are not required for your asset to be approved, but
 if you follow these recommendations, you can help make the asset
 library a better place for all users.
 
+* When creating non-project assets, it is common practice to place your files
+  inside of an **addons/AssetName/** folder. Do this to avoid having your files 
+  clash with other assets, or with the files of users installing your asset. 
+  This folder will **not** be automatically generated when a user installs your asset.
+
 * Fix or suppress all script **warnings**. The warning system is there to
   help identify issues with your code, but people using your asset
   don't need to see them.


### PR DESCRIPTION
Added asset file structure (addons/AssetName) to reccomendations. Assets on the Asset Library are inconsistent in file structure. This is often problematic, as the LICENSE file is typically placed inside of res://, which will usually either get overwritten or ignored.  While the submission guidelines heavily imply this is how you should structure your assets, it was never explicitly stated.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
