### PR TITLE
Remove Giscus from search page

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1763,3 +1763,8 @@ p + .classref-constant {
         padding: 3px 5px;
     }
 }
+
+/* Giscus */
+#godot-giscus {
+    margin-bottom: 1em;
+}

--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -238,6 +238,65 @@ const registerSidebarObserver = (function(){
   };
 })();
 
+/**
+ * Registers Giscus if there's an #godot-giscus container.
+ * @returns {void} Nothing.
+ */
+const registerGiscus = function () {
+  const giscusContainer = document.getElementById("godot-giscus");
+  if (giscusContainer == null) {
+    return;
+  }
+
+  const removeGiscusContainer = function() {
+    giscusContainer.remove();
+  };
+
+  const pageNameMetaElement = Array.from(document.head.querySelectorAll("meta")).find((meta) => meta.name === "doc_pagename");
+  if (pageNameMetaElement == null) {
+    removeGiscusContainer();
+    return;
+  }
+
+  const pageNameDenyList = [
+    "search"
+  ];
+  if (pageNameDenyList.includes(pageNameMetaElement.content)) {
+    removeGiscusContainer();
+    return;
+  }
+
+  // Use https://giscus.app/ to regenerate the script tag if needed.
+  // data-term is set to be language-independent and version-independent, so that comments can be centralized for each page.
+  // This increases the likelihood that users will encounter comments on less frequently visited pages.
+  const scriptElement = document.createElement("script");
+  scriptElement.src = "https://giscus.app/client.js";
+  scriptElement.crossOrigin = "anonymous";
+  scriptElement.async = true;
+
+  const dataset = {
+    repo: "godotengine/godot-docs-user-notes",
+    repoId: "R_kgDOKuNx0w",
+    category: "User-contributed notes",
+    categoryId: "DIC_kwDOKuNx084CbANb",
+    mapping: "specific",
+    term: pageNameMetaElement.content,
+    strict: "1",
+    reactionsEnabled: "0",
+    emitMetadata: "0",
+    inputPosition: "bottom",
+    theme: "preferred_color_scheme",
+    lang: "en",
+    loading: "lazy",
+  };
+
+  for (const [key, value] of Object.entries(dataset)) {
+    scriptElement.dataset[key] = value;
+  }
+
+  giscusContainer.append(scriptElement);
+};
+
 $(document).ready(() => {
   // Remove the search match highlights from the page, and adjust the URL in the
   // navigation history.
@@ -425,6 +484,9 @@ $(document).ready(() => {
 
     registerOnScrollEvent(mediaQuery);
   }
+
+  // Giscus
+  registerGiscus();
 });
 
 // Override the default implementation from doctools.js to avoid this behavior.

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -8,6 +8,7 @@
 {% block extrahead -%}
 <meta name="doc_version" content="{{ version }}" />
 <meta name="doc_is_latest" content="{{ godot_is_latest }}" />
+<meta name="doc_pagename" content="{{ pagename }}" />
 {% endblock -%}
 
 {% block linktags -%}
@@ -68,31 +69,13 @@
   {% block body %}{% endblock %}
 
 {% if (not meta or meta.get('allow_comments') != 'False') and godot_show_article_comments %}
-<hr>
-<h2>User-contributed notes</h2>
-<p>
-  <em>Please read the <a href="https://github.com/godotengine/godot-docs-user-notes/discussions/1">User-contributed notes policy</a> before submitting a comment.</em>
-</p>
-{# Use https://giscus.app/ to regenerate the script tag if needed. #}
-{# data-term is set to be language-independent and version-independent, so that comments can be centralized for each page. #}
-{# This increases the likelihood that users will encounter comments on less frequently visited pages. #}
-<script src="https://giscus.app/client.js"
-  data-repo="godotengine/godot-docs-user-notes"
-  data-repo-id="R_kgDOKuNx0w"
-  data-category="User-contributed notes"
-  data-category-id="DIC_kwDOKuNx084CbANb"
-  data-mapping="specific"
-  data-term="{{ pagename }}"
-  data-strict="1"
-  data-reactions-enabled="0"
-  data-emit-metadata="0"
-  data-input-position="bottom"
-  data-theme="preferred_color_scheme"
-  data-lang="en"
-  data-loading="lazy"
-  crossorigin="anonymous"
-  async></script>
-<br>
+<div id="godot-giscus">
+    <hr>
+        <h2>User-contributed notes</h2>
+    <p>
+        <em>Please read the <a href="https://github.com/godotengine/godot-docs-user-notes/discussions/1">User-contributed notes policy</a> before submitting a comment.</em>
+    </p>
+</div>
 {% endif %}
 
 {%- if self.comments()|trim %}


### PR DESCRIPTION
This moves the Giscus insertion logic inside custom.js.

Technically, it could have worked if I would have done this instead:
```
{% if (not meta or meta.get('allow_comments') != 'False') and godot_show_article_comments and pagename != 'search' %}
```
... but it's easier to maintain my way, as we can add easily new pages to ban.