### PR TITLE
docs: add missing camera translation Y 15

### DIFF
--- a/getting_started/first_3d_game/03.player_movement_code.rst
+++ b/getting_started/first_3d_game/03.player_movement_code.rst
@@ -404,6 +404,9 @@ one).
 
 |image7|
 
+Then move the camera about ``15`` units on the Y axis (the green
+one).
+
 Here's where the magic happens. Select the *CameraPivot* and rotate it ``-45``
 degrees around the X axis (using the red circle). You'll see the camera move as
 if it was attached to a crane.


### PR DESCRIPTION
necessary to match following `image8`