### PR TITLE
macOS: Move Vulkan SDK from a note to a requirement

### DIFF
--- a/contributing/development/compiling/compiling_for_macos.rst
+++ b/contributing/development/compiling/compiling_for_macos.rst
@@ -19,13 +19,8 @@ For compiling under macOS, the following is required:
 - `SCons 3.0+ <https://scons.org/pages/download.html>`_ build system.
 - `Xcode <https://apps.apple.com/us/app/xcode/id497799835>`_
   (or the more lightweight Command Line Tools for Xcode).
-
-.. warning::
-
-    If you are building the ``master`` branch, download and install the
-    `Vulkan SDK for macOS <https://vulkan.lunarg.com/sdk/home>`__. This
-    is **required** to compile Godot 4.x, as MoltenVK is used to translate Vulkan
-    to Metal (macOS doesn't support Vulkan out of the box).
+- `Vulkan SDK <https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.dmg>`_
+  for MoltenVK (macOS doesn't support Vulkan out of the box).
 
 .. note:: If you have `Homebrew <https://brew.sh/>`_ installed, you can easily
           install SCons using the following command::


### PR DESCRIPTION
This is a requirement, so it should go with the other requirements.

I also changed the link to point directly to the DMG - this should be a stable link and I think it's better since it will save users time not having to navigate the LunarG site.