### PR TITLE
Improve the navigation documentation wording

### DIFF
--- a/tutorials/navigation/navigation_connecting_navmesh.rst
+++ b/tutorials/navigation/navigation_connecting_navmesh.rst
@@ -1,7 +1,7 @@
 .. _doc_navigation_connecting_navmesh:
 
-Connecting NavigationMeshes
-===========================
+Connecting navigation meshes
+============================
 
 Different NavigationMeshes are automatically merged by the NavigationServer
 when at least two vertex positions of one edge exactly overlap.
@@ -26,10 +26,10 @@ navigation region edge connections on the NavigationServer and should be avoided
     Exactly means exactly for the vertex position merge. Small float errors
     that happen quite regularly with imported meshes will prevent a successful vertex merge.
 
-Alternatively ``NavigationMesh``s are not merged but still considered as ``connected`` by
+Alternatively navigation meshes are not merged but still considered as ``connected`` by
 the NavigationServer when their edges are nearly parallel and within distance
 to each other. The connection distance is defined by the  ``edge_connection_margin`` for each
-navigation map. In many cases NavigationMesh edges cannot properly connect when they partly overlap.
+navigation map. In many cases navigation mesh edges cannot properly connect when they partly overlap.
 Better avoid any navigation mesh overlap at all time for a consistent merge behavior.
 
 .. image:: img/navigation_edge_connection.png

--- a/tutorials/navigation/navigation_debug_tools.rst
+++ b/tutorials/navigation/navigation_debug_tools.rst
@@ -1,6 +1,6 @@
 .. _doc_navigation_debug_tools:
 
-Navigation Debug Tools
+Navigation debug tools
 ======================
 
 .. note::
@@ -8,16 +8,15 @@ Navigation Debug Tools
     The debug tools, properties and functions are only available in Godot debug builds. 
     Do not use any of them in code that will be part of a release build.
 
-Enabling debug navigation
+Enabling navigation debug
 -------------------------
 
-The navigation debug visualization is enabled by default inside the Editor.
-To visualize navigation meshes and connections also at runtime 
-enable the option ``Visible Navigation`` in the editor debug menu.
+The navigation debug visualizations are enabled by default inside the Editor.
+To visualize navigation meshes and connections at runtime too, enable the option ``Visible Navigation`` in the editor ``Debug`` menu.
 
 .. image:: img/navigation_debug_toggle.png
 
-In Godot debug builds the navigation debug can also be toggled on the NavigationServers from scripts.
+In Godot debug builds the navigation debug can also be toggled through the NavigationServer singletons from scripts.
 
 .. tabs::
  .. code-tab:: gdscript GDScript
@@ -25,32 +24,30 @@ In Godot debug builds the navigation debug can also be toggled on the Navigation
     NavigationServer2D.set_debug_enabled(false)
     NavigationServer3D.set_debug_enabled(true)
 
-Debug navigation settings
+Navigation debug settings
 -------------------------
 
-The appearance of navigation debug can be change in the ProjectSettings under ``debug/shapes/navigation``. 
-Certain debug features can also be enabled or disabled at will but may require a scene restart to apply.
+The appearance of navigation debug can be changed in the ProjectSettings under ``debug/shapes/navigation``.
+Certain debug features can also be enabled or disabled at will but may require a scene restart to take effect.
 
 .. image:: img/nav_debug_settings.png
 
 Debug navigation mesh polygons
 ------------------------------
 
-If ``enable_edge_lines`` is enabled the edges of navigation mesh polygons will be highlighted.
-If ``enable_edge_lines_xray`` is also enabled the edges of navigationmeshes will be visible through geometry.
+If ``enable_edge_lines`` is enabled, the edges of navigation mesh polygons will be highlighted.
+If ``enable_edge_lines_xray`` is also enabled, the edges of navigation meshes will be visible through geometry.
 
-if ``enable_geometry_face_random_color`` is enabled each navigation mesh face receives 
-a random color that is mixed with the main color from ``geometry_face_color``.
+If ``enable_geometry_face_random_color`` is enabled, the color of each navigation mesh face will be mixed with a random color that is itself mixed with the color specified in ``geometry_face_color``.
 
 .. image:: img/nav_debug_xray_edge_lines.png
-
 
 Debug edge connections
 ----------------------
 
-Different navigation meshes connected within ``edge_connection_margin`` distance are overlaid.
-The color of the overlay is controlled with the navigation debug ``edge_connection_color``.
-The connections can be made visible through geometry with the navigation debug ``enable_edge_connections_xray`` property.
+When two navigation meshes are connected within ``edge_connection_margin`` distance, the connection is overlaid.
+The color of the overlay is controlled by ``edge_connection_color``.
+The connections can be made visible through geometry with ``enable_edge_connections_xray``.
 
 .. image:: img/nav_edge_connection2d.gif
 
