### PR TITLE
Update setting_up_xr.rst with consistent spelling in code examples

### DIFF
--- a/tutorials/xr/setting_up_xr.rst
+++ b/tutorials/xr/setting_up_xr.rst
@@ -84,7 +84,7 @@ Next we need to add a script to our root node. Add the following code into this 
     func _ready():
         xr_interface = XRServer.find_interface("OpenXR")
         if xr_interface and xr_interface.is_initialized():
-            print("OpenXR initialised successfully")
+            print("OpenXR initialized successfully")
 
             # Turn off v-sync!
             DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_DISABLED)

--- a/tutorials/xr/setting_up_xr.rst
+++ b/tutorials/xr/setting_up_xr.rst
@@ -9,7 +9,7 @@ Introduction to the XR system in Godot
 Godot provides a modular XR system that abstracts many of the different XR platform specifics away from the user.
 At the core sits the :ref:`XRServer <class_xrserver>` which acts as a central interface to the XR system that allows users to discover interfaces and interact with the components of the XR system.
 
-Each supported XR platform is implemented as an :ref:`XRInterface <class_xrinterface>`. Supported interfaces register themselves with the :ref:`XRServer <class_xrserver>` and can be queried with the ``find_interface`` method on the :ref:`XRServer <class_xrserver>`. When the desired interface is found it can be initialised by calling ``initialize`` on the interface.
+Each supported XR platform is implemented as an :ref:`XRInterface <class_xrinterface>`. Supported interfaces register themselves with the :ref:`XRServer <class_xrserver>` and can be queried with the ``find_interface`` method on the :ref:`XRServer <class_xrserver>`. When the desired interface is found it can be initialized by calling ``initialize`` on the interface.
 
 .. warning::
     A registered interface means nothing more than that the interface is available, if the interface is not supported by the host system, initialization may fail and return ``false``. This can have many reasons and sadly the reasons differ from platform to platform. It can be because the user hasn't installed the required software, or that the user simply hasn't plugged in their headset. You as a developer must thus react properly on an interface failing to initialize.


### PR DESCRIPTION
Most instances of the word "initialized" on this page are spelled with a 'z', except for this one. Edited to make the spelling consistent.
