### PR TITLE
Rename SCons command line options for CCFLAGS, etc. to lowercase

### DIFF
--- a/contributing/development/compiling/introduction_to_the_buildsystem.rst
+++ b/contributing/development/compiling/introduction_to_the_buildsystem.rst
@@ -237,7 +237,7 @@ Several compiler optimization levels can be chosen from:
   build times, but the slowest execution times.
 - ``optimize=custom`` *(advanced users only)*: Do not pass optimization
   arguments to the C/C++ compilers. You will have to pass arguments manually
-  using the ``CFLAGS``, ``CCFLAGS`` and ``CXXFLAGS`` SCons options.
+  using the ``cflags``, ``ccflags`` and ``cxxflags`` SCons options.
 
 Architecture
 ------------


### PR DESCRIPTION
Matching the changes in https://github.com/godotengine/godot/pull/86964.

Shouldn't be cherry-picked, depends on the above PR.

---

Since it's the only mention in the docs, and it's for a very niche use case, I chose not to add a prominent warnings about the change of case in 4.3.