### PR TITLE
Remove outdated notice about changing import type requiring editor restart

### DIFF
--- a/tutorials/assets_pipeline/import_process.rst
+++ b/tutorials/assets_pipeline/import_process.rst
@@ -115,11 +115,6 @@ select the relevant type of resource desired then click **Reimport**:
 
 .. image:: img/import_process_changing_import_type.webp
 
-.. note::
-
-    For technical reasons, the editor must be restarted after changing an import
-    type in the Import dock.
-
 Changing default import parameters
 ----------------------------------
 

--- a/tutorials/assets_pipeline/importing_images.rst
+++ b/tutorials/assets_pipeline/importing_images.rst
@@ -99,11 +99,6 @@ It is possible to choose other types of imported resources in the Import dock:
   used to reduce memory usage for animated 2D sprites. Only supported in 2D due
   to missing support in built-in 3D shaders.
 
-.. note::
-
-    For technical reasons, the editor must be restarted after changing an import
-    type in the Import dock.
-
 Detect 3D
 ^^^^^^^^^
 


### PR DESCRIPTION
This is no longer the case since Godot 4.2.
