### PR TITLE
Little typo fix 06.heads_up_display.rst

### DIFF
--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -40,7 +40,7 @@ Under "Theme Overrides > Fonts", choose "Load" and select the "Xolonium-Regular.
 
 .. image:: img/custom_font_load_font.webp
 
-The font size is still to small, increase it to ``64`` under "Theme Overrides > Font Sizes". 
+The font size is still too small, increase it to ``64`` under "Theme Overrides > Font Sizes". 
 Once you've done this with the ``ScoreLabel``, repeat the changes for the ``Message`` and ``StartButton`` nodes.
 
 .. image:: img/custom_font_size.webp


### PR DESCRIPTION
"too" instead of "to" as should be.

This was fixed in master branch #7673 but not in 4.1 branch.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
