### PR TITLE
Add Seaven Studio to third-party support list and add Godot Foundation link and note

### DIFF
--- a/tutorials/platform/consoles.rst
+++ b/tutorials/platform/consoles.rst
@@ -79,9 +79,11 @@ Following is the list of providers:
   Switch, Xbox One, Playstation 4 & Playstation 5 porting and publishing of Godot games.
 - `Tuanisapps <https://www.tuanisapps.com/>`_ offers
   Switch porting and publishing of Godot games.
+- `Seaven Studio <https://www.seaven-studio.com/>`_ offers
+  Switch, Xbox One, Xbox Series, PlayStation 4 & PlayStation 5 porting of Godot games.
 
 
 If your company offers porting, or porting *and* publishing services for Godot games,
 feel free to
-`open an issue or pull request <https://github.com/godotengine/godot-docs>`_
+`contact the Godot Foundation <https://godot.foundation/#contact>`_
 to add your company to the list above.


### PR DESCRIPTION
- Adds Seaven Studio to third-party support list 
- Changes the contact link to the Godot Foundation

Fixes #8821
Supersedes #7961

![image](https://github.com/godotengine/godot-docs/assets/270928/661c3656-8c26-48b6-9bf8-eceb88895144)

# Edit
- Removed "Adds note that the list is bound to be moved to the Godot Foundation website"