### PR TITLE
Noting that the rebase in 'Updating your branch' requires a force push.

### DIFF
--- a/contributing/workflow/pr_workflow.rst
+++ b/contributing/workflow/pr_workflow.rst
@@ -248,6 +248,10 @@ section <doc_pr_workflow_rebase>` for instructions.
          to find the commit ID of the previous state that you would like to restore, and
          use it as argument of ``git reset --hard`` to go back to that state.
 
+If you had local changes before rebasing, the rebase rewrites your local git history.
+In that case, you will need to force push using ``git push --force origin master``
+instead of pushing normally.
+
 Making changes
 --------------
 


### PR DESCRIPTION
The reasons for this are described in detail in the 'The interactive rebase' section, but other sections such as 'Modifying a pull request' also include a brief note to this effect. This addresses #8256. While the 'interactive rebase' section is more relevant to rebasing a PR, 'Updating your branch' does contemplate that you may have local commits to master, and a force push is necessary in that case.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
