### PR TITLE
Docs: Update link to Android Gradle Build

### DIFF
--- a/classes/class_editorexportplatformandroid.rst
+++ b/classes/class_editorexportplatformandroid.rst
@@ -21,7 +21,7 @@ Tutorials
 
 - :doc:`Exporting for Android <../tutorials/export/exporting_for_android>`
 
-- :doc:`Custom builds for Android <../tutorials/export/android_custom_build>`
+- :doc:`Gradle builds for Android <../tutorials/export/android_gradle_build>`
 
 - :doc:`Android plugins documentation index <../tutorials/platform/index>`
 


### PR DESCRIPTION
Temporary fixup for https://github.com/godotengine/godot-docs/pull/7884 / https://github.com/godotengine/godot-docs/pull/8217 to get CI running again, needs to be fixed in the main repository.