### PR TITLE
Fix C# typos: capitalize method name, use public property names

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_exports.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_exports.rst
@@ -48,8 +48,8 @@ Exporting works with fields and properties. They can have any access modifier.
 
 Exported members can specify a default value; otherwise, the `default value of the type <https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/default-values>`_ is used instead.
 
-An ``int`` like ``_number`` defaults to ``0``. ``_text`` defaults to null
-because ``string`` is a reference type.
+An ``int`` like ``Number`` defaults to ``0``. ``Text`` defaults to null because
+``string`` is a reference type.
 
 .. code-block:: csharp
 

--- a/tutorials/scripting/cross_language_scripting.rst
+++ b/tutorials/scripting/cross_language_scripting.rst
@@ -221,7 +221,7 @@ because no C# static types exist for signals defined by GDScript:
 
 .. code-block:: csharp
 
-    myGDScriptNode.Connect("my_signal", Callable.From(mySignalHandler));
+    myGDScriptNode.Connect("my_signal", Callable.From(MySignalHandler));
 
 Inheritance
 -----------


### PR DESCRIPTION
Fix a few recent typos in my C# page edits. 🙂 