### PR TITLE
Update mouse_and_input_coordinates.rst

### DIFF
--- a/tutorials/inputs/mouse_and_input_coordinates.rst
+++ b/tutorials/inputs/mouse_and_input_coordinates.rst
@@ -36,7 +36,7 @@ for example:
            print("Mouse Motion at: ", event.position)
 
        # Print the size of the viewport.
-       print("Viewport Resolution is: ", get_viewport_rect().size)
+       print("Viewport Resolution is: ", get_viewport().get_visible_rect().size)
 
  .. code-tab:: csharp
 

--- a/tutorials/inputs/mouse_and_input_coordinates.rst
+++ b/tutorials/inputs/mouse_and_input_coordinates.rst
@@ -36,7 +36,7 @@ for example:
            print("Mouse Motion at: ", event.position)
 
        # Print the size of the viewport.
-       print("Viewport Resolution is: ", get_viewport().get_visible_rect().size)
+       print("Viewport Resolution is: ", get_viewport_rect().size)
 
  .. code-tab:: csharp
 
@@ -51,6 +51,8 @@ for example:
         // Print the size of the viewport.
         GD.Print("Viewport Resolution is: ", GetViewportRect().Size);
     }
+
+Note that ... only exists on CanvasItem and otherwise, you'll want to use `get_viewport().get_visible_rect().size`
 
 Alternatively, it's possible to ask the viewport for the mouse position:
 


### PR DESCRIPTION
outdated method that no longer exists in 4.1

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
