### PR TITLE
Update "The Main Game Scene" for clarity

### DIFF
--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -288,7 +288,7 @@ You should be able to move the player around, see mobs spawning, and see the
 player disappear when hit by a mob.
 
 When you're sure everything is working, remove the call to ``new_game()`` from
-``_ready()``.
+``_ready()`` and replace it with ``pass``.
 
 What's our game lacking? Some user interface. In the next lesson, we'll add a
 title screen and display the player's score.


### PR DESCRIPTION
Many people have reported having issues connecting HUD's start_game and the main node's new_game() in the next step of this tutorial. This occurred for me because the documentation states that "new_game()" should be removed from the _ready() function, but does not include instructions to add "pass" back (and pass is not left in the example code when "new_game()" is added to the function, so the initial one will not remain). Having the function declaration alone without "pass" breaks all the following functions, preventing new_game() (or any Main functions) from being connected.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
