### PR TITLE
Remove out of date warning from version_control_systems.rst

### DIFF
--- a/tutorials/best_practices/version_control_systems.rst
+++ b/tutorials/best_practices/version_control_systems.rst
@@ -21,11 +21,6 @@ create additional VCS plugins.
 Official Git plugin
 ^^^^^^^^^^^^^^^^^^^
 
-.. warning::
-
-    As of July 2023, the Git plugin hasn't been updated to work with Godot 4.1
-    and later yet.
-
 Using Git from inside the editor is supported with an official plugin.
 You can find the latest releases on
 `GitHub <https://github.com/godotengine/godot-git-plugin/releases>`__.


### PR DESCRIPTION
Plugin has now been updated to work with Godot versions 4.1 and above.
Although this was removed from the master branch, it still appears in the stable branch (4.2 docs), which can potentially confuse people as the stable branch page is the main page that is indexed by Google.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
