### PR TITLE
Add missing C# code in making plugins tutorial

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -432,7 +432,8 @@ an autoload.
 
 Use the following code to register a singleton from an editor plugin:
 
-::
+.. tabs::
+ .. code-tab:: gdscript GDScript
 
     @tool
     extends EditorPlugin
@@ -448,3 +449,27 @@ Use the following code to register a singleton from an editor plugin:
 
     func _exit_tree():
         remove_autoload_singleton(AUTOLOAD_NAME)
+
+ .. code-tab:: csharp
+
+    #if TOOLS
+    using Godot;
+
+    [Tool]
+    public partial class MyEditorPlugin : EditorPlugin
+    {
+        // Replace this value with a PascalCase autoload name.
+        private const string AutoloadName = "SomeAutoload";
+
+        public override void _EnterTree()
+        {
+            // The autoload can be a scene or script file.
+            AddAutoloadSingleton(AutoloadName, "res://addons/MyAddon/SomeAutoload.tscn");
+        }
+
+        public override void _ExitTree()
+        {
+            RemoveAutoloadSingleton(AutoloadName);
+        }
+    }
+    #endif


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

## What I did

- Added a missing C# code example in 'Registering autoloads/singletons in plugins' section of making plugins tutorial.

#### Closes: #7859 