### PR TITLE
Missing links to shader reference pages

### DIFF
--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -1076,6 +1076,8 @@ For a list of the built-in variables that are available, please see the correspo
 - :ref:`Spatial shaders <doc_spatial_shader>`
 - :ref:`Canvas item shaders <doc_canvas_item_shader>`
 - :ref:`Particle shaders <doc_particle_shader>`
+- :ref:`Sky shaders <doc_sky_shader>`
+- :ref:`Fog shaders <doc_fog_shader>`
 
 Built-in functions
 ------------------


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
Just a tiny change to add links to the new shader types when looking for builtin variables. (4.0 change)