### PR TITLE
GetCollider() Not Working Following Tutorial With v4.1

### DIFF
--- a/getting_started/first_3d_game/06.jump_and_squash.rst
+++ b/getting_started/first_3d_game/06.jump_and_squash.rst
@@ -243,17 +243,19 @@ With this code, if no collisions occurred on a given frame, the loop won't run.
            # We get one of the collisions with the player
            var collision = get_slide_collision(index)
 
+           # Get the object that was collided with
+           var obj = collision.get_collider()
+
            # If the collision is with ground
-           if collision.get_collider() == null:
+           if obj == null:
                continue
 
            # If the collider is with a mob
-           if collision.get_collider().is_in_group("mob"):
-               var mob = collision.get_collider()
+           if obj.is_in_group("mob"):
                # we check that we are hitting it from above.
                if Vector3.UP.dot(collision.get_normal()) > 0.1:
                    # If so, we squash it and bounce.
-                   mob.squash()
+                   obj.squash()
                    target_velocity.y = bounce_impulse
 
  .. code-tab:: csharp


### PR DESCRIPTION
When following the tutorial GetCollider() seems to act like a pop function and cannot be called multiple times, I changed it to only be called once and it worked. I put my example working code for GDScript but I'm new and not sure if that is a proper way to fix it.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
