### PR TITLE
Inspector plugin tutorial: update PackedScene.instance() ref

### DIFF
--- a/tutorials/plugins/editor/inspector_plugins.rst
+++ b/tutorials/plugins/editor/inspector_plugins.rst
@@ -39,7 +39,7 @@ you should remove the instance you have added by calling
 ``remove_inspector_plugin()``.
 
 .. note:: Here, you are loading a script and not a packed scene. Therefore you
-          should use ``new()`` instead of ``instance()``.
+          should use ``new()`` instead of ``instantiate()``.
 
 .. tabs::
   .. code-tab:: gdscript GDScript


### PR DESCRIPTION
I noticed that the tutorial still says `instance()` instead of `instantiate()`, so I changed it to match the 4.x method name.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
