### PR TITLE
Docs CI: Limit concurrent builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,12 @@
 name: Continuous integration
+
 on:
   push:
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
In our everlasting quest to conserve CI resources, this PR limits CI concurrency for both PR builds and pushes/merges to the repo's branches. This is already done [in the main repository](https://github.com/godotengine/godot/blob/master/.github/workflows/runner.yml#L4-L6) and for [other workflows](https://github.com/godotengine/godot-docs/blob/master/.github/workflows/sync_class_ref.yml#L11-L14) in the docs.

This means that whenever a new commit is pushed to one of the branches or a PR, currently ongoing builds for that branch or PR are cancelled.

I often review and merge PRs in batches and as the docs builds can take quite some time, this should save quite a bit of resources. It means in cases of CI fails we won't always see the exact commit it started, but for docs that has never been that interesting: failures are very easy to fix and obvious, and PRs need to pass CI anyway before they are merged. I don't see a real downside here.