### PR TITLE
Reorder instructions in 06.heads_up_display.rst

### DIFF
--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -184,8 +184,8 @@ Add the code below to ``HUD`` to update the score
         GetNode<Label>("ScoreLabel").Text = score.ToString();
     }
 
-Connect the ``timeout()`` signal of ``MessageTimer`` and the ``pressed()``
-signal of ``StartButton``, and add the following code to the new functions:
+Connect the ``pressed()`` signal of ``StartButton`` and the ``timeout()``
+signal of ``MessageTimer``, and add the following code to the new functions:
 
 .. tabs::
  .. code-tab:: gdscript GDScript


### PR DESCRIPTION
I reordered the instructions in the tutorial as the current documentation's sequence — connecting MessageTimer's timeout() followed by StartButton's pressed() — contradicts the code examples, which demonstrate the reverse order.