### PR TITLE
Instancing 4.1 up to date

### DIFF
--- a/getting_started/step_by_step/instancing.rst
+++ b/getting_started/step_by_step/instancing.rst
@@ -1,5 +1,3 @@
-:article_outdated: False
-
 .. _doc_instancing:
 
 Creating instances

--- a/getting_started/step_by_step/instancing.rst
+++ b/getting_started/step_by_step/instancing.rst
@@ -1,4 +1,4 @@
-:article_outdated: True
+:article_outdated: False
 
 .. _doc_instancing:
 


### PR DESCRIPTION
# Step by Step - Instancing 4.1 Up to date

I was able to follow this page without issues on Godot 4.1 and want to flag it as up to date. 
