### PR TITLE
Update gdextension_cpp_example.rst to avoid unquoted compatibility_minimum trap

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -359,7 +359,7 @@ loaded for each platform and the entry function for the module. It is called ``g
     [configuration]
 
     entry_symbol = "example_library_init"
-    compatibility_minimum = 4.1
+    compatibility_minimum = "4.1"
 
     [libraries]
 


### PR DESCRIPTION
Fixes #7864 - demonstrates to reader that `compatibility_minimum` is better enclosed in quotes (to avoid a misleading error from parsing unquoted three-element version numbers e.g. `4.1.1`).

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/80590*

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
