### PR TITLE
Clarifies that Lua-style dictionary keys must be string literals in the GD Reference

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -908,7 +908,7 @@ Associative container which contains values referenced by unique keys.
 Lua-style table syntax is also supported. Lua-style uses ``=`` instead of ``:``
 and doesn't use quotes to mark string keys (making for slightly less to write).
 However, keys written in this form can't start with a digit (like any GDScript
-identifier).
+identifier), and must be string literals.
 
 ::
 


### PR DESCRIPTION
In the dictionary class page it specifies that the Lua-style dictionary keys have to be string literals, but it's exclusively in a code comment in an example on that page. Looking at the script reference (which shows up on google first when looking up "Godot Dictionary Lua-style") clarifies the other important thing about this style of keys. 