### PR TITLE
Remove reference to old target in the macOS docs

### DIFF
--- a/contributing/development/compiling/compiling_for_macos.rst
+++ b/contributing/development/compiling/compiling_for_macos.rst
@@ -71,7 +71,7 @@ Manager.
 
 To create an ``.app`` bundle like in the official builds, you need to use the
 template located in ``misc/dist/macos_tools.app``. Typically, for an optimized
-editor binary built with ``target=release_debug``::
+editor binary built with ``dev_build=yes``::
 
     cp -r misc/dist/macos_tools.app ./Godot.app
     mkdir -p Godot.app/Contents/MacOS


### PR DESCRIPTION
Does what it says on the tin.