### PR TITLE
Ask companies to contact the Foundation for console ports list

### DIFF
--- a/tutorials/platform/consoles.rst
+++ b/tutorials/platform/consoles.rst
@@ -82,6 +82,4 @@ Following is the list of providers:
 
 
 If your company offers porting, or porting *and* publishing services for Godot games,
-feel free to
-`open an issue or pull request <https://github.com/godotengine/godot-docs>`_
-to add your company to the list above.
+please `contact the Godot Foundation <https://godot.foundation/>`_ to add your company to the list above.


### PR DESCRIPTION
Alternative to #7955

This ask companies that offer porting, or porting and publishing services for Godot games to contact the Godot Foundation to add their company in the list, putting the foundation responsible for handling that list instead of the documentation team.

See [this comment](https://github.com/godotengine/godot-docs/pull/7955#issuecomment-1724800062) for more context.
