### PR TITLE
Update recording_with_microphone.html to reflect GDscript code

### DIFF
--- a/tutorials/audio/recording_with_microphone.rst
+++ b/tutorials/audio/recording_with_microphone.rst
@@ -65,7 +65,7 @@ and :ref:`set_recording_active() <class_AudioEffectRecord_method_set_recording_a
 .. tabs::
   .. code-tab:: gdscript GDScript
 
-    func _on_record_button_pressed():
+    func _on_RecordButton_pressed():
         if effect.is_recording_active():
             recording = effect.get_recording()
             $PlayButton.disabled = false
@@ -114,7 +114,7 @@ the recorded stream can be stored into the ``recording`` variable by calling
 .. tabs::
   .. code-tab:: gdscript GDScript
 
-    func _on_play_button_pressed():
+    func _on_PlayButton_pressed():
         print(recording)
         print(recording.format)
         print(recording.mix_rate)
@@ -145,7 +145,7 @@ To playback the recording, you assign the recording as the stream of the
 .. tabs::
   .. code-tab:: gdscript GDScript
 
-    func _on_save_button_pressed():
+    func _on_SaveButton_pressed():
         var save_path = $SaveButton/Filename.text
         recording.save_to_wav(save_path)
         $Status.text = "Saved WAV file to: %s\n(%s)" % [save_path, ProjectSettings.globalize_path(save_path)]


### PR DESCRIPTION
as can be seen in https://github.com/godotengine/godot-demo-projects/blob/master/audio/mic_record/MicRecord.gd, the methods that are connected to signals have different naming in the GDScript code than is reflected in the docs on the demo project