### PR TITLE
c_sharp_exports.rst: clarify why exporting nodes/resources is useful

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_exports.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_exports.rst
@@ -71,7 +71,9 @@ Exported members can specify a default value; otherwise, the `default value of t
         set => _greeting = value;
     }
 
-Resources and nodes can be exported.
+Resources and nodes can be exported. The property editor shows a user-friendly
+assignment dialog for these types. This can be used instead of ``GD.Load`` and
+``GetNode``.
 
 .. code-block:: csharp
 
@@ -80,6 +82,17 @@ Resources and nodes can be exported.
 
     [Export]
     public Node Node { get; set; }
+
+Exporting a specific type of resource or node lets the property editor show a
+filtered list of possibilities.
+
+.. code-block:: csharp
+
+    [Export]
+    public PackedScene PackedScene { get; set; }
+
+    [Export]
+    public RigidBody2D RigidBody2D { get; set; }
 
 Grouping exports
 ----------------

--- a/tutorials/scripting/c_sharp/c_sharp_exports.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_exports.rst
@@ -71,20 +71,9 @@ Exported members can specify a default value; otherwise, the `default value of t
         set => _greeting = value;
     }
 
-Resources and nodes can be exported. The property editor shows a user-friendly
-assignment dialog for these types. This can be used instead of ``GD.Load`` and
-``GetNode``.
-
-.. code-block:: csharp
-
-    [Export]
-    public Resource Resource { get; set; }
-
-    [Export]
-    public Node Node { get; set; }
-
-Exporting a specific type of resource or node lets the property editor show a
-filtered list of possibilities.
+Any type of ``Resource`` or ``Node`` can be exported. The property editor shows
+a user-friendly assignment dialog for these types. This can be used instead of
+``GD.Load`` and ``GetNode``. See :ref:`Nodes and Resources <doc_c_sharp_exports_nodes>`.
 
 .. code-block:: csharp
 
@@ -253,6 +242,8 @@ Color given as red-green-blue value (alpha will always be 1).
 
     [Export(PropertyHint.ColorNoAlpha)]
     private Color Color { get; set; }
+
+.. _doc_c_sharp_exports_nodes:
 
 Nodes
 -----


### PR DESCRIPTION
It's easy to miss how useful this is! It's is in my unwritten top 10 of 4.x features. 🙂 