### PR TITLE
Update OS to Time on pages containing OS.get_ticks_usec()

### DIFF
--- a/contributing/development/core_and_modules/common_engine_methods_and_macros.rst
+++ b/contributing/development/core_and_modules/common_engine_methods_and_macros.rst
@@ -137,11 +137,11 @@ use this snippet:
 
 .. code-block:: cpp
 
-    uint64_t begin = OS::get_singleton()->get_ticks_usec();
+    uint64_t begin = Time::get_singleton()->get_ticks_usec();
 
     // Your code here...
 
-    uint64_t end = OS::get_singleton()->get_ticks_usec();
+    uint64_t end = Time::get_singleton()->get_ticks_usec();
     print_line(vformat("Snippet took %d microseconds", end - begin));
 
 This will print the time spent between the ``begin`` declaration and the ``end``

--- a/tutorials/performance/cpu_optimization.rst
+++ b/tutorials/performance/cpu_optimization.rst
@@ -94,12 +94,12 @@ the following:
 
 ::
 
-    var time_start = OS.get_ticks_usec()
+    var time_start = Time.get_ticks_usec()
 
     # Your function you want to time
     update_enemies()
 
-    var time_end = OS.get_ticks_usec()
+    var time_end = Time.get_ticks_usec()
     print("update_enemies() took %d microseconds" % time_end - time_start)
 
 When manually timing functions, it is usually a good idea to run the function


### PR DESCRIPTION
This pull request updates the example code snippets on the _CPU Optimization_ and _Common Engine Methods and Macros_ pages. get_ticks_usec() has been part of the Time singleton since 4.0.

This is a recreation of #8679 with a clean history.

I also double checked for other references in the docs to either _get_ticks_usec_ or _get_ticks_msec_ but I did not find any other errors.