### PR TITLE
Add another video tutorial playlist

### DIFF
--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -46,6 +46,7 @@ Video tutorials
 - `Gwizz <https://www.youtube.com/@Gwizz1027>`_ (2D, GDScript).
 - `Quiver <https://quiver.dev/>`_ (2D, GDScript).
 - `Maker Tech <https://www.youtube.com/watch?v=0mUoRdYe0s4>`_ (2D, GDScript).
+- `Serkan Tarçın <https://www.youtube.com/playlist?list=PLBeiK76JaICn7fiHKtgOwY7R0T7Uw1VkV>`_ (3D, GDScript).
 
 Text tutorials
 --------------


### PR DESCRIPTION
Added another YouTube playlist which contains 3D and GDScript video tutorials.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
