### PR TITLE
Update gdextension_cpp_example.rst

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -442,7 +442,7 @@ For example:
 
 .. code-block:: none
 
-    [Icon]
+    [icons]
     GDExample = "res://icons/GDExample.svg"
 
 The path should point to a 16 by 16 pixel SVG image. Read the guide for :ref:`creating icons <doc_editor_icons>`


### PR DESCRIPTION
FIX: custom icons not working

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
