### PR TITLE
Fix typo in `gdextension_cpp_example.rst`

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -258,7 +258,6 @@ GDExtension plugin.
 
     #include <gdextension_interface.h>
     #include <godot_cpp/core/defs.hpp>
-    #include <godot_cpp/core/class_db.hpp>
     #include <godot_cpp/godot.hpp>
 
     using namespace godot;


### PR DESCRIPTION
There is no need to include that header in *.cpp file after the merge of https://github.com/godotengine/godot-docs/pull/8009.
