### PR TITLE
Standardize/Improve C# GD.Load() examples

### DIFF
--- a/tutorials/best_practices/godot_interfaces.rst
+++ b/tutorials/best_practices/godot_interfaces.rst
@@ -80,14 +80,14 @@ access.
         // No "preload" loads during scene load exists in C#.
 
         // Initialize with a value. Editable at runtime.
-        public Script MyScript = GD.Load<Script>("MyScript.cs");
+        public Script MyScript = GD.Load<Script>("res://Path/To/MyScript.cs");
 
         // Initialize with same value. Value cannot be changed.
-        public readonly Script MyConstScript = GD.Load<Script>("MyScript.cs");
+        public readonly Script MyConstScript = GD.Load<Script>("res://Path/To/MyScript.cs");
 
         // Like 'readonly' due to inaccessible setter.
         // But, value can be set during constructor, i.e. MyType().
-        public Script Library { get; } = GD.Load<Script>("res://addons/plugin/library.gd");
+        public Script MyNoSetScript { get; } = GD.Load<Script>("res://Path/To/MyScript.cs");
 
         // If need a "const [Export]" (which doesn't exist), use a
         // conditional setter for a tool script that checks if it's executing

--- a/tutorials/best_practices/logic_preferences.rst
+++ b/tutorials/best_practices/logic_preferences.rst
@@ -96,7 +96,7 @@ either? Let's see an example:
         public override void _Ready()
         {
             // Can assign the value during initialization.
-            ABuilding = GD.Load<PackedScene>("res://office.tscn");
+            ABuilding = GD.Load<PackedScene>("res://Office.tscn");
         }
     }
 

--- a/tutorials/best_practices/scenes_versus_scripts.rst
+++ b/tutorials/best_practices/scenes_versus_scripts.rst
@@ -29,9 +29,9 @@ a change in API:
     const MyNode = preload("my_node.gd")
     const MyScene = preload("my_scene.tscn")
     var node = Node.new()
-    var my_node = MyNode.new() # Same method call
-    var my_scene = MyScene.instantiate() # Different method call
-    var my_inherited_scene = MyScene.instantiate(PackedScene.GEN_EDIT_STATE_MAIN) # Create scene inheriting from MyScene
+    var my_node = MyNode.new() # Same method call.
+    var my_scene = MyScene.instantiate() # Different method call.
+    var my_inherited_scene = MyScene.instantiate(PackedScene.GEN_EDIT_STATE_MAIN) # Create scene inheriting from MyScene.
 
   .. code-tab:: csharp
 
@@ -39,8 +39,10 @@ a change in API:
 
     public partial class Game : Node
     {
-        public static CSharpScript MyNode { get; } = GD.Load<CSharpScript>("MyNode.cs");
-        public static PackedScene MyScene { get; } = GD.Load<PackedScene>("MyScene.tscn");
+        public static CSharpScript MyNode { get; } =
+            GD.Load<CSharpScript>("res://Path/To/MyNode.cs");
+        public static PackedScene MyScene { get; } =
+            GD.Load<PackedScene>("res://Path/To/MyScene.tscn");
         private Node _node;
         private Node _myNode;
         private Node _myScene;
@@ -50,8 +52,10 @@ a change in API:
         {
             _node = new Node();
             _myNode = MyNode.New().As<Node>();
-            _myScene = MyScene.Instantiate(); // Different. Instantiated from a PackedScene
-            _myInheritedScene = MyScene.Instantiate(PackedScene.GenEditState.Main); // Create scene inheriting from MyScene
+            // Different than calling new() or MyNode.New(). Instantiated from a PackedScene.
+            _myScene = MyScene.Instantiate();
+            // Create scene inheriting from MyScene.
+            _myInheritedScene = MyScene.Instantiate(PackedScene.GenEditState.Main);
         }
     }
 
@@ -155,14 +159,14 @@ with it, and finally adds it as a child of the ``Main`` node:
         var child = Node.new()
         child.name = "Child"
         child.script = preload("child.gd")
-        child.owner = self
         add_child(child)
+        child.owner = self
 
   .. code-tab:: csharp
 
     using Godot;
 
-    public partial class Main : Resource
+    public partial class Main : Node
     {
         public Node Child { get; set; }
 
@@ -170,9 +174,13 @@ with it, and finally adds it as a child of the ``Main`` node:
         {
             Child = new Node();
             Child.Name = "Child";
-            Child.SetScript(GD.Load<Script>("child.gd"));
-            Child.Owner = this;
+            var childID = Child.GetInstanceId();
+            Child.SetScript(GD.Load<Script>("res://Path/To/Child.cs"));
+            // SetScript() causes the C# wrapper object to be disposed, so obtain a new
+            // wrapper for the Child node using its instance ID before proceeding.
+            Child = (Node)GodotObject.InstanceFromId(childID);
             AddChild(Child);
+            Child.Owner = this;
         }
     }
 
