### PR TITLE
mention molten-vk when compiling for macos

### DIFF
--- a/contributing/development/compiling/compiling_for_macos.rst
+++ b/contributing/development/compiling/compiling_for_macos.rst
@@ -55,6 +55,9 @@ To compile for Apple Silicon (ARM64) powered Macs, use::
 
     scons platform=macos arch=arm64
 
+You may need to install MoltenVK first::
+    brew install molten-vk
+
 To support both architectures in a single "Universal 2" binary, run the above two commands and then use ``lipo`` to bundle them together::
 
     lipo -create bin/godot.macos.editor.x86_64 bin/godot.macos.editor.arm64 -output bin/godot.macos.editor.universal


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
I had to do some research to figure out what I was missing, based on an error when running `scons platform=macos arch=arm64`: "MoltenVK SDK installation directory not found, use 'vulkan_sdk_path' SCons parameter to specify SDK path". Thought I'd open a PR to document it.