### PR TITLE
Disallow page comments on System requirements

### DIFF
--- a/about/system_requirements.rst
+++ b/about/system_requirements.rst
@@ -1,3 +1,5 @@
+:allow_comments: False
+
 .. _doc_system_requirements:
 
 System requirements


### PR DESCRIPTION
Like other pages in the About section, user notes can't be posted.
