### PR TITLE
Fix typos the scene tree key_concepts_overview.rst

### DIFF
--- a/getting_started/introduction/key_concepts_overview.rst
+++ b/getting_started/introduction/key_concepts_overview.rst
@@ -62,7 +62,7 @@ The scene tree
 
 All your game's scenes come together in the **scene tree**, literally a tree of
 scenes. And as scenes are trees of nodes, the scene tree also is a tree of
-nodes. But it's easier to think of your game in terms of scenes as they can
+scenes. But it's easier to think of your game in terms of scenes as they can
 represent characters, weapons, doors, or your user interface.
 
 .. image:: img/key_concepts_scene_tree.webp


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Hi team,

While going through the introduction, I don't know whether this definition of **The scene tree** is supposed to be tree of scenes instead of tree of nodes, which is repeated twice. If this is intention please ignore this pull request.

Thank you.