### PR TITLE
Marked /tutorials/rendering/viewports.rst as outdated

### DIFF
--- a/tutorials/rendering/viewports.rst
+++ b/tutorials/rendering/viewports.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_viewports:
 
 Using Viewports


### PR DESCRIPTION
Fixes: #7343

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
