### PR TITLE
Marking CustomMainLoop sample C# class as GlobalClass

### DIFF
--- a/classes/class_mainloop.rst
+++ b/classes/class_mainloop.rst
@@ -54,6 +54,7 @@ Here is an example script implementing a simple **MainLoop**:
 
     using Godot;
     
+    [GlobalClass]
     public partial class CustomMainLoop : MainLoop
     {
         private double _timeElapsed = 0;


### PR DESCRIPTION
The [sample code](https://docs.godotengine.org/en/latest/classes/class_mainloop.html#tab-0-QyM=) for custom C# `MainLoop` is missing the `[GlobalClass]` export. Without this attribute the sample code will cause an error on startup.
