### PR TITLE
Fixes #4790: Loading a page with some google context breaks the CSS

### DIFF
--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -487,6 +487,11 @@ $(document).ready(() => {
 
   // Giscus
   registerGiscus();
+
+  // Fixes "Loading a page with some google context breaks the CSS"
+  if (window.scrollX != 0) {
+    window.scrollTo(0, window.scrollY);
+  }
 });
 
 // Override the default implementation from doctools.js to avoid this behavior.


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-docs/issues/4790

This fixes the scroll horizontal position when accessing the documentation from a highlited URL, like the ones that Google search produces. 

Let me know if you think of any cases that the scroll.x resetting might be troublesome.