### PR TITLE
Fix syntax error

### DIFF
--- a/getting_started/first_2d_game/03.coding_the_player.rst
+++ b/getting_started/first_2d_game/03.coding_the_player.rst
@@ -232,7 +232,7 @@ the ``_process`` function (make sure it's not indented under the `else`):
  .. code-tab:: gdscript GDScript
 
         position += velocity * delta
-        position = position.clamp(Vector2.ZERO, screen_size)
+        position = position.clamp(Vector2.ZERO, screen_size.size)
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
As mentioned in https://github.com/godotengine/godot-docs/issues/7958, the tutorial documentation is incorrect and will not run as is.

As is the code throws `Invalid type in function 'clamp' in base 'Vector2'. Cannot convert argument 2 from Rect2 to Vector2.` I corrected the code by changing `screen_size` to `screen_size.size`, however updating `_ready()` to use `get_viewport_rect().size` would also be a valid solution.