### PR TITLE
Update spatial_shader.rst

### DIFF
--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -401,7 +401,7 @@ Below is an example of a custom light function using a Lambertian lighting model
 .. code-block:: glsl
 
     void light() {
-        DIFFUSE_LIGHT += clamp(dot(NORMAL, LIGHT), 0.0, 1.0) * ATTENUATION * ALBEDO;
+        DIFFUSE_LIGHT += clamp(dot(NORMAL, LIGHT), 0.0, 1.0) * ATTENUATION * LIGHT_COLOR;
     }
 
 If you want the lights to add together, add the light contribution to ``DIFFUSE_LIGHT`` using ``+=``, rather than overwriting it.


### PR DESCRIPTION
The reference page suggests a very unfortunate lighting function that modulades the color values in ALBEDO with ALBEDO. This does not seem representative of the 4.x shading model. Additionally, it omitted LIGHT_COLOR.

Fix: Replacing the ALBEDO term with LIGHT_COLOR yields a much more predictable diffuse lighting example.