### PR TITLE
conf.py: Fix regression with composite language codes

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -117,7 +117,14 @@ supported_languages = {
     "zh_TW": "Godot Engine %s 正體中文 (台灣) 文件",
 }
 
+# RTD normalized their language codes to ll-cc (e.g. zh-cn),
+# but Sphinx did not and still uses ll_CC (e.g. zh_CN).
+# `language` is the Sphinx configuration so it needs to be converted back.
 language = os.getenv("READTHEDOCS_LANGUAGE", "en")
+if "-" in language:
+    (lang_name, lang_country) = language.split("-")
+    language = lang_name + "_" + lang_country.upper()
+
 if not language in supported_languages.keys():
     print("Unknown language: " + language)
     print("Supported languages: " + ", ".join(supported_languages.keys()))
@@ -127,6 +134,7 @@ if not language in supported_languages.keys():
     language = "en"
 
 is_i18n = tags.has("i18n")  # noqa: F821
+print("Build language: {}, i18n tag: {}".format(language, is_i18n))
 
 exclude_patterns = ["_build"]
 


### PR DESCRIPTION
RTD decided to normalize language codes such as `zh_CN` and `pt_BR` to `zh-cn` and `pt-br`, apparently because it makes URLs prettier... https://blog.readthedocs.com/language-codes-are-now-normalized/

But they didn't take into account that Sphinx doesn't do the same, and still requires `zh_CN` and `pt_BR` for its `language` config value.

So we have to convert it back in `conf.py`, otherwise this breaks our i18n logic, notably to handle the localized class reference and images.

---

I marked it for cherry-picking for all branches, but technically we only build `3.5`, `3.x` (3.6) and `4.x` (4.2) for localization currently. But it's better to keep the `conf.py` file consistent on all branches.