### PR TITLE
Fix example in JSON class.

### DIFF
--- a/classes/class_json.rst
+++ b/classes/class_json.rst
@@ -34,6 +34,7 @@ The **JSON** enables all data types to be converted to and from a JSON string. T
     # Save data
     # ...
     # Retrieve data
+    var json = JSON.new()
     var error = json.parse(json_string)
     if error == OK:
         var data_received = json.data


### PR DESCRIPTION
I tried the first block of example code from https://docs.godotengine.org/en/stable/classes/class_json.html and got an error:

> Identifier "json" not declared in the current scope.

I tried changing it to `var error = JSON.parse(json_string)` but then got this error:

> Cannot call non-static function "parse()" on the class "JSON" directly. Make an instance instead.

So I think it needs this line added: `var json = JSON.new()`