### PR TITLE
Replacing `find_node()` with `get_node()` as `find_node()` doesn't exist

### DIFF
--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -329,7 +329,7 @@ If you are using :ref:`EditorScript<class_EditorScript>`:
 
     func _run():
         # `parent` could be any node in the scene.
-        var parent = get_scene().find_node("Parent")
+        var parent = get_scene().get_node("Parent")
         var node = Node3D.new()
         parent.add_child(node)
 
@@ -342,7 +342,7 @@ If you are using :ref:`EditorScript<class_EditorScript>`:
     public override void _Run()
     {
         // `parent` could be any node in the scene.
-        var parent = GetScene().FindNode("Parent");
+        var parent = GetScene().GetNode("Parent");
         var node = new Node3D();
         parent.AddChild(node);
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Fixes #8218 

https://docs.godotengine.org/en/stable/classes/class_node.html#class-node-method-get-node
