### PR TITLE
add list of cors headers needed in web export

### DIFF
--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -279,7 +279,6 @@ of its original size with gzip compression.
     be used. Instead, you should use an established web server such as Apache or
     nginx.
 
-
 .. _doc_javascript_eval:
 
 Calling JavaScript from script

--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -234,6 +234,15 @@ The ``.pck`` file is binary, usually delivered with the MIME-type
              other than :mimetype:`application/wasm` can prevent some start-up
              optimizations.
 
+.. tip::
+    Godot 4 web exports use the `SharedArrayBuffer <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer>`__, and require the following CORS headers to be set when serving the files:
+
+    ::
+        Cross-Origin-Opener-Policy: same-origin
+        Cross-Origin-Embedder-Policy: require-corp
+
+
+
 Delivering the files with server-side compression is recommended especially for
 the ``.pck`` and ``.wasm`` files, which are usually large in size.
 The WebAssembly module compresses particularly well, down to around a quarter
@@ -246,27 +255,24 @@ of its original size with gzip compression.
 
 .. tip::
 
-    The Godot repository includes a
-    `Python script to host a local web server <https://raw.githubusercontent.com/godotengine/godot/master/platform/web/serve.py>`__.
-    This script is intended for testing the web editor, but it can also be used to test exported projects.
-
-    Save the linked script to a file called ``serve.py``, move this file to the
-    folder containing the exported project's ``index.html``, then run the
-    following command in a command prompt within the same folder:
+    The following repository includes a `Sample node.js web server to host a Godot 4 game's web build locally <https://github.com/liana-p/godot4-web-local-testing-example>`__.
+    The example server can successfully serve a Godot 4 web build locally. The repository contains instructions on how to use it for local testing of games.
+    Simply copy the `export` folder to a Godot project, set up the Godot project to export the game to `export/public/index.html`, then run the server in `export` with the following commands:
 
     ::
+        # You need to have node.js installed to run this.
+        # npm install is only needed the first time
+        npm install
+        # Run the server
+        npm start
 
-        # You may need to replace `python` with `python3` on some platforms.
-        python serve.py --root .
+    This will serve the contents of the `export/public` folder which can be accessed at `http://localhost:3000` in a web browser.
 
     On Windows, you can open a command prompt in the current folder by holding
     :kbd:`Shift` and right-clicking on empty space in Windows Explorer, then
     choosing **Open PowerShell window here**.
 
-    This will serve the contents of the current folder and open the default web
-    browser automatically.
-
-    Note that for production use cases, this Python-based web server should not
+    Note that for production use cases, this node.js-based web server should not
     be used. Instead, you should use an established web server such as Apache or
     nginx.
 

--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -255,26 +255,30 @@ of its original size with gzip compression.
 
 .. tip::
 
-    The following repository includes a `Sample node.js web server to host a Godot 4 game's web build locally <https://github.com/liana-p/godot4-web-local-testing-example>`__.
-    The example server can successfully serve a Godot 4 web build locally. The repository contains instructions on how to use it for local testing of games.
-    Simply copy the `export` folder to a Godot project, set up the Godot project to export the game to `export/public/index.html`, then run the server in `export` with the following commands:
+    The Godot repository includes a
+    `Python script to host a local web server <https://raw.githubusercontent.com/godotengine/godot/master/platform/web/serve.py>`__.
+    This script is intended for testing the web editor, but it can also be used to test exported projects.
+
+    Save the linked script to a file called ``serve.py``, move this file to the
+    folder containing the exported project's ``index.html``, then run the
+    following command in a command prompt within the same folder:
 
     ::
-        # You need to have node.js installed to run this.
-        # npm install is only needed the first time
-        npm install
-        # Run the server
-        npm start
 
-    This will serve the contents of the `export/public` folder which can be accessed at `http://localhost:3000` in a web browser.
+        # You may need to replace `python` with `python3` on some platforms.
+        python serve.py --root .
 
     On Windows, you can open a command prompt in the current folder by holding
     :kbd:`Shift` and right-clicking on empty space in Windows Explorer, then
     choosing **Open PowerShell window here**.
 
-    Note that for production use cases, this node.js-based web server should not
+    This will serve the contents of the current folder and open the default web
+    browser automatically.
+
+    Note that for production use cases, this Python-based web server should not
     be used. Instead, you should use an established web server such as Apache or
     nginx.
+
 
 .. _doc_javascript_eval:
 


### PR DESCRIPTION
Replaces the instructions using the Python local server which doesn't work with Godot 4 games, with a node.js one. The linked Python script didn't work for me, so I set up an example project showing how to locally run a Godot 4 web project. I edited the docs to link to it instead. See related issue #8019 

Also adds instructions for setting up the correct CORS headers to host games with the SharedArrayBuffer, because the page doesn't mention which headers are needed.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
