### PR TITLE
Fixing style guide example on 2 indent levels for continuation lines

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -153,8 +153,8 @@ regular code blocks.
 ::
 
     effect.interpolate_property(sprite, "transform/scale",
-                sprite.get_scale(), Vector2(2.0, 2.0), 0.3,
-                Tween.TRANS_QUAD, Tween.EASE_OUT)
+            sprite.get_scale(), Vector2(2.0, 2.0), 0.3,
+            Tween.TRANS_QUAD, Tween.EASE_OUT)
 
 **Bad**:
 


### PR DESCRIPTION
The original example seems to be using 3 tabs for indentation, but the description said 2 should be used.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
