### PR TITLE
Fix multiple typos related to Particle Systems

### DIFF
--- a/tutorials/3d/particles/creating_a_3d_particle_system.rst
+++ b/tutorials/3d/particles/creating_a_3d_particle_system.rst
@@ -86,7 +86,7 @@ Some of the most notable features that are lost during the conversion include:
 
 You also lose the following properties:
 
-- ``Ammount Ratio``
+- ``Amount Ratio``
 - ``Interp to End``
 - ``Damping as Friction``
 - ``Emission Shape Offset``

--- a/tutorials/3d/particles/properties.rst
+++ b/tutorials/3d/particles/properties.rst
@@ -16,8 +16,8 @@ want to activate or deactivate particle systems dynamically.
 The ``Amount`` property controls the maximum number of particles visible at any given time. Increase the
 value to spawn more particles at the cost of performance.
 
-The ``Amount Ratio`` property is the radio of particles compared to the ammount that will be emitted.
-If it's less than ``1.0`` the ammount of particles emitted through the lifetime will be the ``Ammount`` *
+The ``Amount Ratio`` property is the ratio of particles compared to the amount that will be emitted.
+If it's less than ``1.0``, the amount of particles emitted through the lifetime will be the ``Amount`` *
 ``Amount Ratio``. Changing this value while emitted doesn't affect already created particles and doesn't
 cause the particle system to restart. It's useful for making effects where the number of emitted particels
 varies over time.


### PR DESCRIPTION
Fixes multiple cases where "Amount" was incorrectly spelled as **"Ammount"**, also fixes a typo where "Ratio" was spelled as **"Radio"**.
