### PR TITLE
Sprite2D.gd not sprite_2d.gd in scripting_first_script.rst

### DIFF
--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -85,7 +85,7 @@ other options set to their default values and click the Create button to create 
 
 .. image:: img/scripting_first_script_attach_node_script.webp
 
-The Script workspace should appear with your new ``sprite_2d.gd`` file open and
+The Script workspace should appear with your new ``Sprite2D.gd`` file open and
 the following line of code:
 
 .. tabs::


### PR DESCRIPTION
While following the doc I noticed the file name of the script created don't match the one informed. It should be Sprite2D.gd not sprite_2d.gd

https://docs.godotengine.org/en/stable/getting_started/step_by_step/scripting_first_script.html
