### PR TITLE
Update Sphinx and requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,16 +6,16 @@
 pygments==2.15.1
 
 # Sphinx base and RTD theme.
-sphinx==4.4.0
-sphinx_rtd_theme==1.1.1
+sphinx==5.0.2
+sphinx_rtd_theme==1.2.1
 
 # Sphinx extensions.
 
 # Code tabs extension to display codeblocks in different languages as tabs.
-sphinx-tabs==3.4.0
+sphinx-tabs==3.4.1
 # Adds a 'copy' button to the right of codeblocks.
-sphinx-copybutton==0.5.1
+sphinx-copybutton==0.5.2
 # Custom 404 error page (more useful than the default).
 sphinx-notfound-page==0.8.3
 # Adds Open Graph tags in the HTML `<head>` tag.
-sphinxext-opengraph==0.7.5
+sphinxext-opengraph==0.8.2


### PR DESCRIPTION
In the vein of https://github.com/godotengine/godot-docs/pull/7436, this is a start on updating the version of Sphinx and its requirements we're using as everything is getting kinda old (we use Sphinx 4.x, current is 7.x; this PR updates it to 5.x at least).

Updating to Sphinx 6.x currently seems to break some things (like the sidebar menu toggling) which we need to investigate.

Checked in a local build:
- General build and layout
- Sidebar menu
- Images
- Code tabs
- Code highlighting

Things that seem iffy/may need testing:
- Search

Supersedes https://github.com/godotengine/godot-docs/pull/6575, https://github.com/godotengine/godot-docs/pull/6755, https://github.com/godotengine/godot-docs/pull/6749
Sphinx changelog: https://www.sphinx-doc.org/en/master/changes.html#release-5-0-2-released-jun-17-2022