### PR TITLE
Fix outdated OpenJDK link, updated to use latest/the downloads page.

### DIFF
--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -21,7 +21,7 @@ The following steps detail what is needed to set up the Android SDK and the engi
 Install OpenJDK 17
 ------------------
 
-Download and install `OpenJDK 17 <https://adoptium.net/temurin/releases/?variant=openjdk17>`__.
+Download and install the latest `OpenJDK <https://adoptium.net/temurin/releases/>`__.
 
 Download the Android SDK
 ------------------------


### PR DESCRIPTION
The old link to `OpenJDK` 17 causes errors (Java class version errors) with the Android SDK command line tools. The new link works with the latest `sdkmanager`.

### Fixes this error with the Android `sdkmanager` command line tool:
```
Error: LinkageError occurred while loading main class com.android.sdklib.tool.sdkmanager.SdkManagerCli java.lang.UnsupportedClassVersionError: com/android/sdklib/tool/sdkmanager/SdkManagerCli has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```