### PR TITLE
Slight polish at enum example

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1236,10 +1236,10 @@ a dictionary can also be used with a named enum.
     func _ready():
         # Access values with Name.KEY, prints '5'
         print(State.STATE_JUMP)
-        # Use constant dictionary functions
+        # Use dictionary methods:
         # prints '["STATE_IDLE", "STATE_JUMP", "STATE_SHOOT"]'
         print(State.keys())
-        # prints '["STATE_IDLE", "STATE_JUMP", "STATE_SHOOT"]'
+        # prints '{ "STATE_IDLE": 0, "STATE_JUMP": 5, "STATE_SHOOT": 6 }'
         print(State)
         # prints '[0, 5, 6]'
         print(State.values())


### PR DESCRIPTION
@timothyqiu detected a wrong comment output in https://github.com/godotengine/godot-docs/pull/8599#discussion_r1423315602

I also noticed ` STATE_SHOOT` of the enum is 6 at const but not at enum, also fixed. Made it 7 instead of 5, so it's obvious that the user can step and it's not in i++ order