### PR TITLE
Fix C# differences list for 4.0

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_collections.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_collections.rst
@@ -121,6 +121,7 @@ all                      `System.Linq.Enumerable.All`_
 any                      `System.Linq.Enumerable.Any`_
 append                   Add
 append_array             AddRange
+assign                   Clear and AddRange
 back                     ``Array[^1]`` or `System.Linq.Enumerable.Last`_ or `System.Linq.Enumerable.LastOrDefault`_
 bsearch                  BinarySearch
 bsearch_custom           N/A
@@ -140,6 +141,7 @@ hash                     GD.Hash
 insert                   Insert
 is_empty                 Use ``Count == 0``
 is_read_only             IsReadOnly
+is_same_typed            N/A
 is_typed                 N/A
 make_read_only           MakeReadOnly
 map                      `System.Linq.Enumerable.Select`_
@@ -161,7 +163,6 @@ size                     Count
 slice                    Slice
 sort                     Sort
 sort_custom              `System.Linq.Enumerable.OrderBy`_
-typed_assign             N/A
 operator !=              !RecursiveEqual
 operator +               operator +
 operator <               N/A

--- a/tutorials/scripting/c_sharp/c_sharp_differences.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_differences.rst
@@ -414,8 +414,8 @@ lpad                     `string.PadLeft`_
 lstrip                   `string.TrimStart`_
 match                    StringExtensions.Match (Consider using `RegEx`_)
 matchn                   StringExtensions.MatchN (Consider using `RegEx`_)
-md5_buffer               StringExtensions.MD5Buffer (Consider using `System.Security.Cryptography.MD5.HashData`_)
-md5_text                 StringExtensions.MD5Text (Consider using `System.Security.Cryptography.MD5.HashData`_ with StringExtensions.HexEncode)
+md5_buffer               StringExtensions.Md5Buffer (Consider using `System.Security.Cryptography.MD5.HashData`_)
+md5_text                 StringExtensions.Md5Text (Consider using `System.Security.Cryptography.MD5.HashData`_ with StringExtensions.HexEncode)
 naturalnocasecmp_to      N/A (Consider using `string.Equals`_ or `string.Compare`_)
 nocasecmp_to             StringExtensions.NocasecmpTo or StringExtensions.CompareTo (Consider using `string.Equals`_ or `string.Compare`_)
 num                      `float.ToString`_ or `double.ToString`_
