### PR TITLE
Fixes typo in 2d movement C# code example.

### DIFF
--- a/tutorials/2d/2d_movement.rst
+++ b/tutorials/2d/2d_movement.rst
@@ -131,7 +131,7 @@ while up/down moves it forward or backward in whatever direction it's facing.
         [Export]
         public float RotationSpeed { get; set; } = 1.5f;
 
-        private int _rotationDirection;
+        private float _rotationDirection;
 
         public void GetInput()
         {


### PR DESCRIPTION
The 2D Movement C# code example contains a typo in the _rotationDirection variable, where it is shown as a `int` instead of a `float`, this is a one line modification that corrects this issue.

Resolves https://github.com/godotengine/godot-docs/issues/7539