### PR TITLE
Fix Player Node Type in C# Script of 3D Tutorial (05.spawning_mobs.rst)

### DIFF
--- a/getting_started/first_3d_game/05.spawning_mobs.rst
+++ b/getting_started/first_3d_game/05.spawning_mobs.rst
@@ -256,7 +256,7 @@ Let's code the mob spawning logic. We're going to:
         // And give it a random offset.
         mobSpawnLocation.ProgressRatio = GD.Randf();
 
-        Vector3 playerPosition = GetNode<Player>("Player").Position;
+        Vector3 playerPosition = GetNode<CharacterBody3D>("Player").Position;
         mob.Initialize(mobSpawnLocation.Position, playerPosition);
 
         // Spawn the mob by adding it to the Main scene.
@@ -315,7 +315,7 @@ Here is the complete ``main.gd`` script so far, for reference.
             // And give it a random offset.
             mobSpawnLocation.ProgressRatio = GD.Randf();
 
-            Vector3 playerPosition = GetNode<Player>("Player").Position;
+            Vector3 playerPosition = GetNode<CharacterBody3D>("Player").Position;
             mob.Initialize(mobSpawnLocation.Position, playerPosition);
 
             // Spawn the mob by adding it to the Main scene.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Currently, the C# code example of the [spawning mobs page in the "Your First 3D Game"](https://docs.godotengine.org/en/stable/getting_started/first_3d_game/05.spawning_mobs.html) tutorial does not build due to trying to get a node of type `Player` on a `CharacterBody3D` causing the error: `The type or namespace name 'Player' could not be found`
