### PR TITLE
Updated 3D tutorial to Godot 4.1.1

### DIFF
--- a/getting_started/first_3d_game/09.adding_animations.rst
+++ b/getting_started/first_3d_game/09.adding_animations.rst
@@ -264,6 +264,7 @@ animation. Next, click on **Edit > Copy Tracks** and check "Character.position"
 and "Character.rotation". Click the "Copy" button. Then open ``mob.tscn``,
 create an AnimationPlayer child node and select it. As we did for ``Player``, click on
 *Animation -> New* and name the animation "float". Now click **Edit > Paste Tracks**
+and make sure that the button with an "A+" icon (Autoplay on Load) and the
 looping arrows (Animation looping) are also turned on in the animation editor
 in the bottom panel. That's it; all monsters will now play the float animation.
 

--- a/getting_started/first_3d_game/09.adding_animations.rst
+++ b/getting_started/first_3d_game/09.adding_animations.rst
@@ -260,9 +260,10 @@ For example, both the ``Mob`` and the ``Player`` scenes have a ``Pivot`` and a
 ``Character`` node, so we can reuse animations between them.
 
 Open the *Player* scene, select the AnimationPlayer node and open the "float"
-animation. Next, click on **Animation > Copy**. Then open ``mob.tscn``,
-create an AnimationPlayer child node and select it. Click **Animation > Paste**
-and make sure that the button with an "A+" icon (Autoplay on Load) and the
+animation. Next, click on **Edit > Copy Tracks** and check "Character.position"
+and "Character.rotation". Click the "Copy" button. Then open ``mob.tscn``,
+create an AnimationPlayer child node and select it. As we did for ``Player``, click on
+*Animation -> New* and name the animation "float". Now click **Edit > Paste Tracks**
 looping arrows (Animation looping) are also turned on in the animation editor
 in the bottom panel. That's it; all monsters will now play the float animation.
 


### PR DESCRIPTION
The way to copy animations appears to be different now.

I have followed the 3D tutorial using Godot 4.1.1 and it appears to be up-to-date except for the change in this pull request.

I notice that "v3.2.4.beta2.official" appears in the Project Manager image under "Setting up the game area".