### PR TITLE
Made scrollbar follow user's color theme

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -26,6 +26,7 @@
 
  /* Default (light) theme colors */
  :root {
+    color-scheme: light dark;
     --body-color: #404040;
     --content-wrap-background-color: #efefef;
     --content-background-color: #fcfcfc;


### PR DESCRIPTION
This pull request makes a small fix to the documentation website. The problem is that the scrollbar on the website doesn't follow the user's theme settings. I tested this in different web browsers. We had similar issue on the Godot website as well.
![light scrollbar (1)](https://github.com/godotengine/godot-docs/assets/81252768/0ecae5df-4fc0-4533-b184-3f7f840c569b)
