### PR TITLE
Documented export config files and evironment vars

### DIFF
--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -148,10 +148,6 @@ Now fill in the following forms in your Android Export Presets:
 - **Release User:** Replace with the key alias.
 - **Release Password:** Key password. Note that the keystore password and the key password currently have to be the same.
 
-**Your export_presets.cfg file now contains sensitive information.** If you use
-a version control system, you should remove it from public repositories and add
-it to your ``.gitignore`` file or equivalent.
-
 Don't forget to uncheck the **Export With Debug** checkbox while exporting.
 
 .. image:: img/export-with-debug-button.png
@@ -176,3 +172,30 @@ and ARMv8 is usually sufficient to cover most devices in use today.
 You can optimize the size further by compiling an Android export template with
 only the features you need. See :ref:`doc_optimizing_for_size` for more
 information.
+
+Environment variables
+---------------------
+
+You can use the following environment variables to set export options outside of
+the editor. During the export process, these override the values that you set in
+the export menu.
+
+.. list-table:: Android export environment variables
+   :header-rows: 1
+
+   * - Export option
+     - Environment variable
+   * - Encryption / Encryption Key
+     - GODOT_SCRIPT_ENCRYPTION_KEY
+   * - Options / Keystore / Debug
+     - GODOT_ANDROID_KEYSTORE_DEBUG_PATH
+   * - Options / Keystore / Debug User
+     - GODOT_ANDROID_KEYSTORE_DEBUG_USER
+   * - Options / Keystore / Debug Password
+     - GODOT_ANDROID_KEYSTORE_DEBUG_PASSWORD
+   * - Options / Keystore / Release
+     - GODOT_ANDROID_KEYSTORE_RELEASE_PATH
+   * - Options / Keystore / Release User
+     - GODOT_ANDROID_KEYSTORE_RELEASE_USER
+   * - Options / Keystore / Release Password
+     - GODOT_ANDROID_KEYSTORE_RELEASE_PASSWORD

--- a/tutorials/export/exporting_for_ios.rst
+++ b/tutorials/export/exporting_for_ios.rst
@@ -104,3 +104,22 @@ Plugins for iOS
 
 Special iOS plugins can be used in Godot. Check out the
 :ref:`doc_plugins_for_ios` page.
+
+Environment variables
+---------------------
+
+You can use the following environment variables to set export options outside of
+the editor. During the export process, these override the values that you set in
+the export menu.
+
+.. list-table:: iOS export environment variables
+   :header-rows: 1
+
+   * - Export option
+     - Environment variable
+   * - Encryption / Encryption Key
+     - GODOT_SCRIPT_ENCRYPTION_KEY
+   * - Options / Application / Provisioning Profile UUID Debug
+     - GODOT_IOS_PROVISIONING_PROFILE_UUID_DEBUG
+   * - Options / Application / Provisioning Profile UUID Release
+     - GODOT_IOS_PROVISIONING_PROFILE_UUID_RELEASE

--- a/tutorials/export/exporting_for_linux.rst
+++ b/tutorials/export/exporting_for_linux.rst
@@ -17,3 +17,18 @@ Godot offers a more elegant approach for PC distribution when using the export
 system. When exporting for Linux, the exporter takes all the project files and
 creates a ``data.pck`` file. This file is bundled with a specially optimized
 binary that is smaller, faster and does not contain the editor and debugger.
+
+Environment variables
+---------------------
+
+You can use the following environment variables to set export options outside of
+the editor. During the export process, these override the values that you set in
+the export menu.
+
+.. list-table:: Linux export environment variables
+   :header-rows: 1
+
+   * - Export option
+     - Environment variable
+   * - Encryption / Encryption Key
+     - GODOT_SCRIPT_ENCRYPTION_KEY

