### PR TITLE
Clarify that iOS plugin's files have to be in a very specific directory to work

### DIFF
--- a/tutorials/platform/ios/ios_plugin.rst
+++ b/tutorials/platform/ios/ios_plugin.rst
@@ -27,6 +27,10 @@ When a plugin is active, you can access it in your using ``Engine.get_singleton(
     if Engine.has_singleton("MyPlugin"):
         var singleton = Engine.get_singleton("MyPlugin")
         print(singleton.foo())
+        
+.. note::
+
+   The plugin's files have to be in the ``res://ios/plugins/`` directory or a subdirectory, otherwise the Godot editor will not automatically detect them.      
 
 Creating an iOS plugin
 ----------------------

--- a/tutorials/platform/ios/ios_plugin.rst
+++ b/tutorials/platform/ios/ios_plugin.rst
@@ -27,10 +27,10 @@ When a plugin is active, you can access it in your using ``Engine.get_singleton(
     if Engine.has_singleton("MyPlugin"):
         var singleton = Engine.get_singleton("MyPlugin")
         print(singleton.foo())
-        
+
 .. note::
 
-   The plugin's files have to be in the ``res://ios/plugins/`` directory or a subdirectory, otherwise the Godot editor will not automatically detect them.      
+   The plugin's files have to be in the ``res://ios/plugins/`` directory or a subdirectory, otherwise the Godot editor will not automatically detect them.
 
 Creating an iOS plugin
 ----------------------


### PR DESCRIPTION
I added an additional note to clarify that the plugin's files *have* to be in the specific directory, otherwise it will not work. When developing myself, this was a stumbling block I would like others to be able to avoid.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
