### PR TITLE
Add macOS shortcut in getting started page

### DIFF
--- a/getting_started/first_2d_game/02.player_scene.rst
+++ b/getting_started/first_2d_game/02.player_scene.rst
@@ -53,7 +53,8 @@ or :kbd:`Cmd + S` on macOS.
 Sprite animation
 ~~~~~~~~~~~~~~~~
 
-Click on the ``Player`` node and add (:kbd:`Ctrl + A`) a child node :ref:`AnimatedSprite2D
+Click on the ``Player`` node and add (:kbd:`Ctrl + A` on Windows/Linux or
+:kbd:`Cmd + A` on macOS) a child node :ref:`AnimatedSprite2D
 <class_AnimatedSprite2D>`. The ``AnimatedSprite2D`` will handle the
 appearance and animations for our player. Notice that there is a warning symbol
 next to the node. An ``AnimatedSprite2D`` requires a :ref:`SpriteFrames


### PR DESCRIPTION
Add macOS shortcut in getting started page

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
