### PR TITLE
Update script-based workaround for focus (rebased on master branch now)

### DIFF
--- a/tutorials/inputs/controllers_gamepads_joysticks.rst
+++ b/tutorials/inputs/controllers_gamepads_joysticks.rst
@@ -242,18 +242,12 @@ with the following script and use it to check all your inputs:
                 focused = true
 
 
-    func input_is_action_pressed(action: StringName) -> bool:
-        if focused:
-            return Input.is_action_pressed(action)
-
-        return false
+    func is_input_action_pressed(action: StringName) -> bool:
+        return focused and Input.is_action_pressed(action)
 
 
-    func event_is_action_pressed(event: InputEvent, action: StringName) -> bool:
-        if focused:
-            return Input.is_action_pressed(action)
-
-        return false
+    func is_input_event_action_pressed(event: InputEvent, action: StringName) -> bool:
+        return focused and event.is_action_pressed(action)
 
 Then, instead of using ``Input.is_action_pressed(action)``, use
 ``Focus.input_is_action_pressed(action)`` where ``action`` is the name of


### PR DESCRIPTION
The workaround for Window focus had an error where event_is_action_pressed() did the exact same thing as input_is_action_pressed(), thus making event_is_action_pressed() redundant. I've fixed that, shortened the number of lines needed for both methods and also changed the names of the methods to be more readable.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
