### PR TITLE
Correct mouse_and_input_coordinates.rst

### DIFF
--- a/tutorials/inputs/mouse_and_input_coordinates.rst
+++ b/tutorials/inputs/mouse_and_input_coordinates.rst
@@ -63,4 +63,4 @@ Alternatively, it's possible to ask the viewport for the mouse position:
 
     GetViewport().GetMousePosition();
 
-.. note:: When the mouse mode is set to ``Input.MOUSE_MODE_CAPTURED``, the ``event.position`` value from ``InputEventMouseMotion`` is the center of the screen. Use ``event.relative`` instead of ``event.position`` and ``event.speed`` to process mouse movement and position changes.
+.. note:: When the mouse mode is set to ``Input.MOUSE_MODE_CAPTURED``, the ``event.position`` value from ``InputEventMouseMotion`` is the center of the screen. Use ``event.relative`` instead of ``event.position`` and ``event.velocity`` to process mouse movement and position changes.


### PR DESCRIPTION
This page currently refers to ``event.speed`` which is a field that no longer exists on ``InputEventMouseMotion`` and has since been renamed to ``event.velocity``.