### PR TITLE
Corrected --e to -e for rider docs

### DIFF
--- a/contributing/development/configuring_an_ide/rider.rst
+++ b/contributing/development/configuring_an_ide/rider.rst
@@ -51,7 +51,7 @@ if you want to debug the editor, you need to configure the debugger first.
 
 ::
 
-  --e --path <path to the Godot project>
+  -e --path <path to the Godot project>
 
 This will tell the executable to debug the specified project without using the project manager.
 Use the root path to the project folder, not ``project.godot`` file path.


### PR DESCRIPTION
Note the screenshot in the docs already shows "-e"
![image](https://github.com/godotengine/godot-docs/assets/8689836/76e03bbb-0473-41b4-805a-4bfa7f88fcbc)
