### PR TITLE
Improve GDExtension documentation

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -19,7 +19,7 @@ it is implemented with .NET 6.0.
 .. attention::
 
     Projects written in C# using Godot 4 currently cannot be exported to the web
-    platform. To use C# on that platforms, consider Godot 3 instead.
+    platform. To use C# on the web platform, consider Godot 3 instead.
     Android and iOS platform support is available as of Godot 4.2, but is
     experimental and :ref:`some limitations apply <doc_c_sharp_platforms>`.
 

--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -100,22 +100,23 @@ call the Godot executable:
 
 .. code-block:: none
 
-    godot --dump-extension-api 
+    godot --dump-extension-api
 
-The resulting ``extension_api.json`` file will be created in the executable's 
-directory. Copy it to the project folder and add ``custom_api_file=<PATH_TO_FILE>`` 
+The resulting ``extension_api.json`` file will be created in the executable's
+directory. Copy it to the project folder and add ``custom_api_file=<PATH_TO_FILE>``
 to the scons command below.
 
 To generate and compile the bindings, use this command (replacing ``<platform>``
 with ``windows``, ``linux`` or ``macos`` depending on your OS):
 
-To speed up compilation, add ``-jN`` at the end of the SCons command line where ``N``
-is the number of CPU threads you have on your system. The example below uses 4 threads.
+The build process automatically detects the number of CPU threads to use for
+parallel builds. To specify a number of CPU threads to use, add ``-jN`` at the
+end of the SCons command line where ``N`` is the number of CPU threads to use.
 
 .. code-block:: none
 
     cd godot-cpp
-    scons platform=<platform> -j4 custom_api_file=<PATH_TO_FILE>
+    scons platform=<platform> custom_api_file=<PATH_TO_FILE>
     cd ..
 
 This step will take a while. When it is completed, you should have static
@@ -598,12 +599,12 @@ This is the required syntax:
 
     some_other_node->connect("the_signal", Callable(this, "my_method"));
 
-To connect our signal ``the_signal`` from some other node with our method 
-``my_method``, we need to provide the ``connect`` method with the name of the signal 
-and a ``Callable``. The ``Callable`` holds information about an object on which a method 
-can be called. In our case, it associates our current object instance ``this`` with the 
-method ``my_method`` of the object. Then the ``connect`` method will add this to the 
-observers of ``the_signal``. Whenever ``the_signal`` is now emitted, Godot knows which 
+To connect our signal ``the_signal`` from some other node with our method
+``my_method``, we need to provide the ``connect`` method with the name of the signal
+and a ``Callable``. The ``Callable`` holds information about an object on which a method
+can be called. In our case, it associates our current object instance ``this`` with the
+method ``my_method`` of the object. Then the ``connect`` method will add this to the
+observers of ``the_signal``. Whenever ``the_signal`` is now emitted, Godot knows which
 method of which object it needs to call.
 
 Note that you can only call ``my_method`` if you've previously registered it in

--- a/tutorials/scripting/gdextension/what_is_gdextension.rst
+++ b/tutorials/scripting/gdextension/what_is_gdextension.rst
@@ -55,8 +55,8 @@ Advantages of C++ modules
 We recommend :ref:`C++ modules <doc_custom_modules_in_cpp>` in cases where
 GDExtension isn't enough:
 
-- C++ modules provide deeper integration into the engine. GDExtension's access is not as deep as
-  static modules
+- C++ modules provide deeper integration into the engine. GDExtension's access
+  is not as deep as static modules.
 - You can use C++ modules to provide additional features in a project without
   carrying native library files around. This extends to exported projects.
 
@@ -81,6 +81,8 @@ The bindings below are developed and maintained by the community:
 .. Binding developers: Feel free to open a pull request to add your binding if it's well-developed enough to be used in a project.
 .. Please keep languages sorted in alphabetical order.
 
+- `D <https://github.com/godot-dlang/godot-dlang>`__
+- `Haxe <https://hxgodot.github.io/>`__
 - `Rust <https://github.com/godot-rust/gdextension>`__
 - `Swift <https://github.com/migueldeicaza/SwiftGodot>`__
 
@@ -98,3 +100,9 @@ GDExtension add-ons compiled for a given Godot version are only guaranteed to wo
 with the same minor release series. For example, a GDExtension add-on compiled for
 Godot 4.0 will only work with Godot 4.0, 4.0.1, 4.0.2. In addition, GDExtension is
 not compatible with Godot 3.x.
+
+GDExtension add-ons are also only compatible with engine builds that use the
+level of floating-point precision the extension was compiled for. This means
+that if you use a engine build with double-precision floats, the extension must
+also be compiled for double-precision floats. See
+:ref:`doc_large_world_coordinates` for details.


### PR DESCRIPTION
- Mention additional language bindings that support 4.x (already listed on the FAQ and List of features pages).
- Document compatibility issues with double-precision builds.
- Remove `-j4` flag from example as SCons uses most CPU cores automatically by default in godot-cpp now (like core Godot).
