### PR TITLE
Update link to Rust GDExtension bindings

### DIFF
--- a/tutorials/scripting/gdextension/what_is_gdextension.rst
+++ b/tutorials/scripting/gdextension/what_is_gdextension.rst
@@ -97,7 +97,7 @@ The bindings below are developed and maintained by the community:
 
 - `D <https://github.com/godot-dlang/godot-dlang>`__
 - `Haxe <https://hxgodot.github.io/>`__
-- `Rust <https://github.com/godot-rust/gdextension>`__
+- `Rust <https://github.com/godot-rust/gdext>`__
 - `Swift <https://github.com/migueldeicaza/SwiftGodot>`__
 
 .. note::


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
Hello,

The old link to the gdext[^1] bindings simply redirects to the new one, so I've updated the link in the docs to just point directly to the new link. I've confirmed this change with @bromeon (maintainer of the bindings).

[^1]: https://github.com/godot-rust/gdext