### PR TITLE
Document support for importing KTX images in Importing images

### DIFF
--- a/tutorials/assets_pipeline/exporting_3d_scenes.rst
+++ b/tutorials/assets_pipeline/exporting_3d_scenes.rst
@@ -6,13 +6,13 @@ Exporting 3D scenes
 Overview
 --------
 
-In Godot it is possible to export 3D scenes as a glTF 2.0 file. You can
+In Godot, it is possible to export 3D scenes as a glTF 2.0 file. You can
 export as a glTF binary (``.glb`` file) or glTF embedded with textures
 (``gltf`` + ``.bin`` + textures). This allows you to create scenes in Godot,
 such as a CSG mesh blockout for a level, export it to clean it up in a
 program such as Blender, and then bring it back into Godot.
 
-.. note:: 
+.. note::
 
     Only Blender 2.83 and newer can import glTF files exported by Godot.
 
@@ -28,3 +28,9 @@ There are several limitations with glTF export.
 * No support for exporting particles since their implementation varies across engines.
 * ShaderMaterials cannot be exported.
 * No support for exporting 2D scenes.
+
+.. seealso::
+
+    3D scenes can be saved at runtime using
+    :ref:`runtime file loading and saving <doc_runtime_file_loading_and_saving_3d_scenes>`,
+    including from an exported project.

--- a/tutorials/assets_pipeline/importing_3d_scenes/index.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/index.rst
@@ -19,3 +19,9 @@ dialog, and inherited scenes.
    model_export_considerations
    node_type_customization
    import_configuration
+
+.. seealso::
+
+    3D scenes can be loaded at runtime using
+    :ref:`runtime file loading and saving <doc_runtime_file_loading_and_saving_3d_scenes>`,
+    including from an exported project.

--- a/tutorials/assets_pipeline/importing_audio_samples.rst
+++ b/tutorials/assets_pipeline/importing_audio_samples.rst
@@ -304,3 +304,9 @@ reducing their size greatly and ensuring correct trimming.
 
 As you can see above, sound effects become much larger in file size with reverb
 added.
+
+.. seealso::
+
+    Audio samples can be loaded and saved at runtime using
+    :ref:`runtime file loading and saving <doc_runtime_file_loading_and_saving_audio_video_files>`,
+    including from an exported project.

--- a/tutorials/assets_pipeline/importing_images.rst
+++ b/tutorials/assets_pipeline/importing_images.rst
@@ -13,6 +13,9 @@ Godot can import the following image formats:
 - DirectDraw Surface (``.dds``)
   - If mipmaps are present in the texture, they will be loaded directly.
   This can be used to achieve effects using custom mipmaps.
+- Khronos Texture (``.ktx``)
+  - Decoding is done using `libktx <https://github.com/KhronosGroup/KTX-Software>`__.
+  Only supports 2D images. Cubemaps, texture arrays and de-padding are not supported.
 - OpenEXR (``.exr``)
   - Supports HDR (highly recommended for panorama skies).
 - Radiance HDR (``.hdr``)
@@ -538,3 +541,9 @@ worth exploring:
 - When working with 3D models using a low-poly style and plain colors, you can
   rely on vertex colors instead of textures to represent colors on the model's
   surfaces.
+
+.. seealso::
+
+    Images can be loaded and saved at runtime using
+    :ref:`runtime file loading and saving <doc_runtime_file_loading_and_saving_images>`,
+    including from an exported project.

--- a/tutorials/io/runtime_file_loading_and_saving.rst
+++ b/tutorials/io/runtime_file_loading_and_saving.rst
@@ -67,6 +67,8 @@ several helper methods to decode/encode series of bytes to integers, floats,
 strings and more. These PackedByteArray methods have names that start with
 ``decode_`` and ``encode_``. See also :ref:`doc_binary_serialization_api`.
 
+.. _doc_runtime_file_loading_and_saving_images:
+
 Images
 ------
 
@@ -118,6 +120,8 @@ Example of loading an image and displaying it in a :ref:`class_TextureRect` node
     # Save the converted ImageTexture to a PNG image.
     $TextureRect.texture.get_image().save_png("/path/to/file.png")
 
+.. _doc_runtime_file_loading_and_saving_audio_video_files:
+
 Audio/video files
 -----------------
 
@@ -156,6 +160,8 @@ Example of loading an Ogg Theora video file in a :ref:`class_VideoStreamPlayer` 
     It's still possible to *save* WAV files using
     :ref:`AudioStreamWAV.save_to_wav <class_AudioStreamWAV_method_save_to_wav>`, which is useful
     for procedurally generated audio or microphone recordings.
+
+.. _doc_runtime_file_loading_and_saving_3d_scenes:
 
 3D scenes
 ---------


### PR DESCRIPTION
- Link to Run-time file loading and saving page where relevant.

Don't cherry-pick, as this is only present in 4.2.

- See https://github.com/godotengine/godot/pull/76572.
