### PR TITLE
Adding missing MacOS commands

### DIFF
--- a/getting_started/step_by_step/instancing.rst
+++ b/getting_started/step_by_step/instancing.rst
@@ -128,7 +128,7 @@ and pressing :kbd:`Enter`.
 
 .. image:: img/instancing_property_bounce_updated.webp
 
-Play the game by pressing :kbd:`F5` and notice how all balls now bounce a lot
+Play the game by pressing :kbd:`F5` (:kbd:`Cmd + B` on macOS) and notice how all balls now bounce a lot
 more. As the Ball scene is a template for all instances, modifying it and saving
 causes all instances to update accordingly.
 


### PR DESCRIPTION
Singular instance of the the F5 build command not having it's corresponding MacOS shortcut equivalent.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
