### PR TITLE
Fix UV mapping in ArrayMesh tutorial

### DIFF
--- a/tutorials/3d/procedural_geometry/arraymesh.rst
+++ b/tutorials/3d/procedural_geometry/arraymesh.rst
@@ -265,7 +265,7 @@ that you find online.
             var y = cos(PI * v)
 
             # Loop over segments in ring.
-            for j in range(radial_segments):
+            for j in range(radial_segments + 1):
                 var u = float(j) / radial_segments
                 var x = sin(u * PI * 2.0)
                 var z = cos(u * PI * 2.0)
@@ -284,15 +284,6 @@ that you find online.
                     indices.append(prevrow + j)
                     indices.append(thisrow + j)
                     indices.append(thisrow + j - 1)
-
-            if i > 0:
-                indices.append(prevrow + radial_segments - 1)
-                indices.append(prevrow)
-                indices.append(thisrow + radial_segments - 1)
-
-                indices.append(prevrow)
-                indices.append(prevrow + radial_segments)
-                indices.append(thisrow + radial_segments - 1)
 
             prevrow = thisrow
             thisrow = point
@@ -324,7 +315,7 @@ that you find online.
                 var y = Mathf.Cos(Mathf.Pi * v);
 
                 // Loop over segments in ring.
-                for (var j = 0; j < _radialSegments; j++)
+                for (var j = 0; j < _radialSegments + 1; j++)
                 {
                     var u = ((float)j) / _radialSegments;
                     var x = Mathf.Sin(u * Mathf.Pi * 2);
@@ -346,17 +337,6 @@ that you find online.
                         indices.Add(thisRow + j);
                         indices.Add(thisRow + j - 1);
                     }
-                }
-
-                if (i > 0)
-                {
-                    indices.Add(prevRow + _radialSegments - 1);
-                    indices.Add(prevRow);
-                    indices.Add(thisRow + _radialSegments - 1);
-
-                    indices.Add(prevRow);
-                    indices.Add(prevRow + _radialSegments);
-                    indices.Add(thisRow + _radialSegments - 1);
                 }
 
                 prevRow = thisRow;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
This pull request addresses an issue with UV mapping in the [sample code provided in the Godot Documentation](https://docs.godotengine.org/en/stable/tutorials/3d/procedural_geometry/arraymesh.html#generating-geometry) for creating a procedural mesh. The original code resulted in a UV mapping discrepancy, which has been corrected in this update.

**Problem**: The last radial segment didn't have correct UV mapping.

**Solution**: Created dummy vertices for the last segment of the sphere, and used those to generate correct UV mapping.

![MeshGenerationTest](https://github.com/godotengine/godot-docs/assets/107340417/76a5166c-d9b4-4b6b-9259-c28f8192d7ae)

To test it yourself, you can download this project:
[MeshGenerationTest.zip](https://github.com/godotengine/godot-docs/files/13697722/MeshGenerationTest.zip)
