### PR TITLE
Fix typos: "modelling" -> "modeling"

### DIFF
--- a/tutorials/3d/csg_tools.rst
+++ b/tutorials/3d/csg_tools.rst
@@ -6,7 +6,7 @@ Prototyping levels with CSG
 ===========================
 
 CSG stands for **Constructive Solid Geometry**, and is a tool to combine basic
-shapes or custom meshes to create more complex shapes. In 3D modelling software,
+shapes or custom meshes to create more complex shapes. In 3D modeling software,
 CSG is mostly known as "Boolean Operators".
 
 Level prototyping is one of the main uses of CSG in Godot. This technique allows
@@ -295,7 +295,7 @@ Exporting as glTF
 ------------------------
 
 It can be useful to block out a level using CSG, then export it as a 3d model, to
-import into 3D modelling software. You can do this by selecting **Scene > Export As... >
+import into 3D modeling software. You can do this by selecting **Scene > Export As... >
 glTF 2.0 Scene**.
 
 .. image:: img/export_as_gltf.webp

--- a/tutorials/3d/high_dynamic_range.rst
+++ b/tutorials/3d/high_dynamic_range.rst
@@ -8,7 +8,7 @@ High dynamic range lighting
 Introduction
 ------------
 
-Normally, an artist does all the 3D modelling, then all the texturing, looks at
+Normally, an artist does all the 3D modeling, then all the texturing, looks at
 their awesome looking model in the 3D modeling software and says "looks
 fantastic, ready for integration!" then goes into the game, lighting is setup
 and the game runs.

--- a/tutorials/3d/standard_material_3d.rst
+++ b/tutorials/3d/standard_material_3d.rst
@@ -211,7 +211,7 @@ Vertex Color
 ------------
 
 This setting allows choosing what is done by default to vertex colors that come
-from your 3D modelling application. By default, they are ignored.
+from your 3D modeling application. By default, they are ignored.
 
 .. image:: img/spatial_material4.png
 

--- a/tutorials/animation/2d_skeletons.rst
+++ b/tutorials/animation/2d_skeletons.rst
@@ -9,7 +9,7 @@ Introduction
 ------------
 
 When working with 3D, skeletal deforms are common for characters and creatures
-and most 3D modelling applications support it. For 2D, as this function is not
+and most 3D modeling applications support it. For 2D, as this function is not
 used as often, it's difficult to find mainstream software aimed for this.
 
 One option is to create animations in third-party software such as Spine or

--- a/tutorials/assets_pipeline/importing_scenes.rst
+++ b/tutorials/assets_pipeline/importing_scenes.rst
@@ -766,10 +766,10 @@ after exporting:
 - Adding collision detection to objects.
 - Setting objects as navigation meshes.
 - Deleting nodes that are not used in the game engine (like specific lights used
-  for modelling).
+  for modeling).
 
 To simplify this workflow, Godot offers several suffixes that can be added to
-the names of the objects in your 3D modelling software. When imported, Godot
+the names of the objects in your 3D modeling software. When imported, Godot
 will detect suffixes in object names and will perform actions automatically.
 
 .. warning::

--- a/tutorials/shaders/advanced_postprocessing.rst
+++ b/tutorials/shaders/advanced_postprocessing.rst
@@ -200,5 +200,5 @@ Assign the same vertex shader from above and everything should look exactly the 
 
 The one drawback to using an ArrayMesh over using a QuadMesh is that the ArrayMesh
 is not visible in the editor because the triangle is not constructed until the scene
-is run. To get around that, construct a single triangle Mesh in a modelling program
+is run. To get around that, construct a single triangle Mesh in a modeling program
 and use that in the MeshInstance3D instead.

--- a/tutorials/shaders/making_trees.rst
+++ b/tutorials/shaders/making_trees.rst
@@ -5,7 +5,7 @@ Making trees
 
 This is a short tutorial on how to make trees and other types of vegetation from scratch.
 
-The aim is to not focus on the modelling techniques (there are plenty of tutorials about that), but how to make them look good in Godot.
+The aim is to not focus on the modeling techniques (there are plenty of tutorials about that), but how to make them look good in Godot.
 
 .. image:: img/tree_sway.gif
 
@@ -23,7 +23,7 @@ and opened it in Blender.
 Paint with vertex colors
 ------------------------
 
-The first thing you may want to do is to use the vertex colors to paint how much the tree will sway when there is wind. Just use the vertex color painting tool of your favorite 3D modelling program and paint something like this:
+The first thing you may want to do is to use the vertex colors to paint how much the tree will sway when there is wind. Just use the vertex color painting tool of your favorite 3D modeling program and paint something like this:
 
 .. image:: img/tree_vertex_paint.png
 


### PR DESCRIPTION
The correct spelling is "modeling".