### PR TITLE
Update export template docs to use Godot 4.x target names

### DIFF
--- a/contributing/development/compiling/compiling_for_ios.rst
+++ b/contributing/development/compiling/compiling_for_ios.rst
@@ -78,11 +78,11 @@ should be placed in ``libgodot.ios.debug.xcframework`` and ``libgodot.ios.releas
 
     $ cp -r misc/dist/ios_xcode .
 
-    $ cp libgodot.ios.debug.arm64.a ios_xcode/libgodot.ios.debug.xcframework/ios-arm64/libgodot.a
-    $ lipo -create libgodot.ios.debug.arm64.simulator.a libgodot.ios.debug.x86_64.simulator.a -output ios_xcode/libgodot.ios.debug.xcframework/ios-arm64_x86_64-simulator/libgodot.a
+    $ cp libgodot.ios.template_debug.arm64.a ios_xcode/libgodot.ios.debug.xcframework/ios-arm64/libgodot.a
+    $ lipo -create libgodot.ios.template_debug.arm64.simulator.a libgodot.ios.template_debug.x86_64.simulator.a -output ios_xcode/libgodot.ios.debug.xcframework/ios-arm64_x86_64-simulator/libgodot.a
 
-    $ cp libgodot.ios.opt.arm64.a ios_xcode/libgodot.ios.release.xcframework/ios-arm64/libgodot.a
-    $ lipo -create libgodot.ios.opt.arm64.simulator.a libgodot.ios.opt.x86_64.simulator.a -output ios_xcode/libgodot.ios.release.xcframework/ios-arm64_x86_64-simulator/libgodot.a
+    $ cp libgodot.ios.template_release.arm64.a ios_xcode/libgodot.ios.release.xcframework/ios-arm64/libgodot.a
+    $ lipo -create libgodot.ios.template_release.arm64.simulator.a libgodot.ios.template_release.x86_64.simulator.a -output ios_xcode/libgodot.ios.release.xcframework/ios-arm64_x86_64-simulator/libgodot.a
 
 The MoltenVK static ``.xcframework`` folder must also be placed in the ``ios_xcode``
 folder once it has been created.

--- a/contributing/development/compiling/compiling_for_macos.rst
+++ b/contributing/development/compiling/compiling_for_macos.rst
@@ -128,7 +128,7 @@ of those two architectures by leaving out the ``lipo`` step below.
     scons platform=macos target=template_release arch=x86_64
     scons platform=macos target=template_debug arch=x86_64
 
-- For ARM64 (Apple M1)::
+- For Arm64 (Apple M1)::
 
     scons platform=macos target=template_release arch=arm64
     scons platform=macos target=template_debug arch=arm64
@@ -136,20 +136,20 @@ of those two architectures by leaving out the ``lipo`` step below.
 To support both architectures in a single "Universal 2" binary, run the above
 two commands blocks and then use ``lipo`` to bundle them together::
 
-    lipo -create bin/godot.macos.opt.x86_64 bin/godot.macos.opt.arm64 -output bin/godot.macos.opt.universal
-    lipo -create bin/godot.macos.opt.debug.x86_64 bin/godot.macos.opt.debug.arm64 -output bin/godot.macos.opt.debug.universal
+    lipo -create bin/godot.macos.template_release.x86_64 bin/godot.macos.template_release.arm64 -output bin/godot.macos.template_release.universal
+    lipo -create bin/godot.macos.template_debug.x86_64 bin/godot.macos.template_debug.arm64 -output bin/godot.macos.template_debug.universal
 
 To create an ``.app`` bundle like in the official builds, you need to use the
 template located in ``misc/dist/macos_template.app``. The release and debug
 builds should be placed in ``macos_template.app/Contents/MacOS`` with the names
-``godot_macos_release.64`` and ``godot_macos_debug.64`` respectively. You can do so
+``godot_macos_release.universal`` and ``godot_macos_debug.universal`` respectively. You can do so
 with the following commands (assuming a universal build, otherwise replace the
 ``.universal`` extension with the one of your arch-specific binaries)::
 
     cp -r misc/dist/macos_template.app .
     mkdir -p macos_template.app/Contents/MacOS
-    cp bin/godot.macos.opt.universal macos_template.app/Contents/MacOS/godot_macos_release.64
-    cp bin/godot.macos.opt.debug.universal macos_template.app/Contents/MacOS/godot_macos_debug.64
+    cp bin/godot.macos.template_release.universal macos_template.app/Contents/MacOS/godot_macos_release.universal
+    cp bin/godot.macos.template_debug.universal macos_template.app/Contents/MacOS/godot_macos_debug.universal
     chmod +x macos_template.app/Contents/MacOS/godot_macos*
 
 .. note::

--- a/contributing/development/compiling/compiling_for_web.rst
+++ b/contributing/development/compiling/compiling_for_web.rst
@@ -49,17 +49,17 @@ enabled. Since ``eval()`` calls can be a security concern, the
 
 The engine will now be compiled to WebAssembly by Emscripten. Once finished,
 the resulting file will be placed in the ``bin`` subdirectory. Its name is
-``godot.web.opt.wasm32.zip`` for release or ``godot.web.opt.debug.wasm32.zip``
+``godot.web.template_release.wasm32.zip`` for release or ``godot.web.template_debug.wasm32.zip``
 for debug.
 
 Finally, rename the zip archive to ``web_release.zip`` for the
 release template::
 
-    mv bin/godot.web.opt.wasm32.zip bin/web_release.zip
+    mv bin/godot.web.template_release.wasm32.zip bin/web_release.zip
 
 And ``web_debug.zip`` for the debug template::
 
-    mv bin/godot.web.opt.debug.wasm32.zip bin/web_debug.zip
+    mv bin/godot.web.template_debug.wasm32.zip bin/web_debug.zip
 
 GDExtension
 -----------
@@ -80,8 +80,8 @@ Its name will have ``_dlink`` added.
 Finally, rename the zip archives to ``web_dlink_release.zip`` and
 ``web_dlink_release.zip`` for the release template::
 
-    mv bin/godot.web.opt.wasm32.dlink.zip bin/web_dlink_release.zip
-    mv bin/godot.web.opt.debug.wasm32.dlink.zip bin/web_dlink_debug.zip
+    mv bin/godot.web.template_release.wasm32.dlink.zip bin/web_dlink_release.zip
+    mv bin/godot.web.template_debug.wasm32.dlink.zip bin/web_dlink_debug.zip
 
 Building the editor
 -------------------
@@ -93,7 +93,7 @@ over the native build. You can build the editor with::
     scons platform=web target=editor
 
 Once finished, the resulting file will be placed in the ``bin`` subdirectory.
-Its name will be ``godot.web.opt.tools.wasm32.zip``. You can upload the
+Its name will be ``godot.web.editor.wasm32.zip``. You can upload the
 zip content to your web server and visit it with your browser to use the editor.
 
 Refer to the :ref:`export page <doc_javascript_export_options>` for the web


### PR DESCRIPTION
The compile template target docs for web, macOS, and iOS were still using the Godot 3.x names (opt/debug/tools) instead of the Godot 4.x names (target_release/target_debug/editor). This PR updates them. I have tested compiling macOS and iOS and tested exporting from macOS to verify those but compiling for web fails for me.