### PR TITLE
Fix `const RAY_LENGTH` in code tab title

### DIFF
--- a/tutorials/physics/ray-casting.rst
+++ b/tutorials/physics/ray-casting.rst
@@ -156,6 +156,7 @@ with Area3D, the boolean parameter ``collide_with_areas`` must be set to ``true`
 
 .. tabs::
  .. code-tab:: gdscript GDScript
+
         const RAY_LENGTH = 1000
         
         func _physics_process(delta):


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

The first line of the code snippet was being included in the code tab title (see screenshot). This change adds a newline to prevent that from happening.

![Screenshot_2023-09-27_11-55-02](https://github.com/godotengine/godot-docs/assets/876842/65b13521-f2e5-4c95-b431-6ab9df366455)
