### PR TITLE
Update references to community GDExtensions to point to up-to-date resources

### DIFF
--- a/about/faq.rst
+++ b/about/faq.rst
@@ -198,9 +198,9 @@ Also, see the official blog post on GDExtension, a way to develop native extensi
 * `Introducing GDNative's successor, GDExtension <https://godotengine.org/article/introducing-gd-extensions>`_
 
 You can also take a look at the GDScript implementation, the Godot modules,
-as well as the `unofficial Python support <https://github.com/touilleMan/godot-python>`_ for Godot.
-This would be a good starting point to see how another third-party library
-integrates with Godot.
+as well as the `Jolt physics engine integration <https://github.com/godot-jolt/godot-jolt>`__
+for Godot. This would be a good starting point to see how another
+third-party library integrates with Godot.
 
 How do I install the Godot editor on my system (for desktop integration)?
 -------------------------------------------------------------------------

--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -477,7 +477,7 @@ Scripting
    - Use any build system and language features you wish.
 
 - Actively developed GDExtension bindings for `D <https://github.com/godot-dlang/godot-dlang>`__,
-  `Haxe <https://hxgodot.github.io/>`__, `Python <https://github.com/touilleMan/godot-python>`__, and `Rust <https://github.com/godot-rust/gdextension>`__
+  `Haxe <https://hxgodot.github.io/>`__, `Swift <https://github.com/migueldeicaza/SwiftGodot>`__, and `Rust <https://github.com/godot-rust/gdextension>`__
   bindings provided by the community. (Some of these bindings may be experimental and not production-ready).
 
 Audio

--- a/getting_started/introduction/godot_design_philosophy.rst
+++ b/getting_started/introduction/godot_design_philosophy.rst
@@ -89,8 +89,7 @@ yet it detects types and offers a static language's quality of auto-completion.
 It is also optimized for gameplay code with built-in types like Vectors and Colors.
 
 Note that with GDExtension, you can write high-performance code using compiled
-languages like C, C++, Rust, or Python (using the Cython compiler)
-without recompiling the engine.
+languages like C, C++, Rust, D, Haxe, or Swift without recompiling the engine.
 
 Note that the 3D workspace doesn't feature as many tools as the 2D workspace.
 You'll need external programs or add-ons to edit terrains, animate complex characters, and so on.


### PR DESCRIPTION
godot-python doesn't work with Godot 4.1 as described in https://github.com/touilleMan/godot-python/issues/324, but there are additional language bindings we can link to now.

The example for extending Godot was replaced by an actual library binding as opposed to a language binding (which is quite a different approach in itself).
