### PR TITLE
Fix GDScript HTTPClient tutorial

### DIFF
--- a/tutorials/networking/http_client_class.rst
+++ b/tutorials/networking/http_client_class.rst
@@ -51,69 +51,27 @@ It will connect and fetch a website.
         while http.get_status() == HTTPClient.STATUS_CONNECTING or http.get_status() == HTTPClient.STATUS_RESOLVING:
             http.poll()
             print("Connecting...")
+            
             if not OS.has_feature("web"):
                 OS.delay_msec(500)
             else:
-                yield(Engine.get_main_loop(), "idle_frame")
+                await process_frame
 
         assert(http.get_status() == HTTPClient.STATUS_CONNECTED) # Check if the connection was made successfully.
 
-        # Some headers
-        var headers = [
-            "User-Agent: Pirulo/1.0 (Godot)",
-            "Accept: */*"
-        ]
-
-        err = http.request(HTTPClient.METHOD_GET, "/ChangeLog-5.php", headers) # Request a page from the site (this one was chunked..)
-        assert(err == OK) # Make sure all is OK.
-
-        while http.get_status() == HTTPClient.STATUS_REQUESTING:
-            # Keep polling for as long as the request is being processed.
-            http.poll()
-            print("Requesting...")
+	@@ -74,7 +74,7 @@ It will connect and fetch a website.
             if OS.has_feature("web"):
                 # Synchronous HTTP requests are not supported on the web,
                 # so wait for the next main loop iteration.
-                yield(Engine.get_main_loop(), "idle_frame")
+                await process_frame
             else:
                 OS.delay_msec(500)
 
-        assert(http.get_status() == HTTPClient.STATUS_BODY or http.get_status() == HTTPClient.STATUS_CONNECTED) # Make sure request finished well.
-
-        print("response? ", http.has_response()) # Site might not have a response.
-
-        if http.has_response():
-            # If there is a response...
-
-            headers = http.get_response_headers_as_dictionary() # Get response headers.
-            print("code: ", http.get_response_code()) # Show response code.
-            print("**headers:\\n", headers) # Show headers.
-
-            # Getting the HTTP Body
-
-            if http.is_response_chunked():
-                # Does it use chunks?
-                print("Response is Chunked!")
-            else:
-                # Or just plain Content-Length
-                var bl = http.get_response_body_length()
-                print("Response Length: ", bl)
-
-            # This method works for both anyway
-
-            var rb = PackedByteArray() # Array that will hold the data.
-
-            while http.get_status() == HTTPClient.STATUS_BODY:
-                # While there is body left to be read
-                http.poll()
-                # Get a chunk.
-                var chunk = http.read_response_body_chunk()
-                if chunk.size() == 0:
-                    if not OS.has_feature("web"):
+	@@ -113,7 +113,7 @@ It will connect and fetch a website.
                         # Got nothing, wait for buffers to fill a bit.
                         OS.delay_usec(1000)
                     else:
-                        yield(Engine.get_main_loop(), "idle_frame")
+                        await process_frame
                 else:
                     rb = rb + chunk # Append to read buffer.
             # Done!


### PR DESCRIPTION
Fix the tutorial for the http client tutorial

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
