### PR TITLE
Fix NavigationLink doc using old property names

### DIFF
--- a/tutorials/navigation/navigation_using_navigationlinks.rst
+++ b/tutorials/navigation/navigation_using_navigationlinks.rst
@@ -5,7 +5,7 @@ Using NavigationLinks
 
 .. image:: img/nav_navmesh_links.png
 
-NavigationLinks are used to connect navmesh polygons from :ref:`NavigationRegion2D<class_NavigationRegion2D>` 
+NavigationLinks are used to connect navigation mesh polygons from :ref:`NavigationRegion2D<class_NavigationRegion2D>` 
 and :ref:`NavigationRegion3D<class_NavigationRegion3D>` over arbitrary distances for pathfinding.
 
 NavigationLinks are also used to consider movement shortcuts in pathfinding available through 
@@ -15,7 +15,7 @@ interacting with gameplay objects e.g. ladders, jump pads or teleports.
 :ref:`NavigationLink2D<class_NavigationLink2D>` and 
 :ref:`NavigationLink3D<class_NavigationLink3D>` respectively.
 
-Different NavigationRegions can connect their navmeshes without the need for a NavigationLink 
+Different NavigationRegions can connect their navigation meshes without the need for a NavigationLink 
 as long as they are within navigation map ``edge_connection_margin`` and have compatible ``navigation_layers``.
 As soon as the distance becomes too large, building valid connections becomes a problem - a problem that NavigationLinks can solve.
 
@@ -26,17 +26,17 @@ See :ref:`doc_navigation_connecting_navmesh` to learn more about how to connect 
 
 NavigationLinks share many properties with NavigationRegions like ``navigation_layers``.
 NavigationLinks add a single connection between two positions over an arbitrary distance 
-compared to NavigationRegions that add a more local traversable area with a navmesh resource.
+compared to NavigationRegions that add a more local traversable area with a navigation mesh resource.
 
-NavigationLinks have a ``start_location`` and ``end_location`` and can go in both directions when ``bidirectional`` is enabled.
-When placed a navigationlink connects the navmesh polygons closest to its ``start_location`` and ``end_location`` within search radius for pathfinding.
+NavigationLinks have a ``start_position`` and ``end_position`` and can go in both directions when ``bidirectional`` is enabled.
+When placed a navigationlink connects the navigation mesh polygons closest to its ``start_position`` and ``end_position`` within search radius for pathfinding.
 
 The polygon search radius can be configured globally in the ProjectSettings under ``navigation/2d_or_3d/default_link_connection_radius`` 
 or set for each navigation ``map`` individually using the ``NavigationServer.map_set_link_connection_radius()`` function.
 
-Both ``start_location`` and ``end_location`` have debug markers in the Editor.
+Both ``start_position`` and ``end_position`` have debug markers in the Editor.
 The visible radius of a position shows the polygon search radius. 
-All navmesh polygons inside are compared and the closest is picked for the edge connection.
+All navigation mesh polygons inside are compared and the closest is picked for the edge connection.
 If no valid polygon is found within the search radius the navigation link gets disabled.
 
 .. image:: img/nav_link_debug_visuals.png


### PR DESCRIPTION
Fixes NavigationLink doc using old property names.

The properties that use `location` were renamed to `position` a while ago.
The term `navmesh` mixed with mentions of navigation meshes confused some users so it gets streamlined to just `navigation mesh`.

Could be backported to Godot 4.0 docs.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
