### PR TITLE
Improve `MeshDataTool.get_face_vertex` method description

### DIFF
--- a/classes/class_meshdatatool.rst
+++ b/classes/class_meshdatatool.rst
@@ -318,9 +318,19 @@ Calculates and returns the face normal of the given face.
 
 :ref:`int<class_int>` **get_face_vertex** **(** :ref:`int<class_int>` idx, :ref:`int<class_int>` vertex **)** |const|
 
-Returns the specified vertex of the given face.
+Returns the specified vertex index of the given face.
 
 Vertex argument must be either 0, 1, or 2 because faces contain three vertices.
+
+\ **Example:**\ 
+
+
+.. tabs::
+ .. code-tab:: gdscript GDScript
+
+    var index = mesh_data_tool.get_face_vertex(0, 1) # Gets the index of the second vertex of the first face.
+    var position = mesh_data_tool.get_vertex(index)
+    var normal = mesh_data_tool.get_vertex_normal(index)
 
 .. rst-class:: classref-item-separator
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

## What I did 

- Improved the `MeshDataTool.get_face_vertex` method description by making it more clear about what is the data type that is returned and adding a code example.

#### Fixes: #7852