### PR TITLE
Angular and Linear Damp 

### DIFF
--- a/classes/class_projectsettings.rst
+++ b/classes/class_projectsettings.rst
@@ -8544,7 +8544,7 @@ Suggested values are in the range ``0`` to ``30``. At value ``0`` objects will k
 
 During each physics tick, Godot will multiply the angular velocity of RigidBodies by ``1.0 - combined_damp / physics_ticks_per_second``, where ``combined_damp`` is the sum of the angular damp of the body and this value, or the area's value the body is in if the body defaults to combine damp values. (see :ref:`DampMode<enum_RigidBody2D_DampMode>`)
 
-.. warning:: Godot's damping calculations are simulation tick rate dependent. Changing your physics tick rate may significantly change the outcomes and feel of your simulation. This is true for the entire range of values greater than``0``, but is more pronounced for higher factors.
+.. warning:: Godot's damping calculations are simulation tick rate dependent. Changing your physics tick rate may significantly change the outcomes and feel of your simulation. This is true for the entire range of values greater than 0, but is more pronounced for higher factors.
 
 .. rst-class:: classref-item-separator
 
@@ -8622,7 +8622,7 @@ Suggested values are in the range ``0`` to ``30``. At value ``0`` objects will k
 
 During each physics tick, Godot will multiply the linear velocity of RigidBodies by ``1.0 - combined_damp / physics_ticks_per_second``, where ``combined_damp`` is the sum of the linear damp of the body and this value, or the area's value the body is in if the body defaults to combine damp values. (see :ref:`DampMode<enum_RigidBody2D_DampMode>`)
 
-.. warning:: Godot's damping calculations are simulation tick rate dependent. Changing your physics tick rate may significantly change the outcomes and feel of your simulation. This is true for the entire range of values greater than``0``, but is more pronounced for higher factors.
+.. warning:: Godot's damping calculations are simulation tick rate dependent. Changing your physics tick rate may significantly change the outcomes and feel of your simulation. This is true for the entire range of values greater than 0, but is more pronounced for higher factors.
 
 .. rst-class:: classref-item-separator
 
@@ -8780,7 +8780,7 @@ Suggested values are in the range ``0`` to ``30``. At value ``0`` objects will k
 
 During each physics tick, Godot will multiply the angular velocity of RigidBodies by ``1.0 - combined_damp / physics_ticks_per_second``, where ``combined_damp`` is the sum of the angular damp of the body and this value, or the area's value the body is in if the body defaults to combine damp values. (see :ref:`DampMode<enum_RigidBody3D_DampMode>`)
 
-.. warning:: Godot's damping calculations are simulation tick rate dependent. Changing your physics tick rate may significantly change the outcomes and feel of your simulation. This is true for the entire range of values greater than``0``, but is more pronounced for higher factors.
+.. warning:: Godot's damping calculations are simulation tick rate dependent. Changing your physics tick rate may significantly change the outcomes and feel of your simulation. This is true for the entire range of values greater than 0, but is more pronounced for higher factors.
 
 \ **Note:** Good values are in the range ``0`` to ``1``. At value ``0`` objects will keep moving with the same velocity. Values greater than ``1`` will aim to reduce the velocity to ``0`` in less than a second e.g. a value of ``2`` will aim to reduce the velocity to ``0`` in half a second. A value equal to or greater than the physics frame rate (:ref:`physics/common/physics_ticks_per_second<class_ProjectSettings_property_physics/common/physics_ticks_per_second>`, ``60`` by default) will bring the object to a stop in one iteration.
 
@@ -8860,7 +8860,7 @@ Suggested values are in the range ``0`` to ``30``. At value ``0`` objects will k
 
 During each physics tick, Godot will multiply the linear velocity of RigidBodies by ``1.0 - combined_damp / physics_ticks_per_second``, where ``combined_damp`` is the sum of the linear damp of the body and this value, or the area's value the body is in if the body defaults to combine damp values. (see :ref:`DampMode<enum_RigidBody3D_DampMode>`)
 
-.. warning:: Godot's damping calculations are simulation tick rate dependent. Changing your physics tick rate may significantly change the outcomes and feel of your simulation. This is true for the entire range of values greater than``0``, but is more pronounced for higher factors.
+.. warning:: Godot's damping calculations are simulation tick rate dependent. Changing your physics tick rate may significantly change the outcomes and feel of your simulation. This is true for the entire range of values greater than 0, but is more pronounced for higher factors.
 
 .. rst-class:: classref-item-separator
 

