### PR TITLE
Mark cutout_animation as outdated

### DIFF
--- a/tutorials/animation/cutout_animation.rst
+++ b/tutorials/animation/cutout_animation.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_cutout_animation:
 
 Cutout animation


### PR DESCRIPTION
This tutorial no longer works in Godot 4.x after the Skeletons section.

https://github.com/godotengine/godot-docs/issues/7279 
https://github.com/godotengine/godot-docs/issues/6388

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
