### PR TITLE
Fix minor typo in 04.mob_scene.rst

### DIFF
--- a/getting_started/first_3d_game/04.mob_scene.rst
+++ b/getting_started/first_3d_game/04.mob_scene.rst
@@ -223,7 +223,7 @@ editor. You can also press :kbd:`Ctrl + F2` (:kbd:`Alt + 2` on macOS).
 
 |image8|
 
-Select the :ref:`VisibleOnScreenNotifier3D <class_VisibleOnScreenNotifier3D>` node and on the right side of the interface,
+Select the :ref:`VisibleOnScreenNotifier3D <class_VisibleOnScreenNotifier3D>` node and on the left side of the interface,
 navigate to the *Node* dock. Double-click the ``screen_exited()`` signal.
 
 |image9|


### PR DESCRIPTION
As far as I can tell, when working through the `Getting Started > Your first 3D game > Contents > Designing the mob scene > Leaving the screen` [section](https://docs.godotengine.org/en/stable/getting_started/first_3d_game/04.mob_scene.html#leaving-the-screen), the only place I can find the `VisibleOnScreenNotifier3D node` is in the main panel on the left-hand side of the user interface. Therefore, I believe this is a typo that can be fixed. Thanks.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
