### PR TITLE
Add Go to the list of community maintained GDExtension bindings.

### DIFF
--- a/tutorials/scripting/gdextension/what_is_gdextension.rst
+++ b/tutorials/scripting/gdextension/what_is_gdextension.rst
@@ -96,10 +96,10 @@ The bindings below are developed and maintained by the community:
 .. Please keep languages sorted in alphabetical order.
 
 - `D <https://github.com/godot-dlang/godot-dlang>`__
+- `Go <https://github.com/grow-graphics/gd>`__
 - `Haxe <https://hxgodot.github.io/>`__
 - `Rust <https://github.com/godot-rust/gdext>`__
 - `Swift <https://github.com/migueldeicaza/SwiftGodot>`__
-- `Go <https://github.com/grow-graphics/gd>`__
 
 .. note::
 

--- a/tutorials/scripting/gdextension/what_is_gdextension.rst
+++ b/tutorials/scripting/gdextension/what_is_gdextension.rst
@@ -99,6 +99,7 @@ The bindings below are developed and maintained by the community:
 - `Haxe <https://hxgodot.github.io/>`__
 - `Rust <https://github.com/godot-rust/gdext>`__
 - `Swift <https://github.com/migueldeicaza/SwiftGodot>`__
+- `Go <https://github.com/grow-graphics/gd>`__
 
 .. note::
 


### PR DESCRIPTION
`grow-graphics/gd` is a Go module that exposes Godot via GDExtension, it is being actively developed and is ready for initial use.