### PR TITLE
Replace incorrect Speed variable in C# snippet in scripting_player_input.rst

### DIFF
--- a/getting_started/step_by_step/scripting_player_input.rst
+++ b/getting_started/step_by_step/scripting_player_input.rst
@@ -102,7 +102,7 @@ velocity. Replace the line starting with ``var velocity`` with the code below.
     var velocity = Vector2.Zero;
     if (Input.IsActionPressed("ui_up"))
     {
-        velocity = Vector2.Up.Rotated(Rotation) * Speed;
+        velocity = Vector2.Up.Rotated(Rotation) * _speed;
     }
 
 We initialize the ``velocity`` with a value of ``Vector2.ZERO``, another


### PR DESCRIPTION
Hi, this PR aims to replace an incorrect variable in [this C# snippet](https://docs.godotengine.org/en/stable/getting_started/step_by_step/scripting_player_input.html#moving-when-pressing-up) from "Step by step / Listening to player input":   
The code used a `Speed` variable instead of `_speed`, which was declared in an earlier part of the tutorial.

Here is the current snippet, with the wrong variable name: 

```c#
var velocity = Vector2.Zero;
if (Input.IsActionPressed("ui_up"))
{
    velocity = Vector2.Up.Rotated(Rotation) * Speed;
}
```

And the complete code at the end of the tutorial, where we can clearly see that the intended name was `_speed`:

```c#
using Godot;

public partial class Sprite : Sprite2D
{
    private float _speed = 400;
    private float _angularSpeed = Mathf.Pi;

    public override void _Process(double delta)
    {
        var direction = 0;
        if (Input.IsActionPressed("ui_left"))
        {
            direction = -1;
        }
        if (Input.IsActionPressed("ui_right"))
        {
            direction = 1;
        }

        Rotation += _angularSpeed * direction * (float)delta;

        var velocity = Vector2.Zero;
        if (Input.IsActionPressed("ui_up"))
        {
            velocity = Vector2.Up.Rotated(Rotation) * _speed;
        }

        Position += velocity * (float)delta;
    }
}
```