### PR TITLE
Specify jinja2 max version to avoid warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,6 @@ sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 sphinxcontrib-devhelp==1.0.2
+
+# Required by sphinx-tabs 3.4.0 to avoid getting too new of a version
+jinja2<3.1.0


### PR DESCRIPTION
While running `pip3 -install r requirements.txt`, it initially warned that jinja2 was too new to work with sphinx-tabs.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
