### PR TITLE
[iOS] Remove mention of Command Line Tools.

### DIFF
--- a/contributing/development/compiling/compiling_for_ios.rst
+++ b/contributing/development/compiling/compiling_for_ios.rst
@@ -15,8 +15,7 @@ Requirements
 
 - `Python 3.6+ <https://www.python.org/downloads/macos/>`_.
 - `SCons 3.0+ <https://scons.org/pages/download.html>`_ build system.
-- `Xcode <https://apps.apple.com/us/app/xcode/id497799835>`_
-  (or the more lightweight Command Line Tools for Xcode).
+- `Xcode <https://apps.apple.com/us/app/xcode/id497799835>`_.
 
 If you are building the ``master`` branch:
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/86944

iOS templates can't be built without full Xcode install, since Command Line Tools does not include the required SDK.