### PR TITLE
Change NetworkedMultiplayerENet to ENetMultiplayerPeer in high_level_…

### DIFF
--- a/tutorials/networking/high_level_multiplayer.rst
+++ b/tutorials/networking/high_level_multiplayer.rst
@@ -113,7 +113,7 @@ Initializing as a server, listening on the given port, with a given maximum numb
 
 ::
 
-    var peer = NetworkedMultiplayerENet.new()
+    var peer = ENetMultiplayerPeer.new()
     peer.create_server(SERVER_PORT, MAX_PLAYERS)
     get_tree().network_peer = peer
 
@@ -121,7 +121,7 @@ Initializing as a client, connecting to a given IP and port:
 
 ::
 
-    var peer = NetworkedMultiplayerENet.new()
+    var peer = ENetMultiplayerPeer.new()
     peer.create_client(SERVER_IP, SERVER_PORT)
     get_tree().network_peer = peer
 


### PR DESCRIPTION
Change NetworkedMultiplayerENet to ENetMultiplayerPeer in high_level_multiplayer.rst

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
