### PR TITLE
Fix noise example code (`Identifier "NoiseType" not declared in the current scope.`)

### DIFF
--- a/tutorials/math/random_number_generation.rst
+++ b/tutorials/math/random_number_generation.rst
@@ -445,7 +445,7 @@ terrain. Godot provides :ref:`class_fastnoiselite` for this, which supports
     func _ready():
         randomize()
         # Configure the FastNoiseLite instance.
-        _noise.noise_type = NoiseType.TYPE_SIMPLEX_SMOOTH
+        _noise.noise_type = FastNoiseLite.NoiseType.TYPE_SIMPLEX_SMOOTH
         _noise.seed = randi()
         _noise.fractal_octaves = 4
         _noise.frequency = 1.0 / 20.0


### PR DESCRIPTION
Fixes 'Identifier "NoiseType" not declared in the current scope' when following example: https://docs.godotengine.org/en/stable/tutorials/math/random_number_generation.html#random-noise

<img width="685" alt="Screenshot 2023-06-01 at 20 39 08" src="https://github.com/godotengine/godot-docs/assets/3775267/b9215c72-f8d5-4cc9-8eef-4bf2119ef28e">


<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
