### PR TITLE
Add requirements for companies on the porting page

### DIFF
--- a/tutorials/platform/consoles.rst
+++ b/tutorials/platform/consoles.rst
@@ -75,8 +75,6 @@ Following is the list of providers:
   Switch porting of Godot games.
 - `mazette! games <https://mazette.games/>`_ offers
   Switch, Xbox One and Xbox Series X/S porting and publishing of Godot games.
-- `Olde Sküül <https://oldeskuul.com/>` offers
-  Switch, Xbox One, Playstation 4 & Playstation 5 porting and publishing of Godot games.
 - `Tuanisapps <https://www.tuanisapps.com/>`_ offers
   Switch porting and publishing of Godot games.
 
@@ -84,4 +82,9 @@ Following is the list of providers:
 If your company offers porting, or porting *and* publishing services for Godot games,
 feel free to
 `open an issue or pull request <https://github.com/godotengine/godot-docs>`_
-to add your company to the list above.
+to add your company to the list above if you meet the following requierments:
+
+- You have ported and published at least one Godot game on a console platform (Xbox,
+  playstation, or Nintendo Switch).
+- Your website indicates that you offer porting
+- Your website includes a way to contact you


### PR DESCRIPTION
Given that more companies are getting added to the porting page I figured it was time to add requirements to keep the list useful to developers.

To reiterate what's in the PR a company must have ported and published a Godot game to a console platform (Xbox, Nintendo or Playstation), there must be a way to contact them, and there must be a section of their site going over that they offer porting.

These requirements mean that the two open PRs for FIXER Group and SneakyBox cannot be merged as neither have ported and published a Godot game to console, and SneakyBox has no information on their site that indicates they do publishing.

Additionally I have removed Olde Skuul from the list. Their website has no information on them porting games, Godot or otherwise, to console. There's no contact info. They list the 3 descent games on Steam as something they have worked on yet they're not credited on the Steam store page at all. And on the "Games" page of their website clicking on any of the descent games takes you to "Battle Chess: Game of Kings" on Steam.

Mazette! technically passes if you consider the link to their Twitter and LinkedIn as a way to contact them. I'm ok with keeping it for now though I think we should ask them to add an email.

Also worth noting is this criteria does prevent W4 games, the company started by several maintainers, from being added to the list for now. To be clear In the interest of transparency I am a Godot maintainer, but do not and have never done work for W4.

 Feedback on these requirements is welcome