### PR TITLE
Updates to parts 6 and 7 of the 2D tutorial

### DIFF
--- a/getting_started/first_2d_game/07.finishing-up.rst
+++ b/getting_started/first_2d_game/07.finishing-up.rst
@@ -37,10 +37,33 @@ All audio is automatically imported with the ``Loop`` setting disabled.
 If you want the music to loop seamlessly, click on the Stream file arrow,
 select ``Make Unique``, then click on the Stream file and check the ``Loop`` box. 
 
-To play the music, add ``$Music.play()`` in the ``new_game()``
-function and ``$Music.stop()`` in the ``game_over()`` function.
+To play the music during the game, add the following code to the ``new_game()``
+function:
 
-Finally, add ``$DeathSound.play()`` in the ``game_over()`` function.
+.. tabs::
+ .. code-tab:: gdscript GDScript
+
+    $Music.play()
+
+ .. code-tab:: csharp
+
+    GetNode<AudioStreamPlayer2D>("Music").Play();
+
+To play the death sound and stop the music on game over, add the following
+code to the ``game_over()`` function:
+
+.. tabs::
+ .. code-tab:: gdscript GDScript
+
+    $Music.stop()
+    $DeathSound.play()
+
+ .. code-tab:: csharp
+
+    GetNode<AudioStreamPlayer2D>("Music").Stop();
+    GetNode<AudioStreamPlayer2D>("DeathSound").Play();
+
+You've now finished adding sound to the game.
 
 Keyboard shortcut
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
In the HUD section, X=200 isn't a valid size for the button. If 200 is entered as directed, the size automatically updates to 370. Given the described aim of this change, I suspect 400 was the intended value, and 400 does produce the described result (some padding between the text and the border of the button).

Also adding differentiation between GDScript and C# around the audio scripting in part 7.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
