### PR TITLE
Add information about 3D asset direction conventions to "Importing 3D scenes"

### DIFF
--- a/tutorials/assets_pipeline/importing_scenes.rst
+++ b/tutorials/assets_pipeline/importing_scenes.rst
@@ -29,6 +29,33 @@ Copy the scene file together with the textures and mesh data (if separate) to
 the project repository, then Godot will do a full import when focusing the
 editor window.
 
+3D asset direction conventions
+------------------------------
+
+Godot uses a right-handed, Y-is-up coordinate system, with the -Z axis as
+the camera's forward direction. This is the same as OpenGL. This implies
+that +Z is back, +X is right, and -X is left for a camera.
+
+The convention for 3D assets is to face the opposite direction as the camera,
+so that characters and other assets are facing the camera by default.
+This convention is extremely common in 3D modeling applications, and is
+`codified in glTF as part of the glTF 2.0 specification <https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#coordinate-system-and-units>`.
+This means that for oriented 3D assets (such as characters),
+the +Z axis is the direction of the front, so -Z is the rear,
++X is the left side, and -X is the right side for a 3D asset.
+In Blender, this means that +Y is rear and -Y is front for an asset.
+
+When rotating an oriented 3D asset in Godot, use the ``use_model_front``
+option on the ``look_at`` functions, and use the ``Vector3.MODEL_*``
+constants to perform calculations in the oriented asset's local space.
+
+For assets without an intrinsic front side or forward direction, such as
+a game map or terrain, take note of the cardinal directions instead.
+The convention in Godot and the vast majority of other applications is
+that +X is east and -X is west. Due to Godot's right-handed Y-is-up
+coordinate system, this implies that +Z is south and -Z is north.
+In Blender, this means that +Y is north and -Y is south.
+
 Exporting glTF 2.0 files from Blender (recommended)
 ---------------------------------------------------
 


### PR DESCRIPTION
This PR adds a note to the documentation to explain the different conventions and specifications about orienting 3D assets in Godot. It explains Godot/OpenGL camera directions, Godot/Blender/glTF asset directions, and Godot/Blender cardinal directions. It links to the glTF specification for +Z being codified as asset front. I tried to be careful where I use the words "forward" vs "front" to make things clear.

Why not open this PR earlier: Before we were not certain what would end up in the engine, but now it is fairly certain so now seems like a good time. For example initially there was some push from @TokageItLab to add `GLTF_`* constants and document how glTF works in the core engine. I fully agree that this information must be documented, I just disagreed on it being in the core engine's constants and documentation, so now it can live in the docs repo :)

I'm fully open to feedback on any ways we can make this documentation more clear, concise, and comprehensive. I think we can all agree that coordinate systems are a confusing topic.

The third paragraph in this PR refers to the `use_model_front` option and the `MODEL_`* constants, so it expects that https://github.com/godotengine/godot/pull/75875 and/or https://github.com/godotengine/godot/pull/72842 is merged into the engine.