### PR TITLE
Update thread_safe_apis.rst to mention don't call certain rendering functions on other threads

### DIFF
--- a/tutorials/performance/thread_safe_apis.rst
+++ b/tutorials/performance/thread_safe_apis.rst
@@ -61,7 +61,7 @@ Note that the Multi-Threaded thread model has several known bugs, so it may not 
 in all scenarios.
 
 You should avoid calling functions involving direct interaction with the GPU on other threads, such as creating new textures
-or modifying and retrieving image data, these can lead to performance stalls because these operations require synchronization 
+or modifying and retrieving image data, these operations can lead to performance stalls because they require synchronization 
 with the :ref:`RenderingServer<class_RenderingServer>`, as data needs to be transmitted to or updated on the GPU.
 
 GDScript arrays, dictionaries

--- a/tutorials/performance/thread_safe_apis.rst
+++ b/tutorials/performance/thread_safe_apis.rst
@@ -60,6 +60,10 @@ To make rendering thread-safe, set the **Rendering > Driver > Thread Model** pro
 Note that the Multi-Threaded thread model has several known bugs, so it may not be usable
 in all scenarios.
 
+You should avoid calling functions involving direct interaction with the GPU on other threads, such as creating new textures
+or modifying and retrieving image data, these can lead to performance stalls because these operations require synchronization 
+with the :ref:`RenderingServer<class_RenderingServer>`, as data needs to be transmitted to or updated on the GPU.
+
 GDScript arrays, dictionaries
 -----------------------------
 


### PR DESCRIPTION
For https://github.com/godotengine/godot/issues/86796

But I bet my writing is not good, feel free to correct me if any.
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
