### PR TITLE
Update community tutorials and resources for 4.0+

### DIFF
--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -10,9 +10,7 @@ Think there is something missing here? Feel free to submit a `Pull Request <http
 Where to start
 --------------
 
-The Godot video tutorials by `GDQuest <https://www.youtube.com/channel/UCxboW7x0jZqFdvMdCFKTMsQ/playlists>`_, `Game from Scratch <https://www.youtube.com/watch?v=iDEcP8Mc-7s&list=PLS9MbmO_ssyDk79j9ewONxV88fD5e_o5d>`_ and `KidsCanCode <https://www.youtube.com/channel/UCNaPQ5uLX5iIEHUCLmfAgKg/playlists>`_ are well-regarded in the community and often recommended as a gentle introduction to beginners.
-
-If you're interested in a complete introduction to programming using Godot and GDScript, the unofficial `Godot Tutorials <https://www.youtube.com/channel/UCnr9ojBEQGgwbcKsZC-2rIg>`_ YouTube channel is a good place to start.
+The Godot video tutorials by `GDQuest <https://www.youtube.com/channel/UCxboW7x0jZqFdvMdCFKTMsQ/playlists>`_ are well-regarded in the community and often recommended as a gentle introduction to beginners.
 
 GDQuest's *Learn GDScript From Zero* is a free and open source interactive tutorial for absolute beginners to learn to program with Godot's GDScript language. It is available as a `desktop application <https://gdquest.itch.io/learn-godot-gdscript>`_  or `in the browser <https://gdquest.github.io/learn-gdscript>`_.
 
@@ -21,35 +19,22 @@ Some tutorials mentioned below provide more advanced tutorials, e.g. on 3D or sh
 Video tutorials
 ---------------
 
