### PR TITLE
Change libpath in binding_to_external_libraries.rst

### DIFF
--- a/contributing/development/core_and_modules/binding_to_external_libraries.rst
+++ b/contributing/development/core_and_modules/binding_to_external_libraries.rst
@@ -172,7 +172,7 @@ environment's paths:
     # This is a path relative to /modules/tts/ where your .a libraries reside.
     # If you are compiling the module externally (not in the godot source tree),
     # these will need to be full paths.
-    env.Append(LIBPATH=['libpath'])
+    env.Append(LIBPATH=[Dir('libpath').abspath])
 
     # Check with the documentation of the external library to see which library
     # files should be included/linked.

--- a/contributing/development/core_and_modules/binding_to_external_libraries.rst
+++ b/contributing/development/core_and_modules/binding_to_external_libraries.rst
@@ -169,9 +169,9 @@ environment's paths:
     # LIBPATH and LIBS need to be set on the real "env" (not the clone)
     # to link the specified libraries to the Godot executable.
 
-    # This is a path relative to /modules/tts/ where your .a libraries reside.
-    # If you are compiling the module externally (not in the godot source tree),
-    # these will need to be full paths.
+    # This is an absolute path where your .a libraries reside.
+    # If using a relative path, you must convert it to a
+    # full path using an utility function, such as `Dir('...').abspath`.
     env.Append(LIBPATH=[Dir('libpath').abspath])
 
     # Check with the documentation of the external library to see which library


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
Changed based in this issue:
https://github.com/godotengine/godot/issues/85951 