--- a/tutorials/export/exporting_for_macos.rst
+++ b/tutorials/export/exporting_for_macos.rst
@@ -213,3 +213,34 @@ See `App Sandbox <https://developer.apple.com/documentation/security/app_sandbox
 .. note::
 
     You can override default entitlements by selecting custom entitlements file, in this case all other entitlement are ignored.
+
+Environment variables
+---------------------
+
+You can use the following environment variables to set export options outside of
+the editor. During the export process, these override the values that you set in
+the export menu.
+
+.. list-table:: macOS export environment variables
+   :header-rows: 1
+
+   * - Export option
+     - Environment variable
+   * - Encryption / Encryption Key
+     - GODOT_SCRIPT_ENCRYPTION_KEY
+   * - Options / Codesign / Certificate File
+     - GODOT_MACOS_CODESIGN_CERTIFICATE_FILE
+   * - Options / Codesign / Certificate Password
+     - GODOT_MACOS_CODESIGN_CERTIFICATE_PASSWORD
+   * - Options / Codesign / Provisioning Profile
+     - GODOT_MACOS_CODESIGN_PROVISIONING_PROFILE
+   * - Options / Notarization / API UUID
+     - GODOT_MACOS_NOTARIZATION_API_UUID
+   * - Options / Notarization / API Key
+     - GODOT_MACOS_NOTARIZATION_API_KEY
+   * - Options / Notarization / API Key ID
+     - GODOT_MACOS_NOTARIZATION_API_KEY_ID
+   * - Options / Notarization / Apple ID Name
+     - GODOT_MACOS_NOTARIZATION_APPLE_ID_NAME
+   * - Options / Notarization / Apple ID Password
+     - GODOT_MACOS_NOTARIZATION_APPLE_ID_PASSWORD

--- a/tutorials/export/exporting_for_uwp.rst
+++ b/tutorials/export/exporting_for_uwp.rst
@@ -102,3 +102,22 @@ It's also possible to install by using the ``Add-AppxPackage`` PowerShell cmdlet
 .. note:: If you want to update your already installed app, you must
           update the version number on the new package or first uninstall
           the previous package.
+
+Environment variables
+---------------------
+
+You can use the following environment variables to set export options outside of
+the editor. During the export process, these override the values that you set in
+the export menu.
+
+.. list-table:: UWP export environment variables
+   :header-rows: 1
+
+   * - Export option
+     - Environment variable
+   * - Encryption / Encryption Key
+     - GODOT_SCRIPT_ENCRYPTION_KEY
+   * - Options / Signing / Certificate
+     - GODOT_UWP_SIGNING_CERTIFICATE
+   * - Options / Signing / Password
+     - GODOT_UWP_SIGNING_PASSWORD

--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -368,3 +368,18 @@ defaulting to ``false`` to prevent polluting the global namespace:
         // thus adding a new JavaScript global variable `SomeGlobal`
         JavaScriptBridge.Eval("var SomeGlobal = {};", true);
     }
+
+Environment variables
+---------------------
+
+You can use the following environment variables to set export options outside of
+the editor. During the export process, these override the values that you set in
+the export menu.
+
+.. list-table:: HTML5 export environment variables
+   :header-rows: 1
+
+   * - Export option
+     - Environment variable
+   * - Encryption / Encryption Key
+     - GODOT_SCRIPT_ENCRYPTION_KEY

--- a/tutorials/export/exporting_for_windows.rst
+++ b/tutorials/export/exporting_for_windows.rst
@@ -55,3 +55,24 @@ Under options there is a code signing category.
 ``Enabled`` must be set to true, and ``Identity`` must be set to the signing
 certificate. The other settings can be adjusted as needed. Once this is Done
 Godot will sign your project on export.
+
+Environment variables
+---------------------
+
+You can use the following environment variables to set export options outside of
+the editor. During the export process, these override the values that you set in
+the export menu.
+
+.. list-table:: Windows export environment variables
+   :header-rows: 1
+
+   * - Export option
+     - Environment variable
+   * - Encryption / Encryption Key
+     - GODOT_SCRIPT_ENCRYPTION_KEY
+   * - Options / Codesign / Identity Type
+     - GODOT_WINDOWS_CODESIGN_IDENTITY_TYPE
+   * - Options / Codesign / Identity
+     - GODOT_WINDOWS_CODESIGN_IDENTITY
+   * - Options / Codesign / Password
+     - GODOT_WINDOWS_CODESIGN_PASSWORD

--- a/tutorials/export/exporting_projects.rst
+++ b/tutorials/export/exporting_projects.rst
@@ -130,9 +130,27 @@ select every scene or resource you want to export.
     ``.git`` from being included in the exported PCK file.
 
 Below the list of resources are two filters that can be setup. The first allows
-non resource files such as ``.txt``,``.json`` and ``.csv`` to be exported with
+non resource files such as ``.txt``, ``.json`` and ``.csv`` to be exported with
 the project. The second filter can be used to exclude every file of a certain
 type without manually deselecting every one. For example, ``.png`` files.
+
+Configuration files
+-------------------
+
+The export configuration is stored in two files that can both be found in the project
+directory:
+
+- ``export_presets.cfg``: This file contains the vast majority of the export
+  configuration and can be safely committed to version control. There is nothing
+  in here that you would normally have to keep secret.
+- ``.godot/export_credentials.cfg``: This file contains export options that are
+  considered confidential, like passwords and encryption keys. It should generally
+  **not** be committed to version control or shared with others unless you know
+  exactly what you are doing.
+
+Since the credentials file is usually kept out of version control systems, some
+export options will be missing if you clone the project to a new machine. The easiest
+way to deal with this is to copy the file manually from the old location to the new one.
 
 Exporting from the command line
 -------------------------------


### PR DESCRIPTION
Fixes #7333 

This documents the split of the export configuration into two different files as well as the available environment variables for overriding sensitive export options.

The `Exporting Projects` page was flagged as outdated and I intentionally kept it that way because the page still has issues that are out of the scope of this PR.
