### PR TITLE
Ogg to Ogg Vorbis

### DIFF
--- a/classes/class_audiostream.rst
+++ b/classes/class_audiostream.rst
@@ -21,7 +21,7 @@ Base class for audio streams.
 Description
 -----------
 
-Base class for audio streams. Audio streams are used for sound effects and music playback, and support WAV (via :ref:`AudioStreamWAV<class_AudioStreamWAV>`) and Ogg (via :ref:`AudioStreamOggVorbis<class_AudioStreamOggVorbis>`) file formats.
+Base class for audio streams. Audio streams are used for sound effects and music playback, supporting WAV (via :ref:AudioStreamWAV<class_AudioStreamWAV>) and Ogg Vorbis (via :ref:AudioStreamOggVorbis<class_AudioStreamOggVorbis>) file formats.
 
 .. rst-class:: classref-introduction-group
 


### PR DESCRIPTION
I changed "Ogg" to "Ogg Vorbis" to make it clear that it's referring to the Vorbis codec used in Ogg files.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
