### PR TITLE
Add redirects for old UWP pages to FAQ note

### DIFF
--- a/_tools/redirects/redirects.csv
+++ b/_tools/redirects/redirects.csv
@@ -419,3 +419,5 @@ source,destination
 /tutorials/viewports/multiple_resolutions.html,/tutorials/rendering/multiple_resolutions.html
 /tutorials/viewports/using_viewport_as_texture.html,/tutorials/shaders/using_viewport_as_texture.html
 /tutorials/viewports/viewports.html,/tutorials/rendering/viewports.html
+/contributing/development/compiling/compiling_for_uwp.html,/about/faq.html#which-platforms-are-supported-by-godot
+/tutorials/export/exporting_for_uwp.html,/about/faq.html#which-platforms-are-supported-by-godot


### PR DESCRIPTION
Followup to https://github.com/godotengine/godot-docs/pull/7889: Redirect the deleted UWP pages to the FAQ entry about supported platforms, which now contains a now stating that UWP support was dropped and the reasoning.

Let's see if anchor targets like this work on RTD to directly link to a subheading :) As this was done for Godot 4.2, this should not be cherrypicked.