### PR TITLE
Document limit of VoxelGI and LightmapGI instances that can be rendered

### DIFF
--- a/tutorials/3d/global_illumination/using_lightmap_gi.rst
+++ b/tutorials/3d/global_illumination/using_lightmap_gi.rst
@@ -381,7 +381,6 @@ imported 3D scenes will also speed up baking significantly. However, this will
 require you to reimport all lightmapped 3D scenes before you can bake lightmaps
 again.
 
-
 .. _doc_using_lightmap_gi_denoising:
 
 Denoising
@@ -527,3 +526,12 @@ in Base64.
     The generated EXR file can be viewed and even edited using an image editor
     to perform post-processing if needed. However, keep in mind that changes to
     the EXR file will be lost when baking lightmaps again.
+
+Reducing LightmapGI artifacts
+-----------------------------
+
+If you notice LightmapGI nodes popping in and out of existence as the camera
+moves, this is most likely because the engine is rendering too many LightmapGI
+instances at once. Godot is limited to rendering 8 LightmapGI nodes at once,
+which means up to 8 instances can be in the camera view before some of them will
+start flickering.

--- a/tutorials/3d/global_illumination/using_voxel_gi.rst
+++ b/tutorials/3d/global_illumination/using_voxel_gi.rst
@@ -193,3 +193,14 @@ in your level geometry. This can be remedied in several ways:
 - To combat artifacts that can appear on reflective surfaces, try increasing
   **Bias** and/or **Normal Bias** in the VoxelGIData resource as described above.
   Do not increase these values too high, or light leaking will become more pronounced.
+
+If you notice VoxelGI nodes popping in and out of existence as the camera moves,
+this is most likely because the engine is rendering too many VoxelGI instances
+at once. Godot is limited to rendering 8 VoxelGI nodes at once, which means up
+to 8 instances can be in the camera view before some of them will start
+flickering.
+
+Additionally, for performance reasons, Godot can only blend between 2 VoxelGI
+nodes at a given pixel on the screen. If you have more than 2 VoxelGI nodes
+overlapping, global illumination may appear to flicker as the camera moves or
+rotates.


### PR DESCRIPTION
- This closes https://github.com/godotengine/godot/issues/80361 and https://github.com/godotengine/godot/issues/85630.
