### PR TITLE
Remove outdated Firefox Linux warning

### DIFF
--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -39,13 +39,6 @@ in the user's browser.
              Browsers also require that the web page is served with specific
              `cross-origin isolation headers <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy>`__.
 
-.. note::
-
-    If you use Linux, due to
-    `poor Firefox WebGL performance <https://bugzilla.mozilla.org/show_bug.cgi?id=1010527>`__,
-    it's recommended to play the exported project using a Chromium-based browser
-    instead of Firefox.
-
 WebGL version
 -------------
 


### PR DESCRIPTION
The linked tracking bug has been closed since Firefox 94 which reached stable Nov 2, 2021, because the new WebRender backend improved the benchmarks significantly and is enabled for the majority of linux users.
