### PR TITLE
Fix incomplete thirdparty guidelines on Complying with licenses

### DIFF
--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -5,12 +5,17 @@
 Complying with licenses
 =======================
 
+.. warning::
+
+    The recommendations in this page **are not legal advice.** They are provided
+    in good faith to help users navigate license attribution requirements.
+
 What are licenses?
 ------------------
 
 Godot is created and distributed under the `MIT License <https://opensource.org/licenses/MIT>`_.
-It doesn't have a sole owner either, as every contributor that submits code to
-the project does it under this same license and keeps ownership of the
+It doesn't have a sole owner, as every contributor that submits code to
+the project does it under this same license and keeps ownership of their
 contribution.
 
 The license is the legal requirement for you (or your company) to use and
@@ -24,13 +29,12 @@ with the original one.
     If you are interested in licence compliance as a contributor, you can find
     guidelines :ref:`here <doc_best_practices_for_engine_contributors_license_compliance>`.
 
-.. warning::
+.. tip::
 
-    In your project's credits screen, remember to also list third-party notices
+    Alongside the Godot license text, remember to also list third-party notices
     for assets you're using, such as textures, models, sounds, music and fonts.
-
-    Free assets in particular often come with licenses that require attribution.
-    Double-check their license before using those assets in a project.
+    This includes free assets, which often come with licenses that require
+    attribution.
 
 Requirements
 ------------
@@ -38,18 +42,33 @@ Requirements
 In the case of the MIT license, the only requirement is to include the license
 text somewhere in your game or derivative project.
 
-This text reads as follows:
+This text reads as follows::
 
     This game uses Godot Engine, available under the following license:
 
     Copyright (c) 2014-present Godot Engine contributors.
     Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.
 
-    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
 
-    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
+Beside its own MIT license, Godot includes code from a number of third-party
+libraries. See :ref:`doc_complying_with_licenses_thirdparty` for details.
 
 .. note::
 
@@ -60,31 +79,9 @@ This text reads as follows:
 Inclusion
 ---------
 
-The license does not specify how it has to be included, so anything is valid as
-long as it can be displayed under some condition. These are the most common
-approaches (only need to implement one of them, not all).
-
-.. tip::
-
-    Godot provides several methods to get license information in the Engine
-    singleton. This allows you to source the license information directly from
-    the engine binary, which prevents the information from becoming outdated if
-    you update engine versions.
-
-    For the engine itself:
-
-    - :ref:`Engine.get_license_text<class_Engine_method_get_license_text>`
-
-    For third-party components used by the engine:
-
-    - :ref:`Engine.get_license_info<class_Engine_method_get_license_info>`
-    - :ref:`Engine.get_copyright_info<class_Engine_method_get_copyright_info>`
-
-    For miscellaneous engine contributor information. You don't have to include
-    these ones in your project, but they're listed here for reference:
-
-    - :ref:`Engine.get_author_info<class_Engine_method_get_author_info>`
-    - :ref:`Engine.get_donor_info<class_Engine_method_get_donor_info>`
+The license text must be made available to the user. The license doesn't specify
+how the text has to be included, but here are the most common approaches (you
+only need to implement one of them, not all).
 
 Credits screen
 ^^^^^^^^^^^^^^
@@ -103,7 +100,7 @@ or **Open Source Licenses**.
 Output log
 ^^^^^^^^^^
 
-Printing the licensing text using the :ref:`print() <class_@GlobalScope_method_print>`
+Printing the license text using the :ref:`print() <class_@GlobalScope_method_print>`
 function may be enough on platforms where a global output log is readable.
 This is the case on desktop platforms, Android and HTML5 (but not iOS).
 
@@ -111,12 +108,12 @@ Accompanying file
 ^^^^^^^^^^^^^^^^^
 
 If the game is distributed on desktop platforms, a file containing the license
-can be added to the software that is installed to the user PC.
+text can be added to the software that is installed to the user PC.
 
 Printed manual
 ^^^^^^^^^^^^^^
 
-If the game includes printed manuals, license text can be included there.
+If the game includes a printed manual, the license text can be included there.
 
 Link to the license
 ^^^^^^^^^^^^^^^^^^^
