### PR TITLE
Update shader reference pages for canvas_item shaders and particle shaders for 4.2

### DIFF
--- a/tutorials/shaders/shader_reference/particle_shader.rst
+++ b/tutorials/shaders/shader_reference/particle_shader.rst
@@ -9,8 +9,8 @@ position, and rotation. They are drawn with any regular material for CanvasItem
 or Spatial, depending on whether they are 2D or 3D.
 
 Particle shaders are unique because they are not used to draw the object itself;
-they are used to calculate particle properties, which are then used by the
-CanvasItem of Spatial shader. They contain two processor functions: ``start()``
+they are used to calculate particle properties, which are then used by a
+CanvasItem or Spatial shader. They contain two processor functions: ``start()``
 and ``process()``.
 
 Unlike other shader types, particle shaders keep the data that was output the
@@ -30,15 +30,17 @@ take place over multiple frames.
 Render modes
 ^^^^^^^^^^^^
 
-+-----------------------+----------------------------------------+
-| Render mode           | Description                            |
-+=======================+========================================+
-| **keep_data**         | Do not clear previous data on restart. |
-+-----------------------+----------------------------------------+
-| **disable_force**     | Disable attractor force.               |
-+-----------------------+----------------------------------------+
-| **disable_velocity**  | Ignore **VELOCITY** value.             |
-+-----------------------+----------------------------------------+
++--------------------------+-------------------------------------------+
+| Render mode              | Description                               |
++==========================+===========================================+
+| **keep_data**            | Do not clear previous data on restart.    |
++--------------------------+-------------------------------------------+
+| **disable_force**        | Disable attractor force.                  |
++--------------------------+-------------------------------------------+
+| **disable_velocity**     | Ignore **VELOCITY** value.                |
++--------------------------+-------------------------------------------+
+| **collision_use_scale**  | Scale the particle's size for collisions. |
++--------------------------+-------------------------------------------+
 
 Built-ins
 ^^^^^^^^^
@@ -70,63 +72,37 @@ Global built-ins are available everywhere, including custom functions.
 Start and Process built-ins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-+---------------------------------+--------------------------------------------------------------------------------+
-| Function                        | Description                                                                    |
-+=================================+================================================================================+
-| in float **LIFETIME**           | Particle lifetime.                                                             |
-+---------------------------------+--------------------------------------------------------------------------------+
-| in float **DELTA**              | Delta process time.                                                            |
-+---------------------------------+--------------------------------------------------------------------------------+
-| in uint **NUMBER**              | Unique number since emission start.                                            |
-+---------------------------------+--------------------------------------------------------------------------------+
-| in uint **INDEX**               | Particle index (from total particles).                                         |
-+---------------------------------+--------------------------------------------------------------------------------+
-| in mat4 **EMISSION_TRANSFORM**  | Emitter transform (used for non-local systems).                                |
-+---------------------------------+--------------------------------------------------------------------------------+
-| in uint **RANDOM_SEED**         | Random seed used as base for random.                                           |
-+---------------------------------+--------------------------------------------------------------------------------+
-| inout bool **ACTIVE**           | ``true`` when the particle is active, can be set ``false``.                    |
-+---------------------------------+--------------------------------------------------------------------------------+
-| inout vec4 **COLOR**            | Particle color, can be written to and accessed in mesh's vertex function.      |
-+---------------------------------+--------------------------------------------------------------------------------+
-| inout vec3 **VELOCITY**         | Particle velocity, can be modified.                                            |
-+---------------------------------+--------------------------------------------------------------------------------+
-| inout mat4 **TRANSFORM**        | Particle transform.                                                            |
-+---------------------------------+--------------------------------------------------------------------------------+
-| inout vec4 **CUSTOM**           | Custom particle data. Accessible from shader of mesh as **INSTANCE_CUSTOM**.   |
-+---------------------------------+--------------------------------------------------------------------------------+
-| inout float **MASS**            | Particle mass, intended to be used with attractors. Equals ``1.0`` by default. |
-+---------------------------------+--------------------------------------------------------------------------------+
-
-.. note:: In order to use the ``COLOR`` variable in a StandardMaterial3D, set ``vertex_color_use_as_albedo``
-          to ``true``. In a ShaderMaterial, access it with the ``COLOR`` variable.
-
-Start built-ins
-^^^^^^^^^^^^^^^
-
-+---------------------------------+-------------+
-| Built-in                        | Description |
-+=================================+=============+
-| in bool **RESTART_POSITION**    |             |
-+---------------------------------+-------------+
-| in bool **RESTART_ROT_SCALE**   |             |
-+---------------------------------+-------------+
-| in bool **RESTART_VELOCITY**    |             |
-+---------------------------------+-------------+
-| in bool **RESTART_COLOR**       |             |
-+---------------------------------+-------------+
-| in bool **RESTART_CUSTOM**      |             |
-+---------------------------------+-------------+
-| in bool **RESTART_VELOCITY**    |             |
-+---------------------------------+-------------+
-
-Process built-ins
-^^^^^^^^^^^^^^^^^
+These properties can be accessed from both the ``start()`` and ``process()`` functions. 
 
 +------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