@@ -60,7 +57,7 @@ The connections can be made visible through geometry with the navigation debug `
 
     Edge connections are only visible when the NavigationServer is active.
 
-Debug Performance
+Debug performance
 -----------------
 
 To measure NavigationServer performance a dedicated monitor exists that can be found within the Editor Debugger under `Debugger->Monitors->NavigationProcess`.

--- a/tutorials/navigation/navigation_different_actor_area_access.rst
+++ b/tutorials/navigation/navigation_different_actor_area_access.rst
@@ -9,9 +9,9 @@ A typical example for different area access in gameplay are doors that connect r
 with different navigation meshes and are not accessible by all actors all the time.
 
 Add a NavigationRegion at the door position.
-Add an appropriated navigationmesh the size of the door that can connect with the surrounding navigationmeshes.
-In order to control access enable / disable navigation layer bits so path queries 
-that use the same navigation layer bits can find a path through the "door" navigationmesh.
+Add an appropriate navigation mesh the size of the door that can connect with the surrounding navigation meshes.
+In order to control access, enable / disable navigation layer bits so path queries
+that use the same navigation layer bits can find a path through the "door" navigation mesh.
 
 The bitmask can act as a set of door keys or abilities and only actors with at least 
 one matching and enabled bit layer in their pathfinding query will find a path through this region.
@@ -22,7 +22,7 @@ See :ref:`doc_navigation_advanced_using_navigationlayers` for more information o
 The entire "door" region can also be enabled / disable if required but if disabled will block access for all path queries.
 
 Prefer working with navigation layers in path queries whenever possible as enabling or disabling 
-navigation layers on a region triggers a performance costly recalculation of the navigation map connections.
+navigation layers on a region triggers a costly recalculation of the navigation map connections.
 
 .. warning::
 

--- a/tutorials/navigation/navigation_introduction_2d.rst
+++ b/tutorials/navigation/navigation_introduction_2d.rst
@@ -1,6 +1,6 @@
 .. _doc_navigation_overview_2d:
 
-2D Navigation Overview
+2D navigation overview
 ======================
 
 Godot provides multiple objects, classes and servers to facilitate grid-based or mesh-based navigation and pathfinding for 2D and 3D games.
@@ -11,32 +11,33 @@ Godot provides the following objects and classes for 2D navigation:
 - :ref:`Astar2D<class_Astar2D>`
     ``Astar2D`` objects provide an option to find the shortest path in a graph of weighted **points**.
 
-    The AStar2D class is best suited for cellbased 2D gameplay that does not require actors to reach any possible position within an area but only predefined, distinct positions.
+    The AStar2D class is best suited for cell-based 2D gameplay that does not require actors to reach any possible position within an area but only predefined, distinct positions.
 
 - :ref:`NavigationServer2D<class_NavigationServer2D>`
     ``NavigationServer2D`` provides a powerful server API to find the shortest path between two positions on a area defined by a navigation mesh.
 
-    The NavigationServer is best suited for 2D realtime gameplay that does require actors to reach any possible position within an navmesh defined area.
-    Meshbased navigation scales well with large gameworlds as a large area can often be defined with a single polygon when it would require many, many grid cells.
+    The NavigationServer is best suited for 2D realtime gameplay that does require actors to reach any possible position within a navigation mesh defined area.
+    Mesh-based navigation scales well with large game worlds as a large area can often be defined with a single polygon when it would require many, many grid cells.
 
     The NavigationServer holds different navigation maps that each consist of regions that hold navigation mesh data.
     Agents can be placed on a map for avoidance calculation.
-    RIDs are used to reference the internal maps, regions and agents when communicating with the server.
+    RIDs are used to reference internal maps, regions, and agents when communicating with the server.
 
     The following NavigationServer RID types are available.
         - NavMap RID
             Reference to a specific navigation map that holds regions and agents.
-            The map will attempt to join changed navigation meshes of regions by proximity.
+            The map will attempt to join the navigation meshes of the regions by proximity.
             The map will synchronize regions and agents each physics frame.
         - NavRegion RID
             Reference to a specific navigation region that can hold navigation mesh data.
-            The region can be enabled / disabled or the use restricted with a navigationlayer bitmask.
+            The region can be enabled / disabled or the use restricted with a navigation layer bitmask.
         - NavLink RID
             Reference to a specific navigation link that connects two navigation mesh positions over arbitrary distances.
         - NavAgent RID
-            Reference to a specific avoidance agent with a radius value use solely in avoidance.
+            Reference to a specific avoidance agent.
+            The avoidance is specified by a radius value.
         - NavObstacle RID
-            Reference to a specific avoidance obstacle used to affect and constrain avoidance velocities of agents.
+            Reference to a specific avoidance obstacle used to affect and constrain the avoidance velocity of agents.
 
 The following SceneTree Nodes are available as helpers to work with the NavigationServer2D API.
 
@@ -44,33 +45,34 @@ The following SceneTree Nodes are available as helpers to work with the Navigati
     A Node that holds a NavigationPolygon resource that defines a navigation mesh for the NavigationServer2D.
 
     - The region can be enabled / disabled.
-    - The use in pathfinding can be further restricted through the navigationlayers bitmask.
-    - Regions can join their navigation meshes by proximity for a combined navigation mesh.
+    - The use in pathfinding can be further restricted through the ``navigation_layers`` bitmask.
+    - The NavigationServer2D will join the navigation meshes of regions by proximity for a combined navigation mesh.
 
 - :ref:`NavigationLink2D<class_NavigationLink2D>` Node
-    A Node that connects two positions on navigation mesh over arbitrary distances for pathfinding.
+    A Node that connects two positions on navigation meshes over arbitrary distances for pathfinding.
 
     - The link can be enabled / disabled.
     - The link can be made one-way or bidirectional.
-    - The use in pathfinding can be further restricted through the navigationlayers bitmask.
+    - The use in pathfinding can be further restricted through the ``navigation_layers`` bitmask.
 
     Links tell the pathfinding that a connection exists and at what cost. The actual agent handling and movement needs to happen in custom scripts.
 
 -  :ref:`NavigationAgent2D<class_NavigationAgent2D>` Node
-    An optional helper Node to facilitate common NavigationServer2D API calls for pathfinding and avoidance
-    for a Node2D inheriting parent Node.
+    A helper Node used to facilitate common NavigationServer2D API calls for pathfinding and avoidance.
+    Use this Node with a Node2D inheriting parent Node.
 
 -  :ref:`NavigationObstacle2D<class_NavigationObstacle2D>` Node
-    A Node that can be used to affect and constrain avoidance velocities of avoidance enabled agents.
-    This Node does NOT affect the pathfinding of agents which requires changing the navigation mesh instead.
+    A Node that can be used to affect and constrain the avoidance velocity of avoidance enabled agents.
+    This Node does NOT affect the pathfinding of agents. You need to change the navigation meshes for that instead.
 
 The 2D navigation meshes are defined with the following resources:
 
 - :ref:`NavigationPolygon<class_NavigationPolygon>` Resource
-    A resource that holds 2D navigation mesh data and provides polygon drawtools to define navigation areas inside the Editor as well as at runtime.
+    A resource that holds 2D navigation mesh data.
+    It provides polygon drawing tools to allow defining navigation areas inside the Editor as well as at runtime.
 
     - The NavigationRegion2D Node uses this resource to define its navigation area.
-    - The NavigationServer2D uses this resource to update navmesh of individual regions.
+    - The NavigationServer2D uses this resource to update the navigation mesh of individual regions.
     - The TileSet Editor creates and uses this resource internally when defining tile navigation areas.
 
 .. seealso::
@@ -83,8 +85,8 @@ The 2D navigation meshes are defined with the following resources:
 Setup for 2D scene
 ------------------
 
-The following steps show the basic setup for a minimum viable navigation in 2D that uses the
-NavigationServer2D and a NavigationAgent2D for path movement.
+The following steps show the basic setup for minimal viable navigation in 2D.
+It uses the NavigationServer2D and a NavigationAgent2D for path movement.
 
 #. Add a NavigationRegion2D Node to the scene.
 
@@ -99,8 +101,7 @@ NavigationServer2D and a NavigationAgent2D for path movement.
    .. note::
 
         The navigation mesh defines the area where an actor can stand and move with its center.
-        Leave enough margin between the navpolygon edges and collision objects to not get path
-        following actors repeatedly stuck on collision.
+        Leave enough margin between the navigation polygon edges and collision objects to not get path following actors repeatedly stuck on collision.
 
 #. Add a CharacterBody2D node in the scene with a basic collision shape and a sprite or mesh
    for visuals.
@@ -211,5 +212,4 @@ NavigationServer2D and a NavigationAgent2D for path movement.
 
 .. note::
 
-    On the first frame the NavigationServer map has not synchronized region data and any path query
-    will return empty. Await one frame to pause scripts until the NavigationServer had time to sync.
+    On the first frame the NavigationServer map has not synchronized region data and any path query will return empty. Wait for the NavigationServer synchronization by awaiting one frame in the script.

--- a/tutorials/navigation/navigation_introduction_3d.rst
+++ b/tutorials/navigation/navigation_introduction_3d.rst
@@ -1,6 +1,6 @@
 .. _doc_navigation_overview_3d:
 
-3D Navigation Overview
+3D navigation overview
 ======================
 
 Godot provides multiple objects, classes and servers to facilitate grid-based or mesh-based navigation and pathfinding for 2D and 3D games.
@@ -11,35 +11,33 @@ Godot provides the following objects and classes for 3D navigation:
 - :ref:`Astar3D<class_Astar3D>`
     ``Astar3D`` objects provide an option to find the shortest path in a graph of weighted **points**.
 
-    The AStar3D class is best suited for cellbased 3D gameplay that does not require actors to reach any
-    possible position within an area but only predefined, distinct positions.
+    The AStar3D class is best suited for cell-based 3D gameplay that does not require actors to reach any possible position within an area but only predefined, distinct positions.
 
 - :ref:`NavigationServer3D<class_NavigationServer3D>`
-    ``NavigationServer3D`` provides a powerful server API to find the shortest path between two positions
-    on a area defined by a navigation mesh.
+    ``NavigationServer3D`` provides a powerful server API to find the shortest path between two positions on an area defined by a navigation mesh.
 
-    The NavigationServer is best suited for 3D realtime gameplay that does require actors to reach any
-    possible position within an navmesh defined area. Meshbased navigation scales well with large gameworlds
-    as a large area can often be defined with a single polygon when it would require many, many grid cells.
+    The NavigationServer is best suited for 3D realtime gameplay that does require actors to reach any possible position within a navigation mesh defined area.
+    Mesh-based navigation scales well with large game worlds as a large area can often be defined with a single polygon when it would require many, many grid cells.
 
-    The NavigationServer holds different navigation maps that each consist of regions that hold navigation mesh
-    data. Agents can be placed on a map for avoidance calculation. RIDs are used to reference the internal maps,
-    regions and agents when communicating with the server.
+    The NavigationServer holds different navigation maps that each consist of regions that hold navigation mesh data.
+    Agents can be placed on a map for avoidance calculation.
+    RIDs are used to reference internal maps, regions, and agents when communicating with the server.
 
     The following NavigationServer RID types are available.
         - NavMap RID
             Reference to a specific navigation map that holds regions and agents.
-            The map will attempt to join changed navigation meshes of regions by proximity.
+            The map will attempt to join the navigation meshes of the regions by proximity.
             The map will synchronize regions and agents each physics frame.
         - NavRegion RID
             Reference to a specific navigation region that can hold navigation mesh data.
-            The region can be enabled / disabled or the use restricted with a navigationlayer bitmask.
+            The region can be enabled / disabled or the use restricted with a navigation layer bitmask.
         - NavLink RID
             Reference to a specific navigation link that connects two navigation mesh positions over arbitrary distances.
         - NavAgent RID
-            Reference to a specific avoidance agent with a radius value use solely in avoidance.
+            Reference to a specific avoidance agent.
+            The avoidance is defined by a radius value.
         - NavObstacle RID
-            Reference to a specific avoidance obstacle used to affect and constrain avoidance velocities of agents.
+            Reference to a specific avoidance obstacle used to affect and constrain the avoidance velocity of agents.
 
 The following SceneTree Nodes are available as helpers to work with the NavigationServer3D API.
 
@@ -47,35 +45,35 @@ The following SceneTree Nodes are available as helpers to work with the Navigati
     A Node that holds a Navigation Mesh resource that defines a navigation mesh for the NavigationServer3D.
 
     - The region can be enabled / disabled.
-    - The use in pathfinding can be further restricted through the navigationlayers bitmask.
-    - Regions can join their navigation meshes by proximity for a combined navigation mesh.
+    - The use in pathfinding can be further restricted through the ``navigation_layers`` bitmask.
+    - The NavigationServer3D will join the navigation meshes of regions by proximity for a combined navigation mesh.
 
 - :ref:`NavigationLink3D<class_NavigationLink3D>` Node
-    A Node that connects two positions on navigation mesh over arbitrary distances for pathfinding.
+    A Node that connects two positions on navigation meshes over arbitrary distances for pathfinding.
 
     - The link can be enabled / disabled.
     - The link can be made one-way or bidirectional.
-    - The use in pathfinding can be further restricted through the navigationlayers bitmask.
+    - The use in pathfinding can be further restricted through the ``navigation_layers`` bitmask.
 
     Links tell the pathfinding that a connection exists and at what cost. The actual agent handling and movement needs to happen in custom scripts.
 
 -  :ref:`NavigationAgent3D<class_NavigationAgent3D>` Node
-    An optional helper Node to facilitate common NavigationServer3D API calls for pathfinding and avoidance for
-    a Node3D inheriting parent Node.
+    A helper Node used to facilitate common NavigationServer3D API calls for pathfinding and avoidance.
+    Use this Node with a Node3D inheriting parent Node.
 
 -  :ref:`NavigationObstacle3D<class_NavigationObstacle3D>` Node
-    A Node that can be used to affect and constrain avoidance velocities of avoidance enabled agents.
-    This Node does NOT affect the pathfinding of agents which requires changing the navigation mesh instead.
+    A Node that can be used to affect and constrain the avoidance velocity of avoidance enabled agents.
+    This Node does NOT affect the pathfinding of agents. You need to change the navigation meshes for that instead.
 
 The 3D navigation meshes are defined with the following resources:
 
 - :ref:`NavigationMesh<class_NavigationMesh>` Resource
-    A resource that holds 3D navigation mesh data and provides 3D geometry baking options to define navigation
-    areas inside the Editor as well as at runtime.
+    A resource that holds 3D navigation mesh data.
+    It provides 3D geometry baking options to define navigation areas inside the Editor as well as at runtime.
 
     - The NavigationRegion3D Node uses this resource to define its navigation area.
-    - The NavigationServer3D uses this resource to update navmesh of individual regions.
-    - The GridMap Editor uses this resource when specific navigation meshes are defined for each gridcell.
+    - The NavigationServer3D uses this resource to update the navigation mesh of individual regions.
+    - The GridMap Editor uses this resource when specific navigation meshes are defined for each grid cell.
 
 .. seealso::
 
@@ -85,8 +83,8 @@ The 3D navigation meshes are defined with the following resources:
 Setup for 3D scene
 ------------------
 
-The following steps show how to setup a minimum viable navigation in 3D that uses the NavigationServer3D and
-a NavigationAgent3D for path movement.
+The following steps show a basic setup for minimal viable navigation in 3D.
+It uses the NavigationServer3D and a NavigationAgent3D for path movement.
 
 #. Add a NavigationRegion3D Node to the scene.
 
@@ -103,7 +101,7 @@ a NavigationAgent3D for path movement.
 
    .. image:: img/nav_3d_min_setup_step2.png
 
-#. Now a transparent navigation mesh appeared that hovers some distance on top the planemesh.
+#. Now a transparent navigation mesh appears that hovers some distance on top of the PlaneMesh.
 
    .. image:: img/nav_3d_min_setup_step3.png
 
@@ -216,5 +214,4 @@ a NavigationAgent3D for path movement.
 
 .. note::
 
-    On the first frame the NavigationServer map has not synchronized region data and any path query
-    will return empty. Await one frame to pause scripts until the NavigationServer had time to sync.
+    On the first frame the NavigationServer map has not synchronized region data and any path query will return empty. Wait for the NavigationServer synchronization by awaiting one frame in the script.

--- a/tutorials/navigation/navigation_using_navigationlayers.rst
+++ b/tutorials/navigation/navigation_using_navigationlayers.rst
@@ -10,7 +10,7 @@ NavigationLayers can be named in the ``ProjectSettings`` the same as PhysicsLaye
 
 .. image:: img/navigationlayers_naming.png
 
-If two regions have not a single compatible layer they will not be merged by the NavigationServer. See :ref:`doc_navigation_connecting_navmesh` for more information on merging navmesh.
+If two regions have not a single compatible layer they will not be merged by the NavigationServer. See :ref:`doc_navigation_connecting_navmesh` for more information on merging navigation meshes.
 
 If a region has not a single compatible navigation layer with the ``navigation_layers`` parameter of a path query this regions navigation mesh will be skipped in pathfinding.
 See :ref:`doc_navigation_using_navigationpaths` for more information on querying the NavigationServer for paths.

--- a/tutorials/navigation/navigation_using_navigationmaps.rst
+++ b/tutorials/navigation/navigation_using_navigationmaps.rst
@@ -9,21 +9,21 @@ A NavigationMap is an abstract navigation world on the NavigationServer identifi
 
 A map can hold and connect a near infinite number of navigation regions with navigation meshes to build the traversable areas of a game world for pathfinding.
 
-A map can be joined by avoidance agents to process collision avoidance between the avoidance agents.
+A map can contain avoidance agents. Collision avoidance will be calculated based on the agents present in the map.
 
 .. note::
 
     Different NavigationMaps are completely isolated from each other but navigation regions
-    and avoidance agents can switch between different maps once every server synchronization.
+    and avoidance agents can switch between different maps. Switches will become effective on NavigationServer synchronization.
 
 Default navigation maps
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-By default Godot creates a navigation map RID for each :ref:`World2D<class_World2D>` and :ref:`World3D<class_World3D>` of the root viewport.
+By default Godot creates a navigation map for each :ref:`World2D<class_World2D>` and :ref:`World3D<class_World3D>` of the root viewport.
 
-The 2D default navigation ``map`` can be obtained with ``get_world_2d().get_navigation_map()`` from any :ref:`Node2D<class_Node2D>` inheriting Node.
+The 2D default navigation ``map`` RID can be obtained with ``get_world_2d().get_navigation_map()`` from any :ref:`Node2D<class_Node2D>` inheriting Node.
 
-The 3D default navigation ``map`` can be obtained with ``get_world_3d().get_navigation_map()`` from any :ref:`Node3D<class_Node3D>` inheriting Node.
+The 3D default navigation ``map`` RID can be obtained with ``get_world_3d().get_navigation_map()`` from any :ref:`Node3D<class_Node3D>` inheriting Node.
 
 .. tabs::
  .. code-tab:: gdscript GDScript
@@ -42,15 +42,15 @@ The 3D default navigation ``map`` can be obtained with ``get_world_3d().get_navi
 Creating new navigation maps
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The NavigationServer can create and support as many navigation maps as are required for specific gameplay.
-Additional navigation maps are created and maintained by using the NavigationServer API
+The NavigationServer can create and support as many navigation maps as required for specific gameplay.
+Additional navigation maps are created and handled by using the NavigationServer API
 directly e.g. to support different avoidance agent or actor locomotion types.
 
 For example uses of different navigation maps see :ref:`doc_navigation_different_actor_types` and :ref:`doc_navigation_different_actor_locomotion`.
 
-Each navigation map synchronizes queued changes to its navigation regions and avoidance agents individually.
+Each navigation map individually synchronizes queued changes to its navigation regions and avoidance agents.
 A navigation map that has not received changes will consume little to no processing time.
-Navigation regions and avoidance agents can only be part of a single navigations map but they can switch maps at any time.
+Navigation regions and avoidance agents can only be part of a single navigation map but they can switch map at any time.
 
 .. note::
 

--- a/tutorials/navigation/navigation_using_navigationmeshes.rst
+++ b/tutorials/navigation/navigation_using_navigationmeshes.rst
@@ -1,25 +1,29 @@
 .. _doc_navigation_using_navigationmeshes:
 
-Using NavigationMeshes
-======================
+Using navigation meshes
+=======================
 
-2D and 3D version of the navigation mesh are available as
+2D and 3D versions of the navigation mesh are available as
 :ref:`NavigationPolygon<class_NavigationPolygon>` and
 :ref:`NavigationMesh<class_NavigationMesh>`  respectively.
 
 .. note::
 
-    A navigation mesh describes the traversable safe area for an agent with its center position at zero radius.
+    A navigation mesh only describes a traversable area for an agent's center position. Any radius values an agent may have are ignored.
     If you want pathfinding to account for an agent's (collision) size you need to shrink the navigation mesh accordingly.
 
-Navigation works independent from other engine parts like rendering and physics. A navigation mesh is the data format to exchange information from those other systems as it describes the traversable safe area for a specific agent. All the necessary information from other engine parts need to be already factored in when creating a navigation mesh. E.g. like visuals that an agent should not clip through or physics collision shapes that an agent should not collide with. This process of factoring in all those wanted navigation restrictions from other engine parts like visuals and collision is commonly called navigation mesh baking.
+Navigation works independently from other engine parts like rendering or physics.
+Navigation meshes are the only things considered when doing pathfinding, e.g. visuals and collision shapes for example are completely ignored by the navigation system.
+If you need to take other data (like visuals for example) into account when doing pathfinding, you need to adapt your navigation meshes accordingly.
+The process of factoring in navigation restrictions in navigation meshes is commonly referred to as navigation mesh baking.
 
-If you experience clipping or collision problems while following navigation paths always remember that you need to tell the navigation system through an appropriated navigation mesh what your intentions are. By itself the navigation system will never know "this is a tree / rock / wall collision shape or visual mesh" because it only knows "here I was told I can path safely cause it is on navigation mesh".
+If you experience clipping or collision problems while following navigation paths, always remember that you need to tell the navigation system what your intentions are through an appropriate navigation mesh.
+By itself the navigation system will never know "this is a tree / rock / wall collision shape or visual mesh" because it only knows that "here I was told I can path safely because it is on a navigation mesh".
 
 .. _doc_navigation_navmesh_baking:
 
-Creating 2D NavigationMeshes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Creating 2D navigation meshes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Navigation meshes in the 2D editor are created with the help of the NavigationPolygon draw tools
 that appear in the top bar of the editor when a NavigationRegion2D is selected.
@@ -27,13 +31,13 @@ that appear in the top bar of the editor when a NavigationRegion2D is selected.
 .. image:: img/nav_polydrawtool.png
 
 The NavigationPolygon draw tools can be used to create and edit navigation meshes by defining ``outline`` polygons.
-The outline polygons are later converted to real NavigationMesh resources for the NavigationServer regions.
+The outline polygons are later converted to real navigation mesh resources for the NavigationServer regions.
 
 .. image:: img/nav_polymatroschka.png
 
-Multiple outlines can be added to the same NavPolygon resource as long as they **do not intersect or overlap**.
+Multiple outlines can be added to the same NavigationPolygon resource as long as they **do not intersect or overlap**.
 Each additional outline will cut a hole in the polygon created by the larger outline.
-If the larger polygon is already a hole it will create a new navigation mesh polygon inside.
+If the larger polygon is already a hole, it will create a new navigation mesh polygon inside.
 
 Outlines are not a replacement if the intention is to merge aligned polygons e.g. from grid cells.
 Outlines, as the name would suggest, cannot intersect each other or have any overlapping vertex positions.
@@ -41,20 +45,18 @@ Outlines, as the name would suggest, cannot intersect each other or have any ove
 .. image:: img/nav_polyoutlinefail.png
 
 Outline layouts like seen in this picture will fail the convex partitioning required by the navigation mesh generation.
-In this layout cases the outline tool cannot be used. Use the :ref:`Geometry2D<class_Geometry2D>` class for
-polygon merge or intersect operations to create a valid merged mesh for navigation.
+In these layout cases, the outline tool cannot be used. Use the :ref:`Geometry2D<class_Geometry2D>` class to merge or intersect polygons to create a merged mesh that is valid for navigation.
 
 .. note::
 
-    The NavigationServer does not connect navigation mesh islands from the same NavigationMesh resource.
-    Do not create multiple disconnected islands in the same NavigationRegion2D and NavPoly resource if they should be later connected.
+    The NavigationServer does not connect navigation mesh islands from the same navigation mesh resource.
+    Do not create multiple disconnected islands in the same NavigationRegion2D or NavigationPolygon resource if they should be later connected.
 
-For 2D no similar navigation mesh baking with geometry parsing exists like in 3D.
-The Geometry2D class functions for offset, merge, intersect and clip can be used
-to shrink or enlarge existing NavigationPolygons to different actor sizes.
+For 2D, no similar navigation mesh baking with geometry parsing exists like in 3D.
+The Geometry2D class functions for offset, merge, intersect, and clip can be used to shrink or enlarge existing NavigationPolygons for different actor sizes.
 
-Creating 3D NavigationMeshes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Creating 3D navigation meshes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. image:: img/baked_navmesh.png
 
@@ -62,12 +64,12 @@ Navigation meshes in the 3D editor are created with the help of the
 :ref:`NavigationMeshGenerator<class_NavigationMeshGenerator>` singleton
 and the NavigationMesh bake settings that appear in the editor inspector.
 
-NavigationMesh baking is the process of creating a simplified mesh used for pathfinding out of (complex) 3D level geometry.
+Navigation mesh baking is the process of creating a simplified mesh used for pathfinding out of (complex) 3D level geometry.
 For this process Godot parses scene geometry and hands the raw mesh or collision data to the
-third-party ReCast library for processing and creation of the final navigationmesh.
+third-party ReCast library for processing and creation of the final navigation mesh.
 
-The resulting NavigationMesh is an approximation of the source geometry surfaces
-for both performance and technical reasons. Do not expect the NavigationMesh
+The resulting navigation mesh is an approximation of the source geometry surfaces
+for both performance and technical reasons. Do not expect the navigation mesh
 to perfectly follow the original surfaces. Especially navigation polygons placed
 over ramps will not keep an equal distance to the ground surface. To align an
 actor perfectly with the ground use other means like physics.
@@ -79,9 +81,9 @@ actor perfectly with the ground use other means like physics.
 NavigationMesh rebaking at runtime
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To rebake a ``NavigationMesh`` at runtime, use the NavigationRegion3D.bake_navigation_mesh() function.
-Another option is to use the NavigationMeshGenerator.bake() Singleton function with the NavigationMesh resource directly.
-If the navigation mesh resource is already prepared, the region can be updated with the NavigationServer3D API directly as well.
+To rebake a ``NavigationMesh`` at runtime, use the ``NavigationRegion3D.bake_navigation_mesh()`` function.
+Another option is to use the ``NavigationMeshGenerator.bake()`` singleton function with the NavigationMesh resource directly.
+If the NavigationMesh resource is already prepared, the region can be updated with the NavigationServer3D API directly as well.
 
 .. tabs::
  .. code-tab:: gdscript GDScript
@@ -94,7 +96,7 @@ If the navigation mesh resource is already prepared, the region can be updated w
         var on_thread: bool = true
         bake_navigation_mesh(on_thread)
 
-        # or use the NavigationMeshGenerator Singleton
+        # or use the NavigationMeshGenerator singleton
         var _navigationmesh: NavigationMesh = navigation_mesh
         NavigationMeshGenerator.bake(_navigationmesh, self)
         # remove old resource first to trigger a full update
@@ -108,7 +110,7 @@ If the navigation mesh resource is already prepared, the region can be updated w
 .. note::
 
     Baking a NavigationMesh at runtime is a costly operation.
-    Complex navigation mesh take some time to bake and if done on the main thread can freeze a game.
+    A complex navigation mesh takes some time to bake and if done on the main thread can freeze a game.
     (Re)baking a large navigation mesh is preferably done in a separate thread.
 
 .. warning::
@@ -117,23 +119,23 @@ If the navigation mesh resource is already prepared, the region can be updated w
     to match the actual mesh data stored inside in order to merge
     different navigation meshes without issues.
 
-NavigationRegion2D and Navigation3D both use meshes to mark traversable areas, only the tools to create them are different.
+NavigationRegion2D and NavigationRegion3D both use meshes to mark traversable areas, only the tools to create them are different.
 
-For 2D NavigationPolygon resources are used to draw outline points in the editor. From these outline points the NavigationServer2D creates a mesh to upload navigation data to the NavigationServer.
+For 2D, NavigationPolygon resources are used to draw outline points in the editor. From these outline points the NavigationServer2D creates a mesh to upload navigation data to the NavigationServer.
 
-For 3D NavigationMesh resources are used. Instead of providing draw tools the 3D variant
+For 3D, NavigationMesh resources are used. Instead of providing draw tools the 3D variant
 provides an extensive amount of parameters to bake a navigation mesh directly from 3D source geometry.
 
 .. note::
 
-    Technically there is no hard distinction between 2D and 3D how to use the given toolsets to create flat navigation meshes. The 2D drawing tool can be used to create a flat 3D navmesh and the 3D baking tool can be used to parse flat 3D geometry into 2D appropriated navigationmeshes.
+    Technically there is no hard distinction between 2D and 3D on how to use the given toolsets to create flat navigation meshes. The 2D drawing tool can be used to create a flat 3D navigation mesh and the 3D baking tool can be used to parse flat 3D geometry into appropriate 2D navigation meshes.
 
-2D Navmesh from CollisionPolygons
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+2D navigation mesh from CollisionPolygons
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following script parses all child nodes of a NavigationRegion2D for CollisionPolygons
 and bakes their shape into the NavigationPolygon. As the NavigationPolygon creates the
-navigationmesh from outline data the shapes cannot overlap.
+navigation mesh from outline data the shapes cannot overlap.
 
 .. tabs::
  .. code-tab:: gdscript GDScript
@@ -165,10 +167,10 @@ navigationmesh from outline data the shapes cannot overlap.
 
                 new_navigation_polygon.add_outline(new_collision_outline)
 
-Procedual 2D NavigationMesh
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Procedural 2D navigation mesh
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following script creates a new 2D navigation region and fills it with procedual generated navigation mesh data from a NavigationPolygon resource.
+The following script creates a new 2D navigation region and fills it with procedurally generated navigation mesh data from a NavigationPolygon resource.
 
 .. tabs::
  .. code-tab:: gdscript GDScript
@@ -192,10 +194,10 @@ The following script creates a new 2D navigation region and fills it with proced
 
     NavigationServer2D.region_set_navigation_polygon(new_2d_region_rid, new_navigation_polygon)
 
-Procedual 3D NavigationMesh
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Procedural 3D navigation mesh
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following script creates a new 3D navigation region and fills it with procedual generated navigation mesh data from a NavigationMesh resource.
+The following script creates a new 3D navigation region and fills it with procedurally generated navigation mesh data from a NavigationMesh resource.
 
 .. tabs::
  .. code-tab:: gdscript GDScript
@@ -220,10 +222,10 @@ The following script creates a new 3D navigation region and fills it with proced
     )
     NavigationServer3D.region_set_navigation_mesh(new_3d_region_rid, new_navigation_mesh)
 
-Navmesh for 3D GridMaps
-~~~~~~~~~~~~~~~~~~~~~~~
+Navigation mesh for 3D GridMaps
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following script creates a new 3D navigation mesh for each GridMap items, clears the current grid cells and adds new procedual grid cells with the new navigation mesh.
+The following script creates a new 3D navigation mesh for each GridMap items, clears the current grid cells, and adds new procedural grid cells with the new navigation mesh.
 
 .. tabs::
  .. code-tab:: gdscript GDScript
@@ -254,7 +256,7 @@ The following script creates a new 3D navigation mesh for each GridMap items, cl
     # clear the cells
     clear()
 
-    # add procedual cells using the first item
+    # add procedural cells using the first item
     var _position: Vector3i = Vector3i(global_transform.origin)
     var _item: int = 0
     var _orientation: int = 0

--- a/tutorials/navigation/navigation_using_navigationpaths.rst
+++ b/tutorials/navigation/navigation_using_navigationpaths.rst
@@ -3,11 +3,11 @@
 Using NavigationPaths
 =====================
 
-Obtaining a Navigationpath
+Obtaining a NavigationPath
 --------------------------
 
 Navigation paths can be directly queried from the NavigationServer and do not require any
-additional nodes or objects as long as the navigation map has a navigationmesh to work with.
+additional nodes or objects as long as the navigation map has a navigation mesh to work with.
 
 To obtain a 2D path, use ``NavigationServer2D.map_get_path(map, from, to, optimize, navigation_layers)``.
 
@@ -23,12 +23,12 @@ The second and third parameters are the starting position and the target positio
 
 If the ``optimized`` parameter is ``true``, path positions will be shortened along polygon
 corners with an additional funnel algorithm pass. This works well for free movement
-on navigationmeshes with unequal sized polygons as the path will hug around corners
+on navigation meshes with unequally sized polygons as the path will hug around corners
 along the polygon corridor found by the A* algorithm. With small cells the A* algorithm
 creates a very narrow funnel corridor that can create ugly corner paths when used with grids.
 
 If the ``optimized`` parameter is ``false``, path positions will be placed at the center of each polygon edge.
-This works well for pure grid movement on navmeshes with equal sized polygons as the path will go through the center of the grid cells.
+This works well for pure grid movement on navigation meshes with equally sized polygons as the path will go through the center of the grid cells.
 Outside of grids due to polygons often covering large open areas with a single, long edge this can create paths with unnecessary long detours.
 
 
@@ -65,9 +65,9 @@ Outside of grids due to polygons often covering large open areas with a single, 
 A returned ``path`` by the NavigationServer will be a ``PackedVector2Array`` for 2D or a ``PackedVector3Array`` for 3D.
 These are just a memory-optimized ``Array`` of vector positions.
 All position vectors inside the array are guaranteed to be inside a NavigationPolygon or NavigationMesh.
-The path array, if not empty, has the navigationmesh position closest to the starting position at the first index ``path[0]`` position.
-The closest available navigationmesh position to the target position is the last index ``path[path.size()-1]`` position.
-All index between are the pathpoints that an actor should follow to reach the target without leaving the navigation mesh.
+The path array, if not empty, has the navigation mesh position closest to the starting position at the first index ``path[0]`` position.
+The closest available navigation mesh position to the target position is the last index ``path[path.size()-1]`` position.
+All indexes between are the path points that an actor should follow to reach the target without leaving the navigation mesh.
 
 .. note::
 

--- a/tutorials/navigation/navigation_using_navigationregions.rst
+++ b/tutorials/navigation/navigation_using_navigationregions.rst
@@ -4,7 +4,7 @@ Using NavigationRegions
 =======================
 
 NavigationRegions are the visual Node representation of a ``region`` of the navigation ``map`` on the NavigationServer.
-Each NavigationRegion node holds a resource for the navigationmesh data.
+Each NavigationRegion node holds a resource for the navigation mesh data.
 
 Both 2D and 3D version are available as :ref:`NavigationRegion2D<class_NavigationRegion2D>`
 and :ref:`NavigationRegion3D<class_NavigationRegion3D>` respectively.
@@ -13,16 +13,16 @@ Individual NavigationRegions upload their 2D NavigationPolygon or 3D NavigationM
 The NavigationServer map turns this information into a combined navigation map for pathfinding.
 
 To create a navigation region using the SceneTree add a ``NavigationRegion2D`` or ``NavigationRegion3D`` node to the scene.
-All regions require a navigationmesh resource to function. See :ref:`doc_navigation_using_navigationmeshes` to learn how to create and apply navigationmeshes.
+All regions require a navigation mesh resource to function. See :ref:`doc_navigation_using_navigationmeshes` to learn how to create and apply navigation meshes.
 
 NavigationRegions will automatically push ``global_transform`` changes to the region on the NavigationServer which makes them suitable for moving platforms.
-The NavigationServer will attempt to connect navmeshes of individual regions when they are close enough. For more detail see :ref:`doc_navigation_connecting_navmesh`.
+The NavigationServer will attempt to connect the navigation meshes of individual regions when they are close enough. For more details see :ref:`doc_navigation_connecting_navmesh`.
 To connect NavigationRegions over arbitrary distances see :ref:`doc_navigation_using_navigationlinks` to learn how to create and use ``NavigationLinks``.
 
 .. warning::
 
     While changing the transform of a NavigationRegion node does update the region position on the
-    NavigationServer changing the scale does not. A navigationmesh resource has no scale and needs
+    NavigationServer, changing the scale does not. A navigation mesh resource has no scale and needs
     to be fully updated when source geometry changes scale.
 
 Regions can be enabled / disabled and if disabled will not contribute to future pathfinding queries.

--- a/tutorials/navigation/navigation_using_navigationservers.rst
+++ b/tutorials/navigation/navigation_using_navigationservers.rst
@@ -79,16 +79,16 @@ pathfinding and the NavigationServer2D facilitates the conversions.
 When a guide uses just NavigationServer without the 2D or 3D suffix it usually works for both servers
 by exchange Vector2(x, y) with Vector3(x, 0.0, z) or reverse.
 
-Technically it is possible to use the tools for creating navigationmesh for the other
-dimension, e..g. baking 2D navigationmesh with the 3D NavigationMesh when using
-flat 3D source geometry or creating 3D flat navigationmesh with the
-polygon outline drawtools of NavigationRegion2D and NavigationPolygons.
+Technically it is possible to use the tools for creating navigation meshes in one dimension for the other
+dimension, e.g. baking a 2D navigation mesh with the 3D NavigationMesh when using
+flat 3D source geometry or creating 3D flat navigation meshes with the
+polygon outline draw tools of NavigationRegion2D and NavigationPolygons.
 
 Any RID created with the NavigationServer2D API works on the NavigationServer3D API
 as well and both 2D and 3D avoidance agents can exist on the same map.
 
 .. note::
-    Regions created in 2D and 3D will merge their navigationmeshes when placed on the same map and merge conditions apply.
+    Regions created in 2D and 3D will merge their navigation meshes when placed on the same map and merge conditions apply.
     The NavigationServer does not discriminate between NavigationRegion2D and NavigationRegion3D nodes as both are regions on the server.
     By default those nodes register on different navigation maps so this merge can only happen when maps are changed manually e.g. with scripts.
 


### PR DESCRIPTION
Changed the navigation documentation wording to make it a bit clearer (also fixed some typos).

Here is the detail of the changes
- make some sentences clearer by rewording or making them shorter
- remove unnecessary capital letters in page titles
- add some missing spaces
- add some commas to make sentence parsing easier
- fix some typos/english mistakes

Some changes are arguably pretty small but I think they make the documentation easier to read.
Don't hesitate to tell me if you think some changes are unnecessary though, I'll revert them back.