### PR TITLE
fix: update location of `node_3d_editor_gizmos.cpp`

### DIFF
--- a/contributing/development/editor/introduction_to_editor_development.rst
+++ b/contributing/development/editor/introduction_to_editor_development.rst
@@ -52,7 +52,7 @@ Some important files in the editor are:
   The 2D editor viewport and related functionality (toolbar at the top, editing modes, overlaid helpers/panels, …).
 - `editor/plugins/node_3d_editor_plugin.cpp <https://github.com/godotengine/godot/blob/master/editor/plugins/node_3d_editor_plugin.cpp>`__:
   The 3D editor viewport and related functionality (toolbar at the top, editing modes, overlaid panels, …).
-- `editor/node_3d_editor_gizmos.cpp <https://github.com/godotengine/godot/blob/master/editor/node_3d_editor_gizmos.cpp>`__:
+- `editor/plugins/node_3d_editor_gizmos.cpp <https://github.com/godotengine/godot/blob/master/editor/plugins/node_3d_editor_gizmos.cpp>`__:
   Where the 3D editor gizmos are defined and drawn.
   This file doesn't have a 2D counterpart as 2D gizmos are drawn by the nodes themselves.
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
**PR Summary**:
PR fixes the location of the `node_3d_editor_gizmos.cpp` file. It was moved from `editor` to `editor/plugins`. 
See [Godot PR 50748](https://github.com/godotengine/godot/pull/50748) for more info.