### PR TITLE
Automatically convert spaces to tabs in CodeBlocks

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -846,6 +846,7 @@ code,
 
 .highlight {
     background-color: var(--highlight-background-color);
+    tab-size: 4;
 }
 
 /* Emphasized lines */

--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -291,6 +291,19 @@ $(document).ready(() => {
     }
   }
 
+  // Change indentation from spaces to tabs for codeblocks.
+  const codeBlocks = document.querySelectorAll('.rst-content div[class^="highlight"] pre');
+  for (const codeBlock of codeBlocks) {
+    const classList = codeBlock.parentNode.parentNode.classList;
+    if (!classList.contains('highlight-gdscript') && !classList.contains('highlight-cpp')) {
+      // Only change indentation for GDScript and C++.
+      continue;
+    }
+    let html = codeBlock.innerHTML;
+    html = html.replace(/(?<=^(<span class="w">)?( {4})*)( {4})/gm, '\t');
+    codeBlock.innerHTML = html;
+  }
+
   // See `godot_is_latest` in conf.py
   const isLatest = document.querySelector('meta[name=doc_is_latest]').content.toLowerCase() === 'true';
   if (isLatest) {

--- a/tutorials/migrating/upgrading_to_godot_4.1.rst
+++ b/tutorials/migrating/upgrading_to_godot_4.1.rst
@@ -253,7 +253,7 @@ This means that GDExtensions made for Godot 4.0 will need to be recompiled for G
 
 In Godot 4.0, your "entry_symbol" function looks something like this:
 
-.. code-block:: C++
+.. code-block:: cpp
 
   GDExtensionBool GDE_EXPORT example_library_init(const GDExtensionInterface *p_interface, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
       godot::GDExtensionBinding::InitObject init_obj(p_interface, p_library, r_initialization);
@@ -267,7 +267,7 @@ In Godot 4.0, your "entry_symbol" function looks something like this:
 
 However, for Godot 4.1, it should look like:
 
-.. code-block:: C++
+.. code-block:: cpp
 
   GDExtensionBool GDE_EXPORT example_library_init(GDExtensionInterfaceGetProcAddress p_get_proc_address, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
       godot::GDExtensionBinding::InitObject init_obj(p_get_proc_address, p_library, r_initialization);

--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -158,7 +158,7 @@ Your folder structure should now look like this:
 In the ``src`` folder, we'll start with creating our header file for the
 GDExtension node we'll be creating. We will name it ``gdexample.h``:
 
-.. code-block:: C++
+.. code-block:: cpp
 
     #ifndef GDEXAMPLE_H
     #define GDEXAMPLE_H
@@ -211,7 +211,7 @@ as the ``_process`` function you're used to in GDScript.
 
 Let's implement our functions by creating our ``gdexample.cpp`` file:
 
-.. code-block:: C++
+.. code-block:: cpp
 
     #include "gdexample.h"
     #include <godot_cpp/core/class_db.hpp>
@@ -250,7 +250,7 @@ and source file like we've implemented ``GDExample`` up above. What we need now
 is a small bit of code that tells Godot about all the classes in our
 GDExtension plugin.
 
-.. code-block:: C++
+.. code-block:: cpp
 
     #include "register_types.h"
 
@@ -303,7 +303,7 @@ Furthermore, it sets the level of initialization (core, servers, scene, editor, 
 At last, we need the header file for the ``register_types.cpp`` named
 ``register_types.h``.
 
-.. code-block:: C++
+.. code-block:: cpp
 
     #ifndef GDEXAMPLE_REGISTER_TYPES_H
     #define GDEXAMPLE_REGISTER_TYPES_H
@@ -466,7 +466,7 @@ Lets add a property that allows us to control the amplitude of our wave.
 In our ``gdexample.h`` file we need to add a member variable and getter and setter
 functions:
 
-.. code-block:: C++
+.. code-block:: cpp
 
     ...
     private:
@@ -481,7 +481,7 @@ functions:
 In our ``gdexample.cpp`` file we need to make a number of changes, we will only
 show the methods we end up changing, don't remove the lines we're omitting:
 
-.. code-block:: C++
+.. code-block:: cpp
 
     void GDExample::_bind_methods() {
         ClassDB::bind_method(D_METHOD("get_amplitude"), &GDExample::get_amplitude);
@@ -523,7 +523,7 @@ Let's do the same but for the speed of our animation and use a setter and getter
 function. Our ``gdexample.h`` header file again only needs a few more lines of
 code:
 
-.. code-block:: C++
+.. code-block:: cpp
 
     ...
         double amplitude;
@@ -537,7 +537,7 @@ code:
 This requires a few more changes to our ``gdexample.cpp`` file, again we're only
 showing the methods that have changed so don't remove anything we're omitting:
 
-.. code-block:: C++
+.. code-block:: cpp
 
     void GDExample::_bind_methods() {
         ...
@@ -594,7 +594,7 @@ would need to showcase a far more complete example.
 
 This is the required syntax:
 
-.. code-block:: C++
+.. code-block:: cpp
 
     some_other_node->connect("the_signal", this, "my_method");
 
@@ -607,7 +607,7 @@ emit a signal every time a second has passed and pass the new location along.
 
 In our ``gdexample.h`` header file, we need to define a new member ``time_emit``:
 
-.. code-block:: C++
+.. code-block:: cpp
 
     ...
         double time_passed;
@@ -622,7 +622,7 @@ constructor. We'll look at the other 2 needed changes one by one.
 In our ``_bind_methods`` method, we need to declare our signal. This is done
 as follows:
 
-.. code-block:: C++
+.. code-block:: cpp
 
     void GDExample::_bind_methods() {
         ...
@@ -643,7 +643,7 @@ of type ``Vector2``, respectively named "node" and "new_pos".
 
 Next, we'll need to change our ``_process`` method:
 
-.. code-block:: C++
+.. code-block:: cpp
 
     void GDExample::_process(double delta) {
         time_passed += speed * delta;


### PR DESCRIPTION
Closes #6779
Supersedes #7529

---

A significant improvement from the previous design! This is no longer a Sphinx extention; consequently, it doesn't need to integrate with the build system to function. Instead, it's incorporated in `custom.js` utilizing a single regex instead of relying on multiple passes. Thanks to pulling from the node system, it's also able to apply to specific codeblocks, fixing an oversight from the previous implementation that added tab characters to C#/Python scripts as well

Measurements on my local machine showed a total process time to take between ~4.5ms and ~0.5ms, depending on the amount of codeblocks on the page. I don't know the best means of measuring this for other environments, so the best I can do is compare it to the `linkItem` loop directly above it, which will clock in at ~23ms regardless of the current page

Like the previous PR, this serves to make the displayed GDScript code consistent with its [Style Guide](https://docs.godotengine.org/en/latest/tutorials/scripting/gdscript/gdscript_styleguide.html) (as well as other codeblocks that'd reasonably expect tabs, like the [cpp example](https://docs.godotengine.org/en/latest/tutorials/scripting/gdextension/gdextension_cpp_example.html)). This will make any copy/pasted content immediately suitable for a default workspace, instead of needing to rely on autoformatting and/or the editor throwing an error for inconsistent indentation. Also, as part of making this consistent, all codeblocks now have the `tab-size: 4` css property