### PR TITLE
inspector_plugins.rst: add new "wide" parameter to _parse_property

### DIFF
--- a/tutorials/plugins/editor/inspector_plugins.rst
+++ b/tutorials/plugins/editor/inspector_plugins.rst
@@ -123,12 +123,12 @@ specifically add :ref:`class_EditorProperty`-based controls.
         return true
 
 
-    func _parse_property(object, type, path, hint, hint_text, usage):
+    func _parse_property(object, type, name, hint_type, hint_string, usage_flags, wide):
         # We handle properties of type integer.
         if type == TYPE_INT:
             # Create an instance of the custom property editor and register
             # it to a specific property path.
-            add_property_editor(path, RandomIntEditor.new())
+            add_property_editor(name, RandomIntEditor.new())
             # Inform the editor to remove the default property editor for
             # this property type.
             return true


### PR DESCRIPTION
Godot 4.0 added a new parameter to EditorInspectorPlugin._parse_property.  This was updated in the C# version of the tutorial, but not the gdscript version
