### PR TITLE
Bumping Java JDK to 17 for Latest Android Release

### DIFF
--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -18,10 +18,10 @@ The following steps detail what is needed to set up the Android SDK and the engi
     Projects written in C# using Godot 4 currently cannot be exported to Android.
     To use C# on Android, use Godot 3 instead.
 
-Install OpenJDK 11
+Install OpenJDK 17
 ------------------
 
-Download and install  `OpenJDK 11 <https://adoptium.net/?variant=openjdk11>`__.
+Download and install  `OpenJDK 17 <https://adoptium.net/temurin/releases/?variant=openjdk17>`__.
 
 Download the Android SDK
 ------------------------

--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -21,7 +21,7 @@ The following steps detail what is needed to set up the Android SDK and the engi
 Install OpenJDK 17
 ------------------
 
-Download and install  `OpenJDK 17 <https://adoptium.net/temurin/releases/?variant=openjdk17>`__.
+Download and install `OpenJDK 17 <https://adoptium.net/temurin/releases/?variant=openjdk17>`__.
 
 Download the Android SDK
 ------------------------


### PR DESCRIPTION
The latest version of android sdkmanager requires java greater than 11.  
Bumping the link in the export to android tutorial to java 17, the latest LTS version

Fixes https://github.com/godotengine/godot-docs/issues/7902

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
