### PR TITLE
Fix wrong navigation agent example code in

### DIFF
--- a/tutorials/navigation/navigation_using_navigationagents.rst
+++ b/tutorials/navigation/navigation_using_navigationagents.rst
@@ -145,14 +145,14 @@ toggle avoidance on agents, create or delete avoidance callbacks or switch avoid
 
     var agent: RID = get_rid()
     # Enable avoidance
-    NavigationServer2D::get_singleton()->agent_set_avoidance_enabled(agent, true)
+    NavigationServer2D.agent_set_avoidance_enabled(agent, true)
     # Create avoidance callback
-    NavigationServer2D::get_singleton()->agent_set_avoidance_callback(agent, self._avoidance_done)
+    NavigationServer2D.agent_set_avoidance_callback(agent, Callable(self, "_avoidance_done"))
 
     # Disable avoidance
-    NavigationServer2D::get_singleton()->agent_set_avoidance_enabled(agent, false)
+    NavigationServer2D.agent_set_avoidance_enabled(agent, false)
     # Delete avoidance callback
-    NavigationServer2D::get_singleton()->agent_set_avoidance_callback(agent, Callable())
+    NavigationServer2D.agent_set_avoidance_callback(agent, Callable())
 
 .. tabs::
  .. code-tab:: gdscript GDScript
@@ -161,18 +161,18 @@ toggle avoidance on agents, create or delete avoidance callbacks or switch avoid
 
     var agent: RID = get_rid()
     # Enable avoidance
-    NavigationServer3D::get_singleton()->agent_set_avoidance_enabled(agent, true)
+    NavigationServer3D.agent_set_avoidance_enabled(agent, true)
     # Create avoidance callback
-    NavigationServer3D::get_singleton()->agent_set_avoidance_callback(agent, self._avoidance_done)
+    NavigationServer3D.agent_set_avoidance_callback(agent, Callable(self, "_avoidance_done"))
     # Switch to 3D avoidance
-    NavigationServer3D::get_singleton()->agent_set_use_3d_avoidance(agent, true)
+    NavigationServer3D.agent_set_use_3d_avoidance(agent, true)
 
     # Disable avoidance
-    NavigationServer3D::get_singleton()->agent_set_avoidance_enabled(agent, false)
+    NavigationServer3D.agent_set_avoidance_enabled(agent, false)
     # Delete avoidance callback
-    NavigationServer3D::get_singleton()->agent_set_avoidance_callback(agent, Callable())
+    NavigationServer3D.agent_set_avoidance_callback(agent, Callable())
     # Switch to 2D avoidance
-    NavigationServer3D::get_singleton()->agent_set_use_3d_avoidance(agent, false)
+    NavigationServer3D.agent_set_use_3d_avoidance(agent, false)
 
 NavigationAgent Script Templates
 --------------------------------


### PR DESCRIPTION
Fixes wrong navigation agent example code.

Kinda silly that the NavigationAgent example code had multiple C++ examples in the GDScript section for months that I copied from the source code when drafting the documentation the first time. Now while updating I drafted again with C++ source code and forgot to change.

Not a single user complain and now it was even changed again with the pr today without fixing it and it passed the pr review.

Every single person involved should pour some ash on their head, including me.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
