### PR TITLE
Fix formatting for a link on the Release Policy page

### DIFF
--- a/about/release_policy.rst
+++ b/about/release_policy.rst
@@ -273,5 +273,5 @@ compatibility-breaking changes of this kind.
       optional parameter), a GDExtension compatibility method must be created.
       This ensures that existing GDExtensions continue to work across patch and
       minor releases, so that users don't have to recompile them.
-      See `pull request #76446 <https://github.com/godotengine/godot/pull/76446>`
+      See `pull request #76446 <https://github.com/godotengine/godot/pull/76446>`_
       for more information.


### PR DESCRIPTION
A mistake found its way into https://github.com/godotengine/godot-docs/pull/7518, and the link is [not formatted properly](https://docs.godotengine.org/en/latest/about/release_policy.html#what-are-the-criteria-for-compatibility-across-engine-versions) now:

![image](https://github.com/godotengine/godot-docs/assets/11782833/b4e112ee-bfd4-4803-af5a-57366e3cc332)

This should fix it. Should be cherry-picked when the other PR is cherry-picked.