### PR TITLE
Add support for user-provided comments with Giscus

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -66,6 +66,35 @@
   {% endif %}
 
   {% block body %}{% endblock %}
+
+{% if (not meta or meta.get('allow_comments') != 'False') and godot_show_article_comments %}
+<hr>
+<h2>User-contributed notes</h2>
+<p>
+  <em>Please read the <a href="https://github.com/godotengine/godot-docs-user-notes/discussions/1">User-contributed notes policy</a> before submitting a comment.</em>
+</p>
+{# Use https://giscus.app/ to regenerate the script tag if needed. #}
+{# data-term is set to be language-independent and version-independent, so that comments can be centralized for each page. #}
+{# This increases the likelihood that users will encounter comments on less frequently visited pages. #}
+<script src="https://giscus.app/client.js"
+  data-repo="godotengine/godot-docs-user-notes"
+  data-repo-id="R_kgDOKuNx0w"
+  data-category="User-contributed notes"
+  data-category-id="DIC_kwDOKuNx084CbANb"
+  data-mapping="specific"
+  data-term="{{ pagename }}"
+  data-strict="1"
+  data-reactions-enabled="0"
+  data-emit-metadata="0"
+  data-input-position="bottom"
+  data-theme="preferred_color_scheme"
+  data-lang="en"
+  data-loading="lazy"
+  crossorigin="anonymous"
+  async></script>
+<br>
+{% endif %}
+
 {%- if self.comments()|trim %}
   <div class="articleComments">
     {%- block comments %}{% endblock %}

--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. _doc_complying_with_licenses:
 
 Complying with licenses

--- a/about/docs_changelog.rst
+++ b/about/docs_changelog.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. _doc_docs_changelog:
 
 Documentation changelog

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. meta::
     :keywords: FAQ
 

--- a/about/introduction.rst
+++ b/about/introduction.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. _doc_about_intro:
 
 Introduction

--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. _doc_list_of_features:
 
 List of features

--- a/about/release_policy.rst
+++ b/about/release_policy.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. _doc_release_policy:
 
 Godot release policy

--- a/community/asset_library/index.rst
+++ b/community/asset_library/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Asset Library
 =============
 

--- a/conf.py
+++ b/conf.py
@@ -196,6 +196,8 @@ html_context = {
     "godot_version": "4.3",
     # Enables a banner that displays the up-to-date status of each article.
     "godot_show_article_status": True,
+    # Display user-contributed notes at the bottom of pages that don't have `:allow_comments: False` at the top.
+    "godot_show_article_comments": on_rtd and not is_i18n,
 }
 
 html_logo = "img/docs_logo.svg"

--- a/contributing/development/compiling/index.rst
+++ b/contributing/development/compiling/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Building from source
 ====================
 

--- a/contributing/development/configuring_an_ide/index.rst
+++ b/contributing/development/configuring_an_ide/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. _doc_configuring_an_ide:
 
 Configuring an IDE

--- a/contributing/development/core_and_modules/index.rst
+++ b/contributing/development/core_and_modules/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Engine core and modules
 =======================
 

--- a/contributing/development/debugging/index.rst
+++ b/contributing/development/debugging/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Debugging and profiling
 =======================
 

--- a/contributing/development/debugging/vulkan/index.rst
+++ b/contributing/development/debugging/vulkan/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Vulkan
 ======
 

--- a/contributing/development/editor/index.rst
+++ b/contributing/development/editor/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Editor development
 ==================
 

--- a/contributing/development/file_formats/index.rst
+++ b/contributing/development/file_formats/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Godot file formats
 ==================
 

--- a/contributing/development/index.rst
+++ b/contributing/development/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. _doc_contributing_to_the_engine:
 
 Engine development

--- a/contributing/documentation/index.rst
+++ b/contributing/documentation/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. _doc_contributing_writing_documentation:
 
 Writing documentation

--- a/contributing/workflow/index.rst
+++ b/contributing/workflow/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. _doc_contributing_workflow:
 
 Contribution workflow

--- a/getting_started/first_2d_game/index.rst
+++ b/getting_started/first_2d_game/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. _doc_your_first_2d_game:
 
 Your first 2D game

--- a/getting_started/first_3d_game/index.rst
+++ b/getting_started/first_3d_game/index.rst
@@ -1,3 +1,4 @@
+:allow_comments: False
 :article_outdated: True
 
 .. _doc_your_first_3d_game:

--- a/getting_started/introduction/index.rst
+++ b/getting_started/introduction/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. Intention: provide the necessary information to make the most of the getting
    started series, answering questions like "do I want to learn Godot?", "how
    does it look and feel?", "how does it work?", and "how do I best learn it?".

--- a/getting_started/step_by_step/index.rst
+++ b/getting_started/step_by_step/index.rst
@@ -1,4 +1,4 @@
-:article_outdated: False
+:allow_comments: False
 
 Step by step
 ============

--- a/index.rst
+++ b/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Godot Docs – *master* branch
 ============================
 

--- a/tutorials/2d/index.rst
+++ b/tutorials/2d/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 2D
 ==
 

--- a/tutorials/3d/global_illumination/index.rst
+++ b/tutorials/3d/global_illumination/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. _doc_global_illumination:
 
 Global illumination

--- a/tutorials/3d/index.rst
+++ b/tutorials/3d/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 3D
 ==
 

--- a/tutorials/3d/particles/index.rst
+++ b/tutorials/3d/particles/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. _doc_3d_particles:
 
 Particle systems (3D)

--- a/tutorials/3d/procedural_geometry/index.rst
+++ b/tutorials/3d/procedural_geometry/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. _doc_procedural_geometry:
 
 Procedural geometry

--- a/tutorials/animation/index.rst
+++ b/tutorials/animation/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Animation
 =========
 

--- a/tutorials/assets_pipeline/escn_exporter/index.rst
+++ b/tutorials/assets_pipeline/escn_exporter/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Blender ESCN exporter
 =====================
 

--- a/tutorials/assets_pipeline/importing_3d_scenes/index.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. _doc_importing_3d_scenes:
 
 Importing 3D scenes

--- a/tutorials/assets_pipeline/index.rst
+++ b/tutorials/assets_pipeline/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Assets pipeline
 ===============
 

--- a/tutorials/audio/index.rst
+++ b/tutorials/audio/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 :article_outdated: True
 
 Audio

--- a/tutorials/best_practices/index.rst
+++ b/tutorials/best_practices/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Best practices
 ==============
 

--- a/tutorials/editor/index.rst
+++ b/tutorials/editor/index.rst
@@ -1,3 +1,4 @@
+:allow_comments: False
 :article_outdated: True
 
 Editor introduction

--- a/tutorials/export/index.rst
+++ b/tutorials/export/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Export
 ======
 

--- a/tutorials/i18n/index.rst
+++ b/tutorials/i18n/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Internationalization
 ====================
 

--- a/tutorials/inputs/index.rst
+++ b/tutorials/inputs/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Input handling
 ==============
 

--- a/tutorials/io/index.rst
+++ b/tutorials/io/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 File and data I/O
 =================
 

--- a/tutorials/math/index.rst
+++ b/tutorials/math/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Math
 ====
 

--- a/tutorials/migrating/index.rst
+++ b/tutorials/migrating/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Migrating to a new version
 ==========================
 

--- a/tutorials/navigation/index.rst
+++ b/tutorials/navigation/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Navigation
 ==========
 

--- a/tutorials/networking/index.rst
+++ b/tutorials/networking/index.rst
@@ -1,3 +1,4 @@
+:allow_comments: False
 :article_outdated: True
 
 Networking

--- a/tutorials/performance/index.rst
+++ b/tutorials/performance/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. _doc_performance:
 
 Performance

--- a/tutorials/performance/vertex_animation/index.rst
+++ b/tutorials/performance/vertex_animation/index.rst
@@ -1,3 +1,4 @@
+:allow_comments: False
 :article_outdated: True
 
 Animating thousands of objects

--- a/tutorials/physics/index.rst
+++ b/tutorials/physics/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Physics
 =======
 

--- a/tutorials/platform/android/index.rst
+++ b/tutorials/platform/android/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Android
 =======
 

--- a/tutorials/platform/index.rst
+++ b/tutorials/platform/index.rst
@@ -1,3 +1,4 @@
+:allow_comments: False
 :article_outdated: True
 
 Platform-specific

--- a/tutorials/platform/ios/index.rst
+++ b/tutorials/platform/ios/index.rst
@@ -1,3 +1,4 @@
+:allow_comments: False
 :article_outdated: True
 
 iOS plugins

--- a/tutorials/platform/web/index.rst
+++ b/tutorials/platform/web/index.rst
@@ -1,3 +1,4 @@
+:allow_comments: False
 :article_outdated: True
 
 .. _doc_platform_html5:

--- a/tutorials/plugins/editor/index.rst
+++ b/tutorials/plugins/editor/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Editor plugins
 ==============
 

--- a/tutorials/plugins/index.rst
+++ b/tutorials/plugins/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Plugins
 =======
 

--- a/tutorials/rendering/index.rst
+++ b/tutorials/rendering/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Rendering
 =========
 

--- a/tutorials/scripting/c_sharp/diagnostics/index.rst
+++ b/tutorials/scripting/c_sharp/diagnostics/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. _doc_c_sharp_diagnostics:
 
 C# diagnostics

--- a/tutorials/scripting/c_sharp/index.rst
+++ b/tutorials/scripting/c_sharp/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 C#/.NET
 =======
 
@@ -7,7 +9,6 @@ C# as an option for a scripting language, alongside Godot's own :ref:`GDScript<t
 The standard Godot executable does not contain C# support out of the box. Instead,
 to enable C# support for your project you need to `download a .NET version <https://godotengine.org/download/>`_
 of the editor from the Godot website.
-
 
 .. toctree::
    :maxdepth: 1

--- a/tutorials/scripting/debug/index.rst
+++ b/tutorials/scripting/debug/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Debug
 =====
 

--- a/tutorials/scripting/gdextension/index.rst
+++ b/tutorials/scripting/gdextension/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 GDExtension
 ===========
 

--- a/tutorials/scripting/gdscript/index.rst
+++ b/tutorials/scripting/gdscript/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 GDScript
 ========
 

--- a/tutorials/scripting/index.rst
+++ b/tutorials/scripting/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Scripting
 =========
 

--- a/tutorials/shaders/index.rst
+++ b/tutorials/shaders/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Shaders
 =======
 

--- a/tutorials/shaders/shader_reference/index.rst
+++ b/tutorials/shaders/shader_reference/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Shading reference
 =================
 

--- a/tutorials/shaders/your_first_shader/index.rst
+++ b/tutorials/shaders/your_first_shader/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 Your first shader
 =================
 

--- a/tutorials/ui/index.rst
+++ b/tutorials/ui/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. _doc_user_interface:
 
 User interface (UI)

--- a/tutorials/xr/index.rst
+++ b/tutorials/xr/index.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 XR
 ==
 


### PR DESCRIPTION
In a fashion similar to <https://php.net>'s comments, this allows users to leave comments on pages that don't have `:allow_comments: False` somewhere in the page's source. Both manual and class reference pages can receive comments. Index pages cannot have comments, as discussion should occur on "leaf" pages.

GitHub Discussions is used as a backend on the same repository.[^1] **This means that Discussions *must* be enabled on godotengine/godot-docs before this commit is merged to `master`.** Users can choose to use the "Custom" watch mode if they don't want to get notifications for discussion updates, but still get notifications for issue and pull request updates.

[^1]: We can choose to use a dedicated repository containing just discussions if we wish to do so.

User comments are intended to be used for the following purposes:

- Add a clarification or correct something in the documentation, without having to open a pull request. Contributors are encouraged to take a look at discussions from time to time, and see if there's information worth incorporating in the pages themselves. Don't forget to reply to the comment when doing so :slightly_smiling_face:
- Mention a workaround for a common issue.
- Link to useful third-party resources that are relevant to the current page, such as tutorials or add-ons.

User comments should **not** be used for technical support. Other community platforms should be used for that.

More details can be found in the [User-contributed notes policy](https://github.com/Calinou/godot-docs/discussions/46) I've written.

Page-to-discussion matching is done using the `pagename` Sphinx variable, which is independent of the Godot version and documentation language. Being independent of the Godot version allows keeping old comments when the Godot version changes, while also allowing users from `/stable` and `/4.0` to "see" each other in discussions.

See https://giscus.app for more information.

- See https://github.com/godotengine/godot-proposals/issues/481.

## TODO

- [x] Add `:allow_comments: False` on all index/listing pages.
- [x] Modify `makerst.py` in the main Godot repository to write `:allow_comments: False` at the top of `classes/index.rst`, as was done manually here. https://github.com/godotengine/godot/pull/85006
- [x] Set up Discussions on ~~godotengine/godot-docs~~ [godotengine/godot-docs-user-notes](https://github.com/godotengine/godot-docs-user-notes) and use the Giscus setup form again, so that the discussion category unique ID is updated. [Use the following options, with "Calinou/godot-docs" replaced by "godotengine/godot-docs".](https://github.com/godotengine/godot-docs/assets/180032/9e9412fb-3760-4dbe-9209-00d957b9e018)
  - Rename the default Announcements category to *Page comments* while keeping its type on Announcements. Change its emoji to :left_speech_bubble:. Remove all other categories, so that users cannot create discussions manually (the Giscus app will do it for them).
  - Create a second category called *Rules* with the Announcements type and :straight_ruler: emoji.
  - Create a post called "User-contributed notes policy" in the *Rules* category with the contents from https://github.com/Calinou/godot-docs/discussions/46, then pin the post globally (not in a single category) and lock it. Make sure reactions are **not** allowed when locking the post. Use the Markdown code below.
- [x] Replace URL to the *User-contributed notes* policy in `layout.html` to point to godot-docs' version, rather than the Calinou fork.

## Preview

https://github.com/godotengine/godot-docs-user-notes/discussions

### Example at the bottom of the *3D text* page

*The theme follows the system theme, which means it'll adapt to the documentation's theme automatically.*

![image](https://github.com/godotengine/godot-docs/assets/180032/521b736d-e4f7-44e3-8d80-09d749d7ab38)