### PR TITLE
Update recommended VSCode Godot C# extension

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -118,9 +118,8 @@ executable. Now, when you start the debugger in Visual Studio Code, your Godot p
 
 .. note::
 
-    There is also a `C# Tools for Godot <https://marketplace.visualstudio.com/items?itemName=neikeq.godot-csharp-vscode>`__
+    There is also a `Godot .NET Tools <https://marketplace.visualstudio.com/items?itemName=woberg.godot-dotnet-tools>`__
     Visual Studio Code extension, that is meant to make this setup easier and to provide further useful tools.
-    But it is not yet updated to work with Godot 4.
 
 Visual Studio (Windows only)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The VSCode extension that was recommended for setting up C# debugging (https://marketplace.visualstudio.com/items?itemName=neikeq.godot-csharp-vscode) hasn't been updated since 2022. I have found this newer extension that works fine with Godot 4.x (https://marketplace.visualstudio.com/items?itemName=woberg.godot-dotnet-tools)

This is my first time contributing to the documentation. I hope I did everything right!