### PR TITLE
Remove the documentation of an unimplemented feature of the tilemap selection tool

### DIFF
--- a/tutorials/2d/using_tilemaps.rst
+++ b/tutorials/2d/using_tilemaps.rst
@@ -202,9 +202,7 @@ To remove from the current selection, hold :kbd:`Ctrl` then select a tile.
 The selection can then be used in any other painting mode to quickly create copies
 of an already-placed pattern.
 
-While in Selection mode, you can't place new tiles, but you can still erase
-tiles by right-clicking after making a selection. The whole selection will be erased,
-regardless of where you click in the selection.
+You can remove the selected tiles from the TileMap by pressing :kbd:`Del`.
 
 You can toggle this mode temporarily while in Paint mode by holding :kbd:`Ctrl`
 then performing a selection.


### PR DESCRIPTION
The documentation states that right clicking with the tilemap selection tool removes the selection.
However, when you do so in Godot 4.1.1 nothing happens. A right click behaves exactly the same as a left click.

I initially opened an issue on the engine repository thinking it was a bug, but after talking with contributors it seems more likely that the documentation is wrong.
Removing tiles with the selection tool is not very intuitive and does indeed seem a bit weird.

https://github.com/godotengine/godot/issues/81933