### PR TITLE
Add `--headless` parameter to "compiling with dotnet" examples

### DIFF
--- a/contributing/development/compiling/compiling_with_dotnet.rst
+++ b/contributing/development/compiling/compiling_with_dotnet.rst
@@ -149,7 +149,7 @@ Example (Windows)
     scons p=windows target=template_release module_mono_enabled=yes
     
     # Generate glue sources
-    bin/godot.windows.editor.x86_64.mono --generate-mono-glue modules/mono/glue
+    bin/godot.windows.editor.x86_64.mono --headless --generate-mono-glue modules/mono/glue
     # Build .NET assemblies
     ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=windows
 
@@ -166,7 +166,7 @@ Example (Linux, \*BSD)
     scons p=linuxbsd target=template_release module_mono_enabled=yes
 
     # Generate glue sources
-    bin/godot.linuxbsd.editor.x86_64.mono --generate-mono-glue modules/mono/glue
+    bin/godot.linuxbsd.editor.x86_64.mono --headless --generate-mono-glue modules/mono/glue
     # Generate binaries
     ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=linuxbsd
 


### PR DESCRIPTION
We already tell users to use `--headless` to generate the glue. This PR make it so that we use `--headless` in the examples.

https://github.com/godotengine/godot-docs/blob/9212f4f0a2205186e839e532d45a23a55dbdf917/contributing/development/compiling/compiling_with_dotnet.rst?plain=1#L28-L38