### PR TITLE
Fix incorrect C# example using `_GetConfigurationWarnings`

### DIFF
--- a/tutorials/best_practices/godot_interfaces.rst
+++ b/tutorials/best_practices/godot_interfaces.rst
@@ -108,11 +108,13 @@ access.
         };
 
         // Warn users if the value hasn't been set.
-        public String _GetConfigurationWarnings()
+        public string[] _GetConfigurationWarnings()
         {
             if (EnemyScn == null)
-                return "Must initialize property 'EnemyScn'.";
-            return "";
+            {
+                return new string[] { "Must initialize property 'EnemyScn'." };
+            }
+            return Array.Empty<string>();
         }
     }
 


### PR DESCRIPTION
In #7640 only the method name was changed in that example but not the return type.
