### PR TITLE
Change KinematicBodies to CharacterBodies in collision_shapes_3d.rst and collision_shapes_2d.rst

### DIFF
--- a/tutorials/physics/collision_shapes_2d.rst
+++ b/tutorials/physics/collision_shapes_2d.rst
@@ -40,7 +40,7 @@ primitive shapes. However, for more complex objects, such as a large ship or a
 whole level, you may need convex or concave shapes instead. More on that below.
 
 We recommend favoring primitive shapes for dynamic objects such as RigidBodies
-and KinematicBodies as their behavior is the most reliable. They often provide
+and CharacterBodies as their behavior is the most reliable. They often provide
 better performance as well.
 
 Convex collision shapes
@@ -72,7 +72,7 @@ Concave or trimesh collision shapes
 collision shapes, can take any form, from a few triangles to thousands of
 triangles. Concave shapes are the slowest option but are also the most accurate
 in Godot. **You can only use concave shapes within StaticBodies.** They will not
-work with KinematicBodies or RigidBodies unless the RigidBody's mode is Static.
+work with CharacterBodies or RigidBodies unless the RigidBody's mode is Static.
 
 .. note::
 
@@ -117,7 +117,7 @@ Performance caveats
 You aren't limited to a single collision shape per PhysicsBody. Still, we
 recommend keeping the number of shapes as low as possible to improve
 performance, especially for dynamic objects like RigidBodies and
-KinematicBodies. On top of that, avoid translating, rotating, or scaling
+CharacterBodies. On top of that, avoid translating, rotating, or scaling
 CollisionShapes to benefit from the physics engine's internal optimizations.
 
 When using a single non-transformed collision shape in a StaticBody, the

--- a/tutorials/physics/collision_shapes_3d.rst
+++ b/tutorials/physics/collision_shapes_3d.rst
@@ -37,7 +37,7 @@ primitive shapes. However, for more complex objects, such as a large ship or a
 whole level, you may need convex or concave shapes instead. More on that below.
 
 We recommend favoring primitive shapes for dynamic objects such as RigidBodies
-and KinematicBodies as their behavior is the most reliable. They often provide
+and CharacterBodies as their behavior is the most reliable. They often provide
 better performance as well.
 
 Convex collision shapes
@@ -79,7 +79,7 @@ Concave or trimesh collision shapes
 collision shapes, can take any form, from a few triangles to thousands of
 triangles. Concave shapes are the slowest option but are also the most accurate
 in Godot. **You can only use concave shapes within StaticBodies.** They will not
-work with KinematicBodies or RigidBodies unless the RigidBody's mode is Static.
+work with CharacterBodies or RigidBodies unless the RigidBody's mode is Static.
 
 .. note::
 
@@ -117,7 +117,7 @@ Performance caveats
 You aren't limited to a single collision shape per PhysicsBody. Still, we
 recommend keeping the number of shapes as low as possible to improve
 performance, especially for dynamic objects like RigidBodies and
-KinematicBodies. On top of that, avoid translating, rotating, or scaling
+CharacterBodies. On top of that, avoid translating, rotating, or scaling
 CollisionShapes to benefit from the physics engine's internal optimizations.
 
 When using a single non-transformed collision shape in a StaticBody, the


### PR DESCRIPTION
In ```collision_shapes_3d.rst```, KinematicBodies were still referenced although they have been replaced by CharacterBodies in Godot 4.0.