### PR TITLE
Clarify InputEventScreenDrag only applies to touch events

### DIFF
--- a/classes/class_inputeventscreendrag.rst
+++ b/classes/class_inputeventscreendrag.rst
@@ -12,7 +12,7 @@ InputEventScreenDrag
 
 **Inherits:** :ref:`InputEventFromWindow<class_InputEventFromWindow>` **<** :ref:`InputEvent<class_InputEvent>` **<** :ref:`Resource<class_Resource>` **<** :ref:`RefCounted<class_RefCounted>` **<** :ref:`Object<class_Object>`
 
-Represents a screen drag event.
+Represents a screen drag event. This only applies to touchscreen inputs. 
 
 .. rst-class:: classref-introduction-group
 


### PR DESCRIPTION
I was trying to use this event to check when I was clicking and dragging my mouse across the screen. It was not working, so I asked in Discord.  I was told this is only used for touchscreen. So I added this clarification so others are not confused.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
