### PR TITLE
Update 05.spawning_mobs.rst (typo regarding 'respectively')

### DIFF
--- a/getting_started/first_3d_game/05.spawning_mobs.rst
+++ b/getting_started/first_3d_game/05.spawning_mobs.rst
@@ -145,8 +145,8 @@ Your path should look like this.
 |image18|
 
 To sample random positions on it, we need a :ref:`PathFollow3D <class_PathFollow3D>` node. Add a
-:ref:`PathFollow3D <class_PathFollow3D>` as a child of the ``Path3D``. Rename the two nodes to ``SpawnPath`` and
-``SpawnLocation``, respectively. It's more descriptive of what we'll use them for.
+:ref:`PathFollow3D <class_PathFollow3D>` as a child of the ``Path3D``. Rename the two nodes to ``SpawnLocation`` and
+``SpawnPath``, respectively. It's more descriptive of what we'll use them for.
 
 |image19|
 


### PR DESCRIPTION
The order of mentioned nodes (SpawnPath and SpawnLocation) does not match the previous sentence when using "respectively". The following image confirms the order may be backwards.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
