### PR TITLE
Compiling for x11: use `linker=lld`

### DIFF
--- a/development/compiling/compiling_for_x11.rst
+++ b/development/compiling/compiling_for_x11.rst
@@ -225,7 +225,7 @@ the default GCC + GNU ld setup:
 To do so, install Clang and the ``lld`` package from your distribution's package manager
 then use the following SCons command::
 
-    scons platform=x11 use_llvm=yes use_lld=yes
+    scons platform=x11 use_llvm=yes linker=lld
 
 After the build is completed, a new binary with a ``.llvm`` suffix will be
 created in the ``bin/`` folder.


### PR DESCRIPTION
`use_lld` boolean option has been replaced by `linker=<default|bfd|gold|lld|mold>`

Stable is already up-to-date and mentions `linker`: https://docs.godotengine.org/en/stable/contributing/development/compiling/compiling_for_linuxbsd.html#using-clang-and-lld-for-faster-development