### PR TITLE
Fix typo in resolution_scaling.rst

### DIFF
--- a/tutorials/3d/resolution_scaling.rst
+++ b/tutorials/3d/resolution_scaling.rst
@@ -34,7 +34,7 @@ settings in your in-game menus.
 Resolution scaling options
 --------------------------
 
-In the advanced Project Settings' **Rendering > Scaling 3D** section, you cany
+In the advanced Project Settings' **Rendering > Scaling 3D** section, you can
 find several options for 3D resolution scaling:
 
 Scaling mode


### PR DESCRIPTION
Fixes typo by removing erroneous letter `y`. `cany` -> `can`.

Typo is located here: https://docs.godotengine.org/en/latest/tutorials/3d/resolution_scaling.html#:~:text=3D%20section%2C%20you-,cany,-find%20several%20options

Thank you for such a great game engine!

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
