### PR TITLE
Fix unused image due to bad syntax in Custom performance monitors

### DIFF
--- a/tutorials/scripting/debug/custom_performance_monitors.rst
+++ b/tutorials/scripting/debug/custom_performance_monitors.rst
@@ -91,7 +91,7 @@ Monitors** at the bottom of the editor window. Scroll down to the newly
 available **Game** section and check **Enemies**. You should see a graph
 appearing as follows:
 
-.. :figure: img/custom_performance_monitors_graph_example.webp
+.. figure:: img/custom_performance_monitors_graph_example.webp
    :align: center
    :alt: Example editor graph from a custom performance monitor
 


### PR DESCRIPTION
Comment syntax was used instead of figure syntax.

This is another issue I noticed while working on https://github.com/godotengine/godot-docs/pull/8411.