### PR TITLE
Fixed typos in several doc files

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_differences.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_differences.rst
@@ -128,7 +128,7 @@ clampi                           Mathf.Clamp
 cos                              Mathf.Cos
 cosh                             Mathf.Cosh
 cubic_interpolate                Mathf.CubicInterpolate
-cubic_interpoalte_angle          Mathf.CubicInterpolateAngle
+cubic_interpolate_angle          Mathf.CubicInterpolateAngle
 cubic_interpolate_angle_in_time  Mathf.CubicInterpolateInTime
 cubic_interpolate_in_time        Mathf.CubicInterpolateAngleInTime
 db_to_linear                     Mathf.DbToLinear
@@ -458,7 +458,7 @@ to_upper                 `string.ToUpper`_
 to_utf16_buffer          StringExtensions.ToUtf16Buffer (Consider using `System.Text.Encoding.UTF16.GetBytes`_)
 to_utf32_buffer          StringExtensions.ToUtf32Buffer (Consider using `System.Text.Encoding.UTF32.GetBytes`_)
 to_utf8_buffer           StringExtensions.ToUtf8Buffer (Consider using `System.Text.Encoding.UTF8.GetBytes`_)
-to_wchar_buffer          StringExtensions.ToUtf16Buffer in Windows and StringExtensiont.ToUtf32Buffer in other platforms
+to_wchar_buffer          StringExtensions.ToUtf16Buffer in Windows and StringExtensions.ToUtf32Buffer in other platforms
 trim_prefix              StringExtensions.TrimPrefix
 trim_suffix              StringExtensions.TrimSuffix
 unicode_at               `string[int]`_ indexer
@@ -794,7 +794,7 @@ Dictionary
 ----------
 
 Use ``Godot.Collections.Dictionary`` for an untyped ``Variant`` dictionary.
-``Godot.Colelctions.Dictionary<TKey, TValue>`` is a type-safe wrapper around ``Godot.Collections.Dictionary``.
+``Godot.Collections.Dictionary<TKey, TValue>`` is a type-safe wrapper around ``Godot.Collections.Dictionary``.
 
 See also :ref:`Dictionary in C# <doc_c_sharp_collections_dictionary>`.
 

--- a/tutorials/scripting/debug/debugger_panel.rst
+++ b/tutorials/scripting/debug/debugger_panel.rst
@@ -32,7 +32,7 @@ debugger broke on.
     restarts, even if the script wasn't saved when exiting the editor.
 
     You can also use the ``breakpoint`` keyword in GDScript to create a
-    breakpoint that is stored in the script iself. Unlike breakpoints created by
+    breakpoint that is stored in the script itself. Unlike breakpoints created by
     clicking in the gutter, this keyword-based breakpoint is persistent across
     different machines when using version control.
 

--- a/tutorials/scripting/debug/overview_of_debugging_tools.rst
+++ b/tutorials/scripting/debug/overview_of_debugging_tools.rst
@@ -91,7 +91,7 @@ of the debugger.
     restarts, even if the script wasn't saved when exiting the editor.
 
     You can also use the ``breakpoint`` keyword in GDScript to create a
-    breakpoint that is stored in the script iself. Unlike breakpoints created by
+    breakpoint that is stored in the script itself. Unlike breakpoints created by
     clicking in the gutter, this keyword-based breakpoint is persistent across
     different machines when using version control.
 

--- a/tutorials/scripting/debug/the_profiler.rst
+++ b/tutorials/scripting/debug/the_profiler.rst
@@ -72,7 +72,7 @@ Physics, and Audio, before reaching Script functions, where your code appears.
 
 If you click on the graph, you change which frame's information appears on the
 left. In the top right, there is also a frame counter where you can manually
-adjust the frame you are looking at more granularly.
+adjust the frame you are looking at more granular.
 
 Scope of measurement and measurement windows
 ++++++++++++++++++++++++++++++++++++++++++++

--- a/tutorials/scripting/debug/the_profiler.rst
+++ b/tutorials/scripting/debug/the_profiler.rst
@@ -72,7 +72,7 @@ Physics, and Audio, before reaching Script functions, where your code appears.
 
 If you click on the graph, you change which frame's information appears on the
 left. In the top right, there is also a frame counter where you can manually
-adjust the frame you are looking at more granular.
+adjust the frame you are looking at more granularly.
 
 Scope of measurement and measurement windows
 ++++++++++++++++++++++++++++++++++++++++++++

--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -298,7 +298,7 @@ needs. We call the function ``register_class`` for each of our classes in our li
 
 The important function is the third function called ``example_library_init``.
 We first call a function in our bindings library that creates an initialization object.
-This object registrates the initialization and termination functions of the GDExtension.
+This object registers the initialization and termination functions of the GDExtension.
 Furthermore, it sets the level of initialization (core, servers, scene, editor, level).
 
 At last, we need the header file for the ``register_types.cpp`` named
@@ -635,7 +635,7 @@ are ``PropertyInfo`` types which describe the essentials of each of the method's
 that the parameter will have by default.
 
 So here, we add a signal, with a ``MethodInfo`` which names the signal "position_changed". The
-``PropertyInfo`` parameters describe two esential arguments, one of type ``Object``, the other
+``PropertyInfo`` parameters describe two essential arguments, one of type ``Object``, the other
 of type ``Vector2``, respectively named "node" and "new_pos".
 
 Next, we'll need to change our ``_process`` method:

--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -1310,7 +1310,7 @@ is used, it can be scalar or vector.
 | vec4 **textureGrad** (samplerCubeArray s, vec3 p, vec3 dPdx,                |                                                                     |
 | vec3 dPdy)                                                                  |                                                                     |
 +-----------------------------------------------------------------------------+---------------------------------------------------------------------+
