### PR TITLE
Mark SoftBody page as outdated

### DIFF
--- a/tutorials/physics/soft_body.rst
+++ b/tutorials/physics/soft_body.rst
@@ -1,3 +1,5 @@
+:article_outdated: True
+
 .. _doc_soft_body:
 
 Using SoftBody


### PR DESCRIPTION
Supersedes #7402.

The page needs a part going over the current weirdness with clipping. And something needs to be done for the cape tutorial. The 3D platformer project is still only for 3.x. And the Third person shooter demo while working for 4.0 broke when I tried to update it to 4.1.