### PR TITLE
Add Loop Break To Doc Code

### DIFF
--- a/getting_started/first_3d_game/06.jump_and_squash.rst
+++ b/getting_started/first_3d_game/06.jump_and_squash.rst
@@ -255,6 +255,7 @@ With this code, if no collisions occurred on a given frame, the loop won't run.
                    # If so, we squash it and bounce.
                    mob.squash()
                    target_velocity.y = bounce_impulse
+                   break
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
Issue in collision count loop. 

If multiple collisions occur with mob over one `move_and_slide()`, score is incremented multiple times. Only tested in GDScript, but likely the same issue in C# too.

Found in Godot 4.0.2
