### PR TITLE
Update multi-threaded rendering setting path in Thread-Safe APIs page

### DIFF
--- a/tutorials/performance/thread_safe_apis.rst
+++ b/tutorials/performance/thread_safe_apis.rst
@@ -55,7 +55,7 @@ Rendering
 ---------
 
 Instancing nodes that render anything in 2D or 3D (such as Sprite) is *not* thread-safe by default.
-To make rendering thread-safe, set the **Rendering > Threads > Thread Model** project setting to **Multi-Threaded**.
+To make rendering thread-safe, set the **Rendering > Driver > Thread Model** project setting to **Multi-Threaded**.
 
 Note that the Multi-Threaded thread model has several known bugs, so it may not be usable
 in all scenarios.


### PR DESCRIPTION
Changed from "Rendering > Threads > Thread Model", which used to be the old path for Godot 3.x, to "Rendering > Driver > Thread Model", which is the current one for Godot 4.x.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
