### PR TITLE
Update changing_application_icon_for_windows.rst

### DIFF
--- a/tutorials/export/changing_application_icon_for_windows.rst
+++ b/tutorials/export/changing_application_icon_for_windows.rst
@@ -23,13 +23,13 @@ using this `ImageMagick <https://www.imagemagick.org/>`_ command:
 
 .. code-block:: none
 
-    magick convert icon.png -define icon:auto-resize=256,128,64,48,32,16 icon.ico
+    magick convert icon.png -define icon:auto-resize=16,32,48,64,128,256 icon.ico
 
 Depending on which version of ImageMagick you installed, you might need to leave out the ``magick`` and run this command instead:
 
 .. code-block:: none
 
-    convert icon.png -define icon:auto-resize=256,128,64,48,32,16 icon.ico
+    convert icon.png -define icon:auto-resize=16,32,48,64,128,256 icon.ico
 
 .. warning::
 


### PR DESCRIPTION
The icons appear blurry if the order of the sizes in the commands are reversed. This happened in v3.5.stable, but I did a quick check (correct me if I'm wrong) and I think there has not been much change since then.

Related to https://github.com/godotengine/godot/issues/64073.

I'll add some tips to refresh the icon cache and thumbnails in another pull request.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
