### PR TITLE
Fix OBJECT_POSITION description to match engine behavior.

### DIFF
--- a/tutorials/shaders/shader_reference/fog_shader.rst
+++ b/tutorials/shaders/shader_reference/fog_shader.rst
@@ -59,8 +59,7 @@ be drawn at once.
 +===============================+=================================================================================================+
 | in vec3 **WORLD_POSITION**    | Position of current froxel cell in world space.                                                 |
 +-------------------------------+-------------------------------------------------------------------------------------------------+
-| in vec3 **OBJECT_POSITION**   | Position of current froxel cell relative to the center of the current                           |
-|                               | :ref:`FogVolume <class_FogVolume>`.                                                             |
+| in vec3 **OBJECT_POSITION**   | Position of the center of the current :ref:`FogVolume <class_FogVolume>` in world space.        |
 +-------------------------------+-------------------------------------------------------------------------------------------------+
 | in vec3 **UVW**               | 3-dimensional uv, used to map a 3D texture to the current :ref:`FogVolume <class_FogVolume>`.   |
 +-------------------------------+-------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
While doing some custom SDF work in a fog shader, I noticed the documentation for `OBJECT_POSITION` did not match engine behavior.

You can see an example in the engine's fog shader where they need both `WORLD_POSITION` and `OBJECT_POSITION` to get a position in local space here: https://github.com/godotengine/godot/blob/3710f069293f2fde8afe33fea898c4b36fa5e943/scene/resources/fog_material.cpp#L160