### PR TITLE
PoolVector3Array now should be PackedVector3Array

### DIFF
--- a/tutorials/navigation/navigation_using_navigationservers.rst
+++ b/tutorials/navigation/navigation_using_navigationservers.rst
@@ -135,7 +135,7 @@ Afterwards the function waits for the next physics_frame before continuing with 
 
         # create a procedural navigation mesh for the region
         var new_navigation_mesh: NavigationMesh = NavigationMesh.new()
-        var vertices: PackedVector3Array = PoolVector3Array([
+        var vertices: PackedVector3Array = PackedVector3Array([
             Vector3(0,0,0),
             Vector3(9.0,0,0),
             Vector3(0,0,9.0)


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
