### PR TITLE
Fix outdated use of `File` in `gdscript_basics`

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1865,9 +1865,9 @@ Here is an example:
     var my_file_ref
 
     func _ready():
-        var f = File.new()
+        var f = FileAccess.open("user://example_file.json", FileAccess.READ)
         my_file_ref = weakref(f)
-        # the File class inherits RefCounted, so it will be freed when not in use
+        # the FileAccess class inherits RefCounted, so it will be freed when not in use
 
         # the WeakRef will not prevent f from being freed when other_node is finished
         other_node.use_file(f)


### PR DESCRIPTION
* Fixes: #7665

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
