### PR TITLE
bugfix: call groups on wrong object

### DIFF
--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -416,7 +416,8 @@ the ``new_game()`` function in ``Main``:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-        get_tree().call_group("mobs", "queue_free")
+        var scene_tree = SceneTree.new()
+	    scene_tree.call_group("mobs", "queue_free")
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
It seems that the call_group is on the wrong element. Very new to Godot (hence doing the tutorial)
Perhaps fix is not best practice, or perhaps I even missed something.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
