### PR TITLE
Update documentation for debug_symbols

### DIFF
--- a/contributing/development/compiling/introduction_to_the_buildsystem.rst
+++ b/contributing/development/compiling/introduction_to_the_buildsystem.rst
@@ -160,7 +160,7 @@ Godot provides two aliases for this purpose:
 
 You can manually override options from those aliases by specifying them on the
 same command line with different values. For example, you can use ``scons
-production=yes debug_symbols=yes`` to create production-optimized binaries with
+production=yes debug_symbols=embedded`` to create production-optimized binaries with
 debugging symbols included.
 
 Dev build
@@ -193,7 +193,7 @@ Debugging symbols
 -----------------
 
 By default, ``debug_symbols=no`` is used, which means **no** debugging symbols
-are included in compiled binaries. Use ``debug_symbols=yes`` to include debug
+are included in compiled binaries. Use ``debug_symbols=embedded`` to include debug
 symbols within compiled binaries, which allows debuggers and profilers to work
 correctly. Debugging symbols are also required for Godot's crash stacktraces to
 display with references to source code files and lines.
@@ -203,11 +203,11 @@ than the binaries themselves). As a result, official binaries currently do not
 include debugging symbols. This means you need to compile Godot yourself to have
 access to debugging symbols.
 
-When using ``debug_symbols=yes``, you can also use
-``separate_debug_symbols=yes`` to put debug information in a separate file with
-a ``.debug`` suffix. This allows distributing both files independently. Note
-that on Windows, when compiling with MSVC, debugging information is *always*
-written to a separate ``.pdb`` file regardless of ``separate_debug_symbols``.
+If you prefer, you can use ``debug_symbols=separate`` to put debug information in a
+separate file with a ``.debug`` suffix. This allows distributing both files
+independently. Note that on Windows, when compiling with MSVC, debugging information
+is *always* written to a separate ``.pdb`` file, even if you pass
+``debug_symbols=embedded``.
 
 .. tip::
 

--- a/contributing/development/debugging/using_cpp_profilers.rst
+++ b/contributing/development/debugging/using_cpp_profilers.rst
@@ -30,7 +30,7 @@ build that includes debugging symbols. Official binaries do not include debuggin
 symbols, since these would make the download size significantly larger.
 
 To get profiling data that best matches the production environment (but with debugging symbols),
-you should compile binaries with the ``production=yes debug_symbols=yes`` SCons options.
+you should compile binaries with the ``production=yes debug_symbols=embedded`` SCons options.
 
 It is possible to run a profiler on less optimized builds (e.g. ``target=template_debug`` without LTO),
 but results will naturally be less representative of real world conditions.


### PR DESCRIPTION
Meant to accompany https://github.com/godotengine/godot/pull/84822

- *Production edit: Marked as draft to prevent accidental merge.*