### PR TITLE
Reduce Sphinx build times by using multiple jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 PAPEROPT_a4         = -D latex_paper_size=a4
 PAPEROPT_letter     = -D latex_paper_size=letter
 COMMONSPHINXOPTS    = $(PAPEROPT_$(SPHINXPAPER)) $(SPHINXOPTS) '$(SPHINXSOURCEDIR)'
-DEFAULTSPHINXOPTS   =  -d $(SPHINXBUILDDIR)/doctrees -j $(SPHINXJOBS) $(COMMONSPHINXOPTS)
+DEFAULTSPHINXOPTS   = -d $(SPHINXBUILDDIR)/doctrees -j $(SPHINXJOBS) $(COMMONSPHINXOPTS)
 
 .PHONY: help clean
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SPHINXSOURCEDIR ?= .
 SPHINXBUILDDIR  ?= _build
 SPHINXPAPER     ?=
 FILELIST        ?=
+SPHINXJOBS 	?= 4
 
 # User-friendly check for sphinx-build
 ifneq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 0)
@@ -21,7 +22,7 @@ endif
 PAPEROPT_a4         = -D latex_paper_size=a4
 PAPEROPT_letter     = -D latex_paper_size=letter
 COMMONSPHINXOPTS    = $(PAPEROPT_$(SPHINXPAPER)) $(SPHINXOPTS) '$(SPHINXSOURCEDIR)'
-DEFAULTSPHINXOPTS   = -d $(SPHINXBUILDDIR)/doctrees $(COMMONSPHINXOPTS)
+DEFAULTSPHINXOPTS   =  -d $(SPHINXBUILDDIR)/doctrees -j $(SPHINXJOBS) $(COMMONSPHINXOPTS)
 
 .PHONY: help clean
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SPHINXSOURCEDIR ?= .
 SPHINXBUILDDIR  ?= _build
 SPHINXPAPER     ?=
 FILELIST        ?=
-SPHINXJOBS 	?= 4
+SPHINXJOBS 	    ?= 4
 
 # User-friendly check for sphinx-build
 ifneq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 0)


### PR DESCRIPTION
The default number of sphinx jobs is increased from 1 to 4, and the number of jobs (N) can be set on the command line with

    make SPHINXJOBS=N

According to Steam's latest survey, over 90% of gamers (potential game developers) had access to at least 4 CPU cores in December 2023, so that's a sensible default.
Source: https://web.archive.org/web/20240127204540/https://store.steampowered.com/hwsurvey/cpus/

This can drastically reduce the time needed for a fresh rebuild, which is especially important for new contributors. For my informal tests, I used a Ryzen 5 3600XT PC, with a NVME SSD running Linux. Here are my results:

- With 1 job (make SPHINXJOBS=1), it takes about 25 minutes to build.
- With 12 (make SPHINXJOBS=12), I saw a 4x speed-up, bringing my build time down to just 6 minutes.
- With the default value of 4 jobs (make), I saw a 2x increase, with a build taking only 9 minutes.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
