### PR TITLE
Pin sphinx-contrib libraries to pre-5.0 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,10 @@ sphinx-copybutton==0.5.1
 sphinx-notfound-page==0.8.3
 # Adds Open Graph tags in the HTML `<head>` tag.
 sphinxext-opengraph==0.7.5
+
+# These get pulled in by Sphinx, we need to pin these as higher versions require Sphinx 5.0+.
+sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-devhelp==1.0.2


### PR DESCRIPTION
Manual squash and cherrypick of https://github.com/godotengine/godot-docs/pull/8760 and the followup PRs https://github.com/godotengine/godot-docs/pull/8761 and https://github.com/godotengine/godot-docs/pull/8762.

After updates on the side of Sphinx/Sphinx requirements, we need to pin these versions of these requirements that are included by Sphinx as the just published ones depend on Sphinx 5.0+, while we are still on 4.x.

This needs to be cherrypicked to all active branches that are built on ReadTheDocs to ensure builds keep working there.