### PR TITLE
Re-word 'Comment spacing' note in gdscript_styleguide.rst

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -477,9 +477,9 @@ comments from disabled code.
 
 .. note::
 
-    In the script editor, to toggle the selected code commented, press
-    :kbd:`Ctrl + K`. This feature adds a single ``#`` sign at the start
-    of the selected lines.
+    In the script editor, to toggle commenting of the selected code, press
+    :kbd:`Ctrl + K`. This feature adds/removes a single ``#`` sign before any
+    code on the selected lines.
 
 Whitespace
 ~~~~~~~~~~


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Fixes https://github.com/godotengine/godot-docs/issues/8560
