### PR TITLE
Fix incorrect/misleading explanation of duck typing and dynamic typing in the static typing page

### DIFF
--- a/tutorials/scripting/gdscript/static_typing.rst
+++ b/tutorials/scripting/gdscript/static_typing.rst
@@ -188,10 +188,10 @@ an error or not at runtime.
 This happens when you get a child node. Let's take a timer for example:
 with dynamic code, you can get the node with ``$Timer``. GDScript
 supports `duck-typing <https://stackoverflow.com/a/4205163/8125343>`__,
-so even if your timer is of type ``Timer``, it is also a ``Node`` and an
-``Object``, two classes it extends. With dynamic GDScript, you also
-don't care about the node's type as long as it has the methods you need
-to call.
+so even if your timer is of type ``Timer``, Godot doesn't validate wheter it
+supports operations based on its **type**. Instead, it verifies that the object
+**implements** the specific methods individually. Thus, you don't need to
+care about the node's type, as long as it possesses the methods you need to call.
 
 You can use casting to tell Godot the type you expect when you get a
 node: ``($Timer as Timer)``, ``($Player as CharacterBody2D)``, etc.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

## What I did 

- Adjusted a incorrect/misleading explanation of duck typing and dynamic typing in the static typing page. I based myself on what is written on 'Accessing data or logic from an object' section of [`godot_interfaces.rst`]([/tutorials/vest_practices/godot_interfaces.rst] ).

#### Fixes: #7763