### PR TITLE
Update playing_videos.rst

### DIFF
--- a/tutorials/animation/playing_videos.rst
+++ b/tutorials/animation/playing_videos.rst
@@ -76,7 +76,7 @@ a float. Otherwise, the division's result will always be an integer.
 
 Once you've configured the AspectRatioContainer, reparent your VideoStreamPlayer
 node to be a child of the AspectRatioContainer node. Make sure **Expand** is
-disabled on the VideoStreamPlayer. Your video should now scale automatically
+enabled on the VideoStreamPlayer. Your video should now scale automatically
 to fit the whole screen while avoiding distortion.
 
 .. seealso::


### PR DESCRIPTION
I just started using Godot again after a few years. First thing I tried to do was play video fullscreen without stretching. So, I feel like might be crazy, but it only worked when I _enabled_ expand on the video, contrary to what the manual states.
![image](https://github.com/godotengine/godot-docs/assets/16981283/6ce06dd9-94cb-46b2-bda4-2fceffde58b7)