### PR TITLE
Remove unsupported image format

### DIFF
--- a/tutorials/assets_pipeline/importing_images.rst
+++ b/tutorials/assets_pipeline/importing_images.rst
@@ -22,7 +22,7 @@ Godot can import the following image formats:
 - PNG (``.png``)
   - Precision is limited to 8 bits per channel upon importing (no HDR images).
 - Truevision Targa (``.tga``)
-- SVG (``.svg``, ``.svgz``)
+- SVG (``.svg``)
   - SVGs are rasterized using `ThorVG <https://www.thorvg.org/>`__
   when importing them. `Support is limited <https://www.thorvg.org/about#:~:text=among%20the%20svg%20tiny%20specs%2C%20yet%20unsupported%20features%20in%20the%20thorvg%20are%20the%20following>`__;
   complex vectors may not render correctly.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

## What I did 

- Removed reference to `.svgz` image format from 'Supported image formats' documentation (https://docs.godotengine.org/en/latest/tutorials/assets_pipeline/importing_images.html).

#### Fixes: #7817