### PR TITLE
Remove sphinx_search.extension

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -61,9 +61,6 @@ ogp_site_name = "Godot Engine documentation"
 if not os.getenv("SPHINX_NO_GDSCRIPT"):
     extensions.append("gdscript")
 
-if not os.getenv("SPHINX_NO_SEARCH"):
-    extensions.append("sphinx_search.extension")
-
 if not os.getenv("SPHINX_NO_DESCRIPTIONS"):
     extensions.append("godot_descriptions")
 


### PR DESCRIPTION
This removes the `sphinx_search.extension` in the 3.3 docs. We already removed this in newer branches (originally when implementing Algolia, see https://github.com/godotengine/godot-docs/pull/4884, which has since been reverted).

This has become necessary due to a [security issue](https://github.com/readthedocs/readthedocs-sphinx-search/security/advisories/GHSA-xgfm-fjx6-62mj) and is also nice for consistency in search UX across different Godot docs versions.

This needs to be cherry-picked to the 3.2 branch as well, which is the only other branch still affected.