### PR TITLE
FAQ: Fix link to LOGO_LICENSE.txt after rename

### DIFF
--- a/about/faq.rst
+++ b/about/faq.rst
@@ -29,7 +29,7 @@ different licenses.
 
 For full details, look at the `COPYRIGHT.txt <https://github.com/godotengine/godot/blob/master/COPYRIGHT.txt>`_
 as well as the `LICENSE.txt <https://github.com/godotengine/godot/blob/master/LICENSE.txt>`_
-and `LOGO_LICENSE.txt <https://github.com/godotengine/godot/blob/master/LOGO_LICENSE.md>`_ files
+and `LOGO_LICENSE.txt <https://github.com/godotengine/godot/blob/master/LOGO_LICENSE.txt>`_ files
 in the Godot repository.
 
 Also, see `the license page on the Godot website <https://godotengine.org/license>`_.


### PR DESCRIPTION
Should be merged after https://github.com/godotengine/godot/pull/83095, and cherry-picked to all supported branches (probably down to `3.4` even if we don't have a label for it anymore).