### PR TITLE
Fix mention of Godot3's or_lesser for export_range

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_exports.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_exports.rst
@@ -207,13 +207,13 @@ Allow floats from -10 to 20 and snap the value to multiples of 0.2.
     [Export(PropertyHint.Range, "-10,20,0.2")]
     public float Number { get; set; }
 
-If you add the hints "or_greater" and/or "or_lesser" you can go above
+If you add the hints "or_greater" and/or "or_less" you can go above
 or below the limits when adjusting the value by typing it instead of using
 the slider.
 
 .. code-block:: csharp
 
-    [Export(PropertyHint.Range, "0,100,1,or_greater,or_lesser")]
+    [Export(PropertyHint.Range, "0,100,1,or_greater,or_less")]
     public int Number { get; set; }
 
 Allow values 'y = exp(x)' where 'y' varies between 100 and 1000

--- a/tutorials/scripting/gdscript/gdscript_exports.rst
+++ b/tutorials/scripting/gdscript/gdscript_exports.rst
@@ -163,11 +163,11 @@ Allow floats from -10 to 20 and snap the value to multiples of 0.2.
 
     @export_range(-10, 20, 0.2) var k: float
 
-The limits can be only for the slider if you add the hints "or_greater" and/or "or_lesser".
+The limits can be only for the slider if you add the hints "or_greater" and/or "or_less".
 
 ::
 
-    @export_range(0, 100, 1, "or_greater", "or_lesser")
+    @export_range(0, 100, 1, "or_greater", "or_less")
 
 .. TODO: Document other hint strings usable with export_range.
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

In this page: https://docs.godotengine.org/en/latest/tutorials/scripting/gdscript/gdscript_exports.html#limiting-editor-input-ranges

The docs say to use the keyword "or_lesser" for ranges that can go below what is specified. This was changed in Godot4 and therefore should be "or_less"

I have also updated the C# version (I am assuming they were both changed, but I have not tested this)

This might need to be backported to previous doc versions?