### PR TITLE
Updating the 2D tutorial in light of an editor bug

### DIFF
--- a/getting_started/first_2d_game/03.coding_the_player.rst
+++ b/getting_started/first_2d_game/03.coding_the_player.rst
@@ -478,15 +478,16 @@ be ``RigidBody2D`` nodes, we want the ``body_entered(body: Node2D)`` signal. Thi
 signal will be emitted when a body contacts the player. Click "Connect.." and
 the "Connect a Signal" window appears.
 
-Godot will attempt to create a function with that exact name directly in script
+Godot will create a function with that exact name directly in script
 for you. You don't need to change the default settings right now.
 
 .. warning::
 
-    Normally Godot is meant to automatically create a function for the signal to
-    connect to directly in the script. However, if you're using an external text
-    editor (for example, Visual Studio Code), a bug currently prevents Godot from doing
-    so. You'll be sent to your external editor, but the new function won't be there.
+.. The issue for this bug is #41283
+
+    If you're using an external text editor (for example, Visual Studio Code),
+    a bug currently prevents Godot from doing so. You'll be sent to your external
+    editor, but the new function won't be there.
 
     In this case, you'll need to write the function yourself into the Player's
     script file.

--- a/getting_started/first_2d_game/03.coding_the_player.rst
+++ b/getting_started/first_2d_game/03.coding_the_player.rst
@@ -483,7 +483,7 @@ for you. You don't need to change the default settings right now.
 
 .. warning::
 
-.. The issue for this bug is #41283
+    .. The issue for this bug is #41283
 
     If you're using an external text editor (for example, Visual Studio Code),
     a bug currently prevents Godot from doing so. You'll be sent to your external

--- a/getting_started/first_2d_game/03.coding_the_player.rst
+++ b/getting_started/first_2d_game/03.coding_the_player.rst
@@ -476,14 +476,28 @@ Inspector tab to see the list of signals the player can emit:
 Notice our custom "hit" signal is there as well! Since our enemies are going to
 be ``RigidBody2D`` nodes, we want the ``body_entered(body: Node2D)`` signal. This
 signal will be emitted when a body contacts the player. Click "Connect.." and
-the "Connect a Signal" window appears. We don't need to change any of these
-settings so click "Connect" again. Godot will automatically create a function in
-your player's script.
+the "Connect a Signal" window appears.
+
+Godot will attempt to create a function with that exact name directly in script
+for you. You don't need to change the default settings right now.
+
+.. warning::
+
+    Normally Godot is meant to automatically create a function for the signal to
+    connect to directly in the script. However, if you're using an external text
+    editor (for example, Visual Studio Code), a bug currently prevents Godot from doing
+    so. You'll be sent to your external editor, but the new function won't be there.
+
+    In this case, you'll need to write the function yourself into the Player's
+    script file.
 
 .. image:: img/player_signal_connection.webp
 
-Note the green icon indicating that a signal is connected to this function. Add
-this code to the function:
+Note the green icon indicating that a signal is connected to this function; this does
+not mean the function exists, only that the signal will attempt to connect to a function
+with that name, so double-check that the spelling of the function matches exactly!
+
+Next, add this code to the function:
 
 .. tabs::
  .. code-tab:: gdscript GDScript


### PR DESCRIPTION
Issue #41283 is currently disrupting the flow of the official 2D tutorial for users with external script editors.

This change is to update the tutorial to acknowledge this bug and provide newcomers with clearer guidelines on how to complete the tutorial despite the bug.

It also clarifies a potential point of confusion about how strictly function naming conventions must be adhered to.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
