### PR TITLE
Added xcode-select fix to iOS export page

### DIFF
--- a/tutorials/export/exporting_for_ios.rst
+++ b/tutorials/export/exporting_for_ios.rst
@@ -128,3 +128,36 @@ the export menu.
      - ``GODOT_IOS_PROVISIONING_PROFILE_UUID_DEBUG``
    * - Options / Application / Provisioning Profile UUID Release
      - ``GODOT_IOS_PROVISIONING_PROFILE_UUID_RELEASE``
+
+Troubleshooting
+---------------
+
+xcode-select points at wrong SDK location
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+xcode-select is a tool that comes with XCode and among other things points at iOS development SDKs on your mac.
+If you have Xcode installed, opened it, agreed to the license agreement, and installed the command line tools, 
+xcode-select should point at the right location for the iPhone SDK. 
+If it somehow doesn't, Godot will fail exporting to iOS with an error that may look like this:
+
+::
+
+    MSB3073: The command ""clang" <LOTS OF PATHS AND COMMAND LINE ARGUMENTS HERE>
+    "/Library/Developer/CommandLineTools/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk"" exited with code 1.
+
+In this case, Godot is trying to find the ``Platforms`` folder containing the iPhone SDK inside the 
+``/Library/Developer/CommandLineTools/`` folder, but the ``Platforms`` folder with the iPhone SDK is 
+actually located under ``/Applications/Xcode.app/Contents/Developer``. To verify this, you can open 
+up Terminal and run the following command to see what xcode-select points at:
+
+::
+
+    xcode-select -p
+
+To fix xcode-select pointing at a wrong location, enter this command in Terminal:
+
+::
+
+    sudo xcode-select -switch /Applications/Xcode.app
+
+After running this command, Godot should be able to successfully export to iOS.

--- a/tutorials/export/exporting_for_ios.rst
+++ b/tutorials/export/exporting_for_ios.rst
@@ -135,7 +135,7 @@ Troubleshooting
 xcode-select points at wrong SDK location
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-xcode-select is a tool that comes with XCode and among other things points at iOS development SDKs on your mac.
+xcode-select is a tool that comes with Xcode and among other things points at iOS SDKs on your Mac.
 If you have Xcode installed, opened it, agreed to the license agreement, and installed the command line tools, 
 xcode-select should point at the right location for the iPhone SDK. 
 If it somehow doesn't, Godot will fail exporting to iOS with an error that may look like this:


### PR DESCRIPTION
This PR adds a troubleshooting section to the export to iOS page, and a section about a iPhone SDK path error with a relatively simple fix.