### PR TITLE
Update the information about upcoming and currently supported releases

### DIFF
--- a/about/release_policy.rst
+++ b/about/release_policy.rst
@@ -77,41 +77,44 @@ If you experience an issue using an older patch release, please upgrade to the
 latest patch release of that series and test again before reporting an issue
 on GitHub.
 
-+-------------+----------------------+--------------------------------------------------------------------------+
-| **Version** | **Release date**     | **Support level**                                                        |
-+-------------+----------------------+--------------------------------------------------------------------------+
-| Godot 4.1   | Q2-Q3 2023 (estimate)| |unstable| *Development.* Receives new features as well as bug fixes     |
-| (`master`)  |                      | while under development.                                                 |
-+-------------+----------------------+--------------------------------------------------------------------------+
-| Godot 4.0   | March 2023           | |supported| Receives fixes for bugs, security and platform support       |
-|             |                      | issues, as well as backwards-compatible usability enhancements.          |
-+-------------+----------------------+--------------------------------------------------------------------------+
-| Godot 3.6   | Q2-Q3 2023 (estimate)| |supported| *Beta.* Receives new features as well as bug fixes while     |
-| (`3.x`, LTS)|                      | under development. Will be released *after* 4.0.                         |
-+-------------+----------------------+--------------------------------------------------------------------------+
-| Godot 3.5   | August 2022          | |supported| Receives fixes for bugs, security and platform support       |
-|             |                      | issues, as well as backwards-compatible usability enhancements.          |
-+-------------+----------------------+--------------------------------------------------------------------------+
-| Godot 3.4   | November 2021        | |eol| No longer supported, as fully superseded by the compatible 3.5     |
-|             |                      | release (last update: 3.4.5).                                            |
-+-------------+----------------------+--------------------------------------------------------------------------+
-| Godot 3.3   | April 2021           | |eol| No longer supported, as fully superseded by the compatible 3.4     |
-|             |                      | release (last update: 3.3.4).                                            |
-+-------------+----------------------+--------------------------------------------------------------------------+
-| Godot 3.2   | January 2020         | |eol| No longer supported (last update: 3.2.3).                          |
-+-------------+----------------------+--------------------------------------------------------------------------+
-| Godot 3.1   | March 2019           | |eol| No longer supported (last update: 3.1.2).                          |
-+-------------+----------------------+--------------------------------------------------------------------------+
-| Godot 3.0   | January 2018         | |eol| No longer supported (last update: 3.0.6).                          |
-+-------------+----------------------+--------------------------------------------------------------------------+
-| Godot 2.1   | July 2016            | |eol| No longer supported (last update: 2.1.6).                          |
-+-------------+----------------------+--------------------------------------------------------------------------+
-| Godot 2.0   | February 2016        | |eol| No longer supported (last update: 2.0.4.1).                        |
-+-------------+----------------------+--------------------------------------------------------------------------+
-| Godot 1.1   | May 2015             | |eol| No longer supported.                                               |
-+-------------+----------------------+--------------------------------------------------------------------------+
-| Godot 1.0   | December 2014        | |eol| No longer supported.                                               |
-+-------------+----------------------+--------------------------------------------------------------------------+
++--------------+----------------------+--------------------------------------------------------------------------+
+| **Version**  | **Release date**     | **Support level**                                                        |
++--------------+----------------------+--------------------------------------------------------------------------+
+| Godot 4.2    | November 2023        | |unstable| *Development.* Receives new features, usability and           |
+| (`master`)   | (estimate)           | performance improvements, as well as bug fixes, while under development. |
++--------------+----------------------+--------------------------------------------------------------------------+
+| Godot 4.1    | July 2023            | |supported| Receives fixes for bugs and security issues, as well as      |
+|              |                      | patches that enable platform support.                                    |
++--------------+----------------------+--------------------------------------------------------------------------+
+| Godot 4.0    | March 2023           | |supported| Receives fixes for bugs and security issues, as well as      |
+|              |                      | patches that enable platform support.                                    |
++--------------+----------------------+--------------------------------------------------------------------------+
+| Godot 3.6    | Q3 2023 (estimate)   | |supported| *Beta.* Receives new features, usability and performance     |
+| (`3.x`, LTS) |                      | improvements, as well as bug fixes, while under development.             |
++--------------+----------------------+--------------------------------------------------------------------------+
+| Godot 3.5    | August 2022          | |supported| Receives fixes for bugs and security issues, as well as      |
+|              |                      | patches that enable platform support.                                    |
++--------------+----------------------+--------------------------------------------------------------------------+
+| Godot 3.4    | November 2021        | |eol| No longer supported, as fully superseded by the compatible 3.5     |
+|              |                      | release (last update: 3.4.5).                                            |
++--------------+----------------------+--------------------------------------------------------------------------+
+| Godot 3.3    | April 2021           | |eol| No longer supported, as fully superseded by the compatible 3.4     |
+|              |                      | release (last update: 3.3.4).                                            |
++--------------+----------------------+--------------------------------------------------------------------------+
+| Godot 3.2    | January 2020         | |eol| No longer supported (last update: 3.2.3).                          |
++--------------+----------------------+--------------------------------------------------------------------------+
+| Godot 3.1    | March 2019           | |eol| No longer supported (last update: 3.1.2).                          |
++--------------+----------------------+--------------------------------------------------------------------------+
+| Godot 3.0    | January 2018         | |eol| No longer supported (last update: 3.0.6).                          |
++--------------+----------------------+--------------------------------------------------------------------------+
+| Godot 2.1    | July 2016            | |eol| No longer supported (last update: 2.1.6).                          |
++--------------+----------------------+--------------------------------------------------------------------------+
+| Godot 2.0    | February 2016        | |eol| No longer supported (last update: 2.0.4.1).                        |
++--------------+----------------------+--------------------------------------------------------------------------+
+| Godot 1.1    | May 2015             | |eol| No longer supported.                                               |
++--------------+----------------------+--------------------------------------------------------------------------+
+| Godot 1.0    | December 2014        | |eol| No longer supported.                                               |
++--------------+----------------------+--------------------------------------------------------------------------+
 
 .. |supported| image:: img/supported.png
 .. |partial| image:: img/partial.png


### PR DESCRIPTION
Updated 4.1 and added 4.2 with their current estimates, also adjusted the estimate for 3.6. Changed some wording too, as minor versions only receive patch releases which do not add new usability features, generally.