### PR TITLE
Document `-j auto` in Building the manual

### DIFF
--- a/contributing/documentation/building_the_manual.rst
+++ b/contributing/documentation/building_the_manual.rst
@@ -154,6 +154,11 @@ If you have at least 16 GB of RAM, you can speed up compilation by running:
 
             make html SPHINXOPTS=-j2
 
+You can use ``-j auto`` to use all available CPU threads, but this can use a lot
+of RAM if you have a lot of CPU threads. For instance, on a system with 32 CPU
+threads, ``-j auto`` (which corresponds to ``-j 32`` here) can require 20+ GB of
+RAM for Sphinx alone.
+
 Specifying a list of files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
I was considering defaulting to `-j2` or even `-j3`, but Windows systems with 8 GB of RAM would likely struggle with this.

In the meantime, it's worth documenting Sphinx's `-j auto` for people with lots of RAM. On a system with 32 threads, a full clean `make html` build can peak to more than 20 GB of RAM for Sphinx itself:

![image](https://github.com/godotengine/godot-docs/assets/180032/9ab68861-dfde-443f-923e-994cc29048b9)

With `-j auto` on an Intel Core i9-13900K, the documentation builds in 1m16s, whereas `-j4` requires 4m15s.