### PR TITLE
Change Incorrect Keyboard shortcut for switch to 2D workspace on macOS

### DIFF
--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -239,7 +239,7 @@ Let's use a different node here. Godot has a :ref:`Timer <class_Timer>` node
 that's useful to implement skill cooldown times, weapon reloading, and more.
 
 Head back to the 2D workspace. You can either click the "2D" text at the top of
-the window or press :kbd:`Ctrl + F1` (:kbd:`Ctrl + Cmd + 1` on macOS).
+the window or press :kbd:`Ctrl + F1` (:kbd:`Cmd + Ctrl + 1` on macOS).
 
 In the Scene dock, right-click on the Sprite2D node and add a new child node.
 Search for Timer and add the corresponding node. Your scene should now look like


### PR DESCRIPTION
Fixes #8182. This PR fixes an issue where the keyboard shortcut shown in the tutorial is not the keyboard shortcut inside the game engine.