### PR TITLE
Fix list of default comment marker keywords

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -544,11 +544,12 @@ considered a comment.
     In the Godot script editor, special keywords are highlighted within comments
     to bring the user's attention to specific comments:
 
-    - **Critical** *(appears in red)*: ``ALERT``, ``ATTENTION``, ``DANGER``, ``HACK``,
-      ``SECURITY``
-    - **Warning** *(appears in yellow)*: ``BUG``, ``CAUTION``, ``DEPRECATED``, ``FIXME``,
-      ``TASK``, ``TBD``, ``TODO``, ``WARNING``
-    - **Notice** *(appears in green)*: ``NOTE``, ``NOTICE``, ``TEST``, ``TESTING``
+    - **Critical** *(appears in red)*: ``ALERT``, ``ATTENTION``, ``CAUTION``,
+      ``CRITICAL``, ``DANGER``, ``SECURITY``
+    - **Warning** *(appears in yellow)*: ``BUG``, ``DEPRECATED``, ``FIXME``,
+      ``HACK``, ``TASK``, ``TBD``, ``TODO``, ``WARNING``
+    - **Notice** *(appears in green)*: ``INFO``, ``NOTE``, ``NOTICE``, ``TEST``,
+      ``TESTING``
 
     These keywords are case-sensitive, so they must be written in uppercase for them
     to be recognized:


### PR DESCRIPTION
* Bug from #8371.
* See [source code](https://github.com/godotengine/godot/blob/da0b1eb128a522bbef083b9f2a5cc2da6917c3d8/modules/gdscript/editor/gdscript_highlighter.cpp#L825-L827).