### PR TITLE
Update script filename in `scripting_first_script.rst`

### DIFF
--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -89,7 +89,7 @@ other options by default and click the Create button to create the script.
 
 .. image:: img/scripting_first_script_attach_node_script.webp
 
-The Script workspace should appear with your new ``sprite_2d.gd`` file open and
+The Script workspace should appear with your new ``Sprite2D.gd`` file open and
 the following line of code:
 
 .. tabs::
@@ -305,7 +305,7 @@ Our node currently moves by itself. In the next part
 Complete script
 ---------------
 
-Here is the complete ``sprite_2d.gd`` file for reference.
+Here is the complete ``Sprite2D.gd`` file for reference.
 
 .. tabs::
  .. code-tab:: gdscript GDScript

--- a/getting_started/step_by_step/scripting_player_input.rst
+++ b/getting_started/step_by_step/scripting_player_input.rst
@@ -11,7 +11,7 @@ Listening to player input
 
 Building upon the previous lesson :ref:`doc_scripting_first_script`, let's look
 at another important feature of any game: giving control to the player.
-To add this, we need to modify our ``sprite_2d.gd`` code.
+To add this, we need to modify our ``Sprite2D.gd`` code.
 
 .. image:: img/scripting_first_script_moving_with_input.gif
 
@@ -114,7 +114,7 @@ causing the sprite to move forward.
 Complete script
 ---------------
 
-Here is the complete ``sprite_2d.gd`` file for reference.
+Here is the complete ``Sprite2D.gd`` file for reference.
 
 .. tabs::
  .. code-tab:: gdscript GDScript

--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -185,7 +185,7 @@ following code, which we saw two lessons ago:
         Position += velocity * (float)delta;
     }
 
-Your complete ``sprite_2d.gd`` code should look like the following.
+Your complete ``Sprite2D.gd`` code should look like the following.
 
 .. tabs::
  .. code-tab:: gdscript GDScript
@@ -342,7 +342,7 @@ Complete script
 ---------------
 
 That's it for our little moving and blinking Godot icon demo!
-Here is the complete ``sprite_2d.gd`` file for reference.
+Here is the complete ``Sprite2D.gd`` file for reference.
 
 .. tabs::
  .. code-tab:: gdscript GDScript


### PR DESCRIPTION
By default, the script is named `Sprite2D.gd` (not `sprite_2d.gd`) as shown in the relevant image. This PR updates the guide to reflect this. 

**EDIT**: The following two lessons build off the first, so I updated the script name in those as well.