### PR TITLE
Changed a code example that didn't follow the style guide

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -784,7 +784,7 @@ variables, in that order.
 
 ::
 
-    signal spawn_player(position)
+    signal player_spawned(position)
 
     enum Jobs {KNIGHT, WIZARD, ROGUE, HEALER, SHAMAN}
 


### PR DESCRIPTION
The style guide says to name signals in past tense. The style guide also contains a code example with "signal spawn_player". I don't see any reason to break naming conventions here.
