### PR TITLE
Link to C# Variant-compatible section directly

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_collections.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_collections.rst
@@ -46,8 +46,8 @@ To choose which collection type to use for each situation, consider the followin
 * Does your collection need to interact with the Godot engine?
   (e.g.: the type of an exported property, calling a Godot method).
 
-   * If yes, since Godot only supports :ref:`Variant-compatible <doc_c_sharp_variant>`
-     types, use a Godot collection.
+   * If yes, since Godot only supports :ref:`c_sharp_variant_compatible_types`,
+     use a Godot collection.
    * If not, consider `choosing an appropriate .NET collection <https://learn.microsoft.com/en-us/dotnet/standard/collections/selecting-a-collection-class>`_.
 
 * Do you need a Godot collection that represents a list or sequential set of data?
@@ -89,8 +89,7 @@ GDScript                C#
 ======================  ==============================================================
 
 Other C# arrays are not supported by the Godot C# API since a packed array equivalent
-does not exist. See :ref:`Variant <doc_c_sharp_variant>` for a list of all the compatible
-types.
+does not exist. See the list of :ref:`c_sharp_variant_compatible_types`.
 
 .. _doc_c_sharp_collections_array:
 
@@ -101,7 +100,7 @@ Godot arrays are implemented as an array of ``Variant`` and can contain several 
 of any type. In C#, the equivalent type is ``Godot.Collections.Array``.
 
 The generic ``Godot.Collections.Array<T>`` type allows restricting the element type to
-a :ref:`Variant-compatible <doc_c_sharp_variant>` type.
+a :ref:`Variant-compatible type <c_sharp_variant_compatible_types>`.
 
 An untyped ``Godot.Collections.Array`` can be converted to a typed array using the
 ``Godot.Collections.Array<T>(Godot.Collections.Array)`` constructor.
@@ -195,7 +194,7 @@ Godot dictionaries are implemented as a dictionary with ``Variant`` keys and val
 In C#, the equivalent type is ``Godot.Collections.Dictionary``.
 
 The generic ``Godot.Collections.Dictionary<TKey, TValue>`` type allows restricting the key
-and value types to a :ref:`Variant-compatible <doc_c_sharp_variant>` type.
+and value types to a :ref:`Variant-compatible type <c_sharp_variant_compatible_types>`.
 
 An untyped ``Godot.Collections.Dictionary`` can be converted to a typed dictionary using the
 ``Godot.Collections.Dictionary<TKey, TValue>(Godot.Collections.Dictionary)`` constructor.

--- a/tutorials/scripting/c_sharp/c_sharp_differences.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_differences.rst
@@ -810,7 +810,7 @@ Variant
 -------
 
 ``Godot.Variant`` is used to represent Godot's native :ref:`Variant <class_Variant>` type.
-Any Variant-compatible type can be converted from/to it.
+Any :ref:`Variant-compatible type <c_sharp_variant_compatible_types>` can be converted from/to it.
 
 See also: :ref:`doc_c_sharp_variant`.
 

--- a/tutorials/scripting/c_sharp/c_sharp_exports.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_exports.rst
@@ -26,7 +26,7 @@ them visible and editable in the editor. This way, artists and game designers
 can modify values that later influence how the program runs. For this, a
 special export syntax is provided.
 
-Exporting can only be done with :ref:`Variant-compatible <doc_c_sharp_variant>` types.
+Exporting can only be done with :ref:`c_sharp_variant_compatible_types`.
 
 .. note::
 
@@ -543,7 +543,7 @@ The default value of Godot dictionaries is null. A different default can be spec
 Exporting C# arrays
 ^^^^^^^^^^^^^^^^^^^
 
-C# arrays can exported as long as the element type is a :ref:`Variant-compatible <doc_c_sharp_variant>` type.
+C# arrays can exported as long as the element type is a :ref:`Variant-compatible type <c_sharp_variant_compatible_types>`.
 
 .. code-block:: csharp
 

--- a/tutorials/scripting/c_sharp/c_sharp_signals.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_signals.rst
@@ -91,7 +91,7 @@ your custom signal names are listed under the nested ``SignalName`` class.
 
 In contrast with other C# events, you cannot use ``Invoke`` to raise events tied to Godot signals.
 
-Signals support arguments of any :ref:`Variant-compatible <doc_c_sharp_variant>` type.
+Signals support arguments of any :ref:`Variant-compatible type <c_sharp_variant_compatible_types>`.
 
 Consequently, any ``Node`` or ``RefCounted`` will be compatible automatically, but custom data objects will need
 to inherit from ``GodotObject`` or one of its subclasses.

