### PR TITLE
Use relative font size for `code` elements

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -798,7 +798,7 @@ html.writer-html5 .rst-content .wy-table-responsive > table td > p code.literal 
 code,
 .rst-content tt,
 .rst-content code {
-    font-size: 14px;
+    font-size: .875em;
     font-family: var(--monospace-font-family);
     background-color: var(--code-background-color);
     border: none;


### PR DESCRIPTION
Fixes too small font size in headers ([example](https://docs.godotengine.org/en/latest/tutorials/scripting/gdscript/gdscript_documentation_comments.html)). The size in the text hasn't changed (at least for the font on my OS).

![](https://github.com/godotengine/godot-docs/assets/47700418/723e7d7b-1cd2-454f-bd48-ed1411c02142)