### PR TITLE
Importing Audio Samples: loop points are in samples, not seconds

### DIFF
--- a/tutorials/assets_pipeline/importing_audio_samples.rst
+++ b/tutorials/assets_pipeline/importing_audio_samples.rst
@@ -150,8 +150,8 @@ metadata, but you can choose to apply a specific loop mode:
 
 When choosing one of the **Forward**, **Ping-Pong** or **Backward** loop modes,
 loop points can also be defined to make only a specific part of the sound loop.
-**Loop Begin** is set in seconds after the beginning of the audio file. **Loop
-End** is also set in seconds after the beginning of the audio file, but will use
+**Loop Begin** is set in samples after the beginning of the audio file. **Loop
+End** is also set in samples after the beginning of the audio file, but will use
 the end of the audio file if set to ``-1``.
 
 .. warning::


### PR DESCRIPTION
Importing Audio Samples incorrectly said that loop points are in seconds. I've corrected that to say samples (which is the case as of 4.1.2)

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
