### PR TITLE
Remove outdated custom mouse cursor demo project reference

### DIFF
--- a/tutorials/inputs/custom_mouse_cursor.rst
+++ b/tutorials/inputs/custom_mouse_cursor.rst
@@ -87,12 +87,6 @@ Create a Node and attach the following script.
     Check :ref:`Input.set_custom_mouse_cursor() <class_Input_method_set_custom_mouse_cursor>`'s
     documentation for more information on usage and platform-specific caveats.
 
-Demo project
-------------
-
-Find out more by studying this demo project:
-https://github.com/guilhermefelipecgs/custom_hardware_cursor
-
 Cursor list
 -----------
 


### PR DESCRIPTION
Hi there,

I'm totally new to Godot (version 4.1.2) and I'm currently trying to get the [custom mouse tutorial by Jon Topielski](https://www.youtube.com/watch?v=JrQ1-Ea6_KM) I found [on YouTube](https://github.com/jontopielski/cursor-tutorial/tree/main) to work in Godot 4.1.2. His tutorial also doesn't work out of the box in Godot 4.1.2, but it doesn't seem as outdated as the one currently linked in the docs. 

Once I have a working code snippet for a custom mouse cursor demo project in Godot 4.1.2, I'd be happy to share and link it here in the docs, if that sounds interesting for you? :)
