### PR TITLE
changed "class_name" with actual GDScript keyword "class" in the example

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -37,7 +37,7 @@ here's an example of how GDScript looks.
     @icon("res://path/to/optional/icon.svg")
 
     # (optional) class definition:
-    class_name MyClass
+    class MyClass
 
     # Inheritance:
     extends BaseClass


### PR DESCRIPTION
right now example contain "class_name" which create confusion in readers, it should be "class" keyword instead.