### PR TITLE
C# code example bug in CharacterBody2D tutorial

### DIFF
--- a/tutorials/physics/using_character_body_2d.rst
+++ b/tutorials/physics/using_character_body_2d.rst
@@ -511,7 +511,7 @@ Here's the code for the player body:
                 velocity.Y = _jumpSpeed;
 
             // Get the input direction.
-            Vector2 direction = Input.GetAxis("ui_left", "ui_right");
+            float direction = Input.GetAxis("ui_left", "ui_right");
             velocity.X = direction * _speed;
 
             Velocity = velocity;


### PR DESCRIPTION
As can be seen on [line 346](https://github.com/fearn-e/godot-docs/blob/10f00f11767427941eec18dbd8bfe5334384a3af/tutorials/physics/using_character_body_2d.rst?plain=1#L346) of the same page, `Input.GetAxis()` should be assigned to a float, not a Vector2 as it is here.