### PR TITLE
Update physics_introduction.rst

### DIFF
--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -289,16 +289,16 @@ For example, here is the code for an "Asteroids" style spaceship:
         public override void _IntegrateForces(PhysicsDirectBodyState2D state)
         {
             if (Input.IsActionPressed("ui_up"))
-                AppliedForce = _thrust.Rotated(Rotation);
+                state.AppliedForce = _thrust.Rotated(Rotation);
             else
-                AppliedForce = new Vector2();
+                state.AppliedForce = new Vector2();
 
             var rotationDir = 0;
             if (Input.IsActionPressed("ui_right"))
                 rotationDir += 1;
             if (Input.IsActionPressed("ui_left"))
                 rotationDir -= 1;
-            AppliedTorque = rotationDir * _torque;
+            state.AppliedTorque = rotationDir * _torque;
         }
     }
 

--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -291,7 +291,7 @@ For example, here is the code for an "Asteroids" style spaceship:
             if (Input.IsActionPressed("ui_up"))
                 state.ApplyForce(_thrust.Rotated(Rotation));
             else
-                state.AppliedForce = new Vector2();
+                state.ApplyForce(new Vector2());
 
             var rotationDir = 0;
             if (Input.IsActionPressed("ui_right"))

--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -298,7 +298,7 @@ For example, here is the code for an "Asteroids" style spaceship:
                 rotationDir += 1;
             if (Input.IsActionPressed("ui_left"))
                 rotationDir -= 1;
-            state.AppliedTorque = rotationDir * _torque;
+            state.ApplyTorque(rotationDir * _torque);
         }
     }
 

--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -286,7 +286,7 @@ For example, here is the code for an "Asteroids" style spaceship:
         private Vector2 _thrust = new Vector2(0, -250);
         private float _torque = 20000;
 
-        public override void _IntegrateForces(Physics2DDirectBodyState state)
+        public override void _IntegrateForces(PhysicsDirectBodyState2D state)
         {
             if (Input.IsActionPressed("ui_up"))
                 AppliedForce = _thrust.Rotated(Rotation);

--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -289,7 +289,7 @@ For example, here is the code for an "Asteroids" style spaceship:
         public override void _IntegrateForces(PhysicsDirectBodyState2D state)
         {
             if (Input.IsActionPressed("ui_up"))
-                state.AppliedForce = _thrust.Rotated(Rotation);
+                state.ApplyForce(_thrust.Rotated(Rotation));
             else
                 state.AppliedForce = new Vector2();
 


### PR DESCRIPTION
In the Using RigidBody2D Code Example, the example code used the previous version of PhysicsDirectBodyState2D: Physics2DDirectBodyState.

This changes the example code to correctly reflect the Godot 4.0 c# naming.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
