### PR TITLE
Clarify that EditorScript can only run using the internal script editor

### DIFF
--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -505,8 +505,8 @@ Scripts that extend EditorScript must be ``@tool`` scripts to function.
 
 .. note::
 
-    If you are using an external editor, open the script inside the Godot
-    script editor so you can execute the function.
+    EditorScripts can only be run from the Godot script editor. If you are using
+    an external editor, open the script inside the Godot script editor to run it.
 
 .. danger::
 

--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -503,6 +503,11 @@ currently focused on the script editor.
 
 Scripts that extend EditorScript must be ``@tool`` scripts to function.
 
+.. note::
+
+    If you are using an external editor, open the script inside the Godot
+    script editor so you can execute the function.
+
 .. danger::
 
     EditorScripts have no undo/redo functionality, so **make sure to save your


### PR DESCRIPTION
Unless there's some hidden functionality somewhere, the docs state incorrectly that you can run an C# EditorScript even though there is no File > Run for C# scripts.

Edit: found that both C# and GDScript scripts can run, but only using the internal editor. This PR adds a note about that to the docs.