### PR TITLE
Custom editor icon section's command wrong or out of date

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -442,8 +442,9 @@ For example:
 
 .. code-block:: none
 
-    [Icon]
-    GDExample = "res://icons/GDExample.svg"
+    [icons]
+
+    GDExample = "res://icons/gd_example.svg"
 
 The path should point to a 16 by 16 pixel SVG image. Read the guide for :ref:`creating icons <doc_editor_icons>`
 for more information.


### PR DESCRIPTION
4.1.1.stable

https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

In the "*.gdextension" code block, the [Icon] tag does not work in 4.1.1.stable version, and it does not match the naming conventions of other tags. I test it, [icons] tag is worked well. In addition, I added a blank lines between the tag and the content to make it more consistent with other "*.gdextension" code block formatting.

Bugsquad edit: Fixes https://github.com/godotengine/godot-docs/issues/7885
