### PR TITLE
Fix references to XR_ENV_BLEND_MODE_ALPHA_BLEND in openxr_passthrough…

### DIFF
--- a/tutorials/xr/openxr_passthrough.rst
+++ b/tutorials/xr/openxr_passthrough.rst
@@ -57,7 +57,7 @@ This will return a list of supported blend modes for submitting the main render 
 
 We need to check if ``XR_ENV_BLEND_MODE_ALPHA_BLEND`` is present in this list.
 If so we can tell OpenXR to expect an image that can be alpha blended with a background.
-To do this, we simply call ``set_environment_blend_mode(XR_ENV_BLEND_MODE_ALPHA_BLEND)``.
+To do this, we simply call ``set_environment_blend_mode(xr_interface.XR_ENV_BLEND_MODE_ALPHA_BLEND)``.
 
 We must also set ``transparent_bg`` to true to ensure we submit the right image.
 
@@ -74,8 +74,8 @@ Putting the above together we can use the following code as a base:
       return xr_interface.start_passthrough()
     else:
       var modes = xr_interface.get_supported_environment_blend_modes()
-      if XR_ENV_BLEND_MODE_ALPHA_BLEND in modes:
-        xr_interface.set_environment_blend_mode(XR_ENV_BLEND_MODE_ALPHA_BLEND)
+      if xr_interface.XR_ENV_BLEND_MODE_ALPHA_BLEND in modes:
+        xr_interface.set_environment_blend_mode(xr_interface.XR_ENV_BLEND_MODE_ALPHA_BLEND)
         return true
       else:
         return false


### PR DESCRIPTION
The code example at the end of the openXR passthrough tutorial refers to the `XR_ENV_BLEND_MODE_ALPHA_BLEND`  constant. That constant, however, is not accessible in the scope. Instead, it is a member of the `xr_interface` object.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
