### PR TITLE
Update some C# examples

### DIFF
--- a/getting_started/first_2d_game/03.coding_the_player.rst
+++ b/getting_started/first_2d_game/03.coding_the_player.rst
@@ -40,7 +40,7 @@ Start by declaring the member variables this object will need:
     public partial class Player : Area2D
     {
         [Export]
-        public int Speed = 400; // How fast the player will move (pixels/sec).
+        public int Speed { get; set; } = 400; // How fast the player will move (pixels/sec).
 
         public Vector2 ScreenSize; // Size of the game window.
     }

--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -101,7 +101,7 @@ the following line of code:
 
     using Godot;
 
-    public partial class Sprite : Sprite2D
+    public partial class MySprite2D : Sprite2D
     {
     }
 
@@ -143,7 +143,7 @@ Add the following code to your script:
 
  .. code-tab:: csharp C#
 
-    public Sprite()
+    public MySprite2D()
     {
         GD.Print("Hello, world!");
     }
@@ -183,8 +183,8 @@ angular speed in radians per second.  Add the following after the ``extends Spri
 
  .. code-tab:: csharp C#
 
-    private int Speed = 400;
-    private float AngularSpeed = Mathf.Pi;
+    private int _speed = 400;
+    private float _angularSpeed = Mathf.Pi;
 
 Member variables sit near the top of the script, after any "extends" lines,
 but before functions. Every node
@@ -226,7 +226,7 @@ At the bottom of the script, define the function:
 
     public override void _Process(double delta)
     {
-        Rotation += AngularSpeed * (float)delta;
+        Rotation += _angularSpeed * (float)delta;
     }
 
 The ``func`` keyword defines a new function. After it, we have to write the
@@ -272,7 +272,7 @@ them.
 
  .. code-tab:: csharp C#
 
-    var velocity = Vector2.Up.Rotated(Rotation) * Speed;
+    var velocity = Vector2.Up.Rotated(Rotation) * _speed;
 
     Position += velocity * (float)delta;
 
@@ -327,15 +327,15 @@ Here is the complete ``sprite_2d.gd`` file for reference.
 
     using Godot;
 
-    public partial class Sprite : Sprite2D
+    public partial class MySprite2D : Sprite2D
     {
-        private int Speed = 400;
-        private float AngularSpeed = Mathf.Pi;
+        private int _speed = 400;
+        private float _angularSpeed = Mathf.Pi;
 
         public override void _Process(double delta)
         {
-            Rotation += AngularSpeed * (float)delta;
-            var velocity = Vector2.Up.Rotated(Rotation) * Speed;
+            Rotation += _angularSpeed * (float)delta;
+            var velocity = Vector2.Up.Rotated(Rotation) * _speed;
 
             Position += velocity * (float)delta;
         }

--- a/getting_started/step_by_step/scripting_player_input.rst
+++ b/getting_started/step_by_step/scripting_player_input.rst
@@ -56,7 +56,7 @@ code below.
         direction = 1;
     }
 
-    Rotation += AngularSpeed * direction * (float)delta;
+    Rotation += _angularSpeed * direction * (float)delta;
 
 Our ``direction`` local variable is a multiplier representing the direction in
 which the player wants to turn. A value of ``0`` means the player isn't pressing
