### PR TITLE
Improve table theming

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -112,7 +112,7 @@
     --copybtn-tooltip-background-color: #24292f;
     --copybtn-box-shadow: 0 1px 0 rgba(27,31,36,0.04), inset 0 1px 0 rgba(255,255,255,0.25);
     --copybtn-border-color-success: #2da44e;
-    
+
     --contribute-background-color: #d7dee8;
     --contribute-text-color: #646e72;
 
@@ -726,7 +726,7 @@ footer {
 
 .rst-content table.docutils,
 .wy-table-bordered-all {
-    border: 4px solid var(--code-border-color);
+    border: none;
 }
 
 .wy-table-bordered-all td,
@@ -734,14 +734,14 @@ footer {
 .rst-content table.docutils td,
 .rst-content table.docutils thead th,
 .rst-content table.field-list thead th {
-    border-bottom: 2px solid var(--code-border-color);
-    border-left: 2px solid var(--code-border-color);
+    border: none;
+    border-left: 1px solid var(--code-border-color);
     padding: 4px 16px;
 }
 
 html.writer-html5 .rst-content table.docutils th {
+    border: none;
     border-bottom: 4px solid var(--code-border-color);
-    border-left: 2px solid var(--code-border-color);
     padding: 8px 16px;
     vertical-align: middle;
 }
@@ -1714,7 +1714,7 @@ p + .classref-constant {
     left: 3.5px;
     top: 3.5px;
     color: var(--copybtn-icon-color);
-    pointer-events: none; 
+    pointer-events: none;
 }
 .highlight button.copybtn.success {
     border-color: var(--copybtn-border-color-success);


### PR DESCRIPTION
- Reduce borders to make tables more modern-looking and compact, which helps with readability on displays with narrow width or low height.

## Preview

### Example 1

#### Dark theme

Before | After
-|-
![Screenshot_20230524_162857](https://github.com/godotengine/godot-docs/assets/180032/a7e5e179-7fdb-4354-8816-628e45570101) | ![Screenshot_20230524_162521](https://github.com/godotengine/godot-docs/assets/180032/0e4229d4-5a41-4357-ad6c-005d317ecb7c)

#### Light theme

Before | After
-|-
![Screenshot_20230524_162919](https://github.com/godotengine/godot-docs/assets/180032/564805b8-b794-427a-aaf7-61a26fd69825) | ![Screenshot_20230524_162609](https://github.com/godotengine/godot-docs/assets/180032/9f6c39a5-a81f-4b92-b7d8-b83a154fdbe4)

### Example 2

#### Dark theme

Before | After
-|-
![Screenshot_20230524_162907](https://github.com/godotengine/godot-docs/assets/180032/8bdc0589-880b-4f93-a581-eb1c22ea25f6) | ![Screenshot_20230524_162514](https://github.com/godotengine/godot-docs/assets/180032/bf74bcb2-685e-47b7-bf2c-07f5e690f3df)

#### Light theme

Before | After
-|-
![Screenshot_20230524_162924](https://github.com/godotengine/godot-docs/assets/180032/58fb7c11-f3fa-445c-91de-d574c57f2b4c) | ![Screenshot_20230524_162603](https://github.com/godotengine/godot-docs/assets/180032/e8daf93f-8399-46d7-b9a9-cefe7d93f744)