### PR TITLE
Remove outdated VS setup and 2019 support info

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -77,7 +77,6 @@ click on **Editor → Editor Settings** and scroll down to
 external editor of choice. Godot currently supports the following
 external editors:
 
-- Visual Studio 2019
 - Visual Studio 2022
 - Visual Studio Code
 - MonoDevelop
@@ -149,16 +148,6 @@ While installing Visual Studio, select this workload:
 In Godot's **Editor → Editor Settings** menu:
 
 - Set **Dotnet** -> **Editor** -> **External Editor** to **Visual Studio**.
-
-Next, you can download the Godot Visual Studio extension from github
-`here <https://github.com/godotengine/godot-csharp-visualstudio/releases>`__.
-Double click on the downloaded file and follow the installation process.
-
-.. note:: The option to debug your game in Visual Studio may not appear after
-          installing the extension. To enable debugging, there is a
-          `workaround for Visual Studio 2019 <https://github.com/godotengine/godot-csharp-visualstudio/issues/10#issuecomment-720153256>`__.
-          There is
-          `a separate issue about this problem in Visual Studio 2022 <https://github.com/godotengine/godot-csharp-visualstudio/issues/28>`__.
 
 .. note:: If you see an error like "Unable to find package Godot.NET.Sdk",
           your NuGet configuration may be incorrect and need to be fixed.


### PR DESCRIPTION
Removes VS 2019 from the list of supported IDEs. It doesn't support .NET SDK 6.0 and can't build Godot projects. https://learn.microsoft.com/en-us/visualstudio/releases/2019/compatibility#-visual-studio-2019-support-for-net-development

Removes mention of the VS extension. It only applies to 3.x projects and debugging is done with ordinary debugging tools after the move to .NET in 4.x.

* Related: https://github.com/godotengine/godot-docs/issues/6911 (but I only saw this issue after preparing this change)

IMO this page should also include debugger setup. It is more normal than it was before, but it's still more involved than *just* hitting F5. I don't have VS and don't have the time to write this up though.

This should be applied to the 4.x branches.