### PR TITLE
fixed vector value in bullet example

### DIFF
--- a/tutorials/scripting/instancing_with_signals.rst
+++ b/tutorials/scripting/instancing_with_signals.rst
@@ -30,7 +30,7 @@ given velocity:
 
     extends Area2D
 
-    var velocity = Vector2(1, 0)
+    var velocity = Vector2.RIGHT
 
     func _physics_process(delta):
         position += velocity * delta

--- a/tutorials/scripting/instancing_with_signals.rst
+++ b/tutorials/scripting/instancing_with_signals.rst
@@ -30,7 +30,7 @@ given velocity:
 
     extends Area2D
 
-    var velocity = Vector2.ZERO
+    var velocity = Vector2(1, 0)
 
     func _physics_process(delta):
         position += velocity * delta
@@ -41,7 +41,7 @@ given velocity:
 
     public partial class Bullet : Area2D
     {
-        public Vector2 Velocity { get; set; } = Vector2.Zero;
+        public Vector2 Velocity { get; set; } = Vector2(1.0, 0.0);
 
         public override void _PhysicsProcess(double delta)
         {

--- a/tutorials/scripting/instancing_with_signals.rst
+++ b/tutorials/scripting/instancing_with_signals.rst
@@ -41,7 +41,7 @@ given velocity:
 
     public partial class Bullet : Area2D
     {
-        public Vector2 Velocity { get; set; } = Vector2(1.0, 0.0);
+        public Vector2 Velocity { get; set; } = Vector2.Right;
 
         public override void _PhysicsProcess(double delta)
         {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Fixes code example in the Instancing with Signals tutorial as mentioned in issue #7963 