### PR TITLE
Update exporting_pcks.rst

### DIFF
--- a/tutorials/export/exporting_pcks.rst
+++ b/tutorials/export/exporting_pcks.rst
@@ -132,7 +132,7 @@ The PCK file contains a “mod_scene.tscn” test scene in its root.
 .. note::
     For a C# project, you need to build the DLL and place it in the project directory first.
     Then, before loading the resource pack, you need to load its DLL as follows:
-    ``Assembly.LoadFile("mod.dll")``
+    ``var context = AssemblyLoadContext.GetLoadContext(typeof(Godot.Bridge.ScriptManagerBridge).Assembly); var assembly = context.LoadFromAssemblyPath("mod.dll"); Godot.Bridge.ScriptManagerBridge.LookupScriptsInAssembly(assembly);``
 
 Summary
 -------


### PR DESCRIPTION
Updating C# assembly loading instructions according to https://github.com/godotengine/godot/issues/75352#issuecomment-1807234258. Simply loading the assembly is no longer enough with godot 4 and @granitrocky identified how to load the dlls correctly.

Wasn't sure how to properly format the code inside the note block, so please suggest improvements, if necessary.