--- a/classes/class_projectsettings.rst
+++ b/classes/class_projectsettings.rst
@@ -8536,9 +8536,15 @@ If in doubt, leave this setting empty.
 
 :ref:`float<class_float>` **physics/2d/default_angular_damp** = ``1.0``
 
-The default angular damp in 2D.
+The default angular damp in 2D. RigidBodies will fall back to this value when combining their own damping values and no area damping value is present.
 
-\ **Note:** Good values are in the range ``0`` to ``1``. At value ``0`` objects will keep moving with the same velocity. Values greater than ``1`` will aim to reduce the velocity to ``0`` in less than a second e.g. a value of ``2`` will aim to reduce the velocity to ``0`` in half a second. A value equal to or greater than the physics frame rate (:ref:`physics/common/physics_ticks_per_second<class_ProjectSettings_property_physics/common/physics_ticks_per_second>`, ``60`` by default) will bring the object to a stop in one iteration.
+Suggested values are in the range ``0`` to ``30``. At value ``0`` objects will keep moving with the same velocity. Greater values will stop the object faster. A value equal to or greater than the physics tick rate (:ref:`physics/common/physics_ticks_per_second<class_ProjectSettings_property_physics/common/physics_ticks_per_second>`, ``60`` by default) will bring the object to a stop in one iteration.
+
+.. note:: Godot damping calculations are velocity-dependent, meaning bodies moving faster will take a longer time to come to rest. They do not simulate inertia, friction, or air resistance. Therefore heavier or larger bodies will lose speed at the same proportional rate as lighter or smaller bodies.
+
+During each physics tick, Godot will multiply the angular velocity of RigidBodies by ``1.0 - combined_damp / physics_ticks_per_second``, where ``combined_damp`` is the sum of the angular damp of the body and this value, or the area's value the body is in if the body defaults to combine damp values. (see :ref:`DampMode<enum_RigidBody2D_DampMode>`)
+
+.. warning:: Godot's damping calculations are simulation tick rate dependent. Changing your physics tick rate may significantly change the outcomes and feel of your simulation. This is true for the entire range of values greater than``0``, but is more pronounced for higher factors.
 
 .. rst-class:: classref-item-separator
 
@@ -8608,9 +8614,15 @@ The default gravity direction in 2D.
 
 :ref:`float<class_float>` **physics/2d/default_linear_damp** = ``0.1``
 
-The default linear damp in 2D.
+The default linear damp in 2D. RigidBodies will fall back to this value when combining their own damping values and no area damping value is present.
 
-\ **Note:** Good values are in the range ``0`` to ``1``. At value ``0`` objects will keep moving with the same velocity. Values greater than ``1`` will aim to reduce the velocity to ``0`` in less than a second e.g. a value of ``2`` will aim to reduce the velocity to ``0`` in half a second. A value equal to or greater than the physics frame rate (:ref:`physics/common/physics_ticks_per_second<class_ProjectSettings_property_physics/common/physics_ticks_per_second>`, ``60`` by default) will bring the object to a stop in one iteration.
+Suggested values are in the range ``0`` to ``30``. At value ``0`` objects will keep moving with the same velocity. Greater values will stop the object faster. A value equal to or greater than the physics tick rate (:ref:`physics/common/physics_ticks_per_second<class_ProjectSettings_property_physics/common/physics_ticks_per_second>`, ``60`` by default) will bring the object to a stop in one iteration.
+
+.. note:: Godot damping calculations are velocity-dependent, meaning bodies moving faster will take a longer time to come to rest. They do not simulate inertia, friction, or air resistance. Therefore heavier or larger bodies will lose speed at the same proportional rate as lighter or smaller bodies.
+
+During each physics tick, Godot will multiply the linear velocity of RigidBodies by ``1.0 - combined_damp / physics_ticks_per_second``, where ``combined_damp`` is the sum of the linear damp of the body and this value, or the area's value the body is in if the body defaults to combine damp values. (see :ref:`DampMode<enum_RigidBody2D_DampMode>`)
+
+.. warning:: Godot's damping calculations are simulation tick rate dependent. Changing your physics tick rate may significantly change the outcomes and feel of your simulation. This is true for the entire range of values greater than``0``, but is more pronounced for higher factors.
 
 .. rst-class:: classref-item-separator
 
