### PR TITLE
Add note for windows laptop to class reference doc

### DIFF
--- a/getting_started/introduction/first_look_at_the_editor.rst
+++ b/getting_started/introduction/first_look_at_the_editor.rst
@@ -136,7 +136,7 @@ Godot comes with a built-in class reference.
 You can search for information about a class, method, property, constant, or
 signal by any one of the following methods:
 
-* Pressing :kbd:`F1` (or :kbd:`Alt + Space` on macOS) anywhere in the editor.
+* Pressing :kbd:`F1` (or :kbd:`Alt + Space` on macOS, or :kbd:`fn + F1` for Windows laptops with a :kbd:`fn` key) anywhere in the editor.
 * Clicking the "Search Help" button in the top-right of the Script main screen.
 * Clicking on the Help menu and Search Help.
 * Clicking while pressing the :kbd:`Ctrl` key on a class name, function name,

--- a/getting_started/introduction/first_look_at_the_editor.rst
+++ b/getting_started/introduction/first_look_at_the_editor.rst
@@ -136,7 +136,7 @@ Godot comes with a built-in class reference.
 You can search for information about a class, method, property, constant, or
 signal by any one of the following methods:
 
-* Pressing :kbd:`F1` (or :kbd:`Alt + Space` on macOS, or :kbd:`fn + F1` for Windows laptops with a :kbd:`fn` key) anywhere in the editor.
+* Pressing :kbd:`F1` (or :kbd:`Alt + Space` on macOS, or :kbd:`fn + F1` for laptops with a :kbd:`fn` key) anywhere in the editor.
 * Clicking the "Search Help" button in the top-right of the Script main screen.
 * Clicking on the Help menu and Search Help.
 * Clicking while pressing the :kbd:`Ctrl` key on a class name, function name,


### PR DESCRIPTION
For windows laptops with a 'function' key, F1 actually opens a microsoft edge browser and makes a useless bing query. We can still open the integrated class reference by using 'fn + F1'. Reflect this in the documentation.
