### PR TITLE
Update external_editor.rst: point out C# instructions

### DIFF
--- a/tutorials/editor/external_editor.rst
+++ b/tutorials/editor/external_editor.rst
@@ -5,6 +5,11 @@ Using an external text editor
 
 This page explains how to code using an external text editor.
 
+.. note::
+
+    To code C# in an external editor, see
+    :ref:`the C# guide to configure an external editor <doc_c_sharp_setup_external_editor>`.
+
 Godot can be used with an external text editor, such as Sublime Text or Visual
 Studio Code. Browse to the relevant editor settings:
 **Editor > Editor Settings > Text Editor > External**

--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -55,6 +55,8 @@ If you are building Godot from source, make sure to follow the steps to enable
 .NET support in your build as outlined in the :ref:`doc_compiling_with_dotnet`
 page.
 
+.. _doc_c_sharp_setup_external_editor:
+
 Configuring an external editor
 ------------------------------
 


### PR DESCRIPTION
The instructions on `tutorials/editor/external_editor.rst` don't work well for C#, e.g. not opening the solution properly and preventing C# intellisense/autocomplete from working. It also has the dev install some extensions that aren't necessary for C#.

Add a note pointing to the C# setup page.