### PR TITLE
Update pygments to 2.15.1 and restore fixed shader syntax highlighting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # https://github.com/readthedocs/readthedocs.org/blob/master/requirements/docs.txt
 
 # Base dependencies
-pygments==2.14.0
+pygments==2.15.1
 
 # Sphinx base and RTD theme.
 sphinx==4.4.0

--- a/tutorials/shaders/shader_reference/shader_preprocessor.rst
+++ b/tutorials/shaders/shader_reference/shader_preprocessor.rst
@@ -61,8 +61,7 @@ anywhere within the shader (including in uniform hints).
 ``#define`` can also be used to insert arbitrary shader code at any location,
 while constants can't do that.
 
-.. FIXME: An upstream bug (https://github.com/pygments/pygments/pull/2350), fixed but not published yet.
-.. code-block:: none
+.. code-block:: glsl
 
     shader_type spatial;
 

--- a/tutorials/shaders/shaders_style_guide.rst
+++ b/tutorials/shaders/shaders_style_guide.rst
@@ -346,8 +346,7 @@ the console, extra indentation should **not** be added within ``#if``,
 
 **Bad**:
 
-.. FIXME: An upstream bug in Pygment related to #ifdef.
-.. code-block:: none
+.. code-block:: glsl
 
     #define heightmap_enabled
 


### PR DESCRIPTION
Updates pygments to 2.15.1 now that PR's https://github.com/pygments/pygments/pull/2350 and https://github.com/pygments/pygments/pull/2357 have been merged and tested in the wild for a while. Also restores the GLSL syntax highlighting to the previously buggy codeblocks that those PR's fixed.

I did a clean build and everything seems to work with no warnings or errors. If  you are testing locally, remember to upgrade your packages (`pip install -U -r requirements.txt` or pip3).

![code](https://github.com/godotengine/godot-docs/assets/22456603/12ab4673-e432-40ea-a77d-c742819abbd2)
