### PR TITLE
Added Queble YouTube link in 'tutorials.rst'

### DIFF
--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -49,6 +49,7 @@ Video tutorials
 - `Clear Code <https://www.youtube.com/watch?v=nAh_Kx5Zh5Q>`_ (2D, GDScript, Programming Basics).
 - `Game Dev Artisan <https://www.youtube.com/@GameDevArtisan>`_ (2D, GDScript).
 - `FencerDevLog <https://www.youtube.com/@FencerDevLog>`_ (2D, 3D, GDScript, Shaders).
+- `Queble <https://www.youtube.com/@queblegamedevelopment4143>`_ (2D, GDScript).
 
 Text tutorials
 --------------


### PR DESCRIPTION
Added my YouTube link to the **Tutorials and resources** page in the docs.
My channel contains mostly basic Godot tutorials and videos.
