### PR TITLE
Update SCons link-time optimization option for 3.5 and later

### DIFF
--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -270,7 +270,7 @@ Manager.
           SCons options ``target=template_release production=yes``.
 
           If you are compiling Godot with GCC, you can make the binary
-          even smaller and faster by adding the SCons option ``use_lto=yes``.
+          even smaller and faster by adding the SCons option ``lto=full``.
           As link-time optimization is a memory-intensive process,
           this will require about 7 GB of available RAM while compiling.
 

--- a/contributing/development/compiling/compiling_for_windows.rst
+++ b/contributing/development/compiling/compiling_for_windows.rst
@@ -153,7 +153,7 @@ dependencies. Running it will bring up the Project Manager.
           SCons option ``target=template_release``.
 
           If you are compiling Godot with MinGW, you can make the binary
-          even smaller and faster by adding the SCons option ``use_lto=yes``.
+          even smaller and faster by adding the SCons option ``lto=full``.
           As link-time optimization is a memory-intensive process,
           this will require about 7 GB of available RAM while compiling.
 

--- a/contributing/development/compiling/optimizing_for_size.rst
+++ b/contributing/development/compiling/optimizing_for_size.rst
@@ -79,7 +79,7 @@ and MSVC compilers:
 
 ::
 
-    scons p=windows target=template_release use_lto=yes
+    scons p=windows target=template_release lto=full
 
 Linking becomes much slower and more RAM-consuming with this option,
 so it should be used only for release builds:

--- a/contributing/development/debugging/using_cpp_profilers.rst
+++ b/contributing/development/debugging/using_cpp_profilers.rst
@@ -29,14 +29,8 @@ To get useful profiling information, it is **absolutely required** to use a Godo
 build that includes debugging symbols. Official binaries do not include debugging
 symbols, since these would make the download size significantly larger.
 
-To get profiling data that best matches the production environment, you should
-compile binaries with the following SCons options:
-
-- For editor binaries: ``target=editor use_lto=yes``
-- For debug export templates: ``target=template_debug use_lto=yes``
-- For release export templates: ``target=template_release debug_symbols=yes``
-
-  - ``debug_symbols=yes`` is required as export templates are stripped from debugging symbols by default.
+To get profiling data that best matches the production environment (but with debugging symbols),
+you should compile binaries with the ``production=yes debug_symbols=yes`` SCons options.
 
 It is possible to run a profiler on less optimized builds (e.g. ``target=template_debug`` without LTO),
 but results will naturally be less representative of real world conditions.


### PR DESCRIPTION
- `master` version of https://github.com/godotengine/godot-docs/pull/7583.