### PR TITLE
Changed Input. to event. in the event_is_action_pressed() example function

### DIFF
--- a/tutorials/inputs/controllers_gamepads_joysticks.rst
+++ b/tutorials/inputs/controllers_gamepads_joysticks.rst
@@ -251,7 +251,7 @@ with the following script and use it to check all your inputs:
 
     func event_is_action_pressed(event: InputEvent, action: StringName) -> bool:
         if focused:
-            return Input.is_action_pressed(action)
+            return event.is_action_pressed(action)
 
         return false
 


### PR DESCRIPTION
The function event_is_action_pressed() within the Windows focus handling section was using the same code from the above function input_is_action_pressed and was not using the event parameter which is was made for.

The function is designed to replace event.is_action_pressed() to handle a defocused window and controller inputs.

I believe this is a simple typo.