### PR TITLE
3d game tutorial bug on squashing

### DIFF
--- a/getting_started/first_3d_game/06.jump_and_squash.rst
+++ b/getting_started/first_3d_game/06.jump_and_squash.rst
@@ -251,7 +251,7 @@ With this code, if no collisions occurred on a given frame, the loop won't run.
            if collision.get_collider().is_in_group("mob"):
                var mob = collision.get_collider()
                # we check that we are hitting it from above.
-               if Vector3.UP.dot(collision.get_normal()) > 0.1:
+               if not mob.is_queued_for_deletion() and Vector3.UP.dot(collision.get_normal()) > 0.1:
                    # If so, we squash it and bounce.
                    mob.squash()
                    target_velocity.y = bounce_impulse
@@ -274,7 +274,7 @@ With this code, if no collisions occurred on a given frame, the loop won't run.
             if (collision.GetCollider() is Mob mob)
             {
                 // We check that we are hitting it from above.
-                if (Vector3.Up.Dot(collision.GetNormal()) > 0.1f)
+                if (mob.IsQueuedForDeletion() && Vector3.Up.Dot(collision.GetNormal()) > 0.1f)
                 {
                     // If so, we squash it and bounce.
                     mob.Squash();
@@ -299,6 +299,12 @@ information about where and how the collision occurred. For example, we use its
 .. note::
 
     The method ``is_in_group()`` is available on every :ref:`Node<class_Node>`.
+
+Multiple Godot collisions can happend during the same frame including multiple collisions
+with the same object. That is why we should prevent ourselves from emitting the squash events
+multiple times by checking if the mob object is queued for deletion. This will work since
+we will be deleting the mob once squashed. We do this with the ``is_queued_for_deletion`` 
+method.
 
 To check that we are landing on the monster, we use the vector dot product:
 ``Vector3.UP.dot(collision.get_normal()) > 0.1``. The collision normal is a 3D vector

--- a/getting_started/first_3d_game/06.jump_and_squash.rst
+++ b/getting_started/first_3d_game/06.jump_and_squash.rst
@@ -300,9 +300,9 @@ information about where and how the collision occurred. For example, we use its
 
     The method ``is_in_group()`` is available on every :ref:`Node<class_Node>`.
 
-Multiple Godot collisions can happend during the same frame including multiple collisions
-with the same object. That is why we should prevent ourselves from emitting the squash events
-multiple times by checking if the mob object is queued for deletion. This will work since
+Multiple Godot collisions can happen during the same frame including multiple collisions
+with the same object. That is why we should prevent ourselves from emitting the squash event
+multiple times by checking if the mob node is queued for deletion. This will work since
 we will be deleting the mob once squashed. We do this with the ``is_queued_for_deletion`` 
 method.
 

--- a/getting_started/first_3d_game/07.killing_player.rst
+++ b/getting_started/first_3d_game/07.killing_player.rst
@@ -391,7 +391,7 @@ Finally, the longest script, ``Player.gd``:
             if collision.get_collider().is_in_group("mob"):
                 var mob = collision.get_collider()
                 # we check that we are hitting it from above.
-                if Vector3.UP.dot(collision.get_normal()) > 0.1:
+                if not mob.is_queued_for_deletion() and Vector3.UP.dot(collision.get_normal()) > 0.1:
                     # If so, we squash it and bounce.
                     mob.squash()
                     target_velocity.y = bounce_impulse
@@ -491,7 +491,7 @@ Finally, the longest script, ``Player.gd``:
                 if (collision.GetCollider() is Mob mob)
                 {
                     // We check that we are hitting it from above.
-                    if (Vector3.Up.Dot(collision.GetNormal()) > 0.1f)
+                    if (mob.IsQueuedForDeletion() && Vector3.Up.Dot(collision.GetNormal()) > 0.1f)
                     {
                         // If so, we squash it and bounce.
                         mob.Squash();


### PR DESCRIPTION
The collision detection with the enemies in the "Your first 3D Game" tutorial is written in way that makes it possible for the squash event to be emitted multiple times. This happened to me regularly and messed up the score tracking afterwards because it incremented the score by more than one. I am not sure if this is the best to do this or to handle collisions in Godot 4 in general as I am still rather new but I thought I'd submit it as an issue here.

* *Bugsquad edit, alternative to: #7767*