### PR TITLE
Lambdas need an explicit `return`

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1347,6 +1347,12 @@ Lambda functions can be named for debugging purposes::
     var lambda = func my_lambda(x):
         print(x)
 
+Note that if you want to return a value from a lambda, an explicit ``return``
+is required (you can't omit ``return``)::
+
+    var lambda = func(x): return x ** 2
+    print(lambda.call(2)) # Prints `4`.
+
 Lambda functions capture the local environment. Local variables are passed by value, so they won't be updated in the lambda if changed in the local function::
 
     var x = 42


### PR DESCRIPTION
Extend the documentation so that it is clear that lambdas require an explicit return . 

Also add an according example.

fixes: https://github.com/godotengine/godot-docs/issues/8729

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
