### PR TITLE
Added a note about problems that may occur when exporting to Android with Gradle

### DIFF
--- a/tutorials/export/android_gradle_build.rst
+++ b/tutorials/export/android_gradle_build.rst
@@ -2,6 +2,11 @@
 
 Gradle builds for Android
 =========================
+.. note::
+
+    When using the Eclipse OpenJDK, you may encounter errors regarding the Java Virtual Machine.
+    To fix this, you could for example use :ref:`Microsofts build of OpenJDK<https://learn.microsoft.com/de-de/java/openjdk/download#openjdk-17>`.
+
 
 Godot provides the option to build using the gradle buildsystem. Instead of
 using the already pre-built template that ships with Godot, an Android


### PR DESCRIPTION
On the page [Exporting for Android](https://docs.godotengine.org/en/stable/tutorials/export/exporting_for_android.html) there is a reference to use the Eclipse OpenJDK 17. If you try to export with Gradle, using mentioned above version of OpenJDK, you may get errors regarding the JVM which leads to the build failing (Only a generic error message is shown without any mention about the error type). This PR adds a note about that issue at the top of the page.