### PR TITLE
Mention that all font sizes in Godot are in pixels, not points in Using fonts

### DIFF
--- a/tutorials/ui/gui_using_fonts.rst
+++ b/tutorials/ui/gui_using_fonts.rst
@@ -145,9 +145,13 @@ property that accepts a Font resource.
 
    Fonts that have a pixel art appearance should have bilinear filtering disabled
    by changing the **Rendering > Textures > Canvas Textures > Default Texture Filter**
-   project setting to **Nearest**. The font size must also be an integer multiple of the
-   design size (which varies on a per-font basis), and the Control node using the font
-   must be scaled by an integer multiple as well. Otherwise, the font may look blurry.
+   project setting to **Nearest**.
+
+   The font size must also be an integer multiple of the design size (which
+   varies on a per-font basis), and the Control node using the font must be
+   scaled by an integer multiple as well. Otherwise, the font may look blurry.
+   Font sizes in Godot are specified in pixels (px), not points (pt). Keep this
+   in mind when comparing font sizes across different software.
 
    The texture filter mode can also be set on individual nodes that inherit from CanvasItem
    by setting :ref:`CanvasItem.texture_filter <class_CanvasItem_property_texture_filter>`.


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-docs/pull/7355.
