### PR TITLE
Replace `,` with `.` in `gui_containers.rst`

### DIFF
--- a/tutorials/ui/gui_containers.rst
+++ b/tutorials/ui/gui_containers.rst
@@ -6,7 +6,7 @@ Using Containers
 ================
 
 :ref:`Anchors <doc_size_and_anchors>` are an efficient way to handle
-different aspect ratios for basic multiple resolution handling in GUIs,
+different aspect ratios for basic multiple resolution handling in GUIs.
 
 For more complex user interfaces, they can become difficult to use.
 


### PR DESCRIPTION
A sentence in `gui_containers.rst` was incorrectly ended with a comma. Replace it with a period.