### PR TITLE
Document `source_color` shader hint being relevant for 2D HDR

### DIFF
--- a/tutorials/3d/environment_and_post_processing.rst
+++ b/tutorials/3d/environment_and_post_processing.rst
@@ -660,6 +660,18 @@ There are 2 ways to use glow in 2D:
    bullet have their **Modulate** property increased to overbright values using the
    RAW mode in the color picker.
 
+.. warning::
+
+    The 2D renderer renders in linear color space if the
+    **Rendering > Viewport > HDR 2D** project setting is enabled, so
+    ``source_color`` must also be used for uniform samplers that are
+    used as color input in ``canvas_item`` shaders. If this is not done,
+    the texture will appear washed out.
+
+    If 2D HDR is disabled, ``source_color`` will keep working correctly in
+    ``canvas_item`` shaders, so it's recommend to use it when relevant either
+    way.
+
 .. _doc_environment_and_post_processing_using_glow_to_blur_the_screen:
 
 Using glow to blur the screen

--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -760,9 +760,18 @@ used, and how the editor should allow users to modify it.
     uniform vec4 other_color : source_color = vec4(1.0); // Default values go after the hint.
     uniform sampler2D image : source_color;
 
-It's important to understand that textures that are supplied as color require
-hints for proper sRGB->linear conversion (i.e. ``source_color``), as Godot's 3D
-engine renders in linear color space.
+It's important to understand that textures *that are supplied as color* require
+hints for proper sRGB -> linear conversion (i.e. ``source_color``), as Godot's
+3D engine renders in linear color space. If this is not done, the texture will
+appear washed out.
+
+.. note::
+
+    The 2D renderer also renders in linear color space if the
+    **Rendering > Viewport > HDR 2D** project setting is enabled, so
+    ``source_color`` must also be used in ``canvas_item`` shaders. If 2D HDR is
+    disabled, ``source_color`` will keep working correctly in ``canvas_item``
+    shaders, so it's recommend to use it either way.
 
 Full list of hints below:
 


### PR DESCRIPTION
Don't cherry-pick for 4.1, as 2D HDR is only available in 4.2.

- This closes https://github.com/godotengine/godot/issues/84260.
