### PR TITLE
More precise documentation about property underlying access

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1579,7 +1579,7 @@ Example::
         set(value):
             milliseconds = value * 1000
 
-Using the variable name to set it inside its own setter or to get it inside its own getter will directly access the underlying member, 
+Using the variable's name to set it inside its own setter or to get it inside its own getter will directly access the underlying member, 
 so it won't generate infinite recursion and saves you from explicitly declaring another variable::
 
     signal changed(new_value)

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1579,7 +1579,7 @@ Example::
         set(value):
             milliseconds = value * 1000
 
-Using the variable name to set inside its own setter or to get inside its own getter will directly access the underlying member, 
+Using the variable name to set it inside its own setter or to get it inside its own getter will directly access the underlying member, 
 so it won't generate infinite recursion and saves you from explicitly declaring another variable::
 
     signal changed(new_value)

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1579,8 +1579,8 @@ Example::
         set(value):
             milliseconds = value * 1000
 
-Using the variable name inside its own setter or getter will directly access the underlying member, so it
-won't generate infinite recursion and saves you from explicitly declaring another variable::
+Using the variable name to set inside its own setter or to get inside its own getter will directly access the underlying member, 
+so it won't generate infinite recursion and saves you from explicitly declaring another variable::
 
     signal changed(new_value)
     var warns_when_changed = "some value":


### PR DESCRIPTION
The property underlying access is only made when you use the variable name to "set" in the "setter" or to "get" in the "getter".

The previous documentation implies the variable name will access the underlying variable in all cases inside setter or getter.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
