### PR TITLE
fix file casing in singletons_autoload tutorial

### DIFF
--- a/tutorials/scripting/singletons_autoload.rst
+++ b/tutorials/scripting/singletons_autoload.rst
@@ -250,7 +250,7 @@ Finally, we need to fill the empty callback functions in the two scenes:
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    # Add to 'Scene1.gd'.
+    # Add to 'scene_1.gd'.
 
     func _on_button_pressed():
         Global.goto_scene("res://scene_2.tscn")
@@ -270,7 +270,7 @@ and
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    # Add to 'Scene2.gd'.
+    # Add to 'scene_2.gd'.
 
     func _on_button_pressed():
         Global.goto_scene("res://scene_1.tscn")


### PR DESCRIPTION
companion of [#7](https://github.com/godotengine/godot-docs-project-starters/pull/7)

small fixup of the file casing, it is already used in the text and code.

(added cherry-pick 4.0, because the starter zip starts with 4.0 and it shouldn't break translations)
