### PR TITLE
Fix issue with Algolia's docsearch object being missing in pages with tabs

### DIFF
--- a/_static/js/algolia.js
+++ b/_static/js/algolia.js
@@ -3,6 +3,11 @@
 
     var doc_version = document.querySelector('meta[name="doc_version"]').getAttribute('content');
 
+    // If the current page uses tabs, we will need this small patch
+    if (typeof(docsearch) == 'undefined') {
+        docsearch = exports['docsearch'];
+    }
+
     // Initialize the Algolia search widget
     docsearch({
         apiKey: 'c39cb614363a2a156811478bc2d0573b',


### PR DESCRIPTION
Fixes issue https://github.com/godotengine/godot-docs/issues/7469