### PR TITLE
Fix `register_types.h` code in GDExtension example

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -309,8 +309,12 @@ At last, we need the header file for the ``register_types.cpp`` named
     #ifndef GDEXAMPLE_REGISTER_TYPES_H
     #define GDEXAMPLE_REGISTER_TYPES_H
 
-    void initialize_example_module();
-    void uninitialize_example_module();
+    #include <godot_cpp/core/class_db.hpp>
+
+    using namespace godot;
+
+    void initialize_example_module(ModuleInitializationLevel p_level);
+    void uninitialize_example_module(ModuleInitializationLevel p_level);
 
     #endif // GDEXAMPLE_REGISTER_TYPES_H
 


### PR DESCRIPTION
Currently, it is incorrect and does not correspond to code in `register_types.cpp`.
