### PR TITLE
c_sharp_collections.rst: copy variant page's Packed{TYPE}Array order

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_collections.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_collections.rst
@@ -77,15 +77,15 @@ In C#, packed arrays are replaced by ``System.Array``:
 ======================  ==============================================================
 GDScript                C#
 ======================  ==============================================================
+``PackedByteArray``     ``byte[]``
 ``PackedInt32Array``    ``int[]``
 ``PackedInt64Array``    ``long[]``
-``PackedByteArray``     ``byte[]``
 ``PackedFloat32Array``  ``float[]``
 ``PackedFloat64Array``  ``double[]``
 ``PackedStringArray``   ``string[]``
-``PackedColorArray``    ``Color[]``
 ``PackedVector2Array``  ``Vector2[]``
 ``PackedVector3Array``  ``Vector3[]``
+``PackedColorArray``    ``Color[]``
 ======================  ==============================================================
 
 Other C# arrays are not supported by the Godot C# API since a packed array equivalent


### PR DESCRIPTION
These orders are different:

https://github.com/godotengine/godot-docs/blob/9018173eca22b1a28426e347ac49fdefbf65eeff/tutorials/scripting/c_sharp/c_sharp_collections.rst#L80-L88

https://github.com/godotengine/godot-docs/blob/9018173eca22b1a28426e347ac49fdefbf65eeff/tutorials/scripting/c_sharp/c_sharp_variant.rst#L67-L75

This can be a problem if you want to visually inspect both lists to see if they're the same. Not super important, but since I spotted it, figured I'd submit a fix.

The order on the Variant page essentially orders by who defined the type (.NET, Godot) then by data size, which seems reasonable enough to me, so picked that one.