### PR TITLE
Add hint reg. Safari audio autoplay restriction when exporting for the web

### DIFF
--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -139,7 +139,7 @@ player to click, tap or press a key/button to enable audio, for instance when di
 .. seealso:: Google offers additional information about their `Web Audio autoplay
              policies <https://sites.google.com/a/chromium.org/dev/audio-video/autoplay>`__.
 
-			Apple's Safari team also posted additional information about their `Auto-Play Policy Changes for macOS 
+            Apple's Safari team also posted additional information about their `Auto-Play Policy Changes for macOS 
              <https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/>`__.
 
 .. warning:: Access to microphone requires a

--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -139,7 +139,7 @@ player to click, tap or press a key/button to enable audio, for instance when di
 .. seealso:: Google offers additional information about their `Web Audio autoplay
              policies <https://sites.google.com/a/chromium.org/dev/audio-video/autoplay>`__.
 
-            Apple's Safari team also posted additional information about their `Auto-Play Policy Changes for macOS 
+             Apple's Safari team also posted additional information about their `Auto-Play Policy Changes for macOS 
              <https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/>`__.
 
 .. warning:: Access to microphone requires a

--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -133,11 +133,14 @@ engine is started from within a valid input event handler. This requires
 Audio
 ~~~~~
 
-Chrome restricts how websites may play audio. It may be necessary for the
-player to click or tap or press a key to enable audio.
+Some browsers restrict autoplay for audio on websites. The easiest way around this limitation is to request the
+player to click, tap or press a key/button to enable audio, for instance when displaying a splash screen at the start of your game.
 
 .. seealso:: Google offers additional information about their `Web Audio autoplay
              policies <https://sites.google.com/a/chromium.org/dev/audio-video/autoplay>`__.
+
+.. seealso:: Apple's Safari team posted additional information about their `Auto-Play Policy Changes for macOS 
+             <https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/>`__.
 
 .. warning:: Access to microphone requires a
              :ref:`secure context <doc_javascript_secure_contexts>`.

--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -139,7 +139,7 @@ player to click, tap or press a key/button to enable audio, for instance when di
 .. seealso:: Google offers additional information about their `Web Audio autoplay
              policies <https://sites.google.com/a/chromium.org/dev/audio-video/autoplay>`__.
 
-.. seealso:: Apple's Safari team posted additional information about their `Auto-Play Policy Changes for macOS 
+			Apple's Safari team also posted additional information about their `Auto-Play Policy Changes for macOS 
              <https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/>`__.
 
 .. warning:: Access to microphone requires a


### PR DESCRIPTION
Hi there, 

I wondered why the audio of my game uploaded to itch.io isn't autoplaying in Safari.
I then tried to trigger/fake a mouse click via [`Input.parse_input_event()`](https://docs.godotengine.org/en/latest/classes/class_input.html#class-input-method-parse-input-event) in `_ready()`, but this didn't work of course as this is passing an input signal from Godot to Godot inside Godot (silly me! 🤣) and not from the OS to Safari and then to Godot (the game).

After googling for a while, I found a [Webkit blog post by the Safari team explaining how/why audio autoplay is blocked in Safari](https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/) for most of the websites. I thought, it might make sense to add this info to the docs on ["Exporting for the Web"](https://docs.godotengine.org/en/stable/tutorials/export/exporting_for_web.html#audio), in addition to the already existing hint that Chrome also blocks audio autoplay.