### PR TITLE
Update ray-casting.rst to make 3D example simpler

### DIFF
--- a/tutorials/physics/ray-casting.rst
+++ b/tutorials/physics/ray-casting.rst
@@ -157,14 +157,14 @@ The data is similar in 3D space, using Vector3 coordinates. Here an example assu
  .. code-tab:: gdscript GDScript
 
         const RAY_LENGTH = 1000
+        var parameters = PhysicsRayQueryParameters3D.new()
 
-        func _physics_process(delta):
-            var params = PhysicsRayQueryParameters3D.new()
-            params.from = $Camera3D.origin
-            params.to = $Camera3D.project_position(
+        func _physics_process(delta):            
+            parameters.from = $Camera3D.position
+            parameters.to = $Camera3D.project_position(
                     get_viewport().get_mouse_position(),
                     RAY_LENGTH)
-            var result = get_world_3d().direct_space_state.intersect_ray(params)
+            var result = get_world_3d().direct_space_state.intersect_ray(parameters)
 
 Note that to enable collisions with Area3D, the boolean parameter ``params.collide_with_areas`` must be set to ``true``.
 


### PR DESCRIPTION
Hello, I hope I did the right steps for contributing!

The Raycast 3D API is a hot topic, and I noticed a couple of times where new users find it confusing or overcomplicated. 

I believe that one reason is that the current example is a bit too long, and seems complicated at first look. 

I suggest to uncluter the example by:
- use `PhysicsRayQueryParameters3D.new()` to highlight that it's just a two-step process: we first fill in the parameters, then we call intersect_ray
- unclutter the example by removing unnecessary variable assignments
- remove `cam.project_ray_origin`, which basically just returns the camera's origin, so that the reader does not get distrcated/confused
- replace `origin + cam.project_ray_normal(mousepos) * RAY_LENGTH` with `project_position(mousepos, RAY_LENGTH)` (needs to be tested, but I think it is equivalent)
- I renamed `query` to `params` to highlight again that we are just filling a form. It also better match the last noun in `PhysicsRayQueryParameters3D`. But if we go for `params`, we need to change it for the other examples as well.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
