### PR TITLE
Incorrect path in generating *.out tests command in integration tests documentation

### DIFF
--- a/contributing/development/core_and_modules/unit_testing.rst
+++ b/contributing/development/core_and_modules/unit_testing.rst
@@ -319,7 +319,7 @@ Therefore, the process of writing integration tests for GDScript is the followin
             if true # Missing colon here.
                 print("true")
 
-3. Change directory to the root of godot source repository.
+3. Change directory to the Godot source repository root.
 
    .. code-block:: shell
 

--- a/contributing/development/core_and_modules/unit_testing.rst
+++ b/contributing/development/core_and_modules/unit_testing.rst
@@ -329,7 +329,7 @@ Therefore, the process of writing integration tests for GDScript is the followin
 
    .. code-block:: shell
 
-       ./bin/<godot_binary> --gdscript-generate-tests modules/gdscript/tests/scripts
+       bin/<godot_binary> --gdscript-generate-tests modules/gdscript/tests/scripts
 
 You may add the ``--print-filenames`` option to see filenames as their test
 outputs are generated. If you are working on a new feature that is causing

--- a/contributing/development/core_and_modules/unit_testing.rst
+++ b/contributing/development/core_and_modules/unit_testing.rst
@@ -319,18 +319,24 @@ Therefore, the process of writing integration tests for GDScript is the followin
             if true # Missing colon here.
                 print("true")
 
-3. Generate ``*.out`` files to update the expected results from the output:
+3. Change directory to the root of godot source repository.
 
    .. code-block:: shell
 
-       ./bin/<godot_binary> --gdscript-generate-tests godot-source/modules/gdscript/tests/scripts
+       cd godot
+
+4. Generate ``*.out`` files to update the expected results from the output:
+
+   .. code-block:: shell
+
+       ./bin/<godot_binary> --gdscript-generate-tests modules/gdscript/tests/scripts
 
 You may add the ``--print-filenames`` option to see filenames as their test
 outputs are generated. If you are working on a new feature that is causing
 hard crashes, you can use this option to quickly find which test file causes
 the crash and debug from there.
 
-4. Run GDScript tests with:
+5. Run GDScript tests with:
 
    .. code-block:: shell
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

The path to ``bin/`` directory is written from the root as ``./bin/<godot_binary>`` however the path to ``scripts/`` directory is written from outside the root as ``godot-source/modules/gdscript/tests/scripts``, which is inconsistent I think.