### PR TITLE
Update custom "look_at()" method for rigid bodies

### DIFF
--- a/tutorials/physics/rigid_body.rst
+++ b/tutorials/physics/rigid_body.rst
@@ -37,10 +37,10 @@ Here is a custom ``look_at()`` method that will work reliably with rigid bodies:
     extends RigidBody3D
 
     func look_follow(state, current_transform, target_position):
-        var up_dir = Vector3(0, 1, 0)
-        var cur_dir = current_transform.basis * Vector3(0, 0, 1)
+        var up_dir = Vector3.UP
+        var cur_dir = current_transform.basis.z
         var target_dir = current_transform.origin.direction_to(target_position)
-        var rotation_angle = acos(cur_dir.x) - acos(target_dir.x)
+        var rotation_angle = cur_dir.signed_angle_to(target_dir, up_dir)
 
         state.angular_velocity = up_dir * (rotation_angle / state.step)
 
@@ -56,10 +56,10 @@ Here is a custom ``look_at()`` method that will work reliably with rigid bodies:
     {
         private void LookFollow(PhysicsDirectBodyState state, Transform3D currentTransform, Vector3 targetPosition)
         {
-            var upDir = new Vector3(0, 1, 0);
-            var curDir = currentTransform.Basis * new Vector3(0, 0, 1);
+            var upDir = new Vector3.UP;
+            var curDir = currentTransform.Basis.z;
             var targetDir = currentTransform.Origin.DirectionTo(targetPosition);
-            var rotationAngle = Mathf.Acos(curDir.X) - Mathf.Acos(targetDir.X);
+            var rotationAngle = curDir.signed_angle_to(targetDir, up_Dir);
 
             state.SetAngularVelocity(upDir * (rotationAngle / state.GetStep()));
         }

--- a/tutorials/physics/rigid_body.rst
+++ b/tutorials/physics/rigid_body.rst
@@ -56,7 +56,7 @@ Here is a custom ``look_at()`` method that will work reliably with rigid bodies:
     {
         private void LookFollow(PhysicsDirectBodyState state, Transform3D currentTransform, Vector3 targetPosition)
         {
-            var upDir = new Vector3.UP;
+            var upDir = Vector3.Up;
             var curDir = currentTransform.Basis.Z;
             var targetDir = currentTransform.Origin.DirectionTo(targetPosition);
             var rotationAngle = curDir.SignedAngleTo(targetDir, upDir);

--- a/tutorials/physics/rigid_body.rst
+++ b/tutorials/physics/rigid_body.rst
@@ -57,7 +57,7 @@ Here is a custom ``look_at()`` method that will work reliably with rigid bodies:
         private void LookFollow(PhysicsDirectBodyState state, Transform3D currentTransform, Vector3 targetPosition)
         {
             var upDir = new Vector3.UP;
-            var curDir = currentTransform.Basis.z;
+            var curDir = currentTransform.Basis.Z;
             var targetDir = currentTransform.Origin.DirectionTo(targetPosition);
             var rotationAngle = curDir.SignedAngleTo(targetDir, upDir);
 

--- a/tutorials/physics/rigid_body.rst
+++ b/tutorials/physics/rigid_body.rst
@@ -59,7 +59,7 @@ Here is a custom ``look_at()`` method that will work reliably with rigid bodies:
             var upDir = new Vector3.UP;
             var curDir = currentTransform.Basis.z;
             var targetDir = currentTransform.Origin.DirectionTo(targetPosition);
-            var rotationAngle = curDir.signed_angle_to(targetDir, up_Dir);
+            var rotationAngle = curDir.SignedAngleTo(targetDir, upDir);
 
             state.SetAngularVelocity(upDir * (rotationAngle / state.GetStep()));
         }


### PR DESCRIPTION
fixes #3835

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
