### PR TITLE
Fix properties' names stretched on mobile

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -766,6 +766,11 @@ html.writer-html5 .rst-content table.docutils th {
 .wy-table-responsive table.wrap-normal th {
     white-space: normal;
 }
+/* Properties' name must not be streched */
+.classref-reftable-group#properties td:nth-child(2),
+.classref-reftable-group#properties th:nth-child(2) {
+    white-space: nowrap;
+}
 
 /* Make sure line blocks don't stretch tables */
 .wy-table-responsive table .line-block {

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -766,7 +766,7 @@ html.writer-html5 .rst-content table.docutils th {
 .wy-table-responsive table.wrap-normal th {
     white-space: normal;
 }
-/* Properties' name must not be streched */
+/* Properties' names must not be streched */
 .classref-reftable-group#properties td:nth-child(2),
 .classref-reftable-group#properties th:nth-child(2) {
     white-space: nowrap;


### PR DESCRIPTION
This is my first contribution to Godot, I hope I did things well 😊

Fix issue https://github.com/godotengine/godot-docs/issues/7504 where properties' names are stretched on mobile.

Before:

<img width="406" alt="CleanShot 2024-01-12 at 12 18 53@2x" src="https://github.com/godotengine/godot-docs/assets/1923206/fff32ef4-5959-4921-839e-226e1ce76837">

After:

<img width="404" alt="CleanShot 2024-01-12 at 12 19 09@2x" src="https://github.com/godotengine/godot-docs/assets/1923206/4aa42e2d-e073-4b2a-9957-f6840bb1f1b9">
