### PR TITLE
Update 03.coding_the_player.rst

### DIFF
--- a/getting_started/first_2d_game/03.coding_the_player.rst
+++ b/getting_started/first_2d_game/03.coding_the_player.rst
@@ -489,7 +489,7 @@ this code to the function:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    func _on_body_entered(body):
+    func _on_body_entered(_body):
         hide() # Player disappears after being hit.
         hit.emit()
         # Must be deferred as we can't change physics properties on a physics callback.


### PR DESCRIPTION
change _on_body_entered(body) to _on_body_entered(_body) to avoid warnings

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
