### PR TITLE
Replace incorrect Vector2 type in C# snippet in using_character_body_2d.rst

### DIFF
--- a/tutorials/physics/using_character_body_2d.rst
+++ b/tutorials/physics/using_character_body_2d.rst
@@ -511,7 +511,7 @@ Here's the code for the player body:
                 velocity.Y = _jumpSpeed;
 
             // Get the input direction.
-            Vector2 direction = Input.GetAxis("ui_left", "ui_right");
+            float direction = Input.GetAxis("ui_left", "ui_right");
             velocity.X = direction * _speed;
 
             Velocity = velocity;


### PR DESCRIPTION
Hello ! This PR aims to replace an incorrect type in [this C# snippet](https://docs.godotengine.org/en/stable/tutorials/physics/using_character_body_2d.html#tab-5-QyM=) from "Using CharacterBody2D/3D / Platformer movement" of the manual.
The code used a Vector2 type instead of float when setting the value from `Input.GetAxis`, which resulted in the following error:  

![image](https://github.com/godotengine/godot-docs/assets/59795800/a776c6ce-9c8d-4835-940e-6aeed5f8c7c9)