### PR TITLE
Document font size caveats for pixel art fonts in Using fonts

### DIFF
--- a/tutorials/ui/gui_using_fonts.rst
+++ b/tutorials/ui/gui_using_fonts.rst
@@ -147,7 +147,7 @@ property that accepts a Font resource.
    by changing the **Rendering > Textures > Canvas Textures > Default Texture Filter**
    project setting to **Nearest**. The font size must also be an integer multiple of the
    design size (which varies on a per-font basis), and the Control node using the font
-   must be scaled by an integer multiple as well. Otherwise, the font may appear to look blurry.
+   must be scaled by an integer multiple as well. Otherwise, the font may look blurry.
 
    The texture filter mode can also be set on individual nodes that inherit from CanvasItem
    by setting :ref:`CanvasItem.texture_filter <class_CanvasItem_property_texture_filter>`.

--- a/tutorials/ui/gui_using_fonts.rst
+++ b/tutorials/ui/gui_using_fonts.rst
@@ -145,7 +145,9 @@ property that accepts a Font resource.
 
    Fonts that have a pixel art appearance should have bilinear filtering disabled
    by changing the **Rendering > Textures > Canvas Textures > Default Texture Filter**
-   project setting to **Nearest**. Otherwise, the font may appear to look blurry.
+   project setting to **Nearest**. The font size must also be an integer multiple of the
+   design size (which varies on a per-font basis), and the Control node using the font
+   must be scaled by an integer multiple as well. Otherwise, the font may appear to look blurry.
 
    The texture filter mode can also be set on individual nodes that inherit from CanvasItem
    by setting :ref:`CanvasItem.texture_filter <class_CanvasItem_property_texture_filter>`.


### PR DESCRIPTION
- This closes https://github.com/godotengine/godot/issues/74694.
