### PR TITLE
Set godot-cpp branch to 4.0 in GDExtension tutorial in master and stable version

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -58,7 +58,7 @@ Alternatively, you can also clone it to the project folder:
 
     mkdir gdextension_cpp_example
     cd gdextension_cpp_example
-    git clone -b master https://github.com/godotengine/godot-cpp
+    git clone -b 4.0 https://github.com/godotengine/godot-cpp
 
 .. note::
 


### PR DESCRIPTION
This PR sets the branch of godot-cpp for the GDExtension tutorial everywhere to `4.0`.
For this, this PR need to be cherry-picked to `stable` as well (4.0 version is fixed already)

For reference the different versions:
<details>
<summary>
Latest docs
</summary>

![image](https://github.com/godotengine/godot-docs/assets/38077837/0f9a62e8-2548-48ed-97cf-2d64091dc810)
</details>

<details>
<summary>
Stable docs
</summary>

![image](https://github.com/godotengine/godot-docs/assets/38077837/07ec6dd3-e973-4db5-b8b3-06816bb35664)
</details>

<details>
<summary>
Stable docs
</summary>

![image](https://github.com/godotengine/godot-docs/assets/38077837/44236c62-610d-415a-9126-fcef6b25e7ef)
</details>

