### PR TITLE
Update android_plugin.rst  about compatible Android Studio version

### DIFF
--- a/tutorials/platform/android/android_plugin.rst
+++ b/tutorials/platform/android/android_plugin.rst
@@ -52,7 +52,8 @@ Building an Android plugin
 **Prerequisite:** Android Studio is strongly recommended as the IDE to use to create Android plugins. Currently the latest version of Android Studio
 is not compatible with Godot out of the box because it uses a newer version of JDK (via Android Gradle Plugin, AGP) but Godot currently requires JDK 11.
 (see the release notes of `JDK 17 <https://developer.android.com/build/releases/gradle-plugin#jdk-17-agp>`_ and `AGP 8.0 <https://developer.android.com/build/releases/gradle-plugin#8-0-0>`_). However you can configure your Android project to use JDK 11 by setting your project's
-AGP version to 7.6.2 in `File > Project Structure > Project > Android Gradle Plugin Version`.
+AGP version to 7.6.2 in `File > Project Structure > Project > Android Gradle Plugin Version`. Then make sure to set your JDK 11 in 
+`File > Settings > Build, Exection, Deployment > Build Tools > Gradle > Gradle Projects >` **your project** `> Gradle JDK`.
 Or, you can use **Android Studio Electric Eel | 2022.1.1 Patch 2** which is the last release to support JDK 11 out of the box. It can be downloaded from the `Android Studio Archive <https://developer.android.com/studio/archive>`_.
 Alternatively, instead of using Android Studio, you can try adapting the `Godot Google Play Billing <https://github.com/godotengine/godot-google-play-billing>`_ plugin by cloning it and modifying it to fit your project.
 The instructions below assume that you're using Android Studio.

--- a/tutorials/platform/android/android_plugin.rst
+++ b/tutorials/platform/android/android_plugin.rst
@@ -51,7 +51,7 @@ Building an Android plugin
 
 **Prerequisite:** Android Studio is strongly recommended as the IDE to use to create Android plugins. Currently the latest version of Android Studio
 is not compatible with Godot because it requires JDK 17 and Godot requires JDK 11.
-(see release notes `here <https://developer.android.com/build/releases/gradle-plugin#jdk-17-agp>`_ and `here <https://developer.android.com/build/releases/gradle-plugin#8-0-0>`_).
+(see the release notes of `JDK 17 <https://developer.android.com/build/releases/gradle-plugin#jdk-17-agp>`_ and `AGP 8.0 <https://developer.android.com/build/releases/gradle-plugin#8-0-0>`_).
 **Android Studio Electric Eel | 2022.1.1 Patch 2** is the last release to support JDK 11 out of the box. It can be downloaded from the `Android Studio Archive <https://developer.android.com/studio/archive>`_.
 Alternatively, you can try adapting the `Godot Google Play Billing <https://github.com/godotengine/godot-google-play-billing>`_ plugin.
 The instructions below assume that you're using Android Studio.

--- a/tutorials/platform/android/android_plugin.rst
+++ b/tutorials/platform/android/android_plugin.rst
@@ -50,7 +50,7 @@ Building an Android plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Prerequisite:** Android Studio is strongly recommended as the IDE to use to create Android plugins. Currently the latest version of Android Studio
-is not comcompatible with Godot because it requires JDK 17 and Godot requires JDK 11.
+is not compatible with Godot because it requires JDK 17 and Godot requires JDK 11.
 (see release notes `here <https://developer.android.com/build/releases/gradle-plugin#jdk-17-agp>`_ and `here <https://developer.android.com/build/releases/gradle-plugin#8-0-0>`_).
 **Android Studio Electric Eel | 2022.1.1 Patch 2** is the last release to support JDK 11 out of the box. It can be downloaded from the `Android Studio Archive <https://developer.android.com/studio/archive>`_.
 Alternatively, you can try adapting the `Godot Google Play Billing <https://github.com/godotengine/godot-google-play-billing>`_ plugin.

--- a/tutorials/platform/android/android_plugin.rst
+++ b/tutorials/platform/android/android_plugin.rst
@@ -50,10 +50,11 @@ Building an Android plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Prerequisite:** Android Studio is strongly recommended as the IDE to use to create Android plugins. Currently the latest version of Android Studio
-is not compatible with Godot because it requires JDK 17 and Godot requires JDK 11.
-(see the release notes of `JDK 17 <https://developer.android.com/build/releases/gradle-plugin#jdk-17-agp>`_ and `AGP 8.0 <https://developer.android.com/build/releases/gradle-plugin#8-0-0>`_).
-**Android Studio Electric Eel | 2022.1.1 Patch 2** is the last release to support JDK 11 out of the box. It can be downloaded from the `Android Studio Archive <https://developer.android.com/studio/archive>`_.
-Alternatively, you can try adapting the `Godot Google Play Billing <https://github.com/godotengine/godot-google-play-billing>`_ plugin.
+is not compatible with Godot out of the box because it uses a newer version of JDK (via Android Gradle Plugin, AGP) but Godot currently requires JDK 11.
+(see the release notes of `JDK 17 <https://developer.android.com/build/releases/gradle-plugin#jdk-17-agp>`_ and `AGP 8.0 <https://developer.android.com/build/releases/gradle-plugin#8-0-0>`_). However you can configure your Android project to use JDK 11 by setting your project's
+AGP version to 7.6.2 in `File > Project Structure > Project > Android Gradle Plugin Version`.
+Or, you can use **Android Studio Electric Eel | 2022.1.1 Patch 2** which is the last release to support JDK 11 out of the box. It can be downloaded from the `Android Studio Archive <https://developer.android.com/studio/archive>`_.
+Alternatively, instead of using Android Studio, you can try adapting the `Godot Google Play Billing <https://github.com/godotengine/godot-google-play-billing>`_ plugin by cloning it and modifying it to fit your project.
 The instructions below assume that you're using Android Studio.
 
 1. Follow `these instructions <https://developer.android.com/studio/projects/android-library>`__ to create an Android library module for your plugin.

--- a/tutorials/platform/android/android_plugin.rst
+++ b/tutorials/platform/android/android_plugin.rst
@@ -49,8 +49,12 @@ with the following caveats:
 Building an Android plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-**Prerequisite:** `Android Studio <https://developer.android.com/studio>`_ is strongly recommended as the IDE to use to create Android plugins.
-The instructions below assumes that you're using Android Studio.
+**Prerequisite:** Android Studio is strongly recommended as the IDE to use to create Android plugins. Currently the latest version of Android Studio
+is not comcompatible with Godot because it requires JDK 17 and Godot requires JDK 11.
+(see release notes `here <https://developer.android.com/build/releases/gradle-plugin#jdk-17-agp>`_ and `here <https://developer.android.com/build/releases/gradle-plugin#8-0-0>`_).
+**Android Studio Electric Eel | 2022.1.1 Patch 2** is the last release to support JDK 11 out of the box. It can be downloaded from the `Android Studio Archive <https://developer.android.com/studio/archive>`_.
+Alternatively, you can try adapting the `Godot Google Play Billing <https://github.com/godotengine/godot-google-play-billing>`_ plugin.
+The instructions below assume that you're using Android Studio.
 
 1. Follow `these instructions <https://developer.android.com/studio/projects/android-library>`__ to create an Android library module for your plugin.
 


### PR DESCRIPTION
Android Studio Flamingo no longer supports JDK 11. Update documentation to suggest using Electric Eel. Also document possibility of adapting Godot Google Play Billing project as an alternative to Android Studio. https://github.com/godotengine/godot-docs/issues/7395
