### PR TITLE
Update Windows security instructions

### DIFF
--- a/contributing/development/compiling/compiling_for_windows.rst
+++ b/contributing/development/compiling/compiling_for_windows.rst
@@ -104,9 +104,9 @@ The tutorial will assume from now on that you placed the source code in
     add the Godot source folder to the list of exceptions in your antivirus
     software.
 
-    For Windows Defender, hit the :kbd:`Windows` key, type
-    "Windows Defender Settings" then hit :kbd:`Enter`.
-    Under **Virus & threat protection**, go to **Virus & threat protection setting**
+    For Windows Defender, hit the :kbd:`Windows` key, type "Windows Security"
+    then hit :kbd:`Enter`. Click on **Virus & threat protection** on the left
+    panel. Under **Virus & threat protection settings** click on **Mange Settings**
     and scroll down to **Exclusions**. Click **Add or remove exclusions** then
     add the Godot source folder.
 


### PR DESCRIPTION
Updates the instructions for adding a exclusion to windows security. This works for Windows 11 and 10. Supersedes #6541.