### PR TITLE
Fixed typos in custom_performance_monitors.rst

### DIFF
--- a/tutorials/scripting/debug/custom_performance_monitors.rst
+++ b/tutorials/scripting/debug/custom_performance_monitors.rst
@@ -7,11 +7,11 @@ Introduction
 ------------
 
 As explained in the :ref:`doc_debugger_panel` documentation, Godot features a
-**Debugger > Monitor** bottom panel that allows tracking various values with
+**Debugger > Monitors** bottom panel that allows tracking various values with
 graphs showing their evolution over time. The data for those graphs is sourced
 from the engine's :ref:`class_Performance` singleton.
 
-Since Godot 4.0, you can declare custom values to be displayed in this Monitor
+Since Godot 4.0, you can declare custom values to be displayed in the Monitors
 tab. Example use cases for custom performance monitors include:
 
 - Displaying performance metrics that are specific to your project. For
@@ -59,7 +59,7 @@ The main scene features a :ref:`class_Timer` node with the following script atta
 
 
 The second parameter of
-ref:`Performance.add_custom_monitor<class_Performance_method_add_custom_monitor>`
+:ref:`Performance.add_custom_monitor<class_Performance_method_add_custom_monitor>`
 is a :ref:`class_Callable`.
 
 ``enemy.tscn`` is a scene with a Node2D root node and Timer child node. The


### PR DESCRIPTION
Changed Monitor to Monitors and added missing colon in the link to Performance.add_custom_monitor

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
