### PR TITLE
Change outdated and confuse statements from C# performance

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -326,11 +326,16 @@ You can read more about this error on the `C# language reference <https://learn.
 Performance of C# in Godot
 --------------------------
 
-According to some preliminary `benchmarks <https://github.com/cart/godot3-bunnymark>`_,
-the performance of C# in Godot — while generally in the same order of magnitude
-— is roughly **~4×** that of GDScript in some naive cases. C++ is still
-a little faster; the specifics are going to vary according to your use case.
-GDScript is likely fast enough for most general scripting workloads.
+Comparing GDScript to C# is tricky since C# can be faster in some specific cases; generally,
+those cases are when not iterating with the engine. So using C# can bring you performance benefits,
+but it is not guaranteed.
+
+In theory, if C++ (GDNative) is used right it will always be faster than C#, but for most projects,
+the difference is negligible, so use C# or C++ if you like them and know what you are doing; otherwise,
+stick with GDScript, which is likely fast enough for most general scripting workloads.
+
+The project don't need to stick to a single language; it can use multiple of them at the same time.
+Be aware that doing so will bring its own pitfalls.
 
 Most properties of Godot C# objects that are based on ``GodotObject``
 (e.g. any ``Node`` like ``Control`` or ``Node3D`` like ``Camera3D``) require native (interop) calls as they talk to


### PR DESCRIPTION
The _preliminary benchmarks_ were done with a tool that was for version 3.X and is no longer in active development. So it doesn't make sense to keep outdated information on a tutorial page.

And even if it made sense, stating that one language can be 4x faster than the other in specific cases, and saying nothing about what those cases are doesn't help much.

The reason for the edit is the frustration of having multiple people come over time on the forum and discord thinking that by simply using C# they would be writing a more performatic game.

The new statements given are based in the community responses given for people that came for the:
> roughly ~4x speed boost
