### PR TITLE
update get_tree().get_root and GetTree().GetRoot()

### DIFF
--- a/tutorials/inputs/handling_quit_requests.rst
+++ b/tutorials/inputs/handling_quit_requests.rst
@@ -78,7 +78,7 @@ program termination, you should send the notification yourself:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    get_tree().get_root().propagate_notification(NOTIFICATION_WM_CLOSE_REQUEST)
+    get_tree().root.propagate_notification(NOTIFICATION_WM_CLOSE_REQUEST)
 
  .. code-tab:: csharp
 

--- a/tutorials/rendering/multiple_resolutions.rst
+++ b/tutorials/rendering/multiple_resolutions.rst
@@ -109,7 +109,7 @@ little easier. The :ref:`Viewport <class_Viewport>`
 node has several functions to handle resizing, and the root node of the
 scene tree is always a viewport (scenes loaded are instanced as a child
 of it, and it can always be accessed by calling
-``get_tree().get_root()`` or ``get_node("/root")``).
+``get_tree().root`` or ``get_node("/root")``).
 
 In any case, while changing the root Viewport params is probably the
 most flexible way to deal with the problem, it can be a lot of work,

--- a/tutorials/scripting/change_scenes_manually.rst
+++ b/tutorials/scripting/change_scenes_manually.rst
@@ -17,7 +17,7 @@ scenes which one instances and adds to the tree at runtime:
     func _add_a_scene_manually():
         # This is like autoloading the scene, only
         # it happens after already loading the main scene.
-        get_tree().get_root().add_child(simultaneous_scene)
+        get_tree().root.add_child(simultaneous_scene)
 
  .. code-tab:: csharp
 
@@ -32,7 +32,7 @@ scenes which one instances and adds to the tree at runtime:
     {
         // This is like autoloading the scene, only
         // it happens after already loading the main scene.
-        GetTree().GetRoot().AddChild(simultaneousScene);
+        GetTree().Root.AddChild(simultaneousScene);
     }
 
 To complete the cycle and swap out the new scene with the old one,
@@ -124,11 +124,11 @@ a scene's data between scene changes (adding the scene to the root node).
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-        get_tree().get_root().add_child(scene)
+        get_tree().root.add_child(scene)
 
  .. code-tab:: csharp
 
-        GetTree().GetRoot().AddChild(scene);
+        GetTree().Root.AddChild(scene);
 
 Perhaps instead they wish to display multiple scenes at the same time using
 :ref:`SubViewportContainers <class_SubViewportContainer>`. This is optimal in

--- a/tutorials/scripting/scene_tree.rst
+++ b/tutorials/scripting/scene_tree.rst
@@ -69,12 +69,12 @@ two different ways:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-        get_tree().get_root() # Access via scene main loop.
+        get_tree().root # Access via scene main loop.
         get_node("/root") # Access via absolute path.
 
  .. code-tab:: csharp
 
-        GetTree().GetRoot(); // Access via scene main loop.
+        GetTree().Root // Access via scene main loop.
         GetNode("/root"); // Access via absolute path.
 
 This node contains the main viewport. Anything that is a child of a


### PR DESCRIPTION
fixes #7431 
Deletes get_tree().get_root and GetTree().GetRoot(), changing it to get_tree().root and GetTree().Root respectively in the next files:

- handling quit requests

- multiple resolutions

- change scenes manually

- scene tree

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
