### PR TITLE
Update spatial_shader.rst to mention godot use the same VIEW vector for both perspective and orthogonal cameras.

### DIFF
--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -253,7 +253,8 @@ these properties, and if you don't write to them, Godot will optimize away the c
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
 | in bool **FRONT_FACING**               | ``true`` if current face if front face.                                                          |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
-| in vec3 **VIEW**                       | Normalized vector from fragment position to camera (in view space).                              |
+| in vec3 **VIEW**                       | Normalized vector from fragment position to camera (in view space). This is the same for both    |
+|                                        | perspective and orthogonal cameras.                                                              |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
 | in vec2 **UV**                         | UV that comes from vertex function.                                                              |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
As mentioned in https://github.com/godotengine/godot/issues/68881 , we can update the doc for now.

I will take a look whether it's convient to change the VIEW vector to vec3(0, 0, 1) for orthogonal cameras later.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
