### PR TITLE
Corrected exposure_shutter_speed description to match reality and engine functionality. 

### DIFF
--- a/classes/class_cameraattributesphysical.rst
+++ b/classes/class_cameraattributesphysical.rst
@@ -145,7 +145,7 @@ Only available when :ref:`ProjectSettings.rendering/lights_and_shadows/use_physi
 - void **set_shutter_speed** **(** :ref:`float<class_float>` value **)**
 - :ref:`float<class_float>` **get_shutter_speed** **(** **)**
 
-Time for shutter to open and close, measured in seconds. A higher value will let in more light leading to a brighter image, while a lower amount will let in less light leading to a darker image.
+Time for shutter to open and close, evaluated as ``1 / shutter_speed`` seconds. A higher value will allow less light, leading to a darker image, while a lower amount will allow more light leading to a brighter image.
 
 Only available when :ref:`ProjectSettings.rendering/lights_and_shadows/use_physical_light_units<class_ProjectSettings_property_rendering/lights_and_shadows/use_physical_light_units>` is enabled.
 


### PR DESCRIPTION
Due to shutter speed being inversely proportional, higher values correspond to a faster shutter, causing less light to be collected. This behavior is present in-engine, but the documentation had things switched around.

Corresponds to this PR: https://github.com/godotengine/godot/pull/82400