### PR TITLE
Remove duplicate reminders that are very close to each other

### DIFF
--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -337,9 +337,6 @@ window and selecting the ``new_game()`` method or type "new_game" below "Receive
 in the window. Verify that the green connection icon now appears next to
 ``func new_game()`` in the script.
 
-Remember to remove the call to ``new_game()`` from
-``_ready()``.
-
 In ``new_game()``, update the score display and show the "Get Ready" message:
 
 .. tabs::


### PR DESCRIPTION
Was reading through the tutorial and saw this information popping up at least 3 times. There's another reminder a couple lines below saying the same thing. So I'm proposing to remove this one.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
