### PR TITLE
Fix compute_shaders.rst C# code snippets to compile

### DIFF
--- a/tutorials/shaders/compute_shaders.rst
+++ b/tutorials/shaders/compute_shaders.rst
@@ -185,8 +185,8 @@ and create a precompiled version of it using this:
 
     // Load GLSL shader
     var shaderFile = GD.Load<RDShaderFile>("res://compute_example.glsl");
-    var shaderBytecode = shaderFile.GetSpirv();
-    var shader = rd.ShaderCreateFromSpirv(shaderBytecode);
+    var shaderBytecode = shaderFile.GetSpirV();
+    var shader = rd.ShaderCreateFromSpirV(shaderBytecode);
 
 
 Provide input data
@@ -356,11 +356,11 @@ the data and print the results to our console.
  .. code-tab:: csharp
 
     // Read back the data from the buffers
-    var outputBytes = rd.BufferGetData(outputBuffer);
+    var outputBytes = rd.BufferGetData(buffer);
     var output = new float[input.Length];
     Buffer.BlockCopy(outputBytes, 0, output, 0, outputBytes.Length);
-    GD.Print("Input: ", input)
-    GD.Print("Output: ", output)
+    GD.Print("Input: ", input);
+    GD.Print("Output: ", output);
 
 With that, you have everything you need to get started working with compute
 shaders.

--- a/tutorials/shaders/compute_shaders.rst
+++ b/tutorials/shaders/compute_shaders.rst
@@ -359,8 +359,8 @@ the data and print the results to our console.
     var outputBytes = rd.BufferGetData(buffer);
     var output = new float[input.Length];
     Buffer.BlockCopy(outputBytes, 0, output, 0, outputBytes.Length);
-    GD.Print("Input: ", input);
-    GD.Print("Output: ", output);
+    GD.Print("Input: ", string.Join(", ", input));
+    GD.Print("Output: ", string.Join(", ", output));
 
 With that, you have everything you need to get started working with compute
 shaders.


### PR DESCRIPTION
The code in C# examples for [Compute Shaders](https://docs.godotengine.org/en/stable/tutorials/shaders/compute_shaders.html) page don't actually compile.

Updated to work:
- `Spirv` -> `SpirV`
- `outputBuffer` -> `buffer`
- Can't directly print arrays - need to join as a string.

Output after updates in this patch:
```
Input: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
Output: 2, 4, 6, 8, 10, 12, 14, 16, 18, 20
```

Modifies the original work submitted in: https://github.com/godotengine/godot-docs/pull/6159

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