@@ -125,71 +122,40 @@ The Godot Engine developers consider that a link to ``godotengine.org/license``
 in your game documentation or credits would be an acceptable way to satisfy
 the license terms.
 
+.. tip::
+
+    Godot provides several methods to get license information in the
+    :ref:`Engine <class_Engine>` singleton. This allows you to source the
+    license information directly from the engine binary, which prevents the
+    information from becoming outdated if you update engine versions.
+
+    For the engine itself:
+
+    - :ref:`Engine.get_license_text<class_Engine_method_get_license_text>`
+
+    For third-party components used by the engine:
+
+    - :ref:`Engine.get_license_info<class_Engine_method_get_license_info>`
+    - :ref:`Engine.get_copyright_info<class_Engine_method_get_copyright_info>`
+
+.. _doc_complying_with_licenses_thirdparty:
+
 Third-party licenses
 --------------------
 
 Godot itself contains software written by
-`third parties <https://github.com/godotengine/godot/blob/master/COPYRIGHT.txt>`_.
-Most of it does not require license inclusion, but some do.
-Make sure to do it if these are compiled in your Godot export template. If
-you're using the official export templates, all libraries are enabled. This
-means you need to provide attribution for all the libraries listed below.
+`third parties <https://github.com/godotengine/godot/blob/master/thirdparty/README.md>`_,
+which is compatible with, but not covered by Godot's MIT license.
 
-Here's a list of libraries requiring attribution:
+Many of these dependencies are distributed under permissive open source licenses
+which require attribution by explicitly citing their copyright statement and
+license text in the final product's documentation.
 
-FreeType
-^^^^^^^^
+Given the scope of the Godot project, this is fairly difficult to do thoroughly.
+For the Godot editor, the full documentation of third-party copyrights and
+licenses is provided in the `COPYRIGHT.txt <https://github.com/godotengine/godot/blob/master/COPYRIGHT.txt>`_
+file.
 
-Godot uses `FreeType <https://www.freetype.org/>`_ to render fonts. Its license
-requires attribution, so the following text must be included together with the
-Godot license:
-
-    Portions of this software are copyright © <year> The FreeType Project (www.freetype.org).  All rights reserved.
-
-.. note::
-
-    <year> should correspond to the value from the FreeType version used
-    in your build. This information can be found in the editor by opening
-    the **Help > About** dialog and going to the **Third-party Licenses**
-    tab.
-
-ENet
-^^^^
-
-Godot includes the `ENet <http://enet.bespin.org/>`_ library to handle
-high-level multiplayer. ENet has similar licensing terms as Godot:
-
-
-    Copyright (c) 2002-2020 Lee Salzman
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-mbed TLS
-^^^^^^^^
-
-If the project is exported with Godot 3.1 or later, it includes `mbed TLS <https://tls.mbed.org>`_.
-The Apache license needs to be complied to by including the following text:
-
-    Copyright The Mbed TLS Contributors
-
-    Licensed under the Apache License, Version 2.0 (the "License"); you may
-    not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
-.. note::
-
-    If you exported your project using a
-    :ref:`custom build with specific modules disabled <doc_optimizing_for_size>`,
-    you don't need to list the disabled modules' licenses in your exported project.
+A good option for end users to document third-party licenses is to include this
+file in your project's distribution, which you can e.g. rename to
+``GODOT_COPYRIGHT.txt`` to prevent any confusion with your own code and assets.


### PR DESCRIPTION
The three libraries which had been singled out are just a small portion of what actually requires attribution. Listing them all would basically duplicate all of COPYRIGHT.txt, aside from CCO/PD licensed stuff.

Clarify that this is no legal advice.

Also merge in grammar and clarity improvements by John from another PR.

And I just noticed https://github.com/godotengine/godot-docs/pull/7984, so I'll work in the grammar improvements from that PR in this one.
*Edit:* Done, this now includes @JohnVeness' changes.

- Fixes https://github.com/godotengine/godot-docs-l10n/issues/20.
- Supersedes https://github.com/godotengine/godot-docs/pull/7984.