@@ -146,8 +146,8 @@ Here is the complete ``sprite_2d.gd`` file for reference.
 
     public partial class Sprite : Sprite2D
     {
-        private float Speed = 400;
-        private float AngularSpeed = Mathf.Pi;
+        private float _speed = 400;
+        private float _angularSpeed = Mathf.Pi;
 
         public override void _Process(double delta)
         {
@@ -161,12 +161,12 @@ Here is the complete ``sprite_2d.gd`` file for reference.
                 direction = 1;
             }
 
-            Rotation += AngularSpeed * direction * (float)delta;
+            Rotation += _angularSpeed * direction * (float)delta;
 
             var velocity = Vector2.Zero;
             if (Input.IsActionPressed("ui_up"))
             {
-                velocity = Vector2.Up.Rotated(Rotation) * Speed;
+                velocity = Vector2.Up.Rotated(Rotation) * _speed;
             }
 
             Position += velocity * (float)delta;

--- a/tutorials/2d/2d_movement.rst
+++ b/tutorials/2d/2d_movement.rst
@@ -136,7 +136,7 @@ while up/down moves it forward or backward in whatever direction it's facing.
         public void GetInput()
         {
             _rotationDirection = Input.GetAxis("left", "right");
-            Velocity = Transform.x * Input.GetAxis("down", "up") * Speed;
+            Velocity = Transform.X * Input.GetAxis("down", "up") * Speed;
         }
 
         public override void _PhysicsProcess(double delta)
@@ -189,7 +189,7 @@ is set by the mouse position instead of the keyboard. The character will always
         public void GetInput()
         {
             LookAt(GetGlobalMousePosition());
-            Velocity = Transform.x * Input.GetAxis("down", "up") * Speed;
+            Velocity = Transform.X * Input.GetAxis("down", "up") * Speed;
         }
 
         public override void _PhysicsProcess(double delta)

--- a/tutorials/2d/2d_transforms.rst
+++ b/tutorials/2d/2d_transforms.rst
@@ -80,7 +80,7 @@ coordinates, just multiply in the following order:
 
  .. code-tab:: csharp
 
-    var screenCord = (GetViewportTransform() * GetGlobalTransform()).Xform(localPos);
+    var screenCord = GetViewportTransform() * (GetGlobalTransform() * localPos);
 
 Keep in mind, however, that it is generally not desired to work with
 screen coordinates. The recommended approach is to simply work in Canvas

--- a/tutorials/audio/recording_with_microphone.rst
+++ b/tutorials/audio/recording_with_microphone.rst
@@ -82,7 +82,7 @@ and :ref:`set_recording_active() <class_AudioEffectRecord_method_set_recording_a
 
   .. code-tab:: csharp
 
-    public void OnRecordButtonPressed()
+    private void OnRecordButtonPressed()
     {
         if (_effect.IsRecordingActive())
         {
@@ -126,7 +126,7 @@ the recorded stream can be stored into the ``recording`` variable by calling
 
   .. code-tab:: csharp
 
-    public void OnPlayButtonPressed()
+    private void OnPlayButtonPressed()
     {
         GD.Print(_recording);
         GD.Print(_recording.Format);
@@ -152,7 +152,7 @@ To playback the recording, you assign the recording as the stream of the
 
   .. code-tab:: csharp
 
-    public void OnSavebuttonPressed()
+    private void OnSaveButtonPressed()
     {
         string savePath = GetNode<LineEdit>("SaveButton/Filename").Text;
         _recording.SaveToWav(savePath);

--- a/tutorials/best_practices/godot_interfaces.rst
+++ b/tutorials/best_practices/godot_interfaces.rst
@@ -499,12 +499,11 @@ accesses:
 
     public partial class Child : Node
     {
-        public FuncRef FN = null;
+        public Callable? Callable { get; set; }
 
         public void MyMethod()
         {
-            Debug.Assert(FN != null);
-            FN.CallFunc();
+            Callable?.Call();
         }
     }
 
@@ -513,18 +512,18 @@ accesses:
 
     public partial class Parent : Node
     {
-        public Node Child;
+        private Child _child;
 
         public void _Ready()
         {
-            Child = GetNode("Child");
-            Child.Set("FN", GD.FuncRef(this, "PrintMe"));
-            Child.MyMethod();
+            _child = GetNode<Child>("Child");
+            _child.Callable = Callable.From(PrintMe);
+            _child.MyMethod();
         }
 
         public void PrintMe() {
         {
-            GD.Print(GetClass());
+            GD.Print(Name);
         }
     }
 

--- a/tutorials/best_practices/godot_notifications.rst
+++ b/tutorials/best_practices/godot_notifications.rst
@@ -128,9 +128,9 @@ deltatime methods as needed.
         }
 
         // Called during every input event. Equally true for _input().
-        public void _UnhandledInput(InputEvent event)
+        public void _UnhandledInput(InputEvent @event)
         {
-            switch (event)
+            switch (@event)
             {
                 case InputEventKey:
                     if (Input.IsActionJustPressed("ui_accept"))
@@ -242,7 +242,7 @@ nodes that one might create at runtime.
     var parent_cache
 
     func connection_check():
-        return parent.has_user_signal("interacted_with")
+        return parent_cache.has_user_signal("interacted_with")
 
     func _notification(what):
         match what:
@@ -263,34 +263,34 @@ nodes that one might create at runtime.
 
     public partial class MyNode : Node
     {
-        public Node ParentCache = null;
+        private Node _parentCache;
 
         public void ConnectionCheck()
         {
-            return ParentCache.HasUserSignal("InteractedWith");
+            return _parentCache.HasUserSignal("InteractedWith");
         }
 
         public void _Notification(int what)
         {
             switch (what)
             {
-                case NOTIFICATION_PARENTED:
-                    ParentCache = GetParent();
+                case NotificationParented:
+                    _parentCache = GetParent();
                     if (ConnectionCheck())
                     {
-                        ParentCache.Connect("InteractedWith", OnParentInteractedWith);
+                        _parentCache.Connect("InteractedWith", Callable.From(OnParentInteractedWith));
                     }
                     break;
-                case NOTIFICATION_UNPARENTED:
+                case NotificationUnparented:
                     if (ConnectionCheck())
                     {
-                        ParentCache.Disconnect("InteractedWith", OnParentInteractedWith);
+                        _parentCache.Disconnect("InteractedWith", Callable.From(OnParentInteractedWith));
                     }
                     break;
             }
         }
 
-        public void OnParentInteractedWith()
+        private void OnParentInteractedWith()
         {
             GD.Print("I'm reacting to my parent's interaction!");
         }

--- a/tutorials/math/matrices_and_transforms.rst
+++ b/tutorials/math/matrices_and_transforms.rst
@@ -563,21 +563,21 @@ transformations:
     // The transform is the identity transform.
 
 Transforming a position by a transform and its inverse results in the
-same position (same for "xform_inv"):
+same position:
 
 .. tabs::
  .. code-tab:: gdscript GDScript
 
     var ti = transform.affine_inverse()
-    position = transform.xform(position)
-    position = ti.xform(position)
+    position = transform * position
+    position = ti * position
     # The position is the same as before.
 
  .. code-tab:: csharp
 
     Transform2D ti = Transform.AffineInverse();
-    Position = Transform.Xform(Position);
-    Position = ti.Xform(Position);
+    Position = Transform * Position;
+    Position = ti * Position;
     // The position is the same as before.
 
 How does it all work in 3D?

--- a/tutorials/physics/kinematic_character_2d.rst
+++ b/tutorials/physics/kinematic_character_2d.rst
@@ -65,9 +65,9 @@ or lose precision if the frame rate is too high or too low.
 
     using Godot;
 
-    public partial class PhysicsScript : CharacterBody2D
+    public partial class MyCharacterBody2D : CharacterBody2D
     {
-        public override void _PhysicsProcess(float delta)
+        public override void _PhysicsProcess(double delta)
         {
         }
     }
@@ -129,9 +129,9 @@ So, let's move our sprite downwards until it hits the floor:
 
     using Godot;
 
-    public partial class PhysicsScript : CharacterBody2D
+    public partial class MyCharacterBody2D : CharacterBody2D
     {
-        public override void _PhysicsProcess(float delta)
+        public override void _PhysicsProcess(double delta)
         {
             // Move down 1 pixel per physics frame
             MoveAndCollide(new Vector2(0, 1));
@@ -161,15 +161,17 @@ little more like a regular game character:
 
     using Godot;
 
-    public partial class PhysicsScript : CharacterBody2D
+    public partial class MyCharacterBody2D : CharacterBody2D
     {
-        const float gravity = 200.0f;
+        private const float Gravity = 200.0f;
 
-        public override void _PhysicsProcess(float delta)
+        public override void _PhysicsProcess(double delta)
         {
-            velocity.y += delta * gravity;
+            var velocity = Velocity;
+            velocity.Y += (float)delta * Gravity;
+            Velocity = velocity;
 
-            var motion = velocity * delta;
+            var motion = velocity * (float)delta;
             MoveAndCollide(motion);
         }
     }
@@ -205,30 +207,34 @@ This adds basic support for walking when pressing left and right:
 
     using Godot;
 
-    public partial class PhysicsScript : CharacterBody2D
+    public partial class MyCharacterBody2D : CharacterBody2D
     {
-        const float gravity = 200.0f;
-        const int walkSpeed = 200;
+        private const float Gravity = 200.0f;
+        private const int WalkSpeed = 200;
 
-        public override void _PhysicsProcess(float delta)
+        public override void _PhysicsProcess(double delta)
         {
-            velocity.y += delta * gravity;
+            var velocity = Velocity;
+
+            velocity.Y += (float)delta * Gravity;
 
             if (Input.IsActionPressed("ui_left"))
             {
-                velocity.x = -walkSpeed;
+                velocity.X = -WalkSpeed;
             }
             else if (Input.IsActionPressed("ui_right"))
             {
-                velocity.x = walkSpeed;
+                velocity.X = WalkSpeed;
             }
             else
             {
-                velocity.x = 0;
+                velocity.X = 0;
             }
 
+            Velocity = velocity;
+
             // "MoveAndSlide" already takes delta time into account.
-            MoveAndSlide(velocity, new Vector2(0, -1));
+            MoveAndSlide();
         }
     }
 

--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -378,9 +378,9 @@ occurred:
     {
         private Vector2 _velocity = new Vector2(250, 250);
 
-        public override void _PhysicsProcess(float delta)
+        public override void _PhysicsProcess(double delta)
         {
-            var collisionInfo = MoveAndCollide(_velocity * delta);
+            var collisionInfo = MoveAndCollide(_velocity * (float)delta);
             if (collisionInfo != null)
             {
                 var collisionPoint = collisionInfo.GetPosition();
@@ -410,9 +410,9 @@ Or to bounce off of the colliding object:
     {
         private Vector2 _velocity = new Vector2(250, 250);
 
-        public override void _PhysicsProcess(float delta)
+        public override void _PhysicsProcess(double delta)
         {
-            var collisionInfo = MoveAndCollide(_velocity * delta);
+            var collisionInfo = MoveAndCollide(_velocity * (float)delta);
             if (collisionInfo != null)
                 _velocity = _velocity.Bounce(collisionInfo.Normal);
         }
@@ -473,23 +473,28 @@ the ground (including slopes) and jump when standing on the ground:
 
         private void GetInput()
         {
-            _velocity.x = 0;
+            var velocity = Velocity;
+            velocity.X = 0;
 
             var right = Input.IsActionPressed("ui_right");
             var left = Input.IsActionPressed("ui_left");
             var jump = Input.IsActionPressed("ui_select");
 
             if (IsOnFloor() && jump)
-                _velocity.y = _jumpSpeed;
+                velocity.Y = _jumpSpeed;
             if (right)
-                _velocity.x += _runSpeed;
+                velocity.X += _runSpeed;
             if (left)
-                _velocity.x -= _runSpeed;
+                velocity.X -= _runSpeed;
+
+            Velocity = velocity;
         }
 
-        public override void _PhysicsProcess(float delta)
+        public override void _PhysicsProcess(double delta)
         {
-            _velocity.y += _gravity * delta;
+            var velocity = Velocity;
+            velocity.Y += _gravity * (float)delta;
+            Velocity = velocity;
             GetInput();
             MoveAndSlide();
         }

--- a/tutorials/physics/using_area_2d.rst
+++ b/tutorials/physics/using_area_2d.rst
@@ -82,8 +82,7 @@ use ``area_entered``. However, let's assume our player is a ``CharacterBody2D``
 
     public partial class Coin : Area2D
     {
-
-        public void OnCoinBodyEntered(PhysicsBody2D body)
+        private void OnCoinBodyEntered(PhysicsBody2D body)
         {
             QueueFree();
         }

--- a/tutorials/physics/using_character_body_2d.rst
+++ b/tutorials/physics/using_character_body_2d.rst
@@ -187,8 +187,9 @@ the same collision response:
     var collision = MoveAndCollide(Velocity * (float)delta);
     if (collision != null)
     {
-        velocity = velocity.Slide(collision.GetNormal());
+        Velocity = Velocity.Slide(collision.GetNormal());
     }
+
     // using MoveAndSlide
     MoveAndSlide();
 
@@ -250,14 +251,14 @@ Attach a script to the CharacterBody2D and add the following code:
 
     using Godot;
 
-    public partial class CBExample : CharacterBody2D
+    public partial class MyCharacterBody2D : CharacterBody2D
     {
-        public int Speed = 300;
+        private int _speed = 300;
 
         public void GetInput()
         {
             Vector2 inputDir = Input.GetVector("ui_left", "ui_right", "ui_up", "ui_down");
-            Velocity = inputDir * Speed;
+            Velocity = inputDir * _speed;
         }
 
         public override void _PhysicsProcess(double delta)
@@ -334,16 +335,16 @@ uses the mouse pointer. Here is the code for the Player, using ``move_and_slide(
 
     using Godot;
 
-    public partial class CBExample : CharacterBody2D
+    public partial class MyCharacterBody2D : CharacterBody2D
     {
         private PackedScene _bullet = (PackedScene)GD.Load("res://bullet.tscn");
-        public int Speed = 200;
+        private int _speed = 200;
 
         public void GetInput()
         {
             // Add these actions in Project Settings -> Input Map.
             float inputDir = Input.GetAxis("backward", "forward");
-            Velocity = Transform.x * inputDir * Speed;
+            Velocity = Transform.X * inputDir * _speed;
             if (Input.IsActionPressed("shoot"))
             {
                 Shoot();
@@ -403,7 +404,7 @@ And the code for the Bullet:
 
     public partial class Bullet : CharacterBody2D
     {
-        public int Speed = 750;
+        public int _speed = 750;
 
         public void Start(Vector2 position, float direction)
         {
@@ -425,7 +426,7 @@ And the code for the Bullet:
             }
         }
 
-        public void OnVisibilityNotifier2DScreenExited()
+        private void OnVisibilityNotifier2DScreenExited()
         {
             // Deletes the bullet when it exits the screen.
             QueueFree();
@@ -490,10 +491,10 @@ Here's the code for the player body:
 
     using Godot;
 
-    public partial class CBExample : CharacterBody2D
+    public partial class MyCharacterBody2D : CharacterBody2D
     {
-        public float Speed = 100.0f;
-        public float JumpSpeed = -400.0f;
+        private float _speed = 100.0f;
+        private float _jumpSpeed = -400.0f;
 
         // Get the gravity from the project settings so you can sync with rigid body nodes.
         public float Gravity = ProjectSettings.GetSetting("physics/2d/default_gravity").AsSingle();
@@ -507,11 +508,11 @@ Here's the code for the player body:
 
             // Handle jump.
             if (Input.IsActionJustPressed("jump") && IsOnFloor())
-                velocity.Y = JumpSpeed;
+                velocity.Y = _jumpSpeed;
 
             // Get the input direction.
             Vector2 direction = Input.GetAxis("ui_left", "ui_right");
-            velocity.X = direction * Speed;
+            velocity.X = direction * _speed;
 
             Velocity = velocity;
             MoveAndSlide();

--- a/tutorials/plugins/editor/making_main_screen_plugins.rst
+++ b/tutorials/plugins/editor/making_main_screen_plugins.rst
@@ -134,7 +134,7 @@ Add a script to the button like this:
     [Tool]
     public partial class PrintHello : Button
     {
-        public void OnPrintHelloPressed()
+        private void OnPrintHelloPressed()
         {
             GD.Print("Hello from the main screen plugin!");
         }

--- a/tutorials/scripting/resources.rst
+++ b/tutorials/scripting/resources.rst
@@ -130,7 +130,7 @@ To get an instance of the scene, you have to use the
 
     private PackedScene _bulletScene = (PackedScene)GD.Load("res://bullet.tscn");
 
-    public void OnShoot()
+    private void OnShoot()
     {
         Node bullet = _bulletScene.Instantiate();
         AddChild(bullet);

--- a/tutorials/scripting/singletons_autoload.rst
+++ b/tutorials/scripting/singletons_autoload.rst
@@ -224,7 +224,7 @@ current scene and replace it with the requested one.
         // The solution is to defer the load to a later time, when
         // we can be sure that no code from the current scene is running:
 
-        CallDeferred(nameof(DeferredGotoScene), path);
+        CallDeferred(MethodName.DeferredGotoScene, path);
     }
 
     public void DeferredGotoScene(string path)
@@ -264,7 +264,7 @@ Finally, we need to fill the empty callback functions in the two scenes:
 
     // Add to 'Scene1.cs'.
 
-    public void OnButtonPressed()
+    private void OnButtonPressed()
     {
         var global = GetNode<Global>("/root/Global");
         global.GotoScene("res://scene_2.tscn");
@@ -284,7 +284,7 @@ and
 
     // Add to 'Scene2.cs'.
 
-    public void OnButtonPressed()
+    private void OnButtonPressed()
     {
         var global = GetNode<Global>("/root/Global");
         global.GotoScene("res://scene_1.tscn");


### PR DESCRIPTION
- Rename members that have been renamed in Godot's C# API for 4.0.
- Change `delta` parameter type to `double`.
- Ensure parameters match base declaration.
- Follow our code style more closely.
- Other minor code fixes.
- Follow up to https://github.com/godotengine/godot-docs/pull/6693.

These are some of the things I missed in the first PR. Most of the changes are code style changes to follow our guidelines more closely.