### PR TITLE
Fixed typo in pr_workflow.rst

### DIFF
--- a/contributing/workflow/pr_workflow.rst
+++ b/contributing/workflow/pr_workflow.rst
@@ -436,7 +436,7 @@ The interactive rebase
 
 If you didn't follow the above steps closely to *amend* changes into a commit
 instead of creating fixup commits, or if you authored your changes without being
-aware of our workflow and Git usage tips, reviewers might request of you to
+aware of our workflow and Git usage tips, reviewers might request you to
 *rebase* your branch to *squash* some or all of the commits into one.
 
 Indeed, if some commits have been made following reviews to fix bugs, typos, etc.

--- a/contributing/workflow/pr_workflow.rst
+++ b/contributing/workflow/pr_workflow.rst
@@ -436,7 +436,7 @@ The interactive rebase
 
 If you didn't follow the above steps closely to *amend* changes into a commit
 instead of creating fixup commits, or if you authored your changes without being
-aware of our workflow and Git usage tips, reviewers might request of your to
+aware of our workflow and Git usage tips, reviewers might request of you to
 *rebase* your branch to *squash* some or all of the commits into one.
 
 Indeed, if some commits have been made following reviews to fix bugs, typos, etc.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
