### PR TITLE
Fix Rotation-Pivot if Camera is Behind Player

### DIFF
--- a/getting_started/first_3d_game/03.player_movement_code.rst
+++ b/getting_started/first_3d_game/03.player_movement_code.rst
@@ -441,6 +441,21 @@ the ground should fill the background.
 
 Test your scene and you should be able to move in all 8 directions and not glitch through the floor!
 
+.. note::
+
+    If you want your camera behind your CharacterBody3D (you don't want the player 
+    facing the camera), and you want your Character to rotate in the direction of 
+    movement, you can change the GD Player Script *Pivot* code to 
+    subtract the direction instead of add it. This is because in 4.1 Godot rotated 
+    the 3DCharacterBody 180. So, your Pivot line would be:
+
+    .. tabs::
+     .. code-tab:: gdscript GDScript
+
+        extends CharacterBody3D
+            #...
+            $Pivot.look_at(position - direction, Vector3.UP) 
+
 Ultimately, we have both player movement and the view in place. Next, we will
 work on the monsters.
 


### PR DESCRIPTION
JUST one NOTE in the page of tutorial for Player Movement--this is my first attempt at Pull Req so please help me fix/do better next time!!

Added note for PIVOT line in GD Script. Why: In 4.1 CB3D is now rotated 180...so when rotating CharacterBody3D in direction of movement, if you want 3rd person view from behind the player, you need to subtract (not add) here: $Pivot.look_at(position - direction, Vector3.UP) 
This way, your player will correctly rotate with movement. 

I think a lot of people following this tutorial will be adapting it to have their camera behind the player (3rd Person View) and will needlessly become frustrated trying to rotate actual game objects instead of one simple code fix.

<!--
Please target the `master` branch in priority. I don't know if I should do this ^^^ so I am sorry if I messed something up.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
