### PR TITLE
Update scripting_first_script.rst

### DIFF
--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -242,9 +242,9 @@ our sprite's rotation every frame. Here, ``rotation`` is a property inherited
 from the class ``Node2D``, which ``Sprite2D`` extends. It controls the rotation
 of our node and works with radians.
 
-.. tip:: In the code editor, you can ctrl-click (:kbd:`Cmd + Click` on macOS) on
-         any built-in property or function like ``position``, ``rotation``, or
-         ``_process`` to open the corresponding documentation in a new tab.
+.. tip:: In the code editor, you can ctrl-click on any built-in property or
+         function like ``position``, ``rotation``, or ``_process`` to open the
+         corresponding documentation in a new tab.
 
 Run the scene to see the Godot icon turn in-place.
 

--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -1,5 +1,3 @@
-:article_outdated: True
-
 ..
     Intention:
 
@@ -244,9 +242,9 @@ our sprite's rotation every frame. Here, ``rotation`` is a property inherited
 from the class ``Node2D``, which ``Sprite2D`` extends. It controls the rotation
 of our node and works with radians.
 
-.. tip:: In the code editor, you can ctrl-click on any built-in property or
-         function like ``position``, ``rotation``, or ``_process`` to open the
-         corresponding documentation in a new tab.
+.. tip:: In the code editor, you can ctrl-click (:kbd:`Cmd + Click` on macOS) on
+         any built-in property or function like ``position``, ``rotation``, or
+         ``_process`` to open the corresponding documentation in a new tab.
 
 Run the scene to see the Godot icon turn in-place.
 


### PR DESCRIPTION
Remove outdated: true -  I followed the page using Godot 4.1 and everything seems up-to-date.

Add cmd + click for MacOS to follow links in docs.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
