### PR TITLE
Fix broken 3.x server download links

### DIFF
--- a/tutorials/export/exporting_for_dedicated_servers.rst
+++ b/tutorials/export/exporting_for_dedicated_servers.rst
@@ -9,7 +9,7 @@ have a GPU or display server available, you'll need to use a server build of God
 Platform support
 ----------------
 
-- **Linux:** `Download an official Linux server binary <https://godotengine.org/download/server>`__.
+- **Linux:** `Download an official Linux server binary <https://godotengine.org/download/3.x/server>`__.
   To compile a server binary from source, follow instructions in
   :ref:`doc_compiling_for_x11`.
 - **macOS:** :ref:`Compile a server binary from source for macOS <doc_compiling_for_osx>`.
@@ -23,7 +23,7 @@ If your project uses C#, you'll have to use a Mono-enabled server binary.
 "Headless" versus "server" binaries
 -----------------------------------
 
-The `server download page <https://godotengine.org/download/server>`__
+The `server download page <https://godotengine.org/download/3.x/server>`__
 offers two kinds of binaries with several differences.
 
 - **Server:** Use this one for running dedicated servers. It does not contain


### PR DESCRIPTION
Port of https://github.com/godotengine/godot-docs/pull/7300/ to `3.x`, where it is relevant. The 4.x version of this page got reworked in https://github.com/godotengine/godot-docs/pull/7701. Credit goes to **mlgarchery** who pointed this out originally in https://github.com/godotengine/godot-docs/pull/7300.