### PR TITLE
[4.0] Fix wrong navigation agent example code

### DIFF
--- a/tutorials/navigation/navigation_using_navigationagents.rst
+++ b/tutorials/navigation/navigation_using_navigationagents.rst
@@ -127,10 +127,11 @@ used to create or delete avoidance callbacks for the agent RID.
     extends NavigationAgent2D
 
     var agent: RID = get_rid()
-    # Enable
-    NavigationServer2D::get_singleton()->agent_set_callback(agent, self._avoidance_done)
-    # Disable
-    NavigationServer2D::get_singleton()->agent_set_callback(agent, Callable())
+    # Create avoidance callback
+    NavigationServer2D.agent_set_callback(agent, Callable(self, "_avoidance_done"))
+
+    # Delete avoidance callback
+    NavigationServer2D.agent_set_callback(agent, Callable())
 
 .. tabs::
  .. code-tab:: gdscript GDScript
@@ -138,10 +139,11 @@ used to create or delete avoidance callbacks for the agent RID.
     extends NavigationAgent3D
 
     var agent: RID = get_rid()
-    # Enable
-    NavigationServer3D::get_singleton()->agent_set_callback(agent, self._avoidance_done)
-    # Disable
-    NavigationServer3D::get_singleton()->agent_set_callback(agent, Callable())
+    # Create avoidance callback
+    NavigationServer3D.agent_set_callback(agent, Callable(self, "_avoidance_done"))
+
+    # Delete avoidance callback
+    NavigationServer3D.agent_set_callback(agent, Callable())
 
 NavigationAgent Script Templates
 --------------------------------


### PR DESCRIPTION
Fixes wrong navigation agent example code.

Godot 4.0 version of https://github.com/godotengine/godot-docs/pull/7376

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
