### PR TITLE
Added missing C# example in tutorials -> best practices -> godot_notifications.

### DIFF
--- a/tutorials/best_practices/godot_notifications.rst
+++ b/tutorials/best_practices/godot_notifications.rst
@@ -84,6 +84,26 @@ implementing a Timer-timeout loop is another option.
             print("This block runs every 0.5 seconds")
         )
 
+  .. code-tab:: csharp
+
+    using Godot;
+
+    public partial class MyNode : Node
+    {
+
+        // Allows for recurring operations that don't trigger script logic
+        // every frame (or even every fixed frame).
+        public void _Process(double delta)
+        {
+            var timer = new Timer();
+            timer.Autostart = true;
+            timer.WaitTime = 0.5;
+            AddChild(timer);
+            timer.Timeout += () => GD.Print("This block runs every 0.5 seconds");
+        }
+
+    }
+
 Use ``_physics_process()`` when one needs a framerate-independent delta time
 between frames. If code needs consistent updates over time, regardless
 of how fast or slow time advances, this is the right place.

--- a/tutorials/best_practices/godot_notifications.rst
+++ b/tutorials/best_practices/godot_notifications.rst
@@ -92,7 +92,7 @@ implementing a Timer-timeout loop is another option.
     {
         // Allows for recurring operations that don't trigger script logic
         // every frame (or even every fixed frame).
-        public void _Ready(double delta)
+        public void _Ready()
         {
             var timer = new Timer();
             timer.Autostart = true;

--- a/tutorials/best_practices/godot_notifications.rst
+++ b/tutorials/best_practices/godot_notifications.rst
@@ -84,7 +84,7 @@ implementing a Timer-timeout loop is another option.
             print("This block runs every 0.5 seconds")
         )
 
-  .. code-tab:: csharp
+ .. code-tab:: csharp
 
     using Godot;
 

--- a/tutorials/best_practices/godot_notifications.rst
+++ b/tutorials/best_practices/godot_notifications.rst
@@ -90,10 +90,9 @@ implementing a Timer-timeout loop is another option.
 
     public partial class MyNode : Node
     {
-
         // Allows for recurring operations that don't trigger script logic
         // every frame (or even every fixed frame).
-        public void _Process(double delta)
+        public void _Ready(double delta)
         {
             var timer = new Timer();
             timer.Autostart = true;
@@ -101,7 +100,6 @@ implementing a Timer-timeout loop is another option.
             AddChild(timer);
             timer.Timeout += () => GD.Print("This block runs every 0.5 seconds");
         }
-
     }
 
 Use ``_physics_process()`` when one needs a framerate-independent delta time

--- a/tutorials/best_practices/godot_notifications.rst
+++ b/tutorials/best_practices/godot_notifications.rst
@@ -92,7 +92,7 @@ implementing a Timer-timeout loop is another option.
     {
         // Allows for recurring operations that don't trigger script logic
         // every frame (or even every fixed frame).
-        public void _Ready()
+        public override void _Ready()
         {
             var timer = new Timer();
             timer.Autostart = true;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

There's a missing C# code example in https://docs.godotengine.org/en/latest/tutorials/best_practices/godot_notifications.html. All this does is add it in.