### PR TITLE
Update 'Your first 3D shader' for better 4.2 compatibility

### DIFF
--- a/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
@@ -367,7 +367,8 @@ We can even drag the light around and the lighting will update automatically.
 .. note:: The default :ref:`FastNoiseLite <class_fastnoiselite>` implementation in Godot changed in Godot 4. If you want
 your mesh to look smoother, try lowering the number of Octaves in :ref:`FastNoiseLite <class_fastnoiselite>` of your normal map.
 
-Here is the full code for this tutorial. You can see it is not very long as Godot handles most of the difficult stuff for you.
+Here is the full code for this tutorial. You can see it is not very long as
+Godot handles most of the difficult stuff for you.
 
 .. code-block:: glsl
 

--- a/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
@@ -292,9 +292,6 @@ the light is affecting the terrain as if it were a flat plane. This is because
 the light shader uses the normals from the :ref:`Mesh <class_mesh>` to calculate
 light.
 
-.. note:: If you don't see :ref:`OmniLight3D <class_OmniLight3D>` affecting your mesh,
-          delete the ``light()`` function from the shader.
-
 The normals are stored in the Mesh, but we are changing the shape of the Mesh in
 the shader, so the normals are no longer correct. To fix this, we can
 recalculate the normals in the shader or use a normal texture that corresponds
@@ -367,8 +364,8 @@ We can even drag the light around and the lighting will update automatically.
 
 .. image:: img/normalmap2.png
 
-Here is the full code for this tutorial. You can see it is not very long as
-Godot handles most of the difficult stuff for you.
+.. note:: The default :ref:`FastNoiseLite <class_fastnoiselite>` implementation in Godot changed in Godot 4. If you want
+your mesh to look smoother, try lowering the number of Octaves in :ref:`FastNoiseLite <class_fastnoiselite>` of your normal map.
 
 .. code-block:: glsl
 

--- a/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
@@ -292,6 +292,9 @@ the light is affecting the terrain as if it were a flat plane. This is because
 the light shader uses the normals from the :ref:`Mesh <class_mesh>` to calculate
 light.
 
+.. note:: If you don't see OmniLight3D<class_OmniLight3D> affecting your mesh,
+          delete the ``light()`` function from the shader.
+
 The normals are stored in the Mesh, but we are changing the shape of the Mesh in
 the shader, so the normals are no longer correct. To fix this, we can
 recalculate the normals in the shader or use a normal texture that corresponds

--- a/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
@@ -367,6 +367,8 @@ We can even drag the light around and the lighting will update automatically.
 .. note:: The default :ref:`FastNoiseLite <class_fastnoiselite>` implementation in Godot changed in Godot 4. If you want
 your mesh to look smoother, try lowering the number of Octaves in :ref:`FastNoiseLite <class_fastnoiselite>` of your normal map.
 
+Here is the full code for this tutorial. You can see it is not very long as Godot handles most of the difficult stuff for you.
+
 .. code-block:: glsl
 
   shader_type spatial;

--- a/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
@@ -364,8 +364,9 @@ We can even drag the light around and the lighting will update automatically.
 
 .. image:: img/normalmap2.png
 
-.. note:: The default :ref:`FastNoiseLite <class_fastnoiselite>` implementation in Godot changed in Godot 4. If you want
-your mesh to look smoother, try lowering the number of Octaves in :ref:`FastNoiseLite <class_fastnoiselite>` of your normal map.
+.. note:: The default :ref:`FastNoiseLite <class_fastnoiselite>` implementation in Godot
+          changed in Godot 4. If you want your mesh to look smoother, try lowering
+          the number of Octaves in :ref:`FastNoiseLite <class_fastnoiselite>` of your normal map. 
 
 Here is the full code for this tutorial. You can see it is not very long as
 Godot handles most of the difficult stuff for you.

--- a/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
@@ -292,7 +292,7 @@ the light is affecting the terrain as if it were a flat plane. This is because
 the light shader uses the normals from the :ref:`Mesh <class_mesh>` to calculate
 light.
 
-.. note:: If you don't see OmniLight3D<class_OmniLight3D> affecting your mesh,
+.. note:: If you don't see :ref:`OmniLight3D <class_OmniLight3D>` affecting your mesh,
           delete the ``light()`` function from the shader.
 
 The normals are stored in the Mesh, but we are changing the shape of the Mesh in


### PR DESCRIPTION
New mesh shaders are being generated with light() function, which affects the tutorial flow. When adding OmniLight3D, nothing will happen to your mesh, unless you delete light() function from a shader. I've just encountered that problem and fixed it only by chance (diffing my shader code and shader code from the end of tutorial)
