### PR TITLE
the code written in doc doesn't work

### DIFF
--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -82,7 +82,7 @@ to instance.
 
     extends Node
 
-    @export var mob_scene: PackedScene
+    @export var mob_scene: PackedScene.new()
     var score
 
  .. code-tab:: csharp


### PR DESCRIPTION
must add .new() after PackedScene (main script, line 2) to be able to instantiate it in _on_mob_timer_timeout() function

this solves the following error:
![image](https://github.com/godotengine/godot-docs/assets/80306067/be99c73b-36fe-4047-a553-c42ec3407f14)

OS: ubuntu 22.04.3 LTS, 64-bit
Godot version: 4.2.1.stable
