### PR TITLE
Removed reference to 'DEPTH' in CanvasItem shaders

### DIFF
--- a/tutorials/shaders/shader_reference/canvas_item_shader.rst
+++ b/tutorials/shaders/shader_reference/canvas_item_shader.rst
@@ -159,7 +159,7 @@ it to the ``NORMALMAP`` property. Godot will handle converting it for use in 2D 
 | Built-in                                    | Description                                                   |
 +=============================================+===============================================================+
 | in vec4 **FRAGCOORD**                       | Coordinate of pixel center. In screen space. ``xy`` specifies |
-|                                             | position in window.                                           |
+|                                             | position in window. Origin is lower-left.                     |
 +---------------------------------------------+---------------------------------------------------------------+
 | in vec2 **SCREEN_PIXEL_SIZE**               | Size of individual pixels. Equal to inverse of resolution.    |
 +---------------------------------------------+---------------------------------------------------------------+
@@ -232,7 +232,7 @@ Below is an example of a light shader that takes a CanvasItem's normal map into 
 | Built-in                         | Description                                                                  |
 +==================================+==============================================================================+
 | in vec4 **FRAGCOORD**            | Coordinate of pixel center. In screen space. ``xy`` specifies                |
-|                                  | position in window.                                                          |
+|                                  | position in window. Origin is lower-left.                                    |
 +----------------------------------+------------------------------------------------------------------------------+
 | in vec3 **NORMAL**               | Input Normal.                                                                |
 +----------------------------------+------------------------------------------------------------------------------+

--- a/tutorials/shaders/shader_reference/canvas_item_shader.rst
+++ b/tutorials/shaders/shader_reference/canvas_item_shader.rst
@@ -159,8 +159,7 @@ it to the ``NORMALMAP`` property. Godot will handle converting it for use in 2D 
 | Built-in                                    | Description                                                   |
 +=============================================+===============================================================+
 | in vec4 **FRAGCOORD**                       | Coordinate of pixel center. In screen space. ``xy`` specifies |
-|                                             | position in window, ``z`` specifies fragment depth if         |
-|                                             | ``DEPTH`` is not used. Origin is lower-left.                  |
+|                                             | position in window.                                           |
 +---------------------------------------------+---------------------------------------------------------------+
 | in vec2 **SCREEN_PIXEL_SIZE**               | Size of individual pixels. Equal to inverse of resolution.    |
 +---------------------------------------------+---------------------------------------------------------------+
@@ -233,8 +232,7 @@ Below is an example of a light shader that takes a CanvasItem's normal map into 
 | Built-in                         | Description                                                                  |
 +==================================+==============================================================================+
 | in vec4 **FRAGCOORD**            | Coordinate of pixel center. In screen space. ``xy`` specifies                |
-|                                  | position in window, ``z`` specifies fragment depth if                        |
-|                                  | ``DEPTH`` is not used. Origin is lower-left.                                 |
+|                                  | position in window.                                                          |
 +----------------------------------+------------------------------------------------------------------------------+
 | in vec3 **NORMAL**               | Input Normal.                                                                |
 +----------------------------------+------------------------------------------------------------------------------+


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Removed references to a 'DEPTH' constant that doesn't exist and unused 'z' coordinates from the CanvasItem shader page, as brought up by issue #8541. 