-- `Godot Tutorials <https://www.youtube.com/channel/UCnr9ojBEQGgwbcKsZC-2rIg>`_ (2D, GDScript, Programming Basics).
-- `Emilio <https://www.youtube.com/channel/UC9DR22-qohBDtZ74R3FxOZg>`_ (2D, GDScript).
-- `FinePointCGI <https://www.youtube.com/channel/UCSojAWUnEUTUcdA9iJ6bryQ>`_ (2D, 3D, GDScript and C#).
-- `GDQuest <https://www.youtube.com/channel/UCxboW7x0jZqFdvMdCFKTMsQ/playlists>`_ (2D and 3D, GDScript and C#).
-- `Game Development Center <https://www.youtube.com/c/GameDevelopmentCenter>`_ (2D, networked multiplayer, GDScript).
-- `Game Endeavor <https://www.youtube.com/channel/UCLweX1UtQjRjj7rs_0XQ2Eg/videos>`_ (2D, GDScript).
-- `Game from Scratch <https://www.youtube.com/watch?v=iDEcP8Mc-7s&list=PLS9MbmO_ssyDk79j9ewONxV88fD5e_o5d>`_ (2D and 3D, GDScript and C#).
-- `HeartBeast <https://www.youtube.com/watch?v=wETY5_9kFtA&list=PL9FzW-m48fn2jlBu_0DRh7PvAt-GULEmd>`_ (2D, GDScript).
-- `KidsCanCode <https://www.youtube.com/channel/UCNaPQ5uLX5iIEHUCLmfAgKg/playlists>`__ (2D and 3D, GDScript).
-- `Mister Taft Creates <https://www.youtube.com/playlist?list=PL4vbr3u7UKWqwQlvwvgNcgDL1p_3hcNn2>`_ (2D, GDScript).
-- `Miziziziz <https://www.youtube.com/playlist?list=PLmugv6_kd0qNyt0WHVnac1f5IFzG-7grN>`_ (2D and 3D, GDScript).
-- `P1X / Krzysztof Jankowski <https://www.youtube.com/playlist?list=PLvDk7UKhld4xGPovdB4IFtAHYMYjx_-3K>`_ (3D).
-- `Pigdev <https://www.youtube.com/playlist?list=PLPMN4vCRFdordS3E-3zi0Hdh7pAsbWQ6a>`_ (2D, GDScript).
-- `Steincodes <https://www.youtube.com/c/steincodes/playlists>`__ (2D, GDScript).
-- `TheBuffED <https://www.youtube.com/watch?v=ygGaN1EOQEA&list=PLvN5Z3tTxXEDfQkt4Frg6ALirespSwZd7>`_ (2D, GDScript).
-- `Code with Tom <https://www.youtube.com/playlist?list=PLiUQR4U_J9ec0k91iHPme_qtfS1nrWF3W>`_ (2D and 3D, GDScript).
-- `BornCG <https://www.youtube.com/playlist?list=PLda3VoSoc_TSBBOBYwcmlamF1UrjVtccZ>`_ (2D and 3D, GDScript).
-- `TheGuideKnight <https://www.youtube.com/playlist?list=PLYcTJBw32KtX2fvOdtO_fS3Nd6sxM71tn>`_ (2D, GDScript).
-- `GDScript Dude <https://www.youtube.com/channel/UCQs0i6vKISElM6mh7OzLouQ>`_ (GDScript).
-- `Garbaj <https://www.youtube.com/c/Garbaj/>`_ (3D, GDScript).
-- `Kasper Frandsen <https://www.youtube.com/c/KasperFrandsen/>`_ (3D, Shaders).
-- `bitbrain <https://www.youtube.com/watch?v=lFIBn8kJ-IM&list=PL4AhUX6lGjJWfiDORSmEu8x_myelbe1p2>`_ (2D, GDScript).
-- `Gwizz <https://www.youtube.com/@Gwizz1027>`_ (2D, GDScript).
-- `Quiver <https://quiver.dev/>`_ (2D, GDScript).
-- `Maker Tech <https://www.youtube.com/watch?v=0mUoRdYe0s4>`_ (2D, GDScript).
-- `Clear Code <https://www.youtube.com/watch?v=nAh_Kx5Zh5Q>`_ (2D, GDScript, Programming Basics).
-- `Game Dev Artisan <https://www.youtube.com/@GameDevArtisan>`_ (2D, GDScript).
-- `FencerDevLog <https://www.youtube.com/@FencerDevLog>`_ (2D, 3D, GDScript, Shaders).
-- `Queble <https://www.youtube.com/@queblegamedevelopment4143>`_ (2D, GDScript).
+- `BornCG <https://www.youtube.com/playlist?list=PLda3VoSoc_TTp8Ng3C57spnNkOw3Hm_35>`_ (2D and 3D, GDScript)
+- `Clear Code <https://www.youtube.com/watch?v=nAh_Kx5Zh5Q>`_ (2D, GDScript, Programming Basics)
+- `FencerDevLog <https://www.youtube.com/@FencerDevLog>`_ (2D, 3D, GDScript, Shaders)
+- `FinePointCGI <https://www.youtube.com/channel/UCSojAWUnEUTUcdA9iJ6bryQ>`_ (2D, 3D, GDScript and C#)
+- `GDQuest <https://www.youtube.com/channel/UCxboW7x0jZqFdvMdCFKTMsQ/playlists>`_ (2D and 3D, GDScript and C#)
+- `Game Dev Artisan <https://www.youtube.com/@GameDevArtisan>`_ (2D, GDScript)
+- `Game Development Center <https://www.youtube.com/c/GameDevelopmentCenter>`_ (2D, networked multiplayer, GDScript)
+- `Game Endeavor <https://www.youtube.com/channel/UCLweX1UtQjRjj7rs_0XQ2Eg/videos>`_ (2D, GDScript)
+- `Gwizz <https://www.youtube.com/@Gwizz1027>`_ (2D, GDScript)
+- `Godotneers <https://www.youtube.com/@godotneers>`_ (2D, Shaders, GDScript)
+- `HeartBeast <https://www.youtube.com/@uheartbeast>`_ (2D, GDScript)
+- `KidsCanCode <https://www.youtube.com/channel/UCNaPQ5uLX5iIEHUCLmfAgKg/playlists>`__ (2D and 3D, GDScript)
+- `Maker Tech <https://www.youtube.com/@MakerTech/>`_ (2D, GDScript)
+- `Pigdev <https://www.youtube.com/@pigdev>`_ (2D, GDScript)
+- `Queble <https://www.youtube.com/@queblegamedevelopment4143>`_ (2D, GDScript)
+- `Quiver <https://quiver.dev/>`_ (2D, GDScript)
 
 Text tutorials
 --------------
@@ -64,12 +49,14 @@ Text tutorials
 Devlogs
 -------
 
-- `Andrea Catania (Physics & AI) <https://www.youtube.com/channel/UCm4RuvYtgpgFDTCgaEUT5uQ/videos>`_
 - `Bastiaan Olij (AR & VR) <https://www.youtube.com/channel/UCrbLJYzJjDf2p-vJC011lYw/videos>`_
+- `bitbrain <https://www.youtube.com/@bitbraindev>`_
 - `DevDuck (2D) <https://www.youtube.com/@devduck/videos>`_
 
 Resources
 ---------
 
 - `awesome-godot: A curated list of free/libre plugins, scripts and add-ons <https://github.com/godotengine/awesome-godot>`_
+- `Godot Asset Library <https://godotengine.org/asset-library/asset>`_
+- `Godot Shaders: A community-driven shader library <https://godotshaders.com/>`_
 - `Zeef Godot Engine: A curated directory of resources by Andre Schmitz <https://godot-engine.zeef.com/andre.antonio.schmitz>`_


### PR DESCRIPTION
Supersedes https://github.com/godotengine/godot-docs/pull/8715. Contains most of the changes there, while changing a few links to instead link to updated channels/playlists/videos instead of removing. I also ordered the list alphabetically, removed the '.' after each link for consistency, and added a few more links.

My rough benchmark for these was "has more than a single short video up to date with Godot 4 (i.e., published after March 2023)".