### PR TITLE
Improving unit test documentation page

### DIFF
--- a/contributing/development/core_and_modules/unit_testing.rst
+++ b/contributing/development/core_and_modules/unit_testing.rst
@@ -55,6 +55,12 @@ arguments for doctest.
     detected, so you should strive to fix all warnings before opening a pull
     request.
 
+.. note::
+
+    If you are using a 64-bit compiler architecture, ``<godot_binary>`` will 
+    be your 64-bit binary and the same applies to 32-bit compiler architecture. 
+    So make sure you run the correct binary in order to run the tests.
+
 Filtering tests
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

I think it makes more sense to mention about compiler version inside the unit testing page.
