### PR TITLE
Document more array formats that can be used in vertex arrays

### DIFF
--- a/tutorials/3d/procedural_geometry/arraymesh.rst
+++ b/tutorials/3d/procedural_geometry/arraymesh.rst
@@ -40,7 +40,7 @@ See :ref:`Mesh.ArrayType <enum_Mesh_ArrayType>` for a full list.
     
     * - 2
       - ``ARRAY_TANGENT``
-      - :ref:`PackedFloat32Array <class_PackedFloat32Array>` of groups of 4 floats. The first 3 floats determine the tangent, and the last float the binormal 
+      - :ref:`PackedFloat32Array <class_PackedFloat32Array>` or :ref:`PackedFloat64Array <class_PackedFloat64Array>` of groups of 4 floats. The first 3 floats determine the tangent, and the last float the binormal 
         direction as -1 or 1.
     
     * - 3
@@ -61,7 +61,7 @@ See :ref:`Mesh.ArrayType <enum_Mesh_ArrayType>` for a full list.
     
     * - 11
       - ``ARRAY_WEIGHTS``
-      - :ref:`PackedFloat32Array <class_PackedFloat32Array>` of groups of 4 floats. Each float lists the amount of weight the corresponding bone in ``ARRAY_BONES`` has on a given vertex.
+      - :ref:`PackedFloat32Array <class_PackedFloat32Array>` or :ref:`PackedFloat64Array <class_PackedFloat64Array>` of groups of 4 floats. Each float lists the amount of weight the corresponding bone in ``ARRAY_BONES`` has on a given vertex.
     
     * - 12
       - ``ARRAY_INDEX``


### PR DESCRIPTION
Noticed this while doing some work on vertex formats. 

Tangents:
https://github.com/godotengine/godot/blob/f7bc653cbe81018fe362472a0143b7153a52f929/servers/rendering_server.cpp#L416
Weights:
https://github.com/godotengine/godot/blob/f7bc653cbe81018fe362472a0143b7153a52f929/servers/rendering_server.cpp#L559
