### PR TITLE
Rigidbody2D to Mob cast type error  when using 'mob' as variable name

### DIFF
--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -338,7 +338,7 @@ Note that a new instance must be added to the scene using ``add_child()``.
         // obviously Mob and PathFollow2D, since they appear later on the line.
 
         // Create a new instance of the Mob scene.
-        Mob mob = MobScene.Instantiate<Mob>();
+        Mob monster = MobScene.Instantiate<Mob>();
 
         // Choose a random location on Path2D.
         var mobSpawnLocation = GetNode<PathFollow2D>("MobPath/MobSpawnLocation");
@@ -348,18 +348,18 @@ Note that a new instance must be added to the scene using ``add_child()``.
         float direction = mobSpawnLocation.Rotation + Mathf.Pi / 2;
 
         // Set the mob's position to a random location.
-        mob.Position = mobSpawnLocation.Position;
+        monster.Position = mobSpawnLocation.Position;
 
         // Add some randomness to the direction.
         direction += (float)GD.RandRange(-Mathf.Pi / 4, Mathf.Pi / 4);
-        mob.Rotation = direction;
+        monster.Rotation = direction;
 
         // Choose the velocity.
         var velocity = new Vector2((float)GD.RandRange(150.0, 250.0), 0);
-        mob.LinearVelocity = velocity.Rotated(direction);
+        monster.LinearVelocity = velocity.Rotated(direction);
 
         // Spawn the mob by adding it to the Main scene.
-        AddChild(mob);
+        AddChild(monster);
     }
 
  .. code-tab:: cpp


### PR DESCRIPTION
In C# using mob as the variable name for the Mob causes a cast type error going Rigidbody2D to Mob. Changing the variable to something other than 'mob' solves this issue.

Godot 4.1.1
.NET SDK 6.0.414

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