-| gvec4_type **textureProjGrad** (gsampler2D s, vec3 p, vec2 dPdx, vec2 dPdy) | Performs a texture read with projection/LOD and with explicit        |
+| gvec4_type **textureProjGrad** (gsampler2D s, vec3 p, vec2 dPdx, vec2 dPdy) | Performs a texture read with projection/LOD and with explicit       |
 |                                                                             | gradients.                                                          |
 | gvec4_type **textureProjGrad** (gsampler2D s, vec4 p, vec2 dPdx, vec2 dPdy) |                                                                     |
 |                                                                             |                                                                     |

--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -1310,7 +1310,7 @@ is used, it can be scalar or vector.
 | vec4 **textureGrad** (samplerCubeArray s, vec3 p, vec3 dPdx,                |                                                                     |
 | vec3 dPdy)                                                                  |                                                                     |
 +-----------------------------------------------------------------------------+---------------------------------------------------------------------+
-| gvec4_type **textureProjGrad** (gsampler2D s, vec3 p, vec2 dPdx, vec2 dPdy) | Performs a texture read with projection/LOD and with explcit        |
+| gvec4_type **textureProjGrad** (gsampler2D s, vec3 p, vec2 dPdx, vec2 dPdy) | Performs a texture read with projection/LOD and with explicit        |
 |                                                                             | gradients.                                                          |
 | gvec4_type **textureProjGrad** (gsampler2D s, vec4 p, vec2 dPdx, vec2 dPdy) |                                                                     |
 |                                                                             |                                                                     |

--- a/tutorials/shaders/your_first_shader/your_second_3d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_second_3d_shader.rst
@@ -141,7 +141,7 @@ watery effect.
 
 .. image:: img/rim.png
 
-In order to add fresnal reflectance, we will compute a fresnel term in our
+In order to add fresnel reflectance, we will compute a fresnel term in our
 fragment shader. Here, we aren't going to use a real fresnel term for
 performance reasons. Instead, we'll approximate it using the dot product of the
 ``NORMAL`` and ``VIEW`` vectors. The ``NORMAL`` vector points away from the

--- a/tutorials/ui/gui_using_fonts.rst
+++ b/tutorials/ui/gui_using_fonts.rst
@@ -263,7 +263,7 @@ lower than ``(1, 1)``.
 After selecting a font in the FileSystem dock, you can enable the **Mipmaps** in
 the Import dock to improve downscaled font rendering appearance.
 
-Mipmaps can be enabled on MSDF fonts as well. This can improve font rencering
+Mipmaps can be enabled on MSDF fonts as well. This can improve font rendering
 quality a little at smaller-than-default sizes, but MSDF fonts are already
 resistant to graininess out of the box.
 
@@ -576,7 +576,7 @@ Support for OpenType features highly depends on the font used. Some fonts don't
 support any OpenType features, while other fonts can support dozens of
 toggleable features.
 
-There are 2 ways to use OpenType font featutres:
+There are 2 ways to use OpenType font features:
 
 **Globally on a font file**
 
@@ -830,7 +830,7 @@ be prerendered, which is less efficient in terms of file size.
 
 To use existing text as a baseline for prerendering, go to the **Glyphs from the
 Character Map** sub-tab of the Advanced Import Settings dialog, then
-*dobule-click* character sets to be enabled on the right:
+*double-click* character sets to be enabled on the right:
 
 .. figure:: img/using_fonts_advanced_import_settings_prerender_character_map.webp
    :align: center

--- a/tutorials/xr/openxr_hand_tracking.rst
+++ b/tutorials/xr/openxr_hand_tracking.rst
@@ -18,7 +18,7 @@ This allows the sensation of touch.
 Gloves are often also recognised as controllers and often will have additional controls such as buttons embedded.
 
 Three, inferred hand tracking.
-This has been the defacto approach since the early days of VR.
+This has been the de facto approach since the early days of VR.
 As we know the player is holding a controller and we know the position of this controller,
 we can infer where to render the players hand.
 Fingers can be positioned based on the controls the player is interacting with.
@@ -166,7 +166,7 @@ For now the only option available here is through HTC trackers.
 There is an extension that becomes available if HTC trackers are supported by the XR runtime.
 These are fully exposed through the action map system.
 
-Godot has full support for these and you can setup the trackers in the action map. 
+Godot has full support for these and you can setup the trackers in the action map.
 Each tracker is assigned a usage within the SteamVR interface.
 
 These are exposed through the following trackers:

--- a/tutorials/xr/setting_up_xr.rst
+++ b/tutorials/xr/setting_up_xr.rst
@@ -44,7 +44,7 @@ While in Godot 3 most things worked out of the box, Godot 4 needs a little more 
 OpenXR
 ------
 
-OpenXR is a new industry standard that allows different XR platforms to present themselves through a standardised API to XR applications. This standard is an open standard maintained by the Khronos Group and thus aligns very well with Godots interests.
+OpenXR is a new industry standard that allows different XR platforms to present themselves through a standardised API to XR applications. This standard is an open standard maintained by the Khronos Group and thus aligns very well with Godot's interests.
 
 The Vulkan implementation of OpenXR is closely integrated with Vulkan, taking over part of the Vulkan system. This requires tight integration of certain core graphics features in the Vulkan renderer which are needed before the XR system is setup. This was one of the main deciding factors to include OpenXR as a core interface.
 


### PR DESCRIPTION
Fixed typos in:
- c_sharp_differences.rst
- debugger_panel.rst
- gdextension_cpp_example.rst
- gui_using_fonts.rst
- openxr_hand_tracking.rst
- overview_of_debugging_tools.rst
- setting_up_xr.rst
- shading_language.rst
- the_profiler.rst
- your_second_3d_shader.rst

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
