### PR TITLE
explicit the need for code signing when creating an `.app` of the editor

### DIFF
--- a/contributing/development/compiling/compiling_for_macos.rst
+++ b/contributing/development/compiling/compiling_for_macos.rst
@@ -80,8 +80,9 @@ editor binary built with ``target=release_debug``::
 
     cp -r misc/dist/macos_tools.app ./Godot.app
     mkdir -p Godot.app/Contents/MacOS
-    cp bin/godot.macos.opt.tools.universal Godot.app/Contents/MacOS/Godot
+    cp bin/godot.macos.tools.universal Godot.app/Contents/MacOS/Godot
     chmod +x Godot.app/Contents/MacOS/Godot
+    codesign -fs - Godot.app
 
 .. note::
 

--- a/contributing/development/compiling/compiling_for_macos.rst
+++ b/contributing/development/compiling/compiling_for_macos.rst
@@ -82,7 +82,7 @@ editor binary built with ``target=release_debug``::
     mkdir -p Godot.app/Contents/MacOS
     cp bin/godot.macos.tools.universal Godot.app/Contents/MacOS/Godot
     chmod +x Godot.app/Contents/MacOS/Godot
-    codesign -fs - Godot.app
+    codesign --force --timestamp --options=runtime --entitlements misc/dist/macos/editor.entitlements -s - Godot.app
 
 .. note::
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/76629
