### PR TITLE
Update exporting_for_android.rst for linux

### DIFF
--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -50,8 +50,18 @@ Download and install the Android SDK.
 
 .. note::
 
-    If you are using Linux,
-    **do not use an Android SDK provided by your distribution's repositories as it will often be outdated**.
+If you are using Linux,
+    **do not use an Android SDK provided by your distribution's repositories as it will often be outdated**
+    Instead of the previous steps (both Install OpenJDK and download Android SDK), just apply the command " sudo apt update && sudo apt install android-sdk "
+    The location of Android SDK on Linux can be any of the following:
+
+    /home/AccountName/Android/Sdk 
+
+    /usr/lib/android-sdk 
+
+    /Library/Android/sdk/ 
+
+    /Users/[USER]/Library/Android/sdk 
 
 
 Create a debug.keystore


### PR DESCRIPTION
I think we can simplify the steps when installing on Linux the android export: ->For the sdk, just follow one command line found here : https://stackoverflow.com/questions/34556884/how-to-install-android-sdk-on-ubuntu , ->And with no changes for the debug.keystore ,
It works perfectly for me (debian neon plasma kde 64x)

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
