### PR TITLE
Minor edits for scripting_player_input.rst

### DIFF
--- a/getting_started/step_by_step/scripting_player_input.rst
+++ b/getting_started/step_by_step/scripting_player_input.rst
@@ -7,7 +7,7 @@
 Listening to player input
 =========================
 
-Building upon the previous lesson :ref:`doc_scripting_first_script`, let's look
+Building upon the previous lesson, :ref:`doc_scripting_first_script`, let's look
 at another important feature of any game: giving control to the player.
 To add this, we need to modify our ``sprite_2d.gd`` code.
 
@@ -181,7 +181,7 @@ Summary
 
 In summary, every script in Godot represents a class and extends one of the
 engine's built-in classes. The node types your classes inherit from give you
-access to properties like ``rotation`` and ``position`` in our sprite's case.
+access to properties, such as ``rotation`` and ``position`` in our sprite's case.
 You also inherit many functions, which we didn't get to use in this example.
 
 In GDScript, the variables you put at the top of the file are your class's
@@ -196,5 +196,5 @@ button presses from the users. There are quite a few more.
 The ``Input`` singleton allows you to react to the players' input anywhere in
 your code. In particular, you'll get to use it in the ``_process()`` loop.
 
-In the next lesson :ref:`doc_signals`, we'll build upon the relationship between
+In the next lesson, :ref:`doc_signals`, we'll build upon the relationship between
 scripts and nodes by having our nodes trigger code in scripts.


### PR DESCRIPTION
Added two commas before lesson titles and changed "properties like" to "properties, such as".