### PR TITLE
[3.2] Fix ReadTheDocs build and remove sphinx_search.extension

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,9 @@
 version: 2
 
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
 
 sphinx:
   configuration: conf.py

--- a/conf.py
+++ b/conf.py
@@ -61,9 +61,6 @@ ogp_site_name = "Godot Engine documentation"
 if not os.getenv("SPHINX_NO_GDSCRIPT"):
     extensions.append("gdscript")
 
-if not os.getenv("SPHINX_NO_SEARCH"):
-    extensions.append("sphinx_search.extension")
-
 if not os.getenv("SPHINX_NO_DESCRIPTIONS"):
     extensions.append("godot_descriptions")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@
 sphinx==3.5.2
 sphinx_rtd_theme==0.5.2
 docutils<0.18
+Jinja2<3.1
 
 # Code tabs extension for GDScript/C#
 # Stay on 1.3.0 until https://github.com/readthedocs/readthedocs-sphinx-search/issues/82 is fixed.
@@ -19,3 +20,10 @@ sphinxext-opengraph==0.4.2
 
 # Full-page search UI for RTD: https://readthedocs-sphinx-search.readthedocs.io
 readthedocs-sphinx-search==0.1.0
+
+# These get pulled in by Sphinx, we need to pin these as higher versions require Sphinx 5.0+.
+sphinxcontrib-applehelp<=1.0.4
+sphinxcontrib-htmlhelp<=2.0.1
+sphinxcontrib-qthelp<=1.0.3
+sphinxcontrib-serializinghtml<=1.1.5
+sphinxcontrib-devhelp<=1.0.2


### PR DESCRIPTION
Ports https://github.com/godotengine/godot-docs/pull/8784 to 3.2, see that PR for reasoning (and fixes the RTD build, same as https://github.com/godotengine/godot-docs/pull/8785 / https://github.com/godotengine/godot-docs/pull/8786 / https://github.com/godotengine/godot-docs/pull/8787 / https://github.com/godotengine/godot-docs/pull/8788).
