### PR TITLE
Add missing annotation prefix in godot_interfaces

### DIFF
--- a/tutorials/best_practices/godot_interfaces.rst
+++ b/tutorials/best_practices/godot_interfaces.rst
@@ -58,7 +58,7 @@ access.
     @export var script_type: Script
 
     # Must configure from the editor, defaults to null.
-    export var const_script: Script:
+    @export var const_script: Script:
         set(value):
             if Engine.is_editor_hint():
                 const_script = value


### PR DESCRIPTION
Adds the `@`.