@@ -434,10 +434,10 @@ right                    StringExtensions.Right (Consider using `string.Substrin
 rpad                     `string.PadRight`_
 rsplit                   N/A
 rstrip                   `string.TrimEnd`_
-sha1_buffer              StringExtensions.SHA1Buffer (Consider using `System.Security.Cryptography.SHA1.HashData`_)
-sha1_text                StringExtensions.SHA1Text (Consider using `System.Security.Cryptography.SHA1.HashData`_ with StringExtensions.HexEncode)
-sha256_buffer            StringExtensions.SHA256Buffer (Consider using `System.Security.Cryptography.SHA256.HashData`_)
-sha256_text              StringExtensions.SHA256Text (Consider using `System.Security.Cryptography.SHA256.HashData`_ with StringExtensions.HexEncode)
+sha1_buffer              StringExtensions.Sha1Buffer (Consider using `System.Security.Cryptography.SHA1.HashData`_)
+sha1_text                StringExtensions.Sha1Text (Consider using `System.Security.Cryptography.SHA1.HashData`_ with StringExtensions.HexEncode)
+sha256_buffer            StringExtensions.Sha256Buffer (Consider using `System.Security.Cryptography.SHA256.HashData`_)
+sha256_text              StringExtensions.Sha256Text (Consider using `System.Security.Cryptography.SHA256.HashData`_ with StringExtensions.HexEncode)
 similarity               StringExtensions.Similarity
 simplify_path            StringExtensions.SimplifyPath
 split                    StringExtensions.Split (Consider using `string.Split`_)
@@ -445,7 +445,7 @@ split_floats             StringExtensions.SplitFloat
 strip_edges              StringExtensions.StripEdges (Consider using `string.Trim`_, `string.TrimStart`_ or `string.TrimEnd`_)
 strip_escapes            StringExtensions.StripEscapes
 substr                   StringExtensions.Substr (Consider using `string.Substring`_ or `string.AsSpan`_)
-to_ascii_buffer          StringExtensions.ToASCIIBuffer (Consider using `System.Text.Encoding.ASCII.GetBytes`_)
+to_ascii_buffer          StringExtensions.ToAsciiBuffer (Consider using `System.Text.Encoding.ASCII.GetBytes`_)
 to_camel_case            StringExtensions.ToCamelCase
 to_float                 StringExtensions.ToFloat (Consider using `float.TryParse`_ or `double.TryParse`_)
 to_int                   StringExtensions.ToInt (Consider using `int.TryParse`_ or `long.TryParse`_)
@@ -453,9 +453,9 @@ to_lower                 `string.ToLower`_
 to_pascal_case           StringExtensions.ToPascalCase
 to_snake_case            StringExtensions.ToSnakeCase
 to_upper                 `string.ToUpper`_
-to_utf16_buffer          StringExtensions.ToUTF16Buffer (Consider using `System.Text.Encoding.UTF16.GetBytes`_)
-to_utf32_buffer          StringExtensions.ToUTF32Buffer (Consider using `System.Text.Encoding.UTF32.GetBytes`_)
-to_utf8_buffer           StringExtensions.ToUTF8Buffer (Consider using `System.Text.Encoding.UTF8.GetBytes`_)
+to_utf16_buffer          StringExtensions.ToUtf16Buffer (Consider using `System.Text.Encoding.UTF16.GetBytes`_)
+to_utf32_buffer          StringExtensions.ToUtf32Buffer (Consider using `System.Text.Encoding.UTF32.GetBytes`_)
+to_utf8_buffer           StringExtensions.ToUtf8Buffer (Consider using `System.Text.Encoding.UTF8.GetBytes`_)
 trim_prefix              StringExtensions.TrimPrefix
 trim_suffix              StringExtensions.TrimSuffix
 unicode_at               `string[int]`_ indexer
@@ -471,10 +471,10 @@ List of Godot's PackedByteArray methods that create a String and their C# equiva
 =========================  ==============================================================
 GDScript                   C#
 =========================  ==============================================================
-get_string_from_ascii      StringExtensions.GetStringFromASCII (Consider using `System.Text.Encoding.ASCII.GetString`_)
-get_string_from_utf16      StringExtensions.GetStringFromUTF16 (Consider using `System.Text.Encoding.UTF16.GetString`_)
-get_string_from_utf32      StringExtensions.GetStringFromUTF32 (Consider using `System.Text.Encoding.UTF32.GetString`_)
-get_string_from_utf8       StringExtensions.GetStringFromUTF8 (Consider using `System.Text.Encoding.UTF8.GetString`_)
+get_string_from_ascii      StringExtensions.GetStringFromAscii (Consider using `System.Text.Encoding.ASCII.GetString`_)
+get_string_from_utf16      StringExtensions.GetStringFromUtf16 (Consider using `System.Text.Encoding.UTF16.GetString`_)
+get_string_from_utf32      StringExtensions.GetStringFromUtf32 (Consider using `System.Text.Encoding.UTF32.GetString`_)
+get_string_from_utf8       StringExtensions.GetStringFromUtf8 (Consider using `System.Text.Encoding.UTF8.GetString`_)
 hex_encode                 StringExtensions.HexEncode (Consider using `System.Convert.ToHexString`_)
 =========================  ==============================================================
 


### PR DESCRIPTION
Fixes the list of equivalent APIs for 4.0.

The methods haven't changed, it's just the documentation that was wrong. Most likely API that was modified after these lists were added to the documentation, but before 4.0 was released.