### PR TITLE
Added note near top of license compliance section regarding contribution. 

### DIFF
--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -16,6 +16,13 @@ distribute the software (and derivative projects, including games made with it).
 Your game or project can have a different license, but it still needs to comply
 with the original one.
 
+.. note::
+
+    This section covers compliance with licenses from a user perspective.
+    If you are interested in licence complience as a contributor, please see
+    the last two paragraphs of the "Best Practices for Engine Contributors",
+    found in the "Engine Development" section, found under "Contributing".
+
 .. warning::
 
     In your project's credits screen, remember to also list third-party notices

--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -19,8 +19,8 @@ with the original one.
 .. note::
 
     This section covers compliance with licenses from a user perspective.
-    If you are interested in licence compliance as a contributor, please see
-    the last two paragraphs of :ref:`Best Practices for Engine Contributors <doc_best_practices_for_engine_contributors>`
+    If you are interested in licence compliance as a contributor, you can find
+    guidelines :ref:`here. <doc_best_practices_for_engine_contributors_license_compliance>`
 
 .. warning::
 

--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -20,7 +20,7 @@ with the original one.
 
     This section covers compliance with licenses from a user perspective.
     If you are interested in licence compliance as a contributor, you can find
-    guidelines :ref:`here. <doc_best_practices_for_engine_contributors_license_compliance>`
+    guidelines :ref:`here <doc_best_practices_for_engine_contributors_license_compliance>`.
 
 .. warning::
 

--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -20,8 +20,7 @@ with the original one.
 
     This section covers compliance with licenses from a user perspective.
     If you are interested in licence complience as a contributor, please see
-    the last two paragraphs of the "Best Practices for Engine Contributors",
-    found in the "Engine Development" section, found under "Contributing".
+    the last two paragraphs of :ref:`Best Practices for Engine Contributors <doc_best_practices_for_engine_contributors>`
 
 .. warning::
 

--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -19,7 +19,7 @@ with the original one.
 .. note::
 
     This section covers compliance with licenses from a user perspective.
-    If you are interested in licence complience as a contributor, please see
+    If you are interested in licence compliance as a contributor, please see
     the last two paragraphs of :ref:`Best Practices for Engine Contributors <doc_best_practices_for_engine_contributors>`
 
 .. warning::

--- a/contributing/development/best_practices_for_engine_contributors.rst
+++ b/contributing/development/best_practices_for_engine_contributors.rst
@@ -227,10 +227,10 @@ link libraries dynamically. Instead, we bundle them in our source tree.
 .. image:: img/best_practices8.png
 
 As a result, we are very picky with what goes in, and we tend to prefer smaller
-libraries (in fact, single header ones are our favorite). Only in cases where
-there is no other choice we end up bundling something larger.
+libraries (single header ones are our favorite). We will only bundle something
+larger if there is no other choice.
 
-Also, libraries must use a permissive enough license to be included into Godot.
+Libraries must use a permissive enough license to be included into Godot.
 Some examples of acceptable licenses are Apache 2.0, BSD, MIT, ISC, and MPL 2.0.
 In particular, we cannot accept libraries licensed under the GPL or LGPL since
 these licenses effectively disallow static linking in proprietary software

--- a/contributing/development/best_practices_for_engine_contributors.rst
+++ b/contributing/development/best_practices_for_engine_contributors.rst
@@ -230,6 +230,8 @@ As a result, we are very picky with what goes in, and we tend to prefer smaller
 libraries (single header ones are our favorite). We will only bundle something
 larger if there is no other choice.
 
+.. _doc_best_practices_for_engine_contributors_license_compliance:
+
 Libraries must use a permissive enough license to be included into Godot.
 Some examples of acceptable licenses are Apache 2.0, BSD, MIT, ISC, and MPL 2.0.
 In particular, we cannot accept libraries licensed under the GPL or LGPL since

--- a/contributing/development/best_practices_for_engine_contributors.rst
+++ b/contributing/development/best_practices_for_engine_contributors.rst
@@ -236,5 +236,5 @@ In particular, we cannot accept libraries licensed under the GPL or LGPL since
 these licenses effectively disallow static linking in proprietary software
 (which Godot is distributed as in most exported projects). This requirement also
 applies to the editor, since we may want to run it on iOS in the long term.
-Since iOS doesn't support dynamic linking, static linking the only option on
+Since iOS doesn't support dynamic linking, static linking is the only option on
 that platform.


### PR DESCRIPTION
I had a difficult time searching the docs for license compliance from an Engine contribution perspective.  Initially, I didn't realize that the About section Complying with Licenses tab only covers license compliance from a user perspective.  It took some time and digging to locate the information on license compliance as an Engine contributor.  I added a note at the top of the Complying with Licenses section specifying that the page is strictly in regards to user-side compliance and offers a link to the page with the info on license compliance as a contributor.

I also made some grammatical adjustments to the last two paragraphs in the "Best Practices for Engine Contributors" page.