### PR TITLE
Update 06.jump_and_squash.rst

### DIFF
--- a/getting_started/first_3d_game/06.jump_and_squash.rst
+++ b/getting_started/first_3d_game/06.jump_and_squash.rst
@@ -236,25 +236,25 @@ With this code, if no collisions occurred on a given frame, the loop won't run.
  .. code-tab:: gdscript GDScript
 
     func _physics_process(delta):
-       #...
+        #...
 
-       # Iterate through all collisions that occurred this frame
-       for index in range(get_slide_collision_count()):
-           # We get one of the collisions with the player
-           var collision = get_slide_collision(index)
+        # Iterate through all collisions that occurred this frame
+        for index in range(get_slide_collision_count()):
+            # We get one of the collisions with the player
+            var collision = get_slide_collision(index)
 
-           # If the collision is with ground
-           if collision.get_collider() == null:
-               continue
+            # If the collision is with ground
+            if collision.get_collider() == null:
+                continue
 
-           # If the collider is with a mob
-           if collision.get_collider().is_in_group("mob"):
-               var mob = collision.get_collider()
-               # we check that we are hitting it from above.
-               if Vector3.UP.dot(collision.get_normal()) > 0.1:
-                   # If so, we squash it and bounce.
-                   mob.squash()
-                   target_velocity.y = bounce_impulse
+            # If the collider is with a mob
+            if collision.get_collider().is_in_group("mob"):
+                var mob = collision.get_collider()
+                # we check that we are hitting it from above.
+                if Vector3.UP.dot(collision.get_normal()) > 0.1:
+                    # If so, we squash it and bounce.
+                    mob.squash()
+                    target_velocity.y = bounce_impulse
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
Spacing on for loop, only 3 spaces instead of 4. This results in tab allocations in the editor failing when using copy and paste from the docs into the code editor.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
