### PR TITLE
[3.x] Document `LIGHT_COLOR` being multiplied by `PI` in Spatial shader

### DIFF
--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -377,7 +377,10 @@ If you want the lights to add together, add the light contribution to ``DIFFUSE_
 +-----------------------------------+-----------------------------------------------------+
 | in vec3 **ALBEDO**                | Base albedo.                                        |
 +-----------------------------------+-----------------------------------------------------+
-| in vec3 **LIGHT_COLOR**           | Color of light multiplied by energy.                |
+| in vec3 **LIGHT_COLOR**           | Color of light multiplied by ``energy * PI``.       |
+|                                   | The ``PI`` multiplication is present because        |
+|                                   | physically-based lighting models include a          |
+|                                   | division by ``PI``.                                 |
 +-----------------------------------+-----------------------------------------------------+
 | out float **ALPHA**               | Alpha (0..1); if written to, the material will go   |
 |                                   | to the transparent pipeline.                        |


### PR DESCRIPTION
- `3.6` version of https://github.com/godotengine/godot-docs/pull/7561.

- This closes https://github.com/godotengine/godot/issues/78693.