### PR TITLE
Update compiling_with_dotnet.rst: clarify NuGet source creation

### DIFF
--- a/contributing/development/compiling/compiling_with_dotnet.rst
+++ b/contributing/development/compiling/compiling_with_dotnet.rst
@@ -100,23 +100,29 @@ distributed as NuGet packages. This is all transparent to the user, but it can
 make things complicated during development.
 
 In order to use Godot with a development version of those packages, a local
-NuGet source must be created where MSBuild can find them. This can be done with
-the .NET CLI:
+NuGet source must be created where MSBuild can find them.
+
+First, pick a location for the local NuGet source. If you don't have a
+preference, create an empty directory at one of these recommended locations:
+
+- On Windows, ``C:\Users\<username>\MyLocalNugetSource``
+- On Linux, \*BSD, etc., ``~/MyLocalNugetSource``
+
+This path is referred to later as ``<my_local_source>``.
+
+After picking a directory, run this .NET CLI command to configure NuGet to use
+your local source:
 
 ::
 
-    dotnet nuget add source ~/MyLocalNugetSource --name MyLocalNugetSource
+    dotnet nuget add source <my_local_source> --name MyLocalNugetSource
 
-The Godot NuGet packages must be added to that local source. Additionally, we
-must make sure there are no other versions of the package in the NuGet cache, as
-MSBuild may pick one of those instead.
-
-In order to simplify this process, the ``build_assemblies.py`` script provides
-the following ``--push-nupkgs-local`` option:
+When you run the ``build_assemblies.py`` script, pass ``<my_local_source>`` to
+the ``--push-nupkgs-local`` option:
 
 ::
 
-    ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir ./bin --push-nupkgs-local ~/MyLocalNugetSource
+    ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir ./bin --push-nupkgs-local <my_local_source>
 
 This option ensures the packages will be added to the specified local NuGet
 source and that conflicting versions of the package are removed from the NuGet
@@ -132,7 +138,7 @@ the ``--precision=double`` argument:
 
 ::
 
-    ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir ./bin --push-nupkgs-local ~/MyLocalNugetSource --precision=double
+    ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir ./bin --push-nupkgs-local <my_local_source> --precision=double
 
 Examples
 --------


### PR DESCRIPTION
Someone building on Windows and unfamiliar with Linuxy paths, in particular `~`, will try to run `dotnet nuget add source ~/MyLocalNugetSource --name MyLocalNugetSource` verbatim, get an error having to do with `~/MyLocalNugetSource`, and not know where to go from there. (This has brought a few people to the C# Discord help channel.)

I think this page deserves to be friendly even though it's focused on engine devs: people come here without being engine devs to e.g. compile the engine with double precision.

I added a little bit of info on how/where to set up the dir depending on OS, and used `<my_local_source>` to refer to the dir. (Similar to using `<godot_binary>` earlier in the doc.)

The paragraph starting with `The Godot NuGet packages must be added to that local source.` seemed to me like it could be confused for something the doc is instructing the dev to do right then and there, and it seems redundant vs. the explanation that's already there a few paragraphs later, so I tried removing it. Maybe the doc isn't as good at convincing the dev to use the `--push-nupkgs-local` arg, but I'm not sure it's necessary to convince them. I like the flow after the removal.