### PR TITLE
Add c# script name note to scripting_first_script.rst

### DIFF
--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -85,6 +85,11 @@ other options set to their default values and click the Create button to create 
 
 .. image:: img/scripting_first_script_attach_node_script.webp
 
+.. note::
+
+    C# script names need to match their class name. In this case, you should name the
+    file ``MySprite2D.cs``.
+
 The Script workspace should appear with your new ``sprite_2d.gd`` file open and
 the following line of code:
 


### PR DESCRIPTION
Adds a short note regarding C# script naming. This is a somewhat common point of confusion for newer users. Please let me know if I should update the wording here to be clearer/more precise.