### PR TITLE
Document `bullet` parameter for `ul` tag in BBCode in RichTextLabel

### DIFF
--- a/tutorials/ui/bbcode_in_richtextlabel.rst
+++ b/tutorials/ui/bbcode_in_richtextlabel.rst
@@ -399,8 +399,11 @@ Reference
   * - | **ul**
       | Adds an unordered list. List ``{items}`` must be provided by putting one item per
         line of text.
+      | The bullet point can be customized using the ``{bullet}`` parameter,
+        see :ref:`doc_bbcode_in_richtextlabel_unordered_list_bullet`.
 
-    - ``[ul]{items}[/ul]``
+    - | ``[ul]{items}[/ul]``
+      | ``[ul bullet={bullet}]{items}[/ul]``
 
   * - | **ol**
       | Adds an ordered (numbered) list of the given ``{type}`` (see :ref:`doc_bbcode_in_richtextlabel_list_types`).
@@ -410,14 +413,21 @@ Reference
 
   * - | **lb**, **rb**
       | Adds ``[`` and ``]`` respectively. Allows escaping BBCode markup.
+      | These are self-closing tags, which means you do not need to close them
+        (and there is no ``[/lb]`` or ``[/rb]`` closing tag).
 
     - | ``[lb]b[rb]text[lb]/b[rb]`` will display as ``[b]text[/b]``.
 
-  * - | Several Unicode control character can be added using their own tags.
+  * - | Several Unicode control characters can be added using their own self-closing tags.
+      | This can result in easier maintenance compared to pasting those
+      | control characters directly in the text.
 
-    - | ``[lrm]``, ``[rlm]``, ``[lre]``, ``[rle]``, ``[lro]``, ``[rlo]``,
-        ``[pdf]``, ``[alm]``, ``[lri]``, ``[rli]``, ``[fsi]``, ``[pdi]``,
-        ``[zwj]``, ``[zwnj]``, ``[wj]``
+    - | ``[lrm]`` (left-to-right mark), ``[rlm]`` (right-to-left mark), ``[lre]`` (left-to-right embedding),
+      | ``[rle]`` (right-to-left embedding), ``[lro]`` (left-to-right override), ``[rlo]`` (right-to-left override),
+      | ``[pdf]`` (pop directional formatting), ``[alm]`` (Arabic letter mark), ``[lri]`` (left-to-right isolate),
+      | ``[rli]`` (right-to-left isolate), ``[fsi]`` (first strong isolate), ``[pdi]`` (pop directional isolate),
+      | ``[zwj]`` (zero-width joiner), ``[zwnj]`` (zero-width non-joiner), ``[wj]`` (word joiner),
+      | ``[shy]`` (soft hyphen)
 
 .. note::
 
@@ -647,8 +657,8 @@ Cell options
   | `Default` | 1                                          |
   +-----------+--------------------------------------------+
 
-  Cell expansion ration, which cell will try to expand to proportionally to other
-  cells and their expansion ratios.
+  Cell expansion ratio. This defines which cells will try to expand to
+  proportionally to other cells and their expansion ratios.
 
 - **border**
 
@@ -668,8 +678,23 @@ Cell options
   | `Default` | Inherit                                    |
   +-----------+--------------------------------------------+
 
-  Cell background color. For alternating odd/even row backgrounds
+  Cell background color. For alternating odd/even row backgrounds,
   you can use ``bg=odd_color,even_color``.
+
+.. _doc_bbcode_in_richtextlabel_unordered_list_bullet:
+
+Unordered list bullet
+~~~~~~~~~~~~~~~~~~~~~
+
+By default, the ``[ul]`` tag uses the ``U+2022`` "Bullet" Unicode glyph as the
+bullet character. This behavior is similar to web browsers. The bullet character
+can be customized using ``[ul bullet={bullet}]``. If provided, this ``{bullet}``
+parameter must be a *single* character with no enclosing quotes (for example,
+``[bullet=*]``). Additional characters are ignored. The bullet character's
+width does not affect the list's formatting.
+
+See `Bullet (typography) on Wikipedia <https://en.wikipedia.org/wiki/Bullet_(typography)>`__
+for a list of common bullet characters that you can paste directly in the ``bullet`` parameter.
 
 .. _doc_bbcode_in_richtextlabel_list_types:
 


### PR DESCRIPTION
Customizing the bullet character was added by https://github.com/godotengine/godot/pull/75017. This feature isn't present in 3.x or 4.0, only in 4.1.

This also adds `[shy]` (soft hyphen) to the list of control character tags and clarifies which tags are self-closing.
