### PR TITLE
Reimplement space-to-tab regex without lookbehind

### DIFF
--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -299,8 +299,12 @@ $(document).ready(() => {
       // Only change indentation for GDScript and C++.
       continue;
     }
-    let html = codeBlock.innerHTML;
-    html = html.replace(/(?<=^(<span class="w">)?( {4})*)( {4})/gm, '\t');
+    let html = codeBlock.innerHTML.replace(/^(<span class="w">)?( {4})/gm, '\t');
+    let html_old = "";
+    while (html != html_old) {
+      html_old = html;
+      html = html.replace(/\t( {4})/gm, '\t\t')
+    }
     codeBlock.innerHTML = html;
   }
 


### PR DESCRIPTION
Fixes an issue[^1] where space-to-tab conversion didn't function on certain Safari browsers, as regex lookbehind support was only added to them this year. The new implementation is slightly bulkier, but retains the negligible performance cost & the end result is functionally identical

[^1]: https://github.com/godotengine/godot-docs/pull/8153#issuecomment-1781347449