### PR TITLE
[3.3] Pin jinja2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@
 sphinx==3.5.2
 sphinx_rtd_theme==0.5.2
 docutils<0.18
+Jinja2<3.1
 
 # Code tabs extension for GDScript/C#
 # Stay on 1.3.0 until https://github.com/readthedocs/readthedocs-sphinx-search/issues/82 is fixed.


### PR DESCRIPTION
This is needed to fix the 3.3 RTD build, see https://github.com/readthedocs/readthedocs.org/issues/9038