-| Built-in                           | Description                                                                                                                             |
+| Function                           | Description                                                                                                                             |
 +====================================+=========================================================================================================================================+
-| in bool **RESTART**                | ``true`` if the current process frame is first for the particle.                                                                        |
+| in float **LIFETIME**              | Particle lifetime.                                                                                                                      |
++------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
+| in float **DELTA**                 | Delta process time.                                                                                                                     |
++------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
+| in uint **NUMBER**                 | Unique number since emission start.                                                                                                     |
++------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
+| in uint **INDEX**                  | Particle index (from total particles).                                                                                                  |
++------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
+| in mat4 **EMISSION_TRANSFORM**     | Emitter transform (used for non-local systems).                                                                                         |
++------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
+| in uint **RANDOM_SEED**            | Random seed used as base for random.                                                                                                    |
++------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
+| inout bool **ACTIVE**              | ``true`` when the particle is active, can be set ``false``.                                                                             |
++------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
+| inout vec4 **COLOR**               | Particle color, can be written to and accessed in mesh's vertex function.                                                               |
++------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
+| inout vec3 **VELOCITY**            | Particle velocity, can be modified.                                                                                                     |
++------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
+| inout mat4 **TRANSFORM**           | Particle transform.                                                                                                                     |
++------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
+| inout vec4 **CUSTOM**              | Custom particle data. Accessible from shader of mesh as **INSTANCE_CUSTOM**.                                                            |
++------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
+| inout float **MASS**               | Particle mass, intended to be used with attractors. Equals ``1.0`` by default.                                                          |
++------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
+| in vec4 **USERDATAX**              | Vector that enables the integration of supplementary user-defined data into the particle process shader.                                |
+|                                    | ``USERDATAX`` are six built-ins identified by number, ``X`` can be numbers between 1 and 6.                                             |
 +------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | in uint **FLAG_EMIT_POSITION**     | A flag for using on the last argument of ``emit_subparticle`` function to assign a position to a new particle's transform.              |
 +------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
@@ -138,23 +114,68 @@ Process built-ins
 +------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | in uint **FLAG_EMIT_CUSTOM**       | A flag for using on the last argument of ``emit_subparticle`` function to assign a custom data vector to a new particle.                |
 +------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
-| in bool **COLLIDED**               | ``true`` when the particle has collided with a particle collider.                                                                       |
+| in vec3 **EMITTER_VELOCITY**       | Velocity of the Particles node.                                                                                                         |
 +------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
-| in vec3 **COLLISION_NORMAL**       | A normal of the last collision. If there is no collision detected it is equal to ``vec3(0.0)``.                                         |
+| in float **INTERPOLATE_TO_END**    | Value of ``interp_to_end`` property of Particles node.                                                                                  |
 +------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
-| in float **COLLISION_DEPTH**       | A length of normal of the last collision. If there is no collision detected it is equal to ``0.0``.                                     |
+| in uint **AMOUNT_RATIO**           | Value of ``amount_ratio`` property of Particles node.                                                                                   |
 +------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
