### PR TITLE
Specify POT Generation is only available for GDScript files

### DIFF
--- a/tutorials/i18n/localization_using_gettext.rst
+++ b/tutorials/i18n/localization_using_gettext.rst
@@ -59,7 +59,7 @@ Automatic generation using the editor
 -------------------------------------
 
 Since Godot 4.0, the editor can generate a PO template automatically from
-specified scene and script files. This POT generation also supports translation
+specified scene and GDScript files. This POT generation also supports translation
 contexts and pluralization if used in a script, with the optional second
 argument of ``tr()`` and the ``tr_n()`` method.
 


### PR DESCRIPTION
POT Generation currently doesn't support C# scripts, which was unexpected as the docs seemed to make it a given. This small change fixes that.