### PR TITLE
The most important line was missing from the example entitlements file.

### DIFF
--- a/contributing/development/debugging/macos_debug.rst
+++ b/contributing/development/debugging/macos_debug.rst
@@ -29,6 +29,8 @@ Create an ``editor.entitlements`` text file with the following contents:
             <true/>
             <key>com.apple.security.device.camera</key>
             <true/>
+            <key>com.apple.security.get-task-allow</key>
+            <true/>
         </dict>
     </plist>
 


### PR DESCRIPTION
This now provides everything the user needs to copy and paste. As it stands the tutorial is broken.