### PR TITLE
Update high_level_multiplayer.rst

### DIFF
--- a/tutorials/networking/high_level_multiplayer.rst
+++ b/tutorials/networking/high_level_multiplayer.rst
@@ -347,7 +347,7 @@ have loaded the game scene.
 
 
     func _on_player_disconnected(id):
-        player_info.erase(id)
+        players.erase(id)
         player_disconnected.emit(id)
 
 


### PR DESCRIPTION
Erase method was being called on player_info object instead of players dictionary.
