### PR TITLE
Fix wrong property name of ``AnimatedSprite2D``

### DIFF
--- a/getting_started/first_2d_game/04.creating_the_enemy.rst
+++ b/getting_started/first_2d_game/04.creating_the_enemy.rst
@@ -142,7 +142,7 @@ and randomly choose one of the three animation types:
         _animated_sprite->set_animation(mob_types[random->randi() % mob_types.size()]);
     }
 
-First, we get the list of animation names from the AnimatedSprite2D's ``frames``
+First, we get the list of animation names from the AnimatedSprite2D's ``sprite_frames``
 property. This returns an Array containing all three animation names: ``["walk",
 "swim", "fly"]``.
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Fixes #8204 

The property name of ``AnimatedSprite2D`` is different in GDScript/C#/C++, Idk how godot-docs handles this so feel free to request any changes, please.
