### PR TITLE
Link to "Environment and Post-Processing" from "Custom Post-Processing"

### DIFF
--- a/tutorials/shaders/custom_postprocessing.rst
+++ b/tutorials/shaders/custom_postprocessing.rst
@@ -7,8 +7,9 @@ Introduction
 ------------
 
 Godot provides many post-processing effects out of the box, including Bloom,
-DOF, and SSAO. However, advanced use cases may require custom effects. This
-article explains how to write your own custom effects.
+DOF, and SSAO, which are described in :ref:`doc_environment_and_post_processing`.
+However, advanced use cases may require custom effects. This article explains how
+to write your own custom effects.
 
 The easiest way to implement a custom post-processing shader is to use Godot's
 built-in ability to read from the screen texture. If you're not familiar with


### PR DESCRIPTION
Reasoning: It's good to link to pages the user may have been looking for within the first paragraph, if it fits naturally.