### PR TITLE
Add missing comma in instancing.rst

### DIFF
--- a/getting_started/step_by_step/instancing.rst
+++ b/getting_started/step_by_step/instancing.rst
@@ -215,7 +215,7 @@ all working with the Godot editor.
 Summary
 -------
 
-Instancing, the process of producing an object from a blueprint has many handy
+Instancing, the process of producing an object from a blueprint, has many handy
 uses. With scenes, it gives you:
 
 - The ability to divide your game into reusable components.


### PR DESCRIPTION
I added a comma after 'blueprint' in this sentence: "Instancing, the process of producing an object from a blueprint, has many handy uses."