### PR TITLE
Fix vector math tutorial

### DIFF
--- a/tutorials/math/vector_math.rst
+++ b/tutorials/math/vector_math.rst
@@ -232,18 +232,18 @@ Here is a GDScript example of the diagram above using a :ref:`CharacterBody2D
     # object "collision" contains information about the collision
     var collision = move_and_collide(velocity * delta)
     if collision:
-        var reflect = collision.remainder.bounce(collision.normal)
-        velocity = velocity.bounce(collision.normal)
+        var reflect = collision.get_remainder().bounce(collision.get_normal())
+        velocity = velocity.bounce(collision.get_normal())
         move_and_collide(reflect)
 
  .. code-tab:: csharp
 
     // KinematicCollision2D contains information about the collision
-    KinematicCollision2D collision = MoveAndCollide(_velocity * delta);
+    KinematicCollision2D collision = MoveAndCollide(_velocity * (float)delta);
     if (collision != null)
     {
-        var reflect = collision.Remainder.Bounce(collision.Normal);
-        _velocity = _velocity.Bounce(collision.Normal);
+        var reflect = collision.GetRemainder().Bounce(collision.GetNormal());
+        _velocity = _velocity.Bounce(collision.GetNormal());
         MoveAndCollide(reflect);
     }
 


### PR DESCRIPTION
fixes mistakes in the "reflection" code example in both gdscript and c#

cast delta to float in C# example because delta is typed as double and Vector2 cant be multiplied by double as per godotengine/godot#70314
tested in 4.0.2.stable.mono

fixes #7388


<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