@@ -8760,7 +8772,15 @@ Time (in seconds) of inactivity before which a 2D physics body will put to sleep
 
 :ref:`float<class_float>` **physics/3d/default_angular_damp** = ``0.1``
 
-The default angular damp in 3D.
+The default angular damp in 3D. RigidBodies will fall back to this value when combining their own damping values and no area damping value is present.
+
+Suggested values are in the range ``0`` to ``30``. At value ``0`` objects will keep moving with the same velocity. Greater values will stop the object faster. A value equal to or greater than the physics tick rate (:ref:`physics/common/physics_ticks_per_second<class_ProjectSettings_property_physics/common/physics_ticks_per_second>`, ``60`` by default) will bring the object to a stop in one iteration.
+
+.. note:: Godot damping calculations are velocity-dependent, meaning bodies moving faster will take a longer time to come to rest. They do not simulate inertia, friction, or air resistance. Therefore heavier or larger bodies will lose speed at the same proportional rate as lighter or smaller bodies.
+
+During each physics tick, Godot will multiply the angular velocity of RigidBodies by ``1.0 - combined_damp / physics_ticks_per_second``, where ``combined_damp`` is the sum of the angular damp of the body and this value, or the area's value the body is in if the body defaults to combine damp values. (see :ref:`DampMode<enum_RigidBody3D_DampMode>`)
+
+.. warning:: Godot's damping calculations are simulation tick rate dependent. Changing your physics tick rate may significantly change the outcomes and feel of your simulation. This is true for the entire range of values greater than``0``, but is more pronounced for higher factors.
 
 \ **Note:** Good values are in the range ``0`` to ``1``. At value ``0`` objects will keep moving with the same velocity. Values greater than ``1`` will aim to reduce the velocity to ``0`` in less than a second e.g. a value of ``2`` will aim to reduce the velocity to ``0`` in half a second. A value equal to or greater than the physics frame rate (:ref:`physics/common/physics_ticks_per_second<class_ProjectSettings_property_physics/common/physics_ticks_per_second>`, ``60`` by default) will bring the object to a stop in one iteration.
 
@@ -8832,9 +8852,15 @@ The default gravity direction in 3D.
 
 :ref:`float<class_float>` **physics/3d/default_linear_damp** = ``0.1``
 
-The default linear damp in 3D.
+The default linear damp in 3D. RigidBodies will fall back to this value when combining their own damping values and no area damping value is present.
 
-\ **Note:** Good values are in the range ``0`` to ``1``. At value ``0`` objects will keep moving with the same velocity. Values greater than ``1`` will aim to reduce the velocity to ``0`` in less than a second e.g. a value of ``2`` will aim to reduce the velocity to ``0`` in half a second. A value equal to or greater than the physics frame rate (:ref:`physics/common/physics_ticks_per_second<class_ProjectSettings_property_physics/common/physics_ticks_per_second>`, ``60`` by default) will bring the object to a stop in one iteration.
+Suggested values are in the range ``0`` to ``30``. At value ``0`` objects will keep moving with the same velocity. Greater values will stop the object faster. A value equal to or greater than the physics tick rate (:ref:`physics/common/physics_ticks_per_second<class_ProjectSettings_property_physics/common/physics_ticks_per_second>`, ``60`` by default) will bring the object to a stop in one iteration.
+
+.. note:: Godot damping calculations are velocity-dependent, meaning bodies moving faster will take a longer time to come to rest. They do not simulate inertia, friction, or air resistance. Therefore heavier or larger bodies will lose speed at the same proportional rate as lighter or smaller bodies.
+
+During each physics tick, Godot will multiply the linear velocity of RigidBodies by ``1.0 - combined_damp / physics_ticks_per_second``, where ``combined_damp`` is the sum of the linear damp of the body and this value, or the area's value the body is in if the body defaults to combine damp values. (see :ref:`DampMode<enum_RigidBody3D_DampMode>`)
+
+.. warning:: Godot's damping calculations are simulation tick rate dependent. Changing your physics tick rate may significantly change the outcomes and feel of your simulation. This is true for the entire range of values greater than``0``, but is more pronounced for higher factors.
 
 .. rst-class:: classref-item-separator
 


### PR DESCRIPTION
The values are explained in more detail, with correct maths and important caveats highlighted.
The ranges are corrected, as 0..1 was not a good range at all. (in fact, 1 is already the default for 2D). The values are changed as "suggested" instead of "good", because they are very subjective.

Resolves https://github.com/godotengine/godot-docs/issues/8163 