### PR TITLE
Update compiling_for_linuxbsd.rst Added a description that compiling for RISC-V devices 

### DIFF
--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -264,6 +264,7 @@ Manager.
 
     Using Clang appears to be a requirement for OpenBSD, otherwise fonts
     would not build.
+    For RISC-V architecture devices, use the Clang compiler instead of the GCC compiler.
 
 .. note:: If you are compiling Godot for production use, then you can
           make the final executable smaller and faster by adding the


### PR DESCRIPTION
Added a description that compiling for RISC-V devices requires the use of the Clang compiler

As a result of this issue additional notes
https://github.com/godotengine/godot/issues/80676