### PR TITLE
Clarify general usage of CharacterBody2D

### DIFF
--- a/classes/class_characterbody2d.rst
+++ b/classes/class_characterbody2d.rst
@@ -19,7 +19,7 @@ A 2D physics body specialized for characters moved by script.
 Description
 -----------
 
-**CharacterBody2D** is a specialized class for physics bodies that are meant to be user-controlled. They are not affected by physics at all, but they affect other physics bodies in their path. They are mainly used to provide high-level API to move objects with wall and slope detection (:ref:`move_and_slide<class_CharacterBody2D_method_move_and_slide>` method) in addition to the general collision detection provided by :ref:`PhysicsBody2D.move_and_collide<class_PhysicsBody2D_method_move_and_collide>`. This makes it useful for highly configurable physics bodies that must move in specific ways and collide with the world, as is often the case with user-controlled characters.
+**CharacterBody2D** is a specialized class for physics bodies that are meant to be controlled by script, frequently used for player characters. They are not affected by physics at all, but they affect other physics bodies in their path. They are mainly used to provide high-level API to move objects with wall and slope detection (:ref:`move_and_slide<class_CharacterBody2D_method_move_and_slide>` method) in addition to the general collision detection provided by :ref:`PhysicsBody2D.move_and_collide<class_PhysicsBody2D_method_move_and_collide>`. This makes it useful for highly configurable physics bodies that must move in specific ways and collide with the world, as is often the case with player-controlled characters.
 
 For game objects that don't require complex movement or collision detection, such as moving platforms, :ref:`AnimatableBody2D<class_AnimatableBody2D>` is simpler to configure.
 

--- a/classes/class_characterbody3d.rst
+++ b/classes/class_characterbody3d.rst
@@ -19,7 +19,7 @@ A 3D physics body specialized for characters moved by script.
 Description
 -----------
 
-**CharacterBody3D** is a specialized class for physics bodies that are meant to be user-controlled. They are not affected by physics at all, but they affect other physics bodies in their path. They are mainly used to provide high-level API to move objects with wall and slope detection (:ref:`move_and_slide<class_CharacterBody3D_method_move_and_slide>` method) in addition to the general collision detection provided by :ref:`PhysicsBody3D.move_and_collide<class_PhysicsBody3D_method_move_and_collide>`. This makes it useful for highly configurable physics bodies that must move in specific ways and collide with the world, as is often the case with user-controlled characters.
+**CharacterBody3D** is a specialized class for physics bodies that are meant to be controlled by script, frequently used for player characters. They are not affected by physics at all, but they affect other physics bodies in their path. They are mainly used to provide high-level API to move objects with wall and slope detection (:ref:`move_and_slide<class_CharacterBody3D_method_move_and_slide>` method) in addition to the general collision detection provided by :ref:`PhysicsBody3D.move_and_collide<class_PhysicsBody3D_method_move_and_collide>`. This makes it useful for highly configurable physics bodies that must move in specific ways and collide with the world, as is often the case with player-controlled characters.
 
 For game objects that don't require complex movement or collision detection, such as moving platforms, :ref:`AnimatableBody3D<class_AnimatableBody3D>` is simpler to configure.
 


### PR DESCRIPTION
As someone learning Godot, I had a great deal of confusion about the intended usage of CharacterBody2D. 

Specifying in the first sentence that it is used for "user-controlled" gives an (I think?) improper specification for the use of these nodes.

I saw some tutorials using CharacterBody2D/3D for NPCs and I went to Discord to ask if that was improper usage given the documentation, and was advised that the word "user-" (in "user-controlled") was intended to refer to the developer, and that the real purpose is for script-controlled physics body. But I do not think this is fully true, since the 2nd usage of "user-controlled characters" seems to more-clearly refer to player-controlled ones.

This PR hopefully clarifies the usage of CharacterBody2D/3D as "it's for scripted bodies", makes it clear that this is perhaps most commonly used for player-controlled characters, and specifies "player" instead of "user" in the other verbiage so as not to equivocate on what a "user" is (versus a "player").

My first Godot PR so apologies if I've done something wrong.