--- a/tutorials/scripting/c_sharp/c_sharp_variant.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_variant.rst
@@ -5,7 +5,8 @@ C# Variant
 
 For a detailed explanation of Variant in general, see the :ref:`Variant <class_Variant>` documentation page.
 
-``Godot.Variant`` is used to represent Godot's native :ref:`Variant <class_Variant>` type. Any Variant-compatible type can be converted from/to it.
+``Godot.Variant`` is used to represent Godot's native :ref:`Variant <class_Variant>` type. Any
+:ref:`Variant-compatible type <c_sharp_variant_compatible_types>` can be converted from/to it.
 We recommend avoiding ``Godot.Variant`` unless it is necessary to interact with untyped engine APIs.
 Take advantage of C#'s type safety when possible.
 
@@ -21,8 +22,13 @@ to a ``Godot.Variant``.
     Since the Variant type in C# is a struct, it can't be null. To create a "null"
     Variant use the ``default`` keyword or the parameterless constructor.
 
+.. _c_sharp_variant_compatible_types:
+
 Variant-compatible types
 ------------------------
+
+A Variant-compatible type can be converted to and from a ``Godot.Variant``.
+These C# types are Variant-compatible:
 
 * All the `built-in value types <https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/built-in-types-table>`_,
   except ``decimal``, ``nint`` and ``nuint``.

--- a/tutorials/scripting/c_sharp/diagnostics/GD0102.rst
+++ b/tutorials/scripting/c_sharp/diagnostics/GD0102.rst
@@ -16,7 +16,8 @@ Cause
 -----
 
 An unsupported type is specified for a member annotated with the ``[Export]``
-attribute when a :ref:`Variant-compatible <doc_c_sharp_variant>` type is expected.
+attribute when a
+:ref:`Variant-compatible type <c_sharp_variant_compatible_types>` is expected.
 
 Rule description
 ----------------

--- a/tutorials/scripting/c_sharp/diagnostics/GD0202.rst
+++ b/tutorials/scripting/c_sharp/diagnostics/GD0202.rst
@@ -16,8 +16,8 @@ Cause
 -----
 
 An unsupported type is specified for a parameter of a delegate annotated with
-the ``[Signal]`` attribute when a :ref:`Variant-compatible <doc_c_sharp_variant>`
-type is expected.
+the ``[Signal]`` attribute when a
+:ref:`Variant-compatible type <c_sharp_variant_compatible_types>` is expected.
 
 Rule description
 ----------------

--- a/tutorials/scripting/c_sharp/diagnostics/GD0301.rst
+++ b/tutorials/scripting/c_sharp/diagnostics/GD0301.rst
@@ -14,7 +14,7 @@ Cause
 -----
 
 An unsupported type is specified for a generic type argument when a
-:ref:`Variant-compatible <doc_c_sharp_variant>` type is expected.
+:ref:`Variant-compatible type <c_sharp_variant_compatible_types>` is expected.
 
 Rule description
 ----------------

--- a/tutorials/scripting/c_sharp/diagnostics/GD0302.rst
+++ b/tutorials/scripting/c_sharp/diagnostics/GD0302.rst
@@ -14,8 +14,9 @@ Cause
 -----
 
 A generic type is specified for a generic type argument when a
-:ref:`Variant-compatible <doc_c_sharp_variant>` type is expected, but the
-specified generic type is not annotated with the ``[MustBeVariant]`` attribute.
+:ref:`Variant-compatible type <c_sharp_variant_compatible_types>` is expected,
+but the specified generic type is not annotated with the ``[MustBeVariant]``
+attribute.
 
 Rule description
 ----------------


### PR DESCRIPTION
* After https://github.com/godotengine/godot-docs/pull/8878, the C# variant page's first section is longer. Now the variant compatibility rules aren't necessarily visible when you get there, which could be confusing/annoying.

Added a reference to the variant compatibility rules and linked to it from the top of the page, to start with. Then, I looked for references to `doc_c_sharp_variant` that seem like they should probably directly point at the variant compatibility section. And I added a brief description to the section to establish some context when you click a direct reference to that section.

In most cases, `Variant` isn't actually being used--the compatibility rules just have consequences all over the place.

I was tempted to change the section name from `Variant-compatible types` to `Variant-compatible type` to avoid a lot of manual reference naming, but resisted it to avoid unnecessary churn and external link breakage.