### PR TITLE
Fix script error in NavigationMesh example

### DIFF
--- a/tutorials/navigation/navigation_using_navigationmeshes.rst
+++ b/tutorials/navigation/navigation_using_navigationmeshes.rst
@@ -378,7 +378,7 @@ The following script uses the NavigationServer to update a navigation region wit
             PackedInt32Array([0, 1, 2, 3])
         )
 
-        NavigationServer2D.region_set_navigation_polygon(new_2d_region_rid, new_navigation_mesh)
+        NavigationServer2D.region_set_navigation_polygon(region_rid, navigation_mesh)
 
  .. code-tab:: gdscript 3D GDScript
 
@@ -408,4 +408,4 @@ The following script uses the NavigationServer to update a navigation region wit
             PackedInt32Array([0, 1, 2, 3])
         )
 
-        NavigationServer3D.region_set_navigation_mesh(new_3d_region_rid, navigation_mesh)
+        NavigationServer3D.region_set_navigation_mesh(region_rid, navigation_mesh)


### PR DESCRIPTION
Fixes script error in NavigationMesh example.

Some sloppy copy&pasting from reworking the example.
Should also be fixed in the 4.2 version.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
