### PR TITLE
Add request to report missing exposed GDExtension functionality

### DIFF
--- a/tutorials/scripting/gdextension/what_is_gdextension.rst
+++ b/tutorials/scripting/gdextension/what_is_gdextension.rst
@@ -22,6 +22,11 @@ run C or C++ code in a Godot project.
 They also both allow you to integrate third-party libraries into Godot. The one
 you should choose depends on your needs.
 
+.. note:: If you notice that specific systems are not accessible via GDExtension
+          but are via custom modules feel free to open an issue on the
+          `godot-cpp repository <https://github.com/godotengine/godot-cpp>`__ to discuss
+          implementation options to expose the missing functionality.
+
 Advantages of GDExtension
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
* adds note to the "What is GDExtension" docs to call for issue creation when people can't do something in GDExtension that is possible with modules and should be exposed to GDExtension

Created in mind of https://github.com/godotengine/godot-docs/issues/7685#issuecomment-1644017193