### PR TITLE
Mention `@GlobalScope` can be omitted in Class reference

### DIFF
--- a/contributing/documentation/class_reference_primer.rst
+++ b/contributing/documentation/class_reference_primer.rst
@@ -132,7 +132,7 @@ Linking
 """""""
 
 Whenever you link to a member of another class, you need to specify the class name.
-For links to the same class, the class name is optional and can be omitted.
+For links to the same class or to :ref:`class_@GlobalScope`, the class name is optional and can be omitted.
 
 +-------------------------------+-----------------------------------------+----------------------------------------------------------------------+
 | Tag and Description           | Example                                 | Result                                                               |


### PR DESCRIPTION
Dipping my toes into modifying this document. I wanted to say more but for now this is a pretty noteworthy thing to mention.