### PR TITLE
Use Node2D instead of PhysicsBody2D for C# collision example

### DIFF
--- a/getting_started/first_2d_game/03.coding_the_player.rst
+++ b/getting_started/first_2d_game/03.coding_the_player.rst
@@ -497,7 +497,7 @@ this code to the function:
 
  .. code-tab:: csharp
 
-    private void OnBodyEntered(PhysicsBody2D body)
+    private void OnBodyEntered(Node2D body)
     {
         Hide(); // Player disappears after being hit.
         EmitSignal(SignalName.Hit);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
Hi 👋

While reading the ["Getting started"](https://docs.godotengine.org/en/stable/getting_started/introduction/index.html) tutorial, I noticed that the C# method `OnBodyEntered` currently accepts a `PhysicsBody2D` object, rather than a `Node2D` object. This seems to prevent Godot from recognizing it as a valid handler for the `body_entered` signal.

I never used Godot before so it's possible I overlooked something, if that's the case please just close this PR.