### PR TITLE
fixed Localization using gettext wrong word #7749

### DIFF
--- a/tutorials/i18n/localization_using_gettext.rst
+++ b/tutorials/i18n/localization_using_gettext.rst
@@ -214,7 +214,7 @@ You can generate a MO file with the command below:
     msgfmt fr.po --no-hash -o fr.mo
 
 If the PO file is valid, this command will create a ``fr.mo`` file besides
-the PO file. This MO file can then be loaded in Godot as described below.
+the PO file. This MO file can then be loaded in Godot as described above.
 
 The original PO file should be kept in version control so you can update
 your translation in the future. In case you lose the original PO file and


### PR DESCRIPTION
This change resolves #7749 by changing the text description from "below" to "above".

