### PR TITLE
fix typo in bbcode_in_richtextlabel.rst

### DIFF
--- a/tutorials/ui/bbcode_in_richtextlabel.rst
+++ b/tutorials/ui/bbcode_in_richtextlabel.rst
@@ -754,7 +754,7 @@ Tornado
 
 .. image:: img/bbcode_in_richtextlabel_effect_tornado.webp
 
-Tornao makes the text move around in a circle. Its tag format is
+Tornado makes the text move around in a circle. Its tag format is
 ``[tornado radius=10.0 freq=1.0 connected=1]{text}[/tornado]``.
 
 ``radius`` is the radius of the circle that controls the offset, ``freq`` is how


### PR DESCRIPTION
fixes the "tornao" typo in bbcode_in_richtextlabel.rst (its supposed to be tornado)

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
