### PR TITLE
Remove c# exprange info

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_exports.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_exports.rst
@@ -216,15 +216,6 @@ the slider.
     [Export(PropertyHint.Range, "0,100,1,or_greater,or_lesser")]
     public int Number { get; set; }
 
-Allow values 'y = exp(x)' where 'y' varies between 100 and 1000
-while snapping to steps of 20. The editor will present a
-slider for easily editing the value. This only works with floats.
-
-.. code-block:: csharp
-
-    [Export(PropertyHint.ExpRange, "100,1000,20")]
-    public float Number { get; set; }
-
 Floats with easing hint
 -----------------------
 


### PR DESCRIPTION
PropertyHint.ExpRange was removed in godot 3.4.  This commit removes the outdated information from the wiki.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
