### PR TITLE
Update animation_tree.rst to reflect One Shot's C# enums not being li…

### DIFF
--- a/tutorials/animation/animation_tree.rst
+++ b/tutorials/animation/animation_tree.rst
@@ -116,10 +116,10 @@ After setting the request and changing the animation playback, the one-shot node
  .. code-tab:: csharp
 
     // Play child animation connected to "shot" port.
-    animationTree.Set("parameters/OneShot/request", AnimationNodeOneShot.ONE_SHOT_REQUEST_FIRE);
+    animationTree.Set("parameters/OneShot/request", (int) AnimationNodeOneShot.OneShotRequest.Fire);
 
     // Abort child animation connected to "shot" port.
-    animationTree.Set("parameters/OneShot/request", AnimationNodeOneShot.ONE_SHOT_REQUEST_ABORT);
+    animationTree.Set("parameters/OneShot/request", (int) AnimationNodeOneShot.OneShotRequest.Abort);
 
     // Get current state (read-only).
     animationTree.Get("parameters/OneShot/active");


### PR DESCRIPTION
…ke GDScript

One Shot Enums aren't as described and seem to require a cast atm. Might be a better way, but this worked for me and is reasonable

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
