### PR TITLE
Fix dev=yes in unit testing guide

### DIFF
--- a/contributing/development/core_and_modules/unit_testing.rst
+++ b/contributing/development/core_and_modules/unit_testing.rst
@@ -48,8 +48,8 @@ arguments for doctest.
 
 .. note::
 
-    Tests are compiled automatically if you use the ``dev=yes`` SCons option.
-    ``dev=yes`` is recommended if you plan on contributing to the engine
+    Tests are compiled automatically if you use the ``dev_mode=yes`` SCons option.
+    ``dev_mode=yes`` is recommended if you plan on contributing to the engine
     development as it will automatically treat compilation warnings as errors.
     The continuous integration system will fail if any compilation warnings are
     detected, so you should strive to fix all warnings before opening a pull


### PR DESCRIPTION
## Description

This PR fixes the outdated usage of `dev=yes` in contributor guide.

> Tests are compiled automatically if you use the `dev=yes` SCons option. `dev=yes` is recommended if you plan on contributing to the engine development as it will automatically treat compilation warnings as errors. The continuous integration system will fail if any compilation warnings are detected, so you should strive to fix all warnings before opening a pull request.

Link: https://docs.godotengine.org/en/stable/contributing/development/core_and_modules/unit_testing.html

PR that changed the option: https://github.com/godotengine/godot/pull/66242

It is found in 4.0, 4.1, latest, and stable.