### PR TITLE
Document alpha antialiasing in Standard Material 3D

### DIFF
--- a/tutorials/3d/3d_antialiasing.rst
+++ b/tutorials/3d/3d_antialiasing.rst
@@ -57,12 +57,12 @@ shaders are still run for each pixel only once. Therefore, MSAA does not reduce
 transparency aliasing for materials using the **Alpha Scissor** transparency
 mode (1-bit transparency). MSAA is also ineffective on specular aliasing.
 
-To mitigate aliasing on alpha scissor materials, alpha antialiasing (also called
-*alpha to coverage*) can be enabled on specific materials in the
-StandardMaterial3D or ORMMaterial3D properties. This only has an effect when
-MSAA is used (with any level). Alpha to coverage has a moderate performance
-cost, but it's very effective at reducing aliasing on transparent materials
-without introducing any blurriness.
+To mitigate aliasing on alpha scissor materials,
+:ref:`alpha antialiasing <doc_standard_material_3d_alpha_antialiasing>`
+(also called *alpha to coverage*) can be enabled on specific materials in the
+StandardMaterial3D or ORMMaterial3D properties. Alpha to coverage has a
+moderate performance cost, but it's effective at reducing aliasing on
+transparent materials without introducing any blurriness.
 
 MSAA can be enabled in the Project Settings by changing the value of the
 **Rendering > Anti Aliasing > Quality > MSAA 3D** setting. It's important to change

--- a/tutorials/3d/3d_rendering_limitations.rst
+++ b/tutorials/3d/3d_rendering_limitations.rst
@@ -143,7 +143,7 @@ this feature. There are still several ways to avoid this problem:
 
 - If you want a material to fade with distance, use the StandardMaterial3D
   distance fade mode **Pixel Dither** or **Object Dither** instead of
-  **PixelAlpha**. This will make the material opaque, which also speeds up rendering.
+  **Pixel Alpha**. This will make the material opaque, which also speeds up rendering.
 
 .. figure:: img/3d_rendering_limitations_transparency_sorting.webp
    :align: center


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-demo-projects/pull/994 (can be merged independently).

___

- Fix a typo in 3D rendering limitations.