### PR TITLE
Document `VERTEX_ID`, `INSTANCE_ID` built-ins for `canvas_item` vertex shader

### DIFF
--- a/tutorials/shaders/shader_reference/canvas_item_shader.rst
+++ b/tutorials/shaders/shader_reference/canvas_item_shader.rst
@@ -109,6 +109,8 @@ is usually:
 | in mat4 **SCREEN_MATRIX**      | Canvas space to clip space. In clip space          |
 |                                | coordinates ranging from (-1, -1) to (1, 1).       |
 +--------------------------------+----------------------------------------------------+
+| in int  **INSTANCE_ID**        | Instance ID for instancing.                        |
++--------------------------------+----------------------------------------------------+
 | in vec4 **INSTANCE_CUSTOM**    | Instance custom data.                              |
 +--------------------------------+----------------------------------------------------+
 | in bool **AT_LIGHT_PASS**      | Always ``false``.                                  |
@@ -118,6 +120,9 @@ is usually:
 |                                | **TEXTURE_PIXEL_SIZE** = :code:`vec2(1/64, 1/32)`  |
 +--------------------------------+----------------------------------------------------+
 | inout vec2 **VERTEX**          | Vertex, in local space.                            |
++--------------------------------+----------------------------------------------------+
+| in int **VERTEX_ID**           | The index of the current vertex in the vertex      |
+|                                | buffer.                                            |
 +--------------------------------+----------------------------------------------------+
 | inout vec2 **UV**              | Normalized texture coordinates. Range from 0 to 1. |
 +--------------------------------+----------------------------------------------------+


### PR DESCRIPTION
Adds missing documentation for https://github.com/godotengine/godot/pull/54791.

Ordering/description based on the existing documentation for spatial shaders:
https://github.com/godotengine/godot-docs/blob/68234008af4ce6921f69ddf7d0737f00f43471cf/tutorials/shaders/shader_reference/spatial_shader.rst?plain=1#L178-L197
