### PR TITLE
Not relevant 'Known issues' section in 'Version Control Systems'

### DIFF
--- a/tutorials/best_practices/version_control_systems.rst
+++ b/tutorials/best_practices/version_control_systems.rst
@@ -52,9 +52,3 @@ This can lead to files unnecessarily being marked as modified by Git due to thei
 It is better to set this option as::
 
     git config --global core.autocrlf input
-
-Known issues
-------------
-
-**Always close the editor** before running ``git pull``! Otherwise, you may
-`lose data if you synchronize files while the editor is open <https://github.com/godotengine/godot/issues/20250>`__.


### PR DESCRIPTION
Not relevant 'Known issues' section in 'Version Control Systems' best practices. 
For Godot 3.4 and above. 
https://github.com/godotengine/godot/issues/20250

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
