### PR TITLE
Removed the following line of code from gdscript:

### DIFF
--- a/getting_started/first_3d_game/06.jump_and_squash.rst
+++ b/getting_started/first_3d_game/06.jump_and_squash.rst
@@ -243,10 +243,6 @@ With this code, if no collisions occurred on a given frame, the loop won't run.
             # We get one of the collisions with the player
             var collision = get_slide_collision(index)
 
-            # If the collision is with ground
-            if collision.get_collider() == null:
-                continue
-
             # If the collider is with a mob
             if collision.get_collider().is_in_group("mob"):
                 var mob = collision.get_collider()


### PR DESCRIPTION
```
            if collision.get_collider() == null:
                continue
```

This line of code is not needed and is confusing to the reader. When the player collides with the ground, the collision object will be the ground itself. The code above is checking if the collision object is null, which it never will be.

I spent some time trying to figure out why the floor (a StaticBody3d node) would return null when colliding with the player. After adding some logging I discovered that collision.get_collider() was returning an object when colliding with the floor and not null and this if statement was never being executed!

This line of code is actually not in the c# version of the script.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
