### PR TITLE
Update c_sharp_differences.rst ToSignal example

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_differences.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_differences.rst
@@ -854,5 +854,8 @@ Example:
 
 .. code-block:: csharp
 
-  await ToSignal(timer, "timeout");
-  GD.Print("After timeout");
+  public async Task SomeFunction()
+  {
+      await ToSignal(timer, Timer.SignalName.Timeout);
+      GD.Print("After timeout");
+  }


### PR DESCRIPTION
This example should use `SignalName` to show the best practice, and in my opinion it should show the `async` method signature for context and as a hint for anyone new to `await`.

The `SceneTreeTimer` example does it this way: https://docs.godotengine.org/en/latest/classes/class_scenetreetimer.html

```cs
public async Task SomeFunction()
{
    GD.Print("Timer started.");
    await ToSignal(GetTree().CreateTimer(1.0f), SceneTreeTimer.SignalName.Timeout);
    GD.Print("Timer ended.");
}
```

Being able to pass a "raw" `StringName` is important for cross-language scripting when you don't have `SignalName` generation, but that detail belongs in the cross-language scripting page.

(From https://github.com/godotengine/godot-docs-user-notes/discussions/7#discussioncomment-8126206)