### PR TITLE
multiple_resolutions.rst: Clear up confusing terms window and viewport

### DIFF
--- a/tutorials/rendering/multiple_resolutions.rst
+++ b/tutorials/rendering/multiple_resolutions.rst
@@ -72,6 +72,14 @@ that are different from this base size. Godot offers many ways to
 control how the viewport will be resized and stretched to different
 screen sizes.
 
+.. note::
+
+   On this page, *window* refers to the screen area alloted to your game
+   by the system, while *viewport* refers to the root object (accessible 
+   from ``get_tree().root``) which the game controls to fill this screen area.
+   This viewport is a :ref:`Window <class_Window>` instance. Recall from the
+   :ref:`introduction <doc_viewports>` that *all* Window objects are viewports.
+
 To configure the stretch base size at runtime from a script, use the
 ``get_tree().root.content_scale_size`` property (see
 :ref:`Window.content_scale_size <class_Window_property_content_scale_size>`).

--- a/tutorials/rendering/multiple_resolutions.rst
+++ b/tutorials/rendering/multiple_resolutions.rst
@@ -74,7 +74,7 @@ screen sizes.
 
 .. note::
 
-   On this page, *window* refers to the screen area alloted to your game
+   On this page, *window* refers to the screen area allotted to your game
    by the system, while *viewport* refers to the root object (accessible 
    from ``get_tree().root``) which the game controls to fill this screen area.
    This viewport is a :ref:`Window <class_Window>` instance. Recall from the


### PR DESCRIPTION
Clear up a potential misunderstanding for new users.

When I first read this documentation, it left me with the impression that there's a `/root` viewport which lives inside of a window object, and that they must be sized separately. This false impression was reinforced by the existance of both `get_window()` and `get_viewport()` in the API.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
