### PR TITLE
Update README.md - one mistake.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Here are some quick links to the areas you might be interested in:
 
 ## License
 
-At the exception of the `classes/` folder, all the content of this repository is licensed under the Creative Commons Attribution 3.0 Unported license ([CC BY 3.0](https://creativecommons.org/licenses/by/3.0/)) and is to be attributed to "Juan Linietsky, Ariel Manzur and the Godot community".
+At the exception of the `classes/` folder, all the content of this repository is licensed under the Creative Commons Attribution 3.0 Unported license ([CC BY 3.0](https://creativecommons.org/licenses/by/3.0/)) and is to be attributed to "Juan Linietsky, Ariel Manzur, and the Godot community".
 See [LICENSE.txt](/LICENSE.txt) for details.
 
 The files in the `classes/` folder are derived from [Godot's main source repository](https://github.com/godotengine/godot) and are distributed under the MIT license, with the same authors as above.


### PR DESCRIPTION
I have noticed one grammatical mistake in **README** inside section "**License**"

"**Ariel Manzur and the Godot**"  should be "**Ariel Manzur, and the Godot**"

Screenshot-

![Screenshot (122)](https://github.com/godotengine/godot-docs/assets/115995339/5807bddc-068f-4dbe-baf2-2f6d478bbec9)