@@ -207,7 +215,7 @@ In the end, the best approach is to consider the following:
     .. code-tab:: gdscript GDScript
 
       # game.gd
-      class_name Game # extends RefCounted, so it won't show up in the node creation dialog
+      class_name Game # extends RefCounted, so it won't show up in the node creation dialog.
       extends RefCounted
 
       const MyScene = preload("my_scene.tscn")
@@ -222,7 +230,8 @@ In the end, the best approach is to consider the following:
       // Game.cs
       public partial class Game : RefCounted
       {
-          public static PackedScene MyScene { get; } = GD.Load<PackedScene>("MyScene.tscn");
+          public static PackedScene MyScene { get; } =
+              GD.Load<PackedScene>("res://Path/To/MyScene.tscn");
       }
 
       // Main.cs

--- a/tutorials/physics/using_character_body_2d.rst
+++ b/tutorials/physics/using_character_body_2d.rst
@@ -337,7 +337,7 @@ uses the mouse pointer. Here is the code for the Player, using ``move_and_slide(
 
     public partial class MyCharacterBody2D : CharacterBody2D
     {
-        private PackedScene _bullet = (PackedScene)GD.Load("res://bullet.tscn");
+        private PackedScene _bullet = GD.Load<PackedScene>("res://Bullet.tscn");
         private int _speed = 200;
 
         public void GetInput()

--- a/tutorials/scripting/cross_language_scripting.rst
+++ b/tutorials/scripting/cross_language_scripting.rst
@@ -74,9 +74,8 @@ with :ref:`new() <class_CSharpScript_method_new>`.
 
 .. code-block:: gdscript
 
-    var my_csharp_script = load("res://path_to_cs_file.cs")
+    var my_csharp_script = load("res://Path/To/MyCSharpNode.cs")
     var my_csharp_node = my_csharp_script.new()
-    print(my_csharp_node.str2) # barbar
 
 .. warning::
 
@@ -101,8 +100,8 @@ be instantiated with :ref:`GDScript.New() <class_GDScript_method_new>`.
 
 .. code-block:: csharp
 
-    GDScript MyGDScript = (GDScript)GD.Load("res://path_to_gd_file.gd");
-    GodotObject myGDScriptNode = (GodotObject)MyGDScript.New(); // This is a GodotObject
+    GDScript MyGDScript = GD.Load<GDScript>("res://path/to/my_gd_script.gd");
+    GodotObject myGDScriptNode = (GodotObject)MyGDScript.New(); // This is a GodotObject.
 
 Here we are using an :ref:`class_Object`, but you can use type conversion like
 explained in :ref:`doc_c_sharp_features_type_conversion_and_casting`.
@@ -178,7 +177,7 @@ to said method.
     string[] arr = new string[] { "a", "b", "c" };
     myGDScriptNode.Call("print_array", arr); // a, b, c
     myGDScriptNode.Call("print_array", new int[] { 1, 2, 3 }); // 1, 2, 3
-    // Note how the type of each array entry does not matter as long as it can be handled by the marshaller
+    // Note how the type of each array entry does not matter as long as it can be handled by the marshaller.
 
 .. warning::
 

--- a/tutorials/scripting/instancing_with_signals.rst
+++ b/tutorials/scripting/instancing_with_signals.rst
@@ -113,7 +113,7 @@ Here is the code for the player using signals to emit the bullet:
         [Signal]
         public delegate void ShootEventHandler(PackedScene bullet, float direction, Vector2 location);
 
-        private PackedScene _bullet = GD.Load<PackedScene>("res://bullet.tscn");
+        private PackedScene _bullet = GD.Load<PackedScene>("res://Bullet.tscn");
 
         public override void _Input(InputEvent @event)
         {

--- a/tutorials/scripting/resources.rst
+++ b/tutorials/scripting/resources.rst
@@ -87,7 +87,8 @@ There are two ways to load resources from code. First, you can use the ``load()`
 
     public override void _Ready()
     {
-        var texture = (Texture)GD.Load("res://robi.png"); // Godot loads the Resource when it reads the line.
+        // Godot loads the Resource when it executes this line.
+        var texture = GD.Load<Texture>("res://Robi.png");
         var sprite = GetNode<Sprite2D>("sprite");
         sprite.Texture = texture;
     }
@@ -128,7 +129,7 @@ To get an instance of the scene, you have to use the
 
  .. code-tab:: csharp
 
-    private PackedScene _bulletScene = (PackedScene)GD.Load("res://bullet.tscn");
+    private PackedScene _bulletScene = GD.Load<PackedScene>("res://Bullet.tscn");
 
     private void OnShoot()
     {

--- a/tutorials/scripting/singletons_autoload.rst
+++ b/tutorials/scripting/singletons_autoload.rst
@@ -191,7 +191,7 @@ current scene and replace it with the requested one.
 
 
     func _deferred_goto_scene(path):
-        # It is now safe to remove the current scene
+        # It is now safe to remove the current scene.
         current_scene.free()
 
         # Load the new scene.
@@ -224,11 +224,11 @@ current scene and replace it with the requested one.
 
     public void DeferredGotoScene(string path)
     {
-        // It is now safe to remove the current scene
+        // It is now safe to remove the current scene.
         CurrentScene.Free();
 
         // Load a new scene.
-        var nextScene = (PackedScene)GD.Load(path);
+        var nextScene = GD.Load<PackedScene>(path);
 
         // Instance the new scene.
         CurrentScene = nextScene.Instantiate();


### PR DESCRIPTION
Following on from #7193, I've searched the docs for examples of `GD.Load()` that might not illustrate its requirement for absolute paths, fixed them to include a `res://` prefix, and made a few other changes:
* To standardize on the C# style, filenames and directories have been converted to PascalCase, except when loading GDScript files, and in one case a GLSL file (see below).
* I've changed to the typed version of `GD.Load()` (e.g., `GD.Load<PackedScene>()`) when examples were casting the result of an untyped call.
* I've used a `res://Path/To/FileName.extension` convention when the corresponding GDScript did not have an absolute path specified, to illustrate that the file might live in an arbitrary directory. When the GDScript example did have a `res://`, I've used the same absolute path.

Specific items I'd like to point up for review:
* `tutorials/shaders/compute_shaders.rst`: 
    * [I left a GLSL filename snake_cased](https://github.com/wlsnmrk/godot-docs/blob/45c6a1a4e4a5a1efddc6772c501e4f9411146f71/tutorials/shaders/compute_shaders.rst?plain=1#L187). I'm not a GLSL expert, but from some quick searching it seems like snake_case is kind of a de-facto standard. Happy to be corrected.
* `tutorials/best_practices/scenes_versus_scripts.rst`:
    * Required some significant changes in [the example for loading a script and assigning it to a `Node`](https://github.com/godotengine/godot-docs/compare/master...wlsnmrk:godot-docs:gd-load-fixes#diff-10a5f1b0589fa7ad1b08151c1dcd11bb5228644a9fbc421804f65bbece39b2d1R169-R183). I've verified that the updated version runs correctly in a test project, but wouldn't mind if someone double-checked my work.
        * Corresponding GDScript example was a `Node`, so I've changed C# from a `Resource` to a `Node`
        * `SetScript()` disposes the C# wrapper object, and the call comes before the node is in the tree, so I've added the object-ID workaround from https://github.com/godotengine/godot/issues/31994 to obtain a new reference
        * Moved the `AddChild()` call to before setting `Owner` on the child, per [documentation on `Owner`](https://docs.godotengine.org/en/stable/classes/class_node.html#class-node-property-owner)
    * [Changed a comment to hopefully make its meaning a little more clear](https://github.com/godotengine/godot-docs/compare/master...wlsnmrk:godot-docs:gd-load-fixes#diff-10a5f1b0589fa7ad1b08151c1dcd11bb5228644a9fbc421804f65bbece39b2d1R55), following the GDScript example.
* `tutorials/best_practices/godot_interfaces.rst`:
    * ~~I've left a field loading a snake_case GDScript rather than changing it to load a `.cs` script [in one example](https://github.com/wlsnmrk/godot-docs/blob/45c6a1a4e4a5a1efddc6772c501e4f9411146f71/tutorials/best_practices/godot_interfaces.rst?plain=1#L90), since it's loading from a (notional) add-on and those tend to be GDScript rather than C#. However, there doesn't seem to be a corresponding value in the GDSCript example, and I'm not sure if this example really needs to illustrate add-on directory layouts or cross-language scripting. Would be happy to change this to something else.~~ Changed below.
* `tutorials/scripting/resources.rst`:
    * [Changed a comment](https://github.com/godotengine/godot-docs/compare/master...wlsnmrk:godot-docs:gd-load-fixes#diff-9543c0c477dd21ce6356f57c792659ee49439568e90442bc16cf7df93be83461R90) to describe Godot loading the resource when the `GD.Load()` line is _executed_ rather than _read_. I'm not sure what the semantics of this are on the GDScript side, but I believe this to be more correct for C#; happy to be corrected.
    * [I've changed the filename "robi.png" to PascalCase](https://github.com/godotengine/godot-docs/compare/master...wlsnmrk:godot-docs:gd-load-fixes#diff-9543c0c477dd21ce6356f57c792659ee49439568e90442bc16cf7df93be83461R91) (i.e., "Robi.png"), in keeping with all the other changes. However, since it's referred to as "robi.png" in the body of the page, I'm not sure if we should make an exception to the naming convention here to avoid confusion.
* `tutorials/scripting/cross_language_scripting.rst`:
    * [Changed the path for loading a C# script from a GDScript to use PascalCase](https://github.com/godotengine/godot-docs/compare/master...wlsnmrk:godot-docs:gd-load-fixes#diff-7875f3ee292a53a639d2a0c22b902d99c0c356f9ad9339b1abee1f9209d0e2d8R77), to match the corresponding example for loading a GDScript from a C# script, which uses snake_case.