### PR TITLE
Correcting link to class Reference

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1970,7 +1970,7 @@ function.
 Classes as resources
 ^^^^^^^^^^^^^^^^^^^^
 
-Classes stored as files are treated as type :ref:`GDScript <class_GDScript>`. They
+Classes stored as files are treated as :ref:`GDScripts <class_GDScript>`. They
 must be loaded from disk to access them in other classes. This is done using
 either the ``load`` or ``preload`` functions (see below). Instancing of a loaded
 class resource is done by calling the ``new`` function on the class object::

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1970,7 +1970,7 @@ function.
 Classes as resources
 ^^^^^^^^^^^^^^^^^^^^
 
-Classes stored as files are treated as :ref:`resources <class_GDScript>`. They
+Classes stored as files are treated as :ref:`resources <class_Resource>`. They
 must be loaded from disk to access them in other classes. This is done using
 either the ``load`` or ``preload`` functions (see below). Instancing of a loaded
 class resource is done by calling the ``new`` function on the class object::

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1970,7 +1970,7 @@ function.
 Classes as resources
 ^^^^^^^^^^^^^^^^^^^^
 
-Classes stored as files are treated as :ref:`resources <class_Resource>`. They
+Classes stored as files are treated as type :ref:`GDScript <class_GDScript>`. They
 must be loaded from disk to access them in other classes. This is done using
 either the ``load`` or ``preload`` functions (see below). Instancing of a loaded
 class resource is done by calling the ``new`` function on the class object::


### PR DESCRIPTION
line 2016 references Class, should reference Resource

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