-| in vec3 **ATTRACTOR_FORCE**        | A combined force of the attractors at the moment on that particle.                                                                      |
-+------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
-| in vec4 **USERDATAX**              | Vector that enables the integration of supplementary user-defined data into the particle process shader.                                |
-|                                    | ``USERDATAX`` are six built-ins identified by number, ``X`` can be numbers between 1 and 6.                                             |
-+------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
+
+.. note:: In order to use the ``COLOR`` variable in a StandardMaterial3D, set ``vertex_color_use_as_albedo``
+          to ``true``. In a ShaderMaterial, access it with the ``COLOR`` variable.
+
+Start built-ins
+^^^^^^^^^^^^^^^
+
++---------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Built-in                        | Description                                                                                                                                                                           |
++=================================+=======================================================================================================================================================================================+
+| in bool **RESTART_POSITION**    | ``true`` if particle is restarted, or emitted without a custom position (i.e. this particle was created by ``emit_subparticle()`` without the ``FLAG_EMIT_POSITION`` flag).           |
++---------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| in bool **RESTART_ROT_SCALE**   | ``true`` if particle is restarted, or emitted without a custom rotation or scale (i.e. this particle was created by ``emit_subparticle()`` without the ``FLAG_EMIT_ROT_SCALE`` flag). |
++---------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| in bool **RESTART_VELOCITY**    | ``true`` if particle is restarted, or emitted without a custom velocity (i.e. this particle was created by ``emit_subparticle()`` without the ``FLAG_EMIT_VELOCITY`` flag).           |
++---------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| in bool **RESTART_COLOR**       | ``true`` if particle is restarted, or emitted without a custom color (i.e. this particle was created by ``emit_subparticle()`` without the ``FLAG_EMIT_COLOR`` flag).                 |
++---------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| in bool **RESTART_CUSTOM**      | ``true`` if particle is restarted, or emitted without a custom property (i.e. this particle was created by ``emit_subparticle()`` without the ``FLAG_EMIT_CUSTOM`` flag).             |
++---------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Process built-ins
+^^^^^^^^^^^^^^^^^
+
++------------------------------------+-----------------------------------------------------------------------------------------------------+
+| Built-in                           | Description                                                                                         |
++====================================+=====================================================================================================+
+| in bool **RESTART**                | ``true`` if the current process frame is first for the particle.                                    |
++------------------------------------+-----------------------------------------------------------------------------------------------------+
+| in bool **COLLIDED**               | ``true`` when the particle has collided with a particle collider.                                   |
++------------------------------------+-----------------------------------------------------------------------------------------------------+
+| in vec3 **COLLISION_NORMAL**       | A normal of the last collision. If there is no collision detected it is equal to ``vec3(0.0)``.     |
++------------------------------------+-----------------------------------------------------------------------------------------------------+
+| in float **COLLISION_DEPTH**       | A length of normal of the last collision. If there is no collision detected it is equal to ``0.0``. |
++------------------------------------+-----------------------------------------------------------------------------------------------------+
+| in vec3 **ATTRACTOR_FORCE**        | A combined force of the attractors at the moment on that particle.                                  |
++------------------------------------+-----------------------------------------------------------------------------------------------------+
 
 Process functions
 ^^^^^^^^^^^^^^^^^
 
-+--------------------------------------------------------------------------------------------+-----------------------------------------------+
-| Function                                                                                   | Description                                   |
-+============================================================================================+===============================================+
-| bool **emit_subparticle** (mat4 xform, vec3 velocity, vec4 color, vec4 custom, uint flags) | Forces to emit a particle from a sub-emitter. |
-+--------------------------------------------------------------------------------------------+-----------------------------------------------+
+``emit_subparticle`` is currently the only custom function supported by
+particles shaders. It allows users to add a new particle with specified
+parameters from a sub-emitter. The newly created particle will only use the
+properties that match the ``flags`` parameter. For example, the
+following code will emit a particle with a specified position, velocity, and
+color, but unspecified rotation, scale, and custom value:
+
+.. code-block:: glsl
+
+    mat4 custom_transform = mat4(1.0);
+    custom_transform[3].xyz = vec3(10.5, 0.0, 4.0);
+    emit_subparticle(custom_transform, vec3(1.0, 0.5, 1.0), vec4(1.0, 0.0, 0.0, 1.0), vec4(1.0), FLAG_EMIT_POSITION | FLAG_EMIT_VELOCITY | FLAG_EMIT_COLOR);
+
++--------------------------------------------------------------------------------------------+--------------------------------------+
+| Function                                                                                   | Description                          |
++============================================================================================+======================================+
+| bool **emit_subparticle** (mat4 xform, vec3 velocity, vec4 color, vec4 custom, uint flags) | Emits a particle from a sub-emitter. |
++--------------------------------------------------------------------------------------------+--------------------------------------+


### PR DESCRIPTION
This PR fixes some factual errors that I noticed as well as adds information about new built ins that were introduced in 4.2. 

Since it touches on 4.2 content, it is not suitable for cherry picking. 
