### PR TITLE
Fix release builds for new GDExtension developers by fixing release identifiers in `.gdextension`

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -368,21 +368,21 @@ loaded for each platform and the entry function for the module. It is called ``g
     [libraries]
 
     macos.debug = "res://bin/libgdexample.macos.template_debug.framework"
-    macos.release = "res://bin/libgdexample.macos.template_release.framework"
+    macos = "res://bin/libgdexample.macos.template_release.framework"
     windows.debug.x86_32 = "res://bin/libgdexample.windows.template_debug.x86_32.dll"
-    windows.release.x86_32 = "res://bin/libgdexample.windows.template_release.x86_32.dll"
+    windows.x86_32 = "res://bin/libgdexample.windows.template_release.x86_32.dll"
     windows.debug.x86_64 = "res://bin/libgdexample.windows.template_debug.x86_64.dll"
-    windows.release.x86_64 = "res://bin/libgdexample.windows.template_release.x86_64.dll"
+    windows.x86_64 = "res://bin/libgdexample.windows.template_release.x86_64.dll"
     linux.debug.x86_64 = "res://bin/libgdexample.linux.template_debug.x86_64.so"
-    linux.release.x86_64 = "res://bin/libgdexample.linux.template_release.x86_64.so"
+    linux.x86_64 = "res://bin/libgdexample.linux.template_release.x86_64.so"
     linux.debug.arm64 = "res://bin/libgdexample.linux.template_debug.arm64.so"
-    linux.release.arm64 = "res://bin/libgdexample.linux.template_release.arm64.so"
+    linux.arm64 = "res://bin/libgdexample.linux.template_release.arm64.so"
     linux.debug.rv64 = "res://bin/libgdexample.linux.template_debug.rv64.so"
-    linux.release.rv64 = "res://bin/libgdexample.linux.template_release.rv64.so"
+    linux.rv64 = "res://bin/libgdexample.linux.template_release.rv64.so"
     android.debug.x86_64 = "res://bin/libgdexample.android.template_debug.x86_64.so"
-    android.release.x86_64 = "res://bin/libgdexample.android.template_release.x86_64.so"
+    android.x86_64 = "res://bin/libgdexample.android.template_release.x86_64.so"
     android.debug.arm64 = "res://bin/libgdexample.android.template_debug.arm64.so"
-    android.release.arm64 = "res://bin/libgdexample.android.template_release.arm64.so"
+    android.arm64 = "res://bin/libgdexample.android.template_release.arm64.so"
 
 This file contains a ``configuration`` section that controls the entry function of the module.
 You should also set the minimum compatible Godot version with ``compatability_minimum``,


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

In working on [my own GDExtension](https://github.com/Computational-Geometry-G1/godot-wiimote) as a first-time godot developer, I have discovered (while debugging a performance related issue) that the example of a `.gdextension` In the tutorial (the C++ example) is incorrect.

When using scons to build my extension in release mode (`scons target=template_release`) my demo project would fail to open in godot without loading errors. it was only after I saw [this comment](https://github.com/godotengine/godot/issues/71090#issuecomment-1380386350) and tried changing the release identifier to `linux.x86_64` (from `linux.release.x86_64`) that godot successfully loaded with the release version of my extension.

godot 4.1
