### PR TITLE
Remove outdated references to other tutorial

### DIFF
--- a/tutorials/shaders/advanced_postprocessing.rst
+++ b/tutorials/shaders/advanced_postprocessing.rst
@@ -11,18 +11,11 @@ In particular, it will explain how to write a post-processing shader that
 uses the depth buffer. You should already be familiar with post-processing
 generally and, in particular, with the methods outlined in the :ref:`custom post-processing tutorial <doc_custom_postprocessing>`.
 
-In the previous post-processing tutorial, we rendered the scene to a :ref:`Viewport <class_Viewport>`
-and then rendered the Viewport in a :ref:`SubViewportContainer <class_SubViewportContainer>`
-to the main scene. One limitation of this method is that we could not access the
-depth buffer because the depth buffer is only available in shaders and
-Viewports do not maintain depth information.
-
 Full screen quad
 ----------------
 
-In the :ref:`custom post-processing tutorial <doc_custom_postprocessing>`, we
-covered how to use a Viewport to make custom post-processing effects. There are
-two main drawbacks of using a Viewport:
+One way to make custom post-processing effects is by using a viewport. However,
+there are two main drawbacks of using a Viewport:
 
 1. The depth buffer cannot be accessed
 2. The effect of the post-processing shader is not visible in the editor


### PR DESCRIPTION
Way back in the 3.x docs the custom post processing effects tutorial used a viewport ([old doc here](https://docs.godotengine.org/en/3.1/tutorials/viewports/custom_postprocessing.html#doc-custom-postprocessing)). It was heavily altered at some point, I'm going to guess it's because as the advanced tutorial points out, that method of post processing has drawbacks.

This PR removes references to the old tutorial using viewports for post processing effects from the advanced tutorial. Closes #8781.