### PR TITLE
[Input] Fix incorrect setter usage in C#

### DIFF
--- a/tutorials/inputs/handling_quit_requests.rst
+++ b/tutorials/inputs/handling_quit_requests.rst
@@ -60,7 +60,7 @@ procedure:
 
  .. code-tab:: csharp
 
-    GetTree().SetAutoAcceptQuit(false);
+    GetTree().AutoAcceptQuit = false;
 
 Sending your own quit notification
 ----------------------------------


### PR DESCRIPTION
* Closes: #8319

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
