### PR TITLE
Pin sphinxcontrib-applehelp, fix RTD Sphinx build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,6 @@ sphinx-copybutton==0.5.1
 sphinx-notfound-page==0.8.3
 # Adds Open Graph tags in the HTML `<head>` tag.
 sphinxext-opengraph==0.7.5
+
+# This gets pulled in by Sphinx, we need to pin this as higher versions require Sphinx 5.0+.
+sphinxcontrib-applehelp==1.0.4


### PR DESCRIPTION
ReadTheDocs Sphinx builds are currently failing as of 11 hours ago, as the `sphinx` package pulls in `sphinxcontrib-applehelp` automatically, which now requires Sphinx `5.0`+, while we are still on `4.4.0`.

This should fix the build by pinning the last version supporting Sphinx `<5`.