### PR TITLE
Update Navigation Overview for new obstacles

### DIFF
--- a/tutorials/navigation/navigation_introduction_2d.rst
+++ b/tutorials/navigation/navigation_introduction_2d.rst
@@ -35,6 +35,8 @@ Godot provides the following objects and classes for 2D navigation:
             Reference to a specific navigation link that connects two navigation mesh positions over arbitrary distances.
         - NavAgent RID
             Reference to a specific avoidance agent with a radius value use solely in avoidance.
+        - NavObstacle RID
+            Reference to a specific avoidance obstacle used to affect and constrain avoidance velocities of agents.
 
 The following SceneTree Nodes are available as helpers to work with the NavigationServer2D API.
 
@@ -59,10 +61,8 @@ The following SceneTree Nodes are available as helpers to work with the Navigati
     for a Node2D inheriting parent Node.
 
 -  :ref:`NavigationObstacle2D<class_NavigationObstacle2D>` Node
-    A Node that acts as an agent with avoidance radius, to work it needs to be added under a Node2D
-    inheriting parent Node. Obstacles are intended as a last resort option for constantly moving objects
-    that cannot be re(baked) to a navigation mesh efficiently. This node also only works if RVO processing
-    is being used.
+    A Node that can be used to affect and constrain avoidance velocities of avoidance enabled agents.
+    This Node does NOT affect the pathfinding of agents which requires changing the navigation mesh instead.
 
 The 2D navigation meshes are defined with the following resources:
 

--- a/tutorials/navigation/navigation_introduction_3d.rst
+++ b/tutorials/navigation/navigation_introduction_3d.rst
@@ -38,6 +38,8 @@ Godot provides the following objects and classes for 3D navigation:
             Reference to a specific navigation link that connects two navigation mesh positions over arbitrary distances.
         - NavAgent RID
             Reference to a specific avoidance agent with a radius value use solely in avoidance.
+        - NavObstacle RID
+            Reference to a specific avoidance obstacle used to affect and constrain avoidance velocities of agents.
 
 The following SceneTree Nodes are available as helpers to work with the NavigationServer3D API.
 
@@ -62,10 +64,8 @@ The following SceneTree Nodes are available as helpers to work with the Navigati
     a Node3D inheriting parent Node.
 
 -  :ref:`NavigationObstacle3D<class_NavigationObstacle3D>` Node
-    A Node that acts as an agent with avoidance radius, to work it needs to be added under a Node3D
-    inheriting parent Node. Obstacles are intended as a last resort option for constantly moving objects
-    that cannot be re(baked) to a navigation mesh efficiently. This node also only works if RVO processing
-    is being used.
+    A Node that can be used to affect and constrain avoidance velocities of avoidance enabled agents.
+    This Node does NOT affect the pathfinding of agents which requires changing the navigation mesh instead.
 
 The 3D navigation meshes are defined with the following resources:
 


### PR DESCRIPTION
Updates Navigation Overview for new obstacles.

The NavigationObstacle page was updated for Godot 4.1 but the part in the Overview slipped.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
