### PR TITLE
Fix Ray-casting new-line typo

### DIFF
--- a/tutorials/physics/ray-casting.rst
+++ b/tutorials/physics/ray-casting.rst
@@ -156,6 +156,7 @@ with Area3D, the boolean parameter ``collide_with_areas`` must be set to ``true`
 
 .. tabs::
  .. code-tab:: gdscript GDScript
+    
         const RAY_LENGTH = 1000
         
         func _physics_process(delta):


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

The Ray-casting tutorial section contains a new-line typo. This results the first line of code to appear in the code block header (`const RAY_LENGTH = 1000`). This is a one-line fix to resolve the issue from happening.

![librewolf_p34c7MrRGX](https://github.com/godotengine/godot-docs/assets/60201971/97488de5-38f7-4e9f-ae98-51e782d877dd)
