### PR TITLE
Update the list of limitations for the Android editor

### DIFF
--- a/tutorials/editor/using_the_android_editor.rst
+++ b/tutorials/editor/using_the_android_editor.rst
@@ -36,7 +36,6 @@ Limitations & known issues
 Here are the known limitations and issues of the Android editor:
 
 - No C#/Mono support
-- No GDExtension support
 - No support for external script editors
 - While available, the *Vulkan Forward+* renderer is not recommended due to severe performance issues
 - No support for building and exporting an Android APK binary.


### PR DESCRIPTION
Remove 'GDExtension support' from the list, as support for it was added for Godot 4.2 in https://github.com/godotengine/godot/pull/80740.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
