### PR TITLE
Update embree library version (embree3-devel) to install for Fedora.

### DIFF
--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -436,7 +436,7 @@ listed in the :ref:`doc_compiling_for_linuxbsd_oneliners`:
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **Fedora**       | ::                                                                                                        |
 |                  |                                                                                                           |
-|                  |     sudo dnf install embree3-devel enet-devel glslang-devel graphite2-devel harfbuzz-devel libicu-devel \  |
+|                  |     sudo dnf install embree3-devel enet-devel glslang-devel graphite2-devel harfbuzz-devel libicu-devel \ |
 |                  |         libsquish-devel libtheora-devel libvorbis-devel libwebp-devel libzstd-devel mbedtls-devel \       |
 |                  |         miniupnpc-devel                                                                                   |
 +------------------+-----------------------------------------------------------------------------------------------------------+

--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -436,7 +436,7 @@ listed in the :ref:`doc_compiling_for_linuxbsd_oneliners`:
 +------------------+-----------------------------------------------------------------------------------------------------------+
 | **Fedora**       | ::                                                                                                        |
 |                  |                                                                                                           |
-|                  |     sudo dnf install embree-devel enet-devel glslang-devel graphite2-devel harfbuzz-devel libicu-devel \  |
+|                  |     sudo dnf install embree3-devel enet-devel glslang-devel graphite2-devel harfbuzz-devel libicu-devel \  |
 |                  |         libsquish-devel libtheora-devel libvorbis-devel libwebp-devel libzstd-devel mbedtls-devel \       |
 |                  |         miniupnpc-devel                                                                                   |
 +------------------+-----------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Update embree library version (embree3-devel) to install for Fedora. You need embree3 to compile Godot from source while using system libraries, otherwise you will get these errors:

```
In file included from modules/raycast/lightmap_raycaster_embree.cpp:33:
modules/raycast/lightmap_raycaster_embree.h:40:10: fatal error: 'embree3/rtcore.h' file not found
#include <embree3/rtcore.h>
         ^~~~~~~~~~~~~~~~~~
1 error generated.
scons: *** [modules/raycast/lightmap_raycaster_embree.linuxbsd.editor.dev.x86_64.llvm.o] Error 1
In file included from modules/raycast/register_types.cpp:33:
modules/raycast/lightmap_raycaster_embree.h:40:10: fatal error: 'embree3/rtcore.h' file not found
#include <embree3/rtcore.h>
         ^~~~~~~~~~~~~~~~~~
In file included from modules/raycast/raycast_occlusion_cull.cpp:31:
modules/raycast/raycast_occlusion_cull.h:43:10: fatal error: 'embree3/rtcore.h' file not found
#include <embree3/rtcore.h>
         ^~~~~~~~~~~~~~~~~~
1 error generated.
scons: *** [modules/raycast/raycast_occlusion_cull.linuxbsd.editor.dev.x86_64.llvm.o] Error 1
1 error generated.
scons: *** [modules/raycast/register_types.linuxbsd.editor.dev.x86_64.llvm.o] Error 1
scons: building terminated because of errors.
```

Command used to build from source ([4.0.3-stable](https://github.com/godotengine/godot/commit/5222a99f5d38cd5346254cefed8f65315bca4fcb)) successfully on Fedora 38
```
scons platform=linuxbsd builtin_embree=no builtin_enet=no builtin_freetype=no builtin_graphite=no builtin_harfbuzz=no builtin_libogg=no builtin_libpng=no builtin_libtheora=no builtin_libvorbis=no builtin_libwebp=no builtin_mbedtls=no builtin_miniupnpc=no builtin_pcre2=no builtin_zlib=no builtin_zstd=no use_llvm=yes linker=lld dev_build=yes dev_mode=yes tests=yes use_lto=yes
```

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
