### PR TITLE
[3.3] Downgrade Python

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.9"
 
 sphinx:
   configuration: conf.py


### PR DESCRIPTION
Downgrades Python as the Sphinx version we're using on this old branch doesn't support Python 3.10+.