### PR TITLE
changed collisionInfo.Normal to collisionInfo.GetNormal()

### DIFF
--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -414,7 +414,7 @@ Or to bounce off of the colliding object:
         {
             var collisionInfo = MoveAndCollide(_velocity * (float)delta);
             if (collisionInfo != null)
-                _velocity = _velocity.Bounce(collisionInfo.Normal);
+                _velocity = _velocity.Bounce(collisionInfo.GetNormal());
         }
     }
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

issue #7541 

Changed the C# documentation of the example which was incorrect from collisionInfo.Normal to collisionInfo.GetNormal()
