### PR TITLE
Moving disclaimer comments inline

### DIFF
--- a/getting_started/first_2d_game/03.coding_the_player.rst
+++ b/getting_started/first_2d_game/03.coding_the_player.rst
@@ -275,7 +275,7 @@ movement. Let's place this code at the end of the ``_process()`` function:
         if velocity.x != 0:
             $AnimatedSprite2D.animation = "walk"
             $AnimatedSprite2D.flip_v = false
-            ## See the note below about the following boolean assignment.
+            # See the note below about the following boolean assignment.
             $AnimatedSprite2D.flip_h = velocity.x < 0
         elif velocity.y != 0:
             $AnimatedSprite2D.animation = "up"

--- a/getting_started/first_2d_game/03.coding_the_player.rst
+++ b/getting_started/first_2d_game/03.coding_the_player.rst
@@ -275,7 +275,8 @@ movement. Let's place this code at the end of the ``_process()`` function:
         if velocity.x != 0:
             $AnimatedSprite2D.animation = "walk"
             $AnimatedSprite2D.flip_v = false
-            $AnimatedSprite2D.flip_h = velocity.x < 0 ## See the note below about this boolean assignment.
+            ## See the note below about the following boolean assignment.
+            $AnimatedSprite2D.flip_h = velocity.x < 0
         elif velocity.y != 0:
             $AnimatedSprite2D.animation = "up"
             $AnimatedSprite2D.flip_v = velocity.y > 0
@@ -286,7 +287,8 @@ movement. Let's place this code at the end of the ``_process()`` function:
         {
             animatedSprite2D.Animation = "walk";
             animatedSprite2D.FlipV = false;
-            animatedSprite2D.FlipH = velocity.X < 0; // See the note below about this boolean assignment.
+            // See the note below about the following boolean assignment.
+            animatedSprite2D.FlipH = velocity.X < 0;
         }
         else if (velocity.Y != 0)
         {

--- a/getting_started/first_2d_game/03.coding_the_player.rst
+++ b/getting_started/first_2d_game/03.coding_the_player.rst
@@ -275,8 +275,7 @@ movement. Let's place this code at the end of the ``_process()`` function:
         if velocity.x != 0:
             $AnimatedSprite2D.animation = "walk"
             $AnimatedSprite2D.flip_v = false
-            # See the note below about boolean assignment.
-            $AnimatedSprite2D.flip_h = velocity.x < 0
+            $AnimatedSprite2D.flip_h = velocity.x < 0 ## See the note below about this boolean assignment.
         elif velocity.y != 0:
             $AnimatedSprite2D.animation = "up"
             $AnimatedSprite2D.flip_v = velocity.y > 0
@@ -287,8 +286,7 @@ movement. Let's place this code at the end of the ``_process()`` function:
         {
             animatedSprite2D.Animation = "walk";
             animatedSprite2D.FlipV = false;
-            // See the note below about boolean assignment.
-            animatedSprite2D.FlipH = velocity.X < 0;
+            animatedSprite2D.FlipH = velocity.X < 0; // See the note below about this boolean assignment.
         }
         else if (velocity.Y != 0)
         {


### PR DESCRIPTION
Moving disclaimer comments inline to better specify which boolean statement is being referred to.