### PR TITLE
Update Android SDK command line instructions

### DIFF
--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -40,9 +40,10 @@ Download and install the Android SDK.
     - CMake version 3.10.2.4988404
     - NDK version r23c (23.2.8568313)
 
-- Alternatively, you can install the Android SDK using the `command line tools <https://developer.android.com/studio/#command-line-tools-only>`__.
+- Alternatively, you can install the Android SDK with the `sdkmanager` command line tool.
 
-  - Once the command line tools are installed, run the `sdkmanager <https://developer.android.com/studio/command-line/sdkmanager>`__ command to complete the setup process:
+  - Install the command line tools package using these `instructions <https://developer.android.com/tools/sdkmanager>`__.
+  - Once the command line tools are installed, run the following `sdkmanager` command to complete the setup process:
 
 ::
 


### PR DESCRIPTION
When following the [instructions](https://docs.godotengine.org/en/stable/tutorials/export/exporting_for_android.html#download-the-android-sdk) to install the Android SDK using the command line tools, I had some issues until I realised I needed to also follow these instructions: https://developer.android.com/tools/sdkmanager

This wasn't specifically mentioned in the docs, so I updated it to mention this. I also removed outdated links that just redirect to that page.