### PR TITLE
Fixed typo in scripting_first_script.rst

### DIFF
--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -260,7 +260,7 @@ Moving forward
 ~~~~~~~~~~~~~~
 
 Let's now make the node move. Add the following two lines inside of the ``_process()``
-function, ensuring the new lines are indented the same way as the ``rotation += angular * delta`` line before
+function, ensuring the new lines are indented the same way as the ``rotation += angular_speed * delta`` line before
 them.
 
 .. tabs::


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Name of variable is not just `angular` but `angular_speed`.