### PR TITLE
Close #7690 (add info for shader hints and default values)

### DIFF
--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -899,6 +899,8 @@ Uniforms can also be assigned default values:
     uniform vec4 some_vector = vec4(0.0);
     uniform vec4 some_color : source_color = vec4(1.0);
 
+Note that when adding a default value and a hint, the default value goes after the hint.
+
 If you need to make multiple uniforms to be grouped in the specific category of an inspector, you can use a `group_uniform` keyword like:
 
 .. code-block:: glsl

--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -757,7 +757,7 @@ used, and how the editor should allow users to modify it.
 
     uniform vec4 color : source_color;
     uniform float amount : hint_range(0, 1);
-    uniform vec4 other_color : source_color = vec4(1.0);
+    uniform vec4 other_color : source_color = vec4(1.0); # Default values go after the hint
     uniform sampler2D image : source_color;
 
 It's important to understand that textures that are supplied as color require

--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -757,7 +757,7 @@ used, and how the editor should allow users to modify it.
 
     uniform vec4 color : source_color;
     uniform float amount : hint_range(0, 1);
-    uniform vec4 other_color : source_color = vec4(1.0); # Default values go after the hint
+    uniform vec4 other_color : source_color = vec4(1.0); // Default values go after the hint.
     uniform sampler2D image : source_color;
 
 It's important to understand that textures that are supplied as color require


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
closes #7690

This PR clarifies the syntax for adding both a default value and a hint for shader uniforms.