### PR TITLE
Fix Windows build command highlighting.

### DIFF
--- a/contributing/development/compiling/compiling_for_windows.rst
+++ b/contributing/development/compiling/compiling_for_windows.rst
@@ -132,7 +132,9 @@ Running SCons
 ~~~~~~~~~~~~~
 
 After opening a command prompt, change to the root directory of
-the engine source code (using ``cd``) and type::
+the engine source code (using ``cd``) and type:
+
+.. code-block:: doscon
 
     C:\godot> scons platform=windows
 
@@ -215,11 +217,15 @@ Optionally, you can compile with the following for additional features:
           developer mode in Windows; otherwise it won't be used.
 
 When building Godot, you will need to tell SCons to use Direct3D 12 and where to
-look for the additional libraries::
-    
+look for the additional libraries:
+
+.. code-block:: doscon
+
     C:\godot> scons platform=windows d3d12=yes dxc_path=<...> mesa_libs=<...> 
     
-Or, with all options enabled::
+Or, with all options enabled:
+
+.. code-block:: doscon
 
     C:\godot> scons platform=windows d3d12=yes dxc_path=<...> mesa_libs=<...> agility_sdk_path=<...> pix_path=<...>
 
@@ -382,7 +388,9 @@ Creating Windows export templates
 ---------------------------------
 
 Windows export templates are created by compiling Godot without the editor,
-with the following flags::
+with the following flags:
+
+.. code-block:: doscon
 
     C:\godot> scons platform=windows target=template_debug arch=x86_32
     C:\godot> scons platform=windows target=template_release arch=x86_32
@@ -391,7 +399,9 @@ with the following flags::
 
 If you plan on replacing the standard export templates, copy these to the
 following location, replacing ``<version>`` with the version identifier
-(such as ``3.1.1.stable`` or ``3.2.dev``)::
+(such as ``3.1.1.stable`` or ``3.2.dev``):
+
+.. code-block:: none
 
     %USERPROFILE%\AppData\Roaming\Godot\templates\<version>\
 

--- a/contributing/development/compiling/introduction_to_the_buildsystem.rst
+++ b/contributing/development/compiling/introduction_to_the_buildsystem.rst
@@ -93,7 +93,9 @@ generally with this naming convention::
 
     godot.<platform>.<target>[.dev][.double].<arch>[.<extra_suffix>][.<ext>]
 
-For the previous build attempt, the result would look like this::
+For the previous build attempt, the result would look like this:
+
+.. code-block:: console
 
     ls bin
     bin/godot.linuxbsd.editor.x86_64
@@ -103,7 +105,7 @@ whole editor compiled in, and is meant for 64 bits.
 
 A Windows binary with the same configuration will look like this:
 
-.. code-block:: console
+.. code-block:: doscon
 
     C:\godot> dir bin/
     godot.windows.editor.64.exe


### PR DESCRIPTION
Fixes highlighting:

| Before | After |
| -- | -- |
| <img width="852" alt="Screenshot 2023-12-21 at 21 34 20" src="https://github.com/godotengine/godot-docs/assets/7645683/f160a1a1-a5b1-4a30-abd8-aec36fc721ee"> | <img width="852" alt="Screenshot 2023-12-21 at 21 34 31" src="https://github.com/godotengine/godot-docs/assets/7645683/f098a73e-2191-45ce-a485-b1199fe5db47"> |
