### PR TITLE
Fix SIZE built-in in fog shader reference

### DIFF
--- a/tutorials/shaders/shader_reference/fog_shader.rst
+++ b/tutorials/shaders/shader_reference/fog_shader.rst
@@ -63,7 +63,8 @@ be drawn at once.
 +-------------------------------+-------------------------------------------------------------------------------------------------+
 | in vec3 **UVW**               | 3-dimensional uv, used to map a 3D texture to the current :ref:`FogVolume <class_FogVolume>`.   |
 +-------------------------------+-------------------------------------------------------------------------------------------------+
-| in vec3 **EXTENTS**           | Color value of corresponding pixel from half resolution pass. Uses linear filter.               |
+| in vec3 **SIZE**              | Size of the current :ref:`FogVolume <class_FogVolume>` when its                                 |
+|                               | :ref:`shape<class_FogVolume_property_shape>` has a size.                                        |
 +-------------------------------+-------------------------------------------------------------------------------------------------+
 | in vec3 **SDF**               | Signed distance field to the surface of the :ref:`FogVolume <class_FogVolume>`. Negative if     |
 |                               | inside volume, positive otherwise.                                                              |


### PR DESCRIPTION
It has been renamed from EXTENTS in https://github.com/godotengine/godot/commit/a59819630dcdb6dc9680b273d8a77267ea660e96; while its description was completely unrelated (copied from the sky shader reference)

The phrasing isn't the most elegant, but I felt that listing the `FogVolumeShape` enum values like it's done in the `FogVolume` reference would've been too repetitive and unelegant to write in the table.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
