### PR TITLE
Fix table caption text color on dark theme

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -360,7 +360,8 @@ article ol,
 }
 
 body,
-.rst-content table.docutils thead {
+.rst-content table.docutils thead,
+.rst-content table.docutils caption {
     color: var(--body-color);
 }
 


### PR DESCRIPTION
### Dark theme

Before | After
-|-
![Screenshot_20240126_223020](https://github.com/godotengine/godot-docs/assets/180032/cd787675-f1c7-4c26-afaf-c77fa42c7a66) | ![Screenshot_20240126_223024](https://github.com/godotengine/godot-docs/assets/180032/eccd75c6-258a-48d6-965d-266e0b3035dc)

### Light theme

*Text color is slightly less contrasted since it follows the main text color now.*

Before | After
-|-
![Screenshot_20240126_223053](https://github.com/godotengine/godot-docs/assets/180032/721b763f-0a3c-4298-b3ac-ed7b964daf25) | ![Screenshot_20240126_223059](https://github.com/godotengine/godot-docs/assets/180032/42e55639-1672-417e-aa74-95bd38513589)