### PR TITLE
Update gdscript_format_string.rst

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_format_string.rst
+++ b/tutorials/scripting/gdscript/gdscript_format_string.rst
@@ -122,6 +122,12 @@ specifier. Apart from ``s``, these require certain types of parameters.
 +-------+---------------------------------------------------------------------+
 | ``f`` | A **decimal real** number. Expects an integral or real number.      |
 +-------+---------------------------------------------------------------------+
+| ``v`` | A **vector**. Expects any float or int-based vector object (        |
+|       | ``Vector2``, ``Vector3``, ``Vector4``, ``Vector2i``, ``Vector3i`` or|
+|       | ``Vector4i``). Will display the vector coordinates in parentheses,  |
+|       | formatting each coordinate as if it was an ``%f``, and using the    |
+|       | same modifiers.                                                     |
++-------+---------------------------------------------------------------------+
 
 
 Placeholder modifiers
@@ -138,8 +144,8 @@ conditions.
 |         | The leading ``0`` is ignored if ``-`` is present.                 |
 |         | When used after ``.``, see ``.``.                                 |
 +---------+-------------------------------------------------------------------+
-| ``.``   | Before ``f``, set **precision** to 0 decimal places. Can be       |
-|         | followed up with numbers to change. Padded with zeroes.           |
+| ``.``   | Before ``f`` or ``v``, set **precision** to 0 decimal places. Can |
+|         | be followed up with numbers to change. Padded with zeroes.        |
 +---------+-------------------------------------------------------------------+
 | ``-``   | **Pad to the right** rather than the left.                        |
 +---------+-------------------------------------------------------------------+


### PR DESCRIPTION
Added missing documentation for `%v` string formatting for vectors.

Hi, it's my first contribution.
I checked that the "%v" in string formats was marked as implemented last year, and seems to be working, but I couldn't find it documented anywhere.

https://github.com/godotengine/godot-proposals/issues/4972
https://github.com/godotengine/godot/pull/63728

The implementation is quite long so I'm not sure if there are any special cases that should be documented.
This doc seems to be relevant for all 4.x versions and also some 3.x.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
