### PR TITLE
[3.x] Update SCons link-time optimization option for 3.5 and later

### DIFF
--- a/development/compiling/compiling_for_windows.rst
+++ b/development/compiling/compiling_for_windows.rst
@@ -151,7 +151,7 @@ dependencies. Running it will bring up the Project Manager.
           SCons option ``target=release_debug``.
 
           If you are compiling Godot with MinGW, you can make the binary
-          even smaller and faster by adding the SCons option ``use_lto=yes``.
+          even smaller and faster by adding the SCons option ``lto=full``.
           As link-time optimization is a memory-intensive process,
           this will require about 7 GB of available RAM while compiling.
 

--- a/development/compiling/compiling_for_x11.rst
+++ b/development/compiling/compiling_for_x11.rst
@@ -129,7 +129,7 @@ manager.
           SCons option ``target=release_debug``.
 
           If you are compiling Godot with GCC, you can make the binary
-          even smaller and faster by adding the SCons option ``use_lto=yes``.
+          even smaller and faster by adding the SCons option ``lto=full``.
           As link-time optimization is a memory-intensive process,
           this will require about 7 GB of available RAM while compiling.
 

--- a/development/compiling/optimizing_for_size.rst
+++ b/development/compiling/optimizing_for_size.rst
@@ -79,7 +79,7 @@ and MSVC compilers:
 
 ::
 
-    scons p=windows target=release tools=no use_lto=yes
+    scons p=windows target=release tools=no lto=full
 
 Linking becomes much slower and more RAM-consuming with this option,
 so it should be used only for release builds:

--- a/development/cpp/using_cpp_profilers.rst
+++ b/development/cpp/using_cpp_profilers.rst
@@ -29,13 +29,8 @@ To get useful profiling information, it is **absolutely required** to use a Godo
 build that includes debugging symbols. Official binaries do not include debugging
 symbols, since these would make the download size significantly larger.
 
-To get profiling data that best matches the production environment, you should
-compile binaries with the following SCons options:
-
-- For editor binaries: ``target=release_debug use_lto=yes``
-- For debug export templates: ``target=release_debug use_lto=yes``
-- For release export templates: ``tools=no target=release debug_symbols=yes``
-  - ``debug_symbols=yes`` is required as export templates are stripped from debugging symbols by default.
+To get profiling data that best matches the production environment (but with debugging symbols),
+you should compile binaries with the ``production=yes debug_symbols=yes`` SCons options.
 
 It is possible to run a profiler on less optimized builds (e.g. ``target=debug`` without LTO),
 but results will naturally be less representative of real world conditions.


### PR DESCRIPTION
- `3.x` version of https://github.com/godotengine/godot-docs/pull/7582.
