### PR TITLE
Typo in Horizontal Alignment tag on "BBCode in RichTextLabel"

### DIFF
--- a/tutorials/ui/bbcode_in_richtextlabel.rst
+++ b/tutorials/ui/bbcode_in_richtextlabel.rst
@@ -270,7 +270,7 @@ Reference
     - ``[center]{text}[/center]``
 
   * - | **left**
-      | Makes ``{text}`` horizontally right-aligned.
+      | Makes ``{text}`` horizontally left-aligned.
       | Same as ``[p align=left]``.
 
     - ``[left]{text}[/left]``


### PR DESCRIPTION
fixes #8367 

Typo in text
