### PR TITLE
Fixing small wrong info

### DIFF
--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -411,7 +411,7 @@ click "Groups" and you can type a new group name and click "Add".
 .. image:: img/group_tab.webp
 
 Now all mobs will be in the "mobs" group. We can then add the following line to
-the ``new_game()`` function in ``Main``:
+the ``game_over()`` function in ``Main``:
 
 .. tabs::
  .. code-tab:: gdscript GDScript


### PR DESCRIPTION
The docs says to includes the `get_tree().call_group("mobs", "queue_free")` to the `new_game()` when is actually to the `game_over()`

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
