### PR TITLE
Document alternative dotfile creation method for Windows

### DIFF
--- a/tutorials/best_practices/project_organization.rst
+++ b/tutorials/best_practices/project_organization.rst
@@ -80,9 +80,12 @@ This can be useful to speed up the initial project importing.
 
 .. note::
 
-    To create a file whose name starts with a dot on Windows, you can use a
-    text editor such as Notepad++ or use the following command in a
-    command prompt: ``type nul > .gdignore``
+    To create a file whose name starts with a dot on Windows, place a dot
+    at both the beginning and end of the filename (".gdignore."). Windows
+    will automatically remove the trailing dot when you confirm the name.
+
+    Alternatively, you can use a text editor such as Notepad++ or use the
+    following command in a command prompt: ``type nul > .gdignore``
 
 Once the folder is ignored, resources in that folder can't be loaded anymore
 using the ``load()`` and ``preload()`` methods. Ignoring a folder will also


### PR DESCRIPTION
There's a much simpler method of creating a dotfile on Windows directly in Explorer that the documentation doesn't mention.

According to the comments of [this StackOverflow answer](https://superuser.com/questions/64471/create-rename-a-file-folder-that-begins-with-a-dot-in-windows/406758#406758) this method appears to have been added in Windows 7. Since [Godot only supports Windows 7 and later](https://docs.godotengine.org/en/stable/about/list_of_features.html#platforms), a warning about compatibility shouldn't be necessary.