### PR TITLE
Fixes packet details of ENetConnection EVENT_RECEIVE documentation

### DIFF
--- a/classes/class_enetconnection.rst
+++ b/classes/class_enetconnection.rst
@@ -177,7 +177,7 @@ A peer has disconnected. This event is generated on a successful completion of a
 
 :ref:`EventType<enum_ENetConnection_EventType>` **EVENT_RECEIVE** = ``3``
 
-A packet has been received from a peer. The array will contain the peer which sent the packet, the channel number upon which the packet was received, and the received packet.
+A packet has been received from a peer. The array will contain the peer which sent the packet and the channel number upon which the packet was received. The received packet will be queued to the associated :ref:`ENetPacketPeer<class_ENetPacketPeer>`.
 
 .. rst-class:: classref-item-separator
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

The documentation for `ENetConnection#service` explains correctly that packets are queued in the associated `ENetPacketPeer`, however the documentation for `EventType<enum ENetConnection_EventType>#EVENT_RECEIVE` incorrectly states that the received packet is placed in the array returned from `ENetConnection#service`. This PR updates the documentation for `EVENT_RECEIVE` to correctly state that the packet is queued in the associated peer.