### PR TITLE
Update high_level_multiplayer.rst

### DIFF
--- a/tutorials/networking/high_level_multiplayer.rst
+++ b/tutorials/networking/high_level_multiplayer.rst
@@ -196,6 +196,13 @@ For a remote call to be successful, the sending and receiving node need to have 
 must have the same name. When using ``add_child()`` for nodes which are expected to use RPCs, set the argument
 ``force_readable_name`` to ``true``.
 
+.. warning:: 
+
+    If a function is annotated rpc on the client script (resp. server script), then this function must also be declared on the server script (resp. client script), and both
+    must have the same signature, even if this function is not currently used.
+
+    If these conditions are not fulfilled, the script may raise an error or cause unwanted behaviour. See further explanation and troubleshoot on [this post](https://github.com/godotengine/godot/issues/57869#issuecomment-1034215138).
+
 The annotation can take a number of arguments, which have default values. ``@rpc`` is equivalent to:
 
 ::
@@ -238,6 +245,8 @@ The function ``multiplayer.get_remote_sender_id()`` can be used to get the uniqu
         # The server knows who sent the input.
         var sender_id = multiplayer.get_remote_sender_id()
         # Process the input and affect game logic.
+
+    
 
 Channels
 --------


### PR DESCRIPTION
Adding a warning on the fact that a function annotated rpc must exists on both client and server scripts, as explained on  [this post](https://github.com/godotengine/godot/issues/57869#issuecomment-1034215138).


<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
