### PR TITLE
Update class_polygon2d.rst

### DIFF
--- a/classes/class_polygon2d.rst
+++ b/classes/class_polygon2d.rst
@@ -438,7 +438,7 @@ Returns the path to the node associated with the specified bone.
 
 :ref:`PackedFloat32Array<class_PackedFloat32Array>` **get_bone_weights** **(** :ref:`int<class_int>` index **)** |const|
 
-Returns the height values of the specified bone.
+Returns the weight values of the specified bone.
 
 .. rst-class:: classref-item-separator
 


### PR DESCRIPTION
Changed 'height' to 'weight' in 'Method Description'

PackedFloat32Array get_bone_weights  ( int index ) const Returns the weight(height) values of the specified bone

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

fixing this Issue: https://github.com/godotengine/godot-docs/issues/7383
