### PR TITLE
Fix Olde Sküül link

### DIFF
--- a/tutorials/platform/consoles.rst
+++ b/tutorials/platform/consoles.rst
@@ -75,7 +75,7 @@ Following is the list of providers:
   Switch porting of Godot games.
 - `mazette! games <https://mazette.games/>`_ offers
   Switch, Xbox One and Xbox Series X/S porting and publishing of Godot games.
-- `Olde Sküül <https://oldeskuul.com/>` offers
+- `Olde Sküül <https://oldeskuul.com/>`_ offers
   Switch, Xbox One, Playstation 4 & Playstation 5 porting and publishing of Godot games.
 - `Tuanisapps <https://www.tuanisapps.com/>`_ offers
   Switch porting and publishing of Godot games.


### PR DESCRIPTION
There's an issue right now with the Olde Sküül link. It doesn't show as a link, it's kinda broken.

![image](https://github.com/godotengine/godot-docs/assets/270928/d5481cbd-06ad-4664-8f69-3758c7ae6a20)

This PR fixes the link.