### PR TITLE
C#: Document potentially confusing built-in float vs C# float/double

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_differences.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_differences.rst
@@ -342,6 +342,29 @@ Example:
 
     Input.Singleton.JoyConnectionChanged += Input_JoyConnectionChanged;
 
+Float
+-----
+
+Some engine functions return or have as input parameters values of the built-in
+:ref:`float <class_float>` type. This type is a 64-bit double-precision floating-point
+number, equivalent to ``double`` in C# (`System.Double` for .NET).
+
+This can cause confusion when working with C# scripts because the functions will appear
+on documentation as using or returning a Godot's ``float``, but that will require an 8-byte
+C# ``double`` or a conversion to or from another type, such as a 4-byte C# ``float``.
+
+Example:
+
+:ref:`Node._process() <class_Node_method__process>` virtual method receives as an argument
+the ``delta`` time since the last frame, in seconds. This is a built-in :ref:`float <class_float>`
+type, but on C# you should work with the following method signature:
+
+.. code-block:: csharp
+
+    public override void _Process(double delta)
+    {
+    }
+
 String
 ------
 


### PR DESCRIPTION
Current Godot documentation includes numerous usages of the built-in `float` data type on its reference manual. While it is perfectly documented, it would be great to add an additional reference on the "C# API differences to GDScript" section.

Fixes #7975

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
