### PR TITLE
Change cpu_optimization.rst languages to link to gdextension implementations

### DIFF
--- a/tutorials/performance/cpu_optimization.rst
+++ b/tutorials/performance/cpu_optimization.rst
@@ -191,8 +191,7 @@ Other languages
 ~~~~~~~~~~~~~~~
 
 Third parties provide support for several other languages, including `Rust
-<https://github.com/godot-rust/godot-rust>`_ and `Javascript
-<https://github.com/GodotExplorer/ECMAScript>`_.
+<https://github.com/godot-rust/gdext>`_.
 
 C++
 ~~~


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

These links linked to the godot 3 language libraries but the docs are for godot 4. I replaced rust with the new project and removed JS because I don't know of a godot 4 library for it.
