### PR TITLE
Fix version number in GDExtension page

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -35,8 +35,8 @@ of Godot. GDExtensions will not work in older versions of Godot (only Godot 4 an
 .. note::
 
     To use `GDExtension <https://godotengine.org/article/introducing-gd-extensions>`__
-    you need to use the ``4.0`` branch of godot-cpp,
-    which is only compatible with Godot 4.0 and being used here as an example.
+    you need to use the ``4.1`` branch of godot-cpp,
+    which is only compatible with Godot 4.1 and being used here as an example.
     The ``master`` branch is the development branch and is being updated
     regularly to work with godot's ``master`` branch.
 
@@ -48,7 +48,7 @@ a Git submodule:
     mkdir gdextension_cpp_example
     cd gdextension_cpp_example
     git init
-    git submodule add -b 4.0 https://github.com/godotengine/godot-cpp
+    git submodule add -b 4.1 https://github.com/godotengine/godot-cpp
     cd godot-cpp
     git submodule update --init
 
@@ -58,7 +58,7 @@ Alternatively, you can also clone it to the project folder:
 
     mkdir gdextension_cpp_example
     cd gdextension_cpp_example
-    git clone -b 4.0 https://github.com/godotengine/godot-cpp
+    git clone -b 4.1 https://github.com/godotengine/godot-cpp
 
 .. note::
 
@@ -317,7 +317,7 @@ build files in a subsequent tutorial.
 
     This ``SConstruct`` file was written to be used with the latest ``godot-cpp``
     master, you may need to make small changes using it with older versions or
-    refer to the ``SConstruct`` file in the Godot 4.0 documentation.
+    refer to the ``SConstruct`` file in the Godot 4.1 documentation.
 
 Once you've downloaded the ``SConstruct`` file, place it in your GDExtension folder
 structure alongside ``godot-cpp``, ``src`` and ``demo``, then run:


### PR DESCRIPTION
The [documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/gdextension/gdextension_cpp_example.html) stated Godot 4.0 instead of 4.1

Cloning repository 4.0 caused a missing type specifier in **Creating a simple plugin** section in the register_types.cpp implementation. As in godot-cpp 4.0 [docs](https://github.com/godotengine/godot-cpp/tree/4.0#getting-started) `const GDExtensionInterface *p_interface` is used instead of `GDExtensionInterfaceGetProcAddress p_get_proc_address` [(here)](https://github.com/godotengine/godot-cpp/tree/4.1#getting-started) 
gdexample.gdextension also stated `compatibility_minimum = 4.1` so that could cause issues as well.

This correct versioning should fix this version issue, and the project shall compile without any errors.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
