### PR TITLE
Update list_of_features.rst

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -55,7 +55,7 @@ Editor
   Visual Studio Code or Vim.
 - GDScript :ref:`debugger <doc_debugger_panel>`.
 
-   - Support for debugging in threads is available since 4.2(stable).
+   - Support for debugging in threads is available since 4.2.
 - Visual profiler with CPU and GPU time indications for each step of the
   rendering pipeline.
 - Performance monitoring tools, including

--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -55,7 +55,7 @@ Editor
   Visual Studio Code or Vim.
 - GDScript :ref:`debugger <doc_debugger_panel>`.
 
-   - No support for debugging in threads yet.
+   - Support for debugging in threads is available since 4.2(stable).
 - Visual profiler with CPU and GPU time indications for each step of the
   rendering pipeline.
 - Performance monitoring tools, including


### PR DESCRIPTION
In 4.2 release notes, debugging threads is listed as a new feature. Yet in documentation about Godot editor capabilities the opposite was stated.