### PR TITLE
Typo in 05.the_main_game_scene.rst

### DIFF
--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -10,7 +10,7 @@ Create a new scene and add a :ref:`Node <class_Node>` named ``Main``.
 be a container for handling game logic. It does not require 2D functionality itself.)
 
 Click the **Instance** button (represented by a chain link icon) and select your saved
-``player.tscn``.
+``main.tscn``.
 
 .. image:: img/instance_scene.webp
 


### PR DESCRIPTION
The scene name seem wrong since we've just created the main scene and it's the one to be edited

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
