### PR TITLE
Fix typo in lights_and_shadows.rst

### DIFF
--- a/tutorials/3d/lights_and_shadows.rst
+++ b/tutorials/3d/lights_and_shadows.rst
@@ -141,7 +141,7 @@ object. This is called *peter-panning*:
 
 In general, increasing **Shadow Normal Bias** is preferred over increasing
 **Shadow Bias**. Increasing **Shadow Normal Bias** does not cause as much
-peter-panning as increasing **Shadow Normal Bias**, but it can still resolve
+peter-panning as increasing **Shadow Bias**, but it can still resolve
 most shadow acne issues efficiently. The downside of increasing **Shadow Normal
 Bias** is that it can make shadows appear thinner for certain objects.
 


### PR DESCRIPTION
fixes typo in tutorials/3d/lights_and_shadows.rst as per 
"Yes, the second one should be "shadow bias" not "shadow normal bias"" from #7357

fixes #7357

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
