### PR TITLE
Replace references to interpolate_baked with sample_baked.

### DIFF
--- a/tutorials/math/beziers_and_curves.rst
+++ b/tutorials/math/beziers_and_curves.rst
@@ -262,7 +262,7 @@ Traversal at constant speed, then, can be done with the following pseudo-code:
 
     func _process(delta):
         t += delta
-        position = curve.interpolate_baked(t * curve.get_baked_length(), true)
+        position = curve.sample_baked(t * curve.get_baked_length(), true)
 
  .. code-tab:: csharp
 
@@ -271,7 +271,7 @@ Traversal at constant speed, then, can be done with the following pseudo-code:
     public override void _Process(double delta)
     {
         _t += (float)delta;
-        Position = curve.InterpolateBaked(_t * curve.GetBakedLength(), true);
+        Position = curve.SampleBaked(_t * curve.GetBakedLength(), true);
     }
 
 And the output will, then, move at constant speed:


### PR DESCRIPTION
It looks like this method was renamed in v4, but not fully updated in beziers_and_curves.rst.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
