### PR TITLE
fix: vertex coordinates are in local space

### DIFF
--- a/tutorials/shaders/shader_reference/canvas_item_shader.rst
+++ b/tutorials/shaders/shader_reference/canvas_item_shader.rst
@@ -117,7 +117,7 @@ is usually:
 |                                | For a Sprite2D with a texture of size 64x32px,     |
 |                                | **TEXTURE_PIXEL_SIZE** = :code:`vec2(1/64, 1/32)`  |
 +--------------------------------+----------------------------------------------------+
-| inout vec2 **VERTEX**          | Vertex, in image space.                            |
+| inout vec2 **VERTEX**          | Vertex, in local space.                            |
 +--------------------------------+----------------------------------------------------+
 | inout vec2 **UV**              | Normalized texture coordinates. Range from 0 to 1. |
 +--------------------------------+----------------------------------------------------+


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

I couldn't for the life of me figure out what was meant with "image space", so I did some experimentation and figured out that the vertex coordinates are actually in "canvas space".