### PR TITLE
Fixes grammatical error in 'Creating the Enemy'

### DIFF
--- a/getting_started/first_2d_game/04.creating_the_enemy.rst
+++ b/getting_started/first_2d_game/04.creating_the_enemy.rst
@@ -24,7 +24,7 @@ Click Scene -> New Scene from the top menu and add the following nodes:
 Don't forget to set the children so they can't be selected, like you did with
 the Player scene.
 
-Select the ``Mob`` node and set it's ``Gravity Scale``
+Select the ``Mob`` node and set its ``Gravity Scale``
 property in the :ref:`RigidBody2D <class_RigidBody2D>`
 section of the inspector to ``0``.
 This will prevent the mob from falling downwards.


### PR DESCRIPTION
The existing text reads "Select the Mob node and set it's Gravity Scale..."

It is instead grammatically correct to say "and set its" without an apostrophe.