### PR TITLE
Fix some articles being incorrectly marked as outdated

### DIFF
--- a/tutorials/2d/using_tilemaps.rst
+++ b/tutorials/2d/using_tilemaps.rst
@@ -1,5 +1,3 @@
-:article_outdated: True
-
 .. _doc_using_tilemaps:
 
 Using TileMaps

--- a/tutorials/animation/animation_track_types.rst
+++ b/tutorials/animation/animation_track_types.rst
@@ -1,5 +1,3 @@
-:article_outdated: True
-
 .. _doc_animation_track_types:
 
 Animation Track types

--- a/tutorials/rendering/multiple_resolutions.rst
+++ b/tutorials/rendering/multiple_resolutions.rst
@@ -1,5 +1,3 @@
-:article_outdated: True
-
 .. _doc_multiple_resolutions:
 
 Multiple resolutions


### PR DESCRIPTION
These articles were updated for 4.0 and the API hasn't changed in 4.1.

For future reference, I went through all articles currently marked as outdated (100 of them) and these are the only 3 that were true false positives. Many other pages were up-to-date in terms of text content, but screenshots still showed the Godot 3 editor theme (sometimes even 3.0 instead of 3.2+).
