### PR TITLE
fix #8076, update image and remove note in GDScript warning system docs

### DIFF
--- a/tutorials/scripting/gdscript/warning_system.rst
+++ b/tutorials/scripting/gdscript/warning_system.rst
@@ -18,7 +18,9 @@ called **GDScript**:
 
 .. note::
 
-   As shown in the image above, you must enable **Advanced Settings** in order to see the GDScript section.
+   You must enable **Advanced Settings** in order to see the 
+   GDScript section in the sidebar. You can also search for "GDScript" when
+   Advanced Settings is off.
 
 You can find a list of warnings for the active GDScript file in the
 script editor's status bar. The example below has 3 warnings:


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
closes #8076

This updates the GDScript warning system docs with a new image that doesn't highlight the "advanced" switch and removes the note about having to turn on the "advanced" switch.