### PR TITLE
Updated link to qodot plugin

### DIFF
--- a/tutorials/3d/csg_tools.rst
+++ b/tutorials/3d/csg_tools.rst
@@ -18,7 +18,7 @@ Interior environments can be created by using inverted primitives.
           extruded 2D polygons can be used with the CSGPolygon3D node).
 
           If you're looking for an easy to use level design tool for a project,
-          you may want to use `Qodot <https://github.com/Shfty/qodot-plugin>`__
+          you may want to use `Qodot <https://github.com/QodotPlugin/Qodot>`__
           instead. It lets you design levels using
           `TrenchBroom <https://kristianduske.com/trenchbroom/>`__ and import
           them in Godot.


### PR DESCRIPTION
this changes the link to the correct qodot plugin (not the old one for 3.x)

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
