### PR TITLE
Update the Emscripten minimum requirements to 3.1.39

### DIFF
--- a/contributing/development/compiling/compiling_for_web.rst
+++ b/contributing/development/compiling/compiling_for_web.rst
@@ -15,7 +15,7 @@ Requirements
 
 To compile export templates for the Web, the following is required:
 
-- `Emscripten 1.39.9+ <https://emscripten.org>`__.
+- `Emscripten 3.1.39+ <https://emscripten.org>`__.
 - `Python 3.6+ <https://www.python.org/>`__.
 - `SCons 3.0+ <https://scons.org/pages/download.html>`__ build system.
 
@@ -24,6 +24,10 @@ To compile export templates for the Web, the following is required:
 
              For a general overview of SCons usage for Godot, see
              :ref:`doc_introduction_to_the_buildsystem`.
+
+.. note:: Emscripten 3.1.39+ is recommended, but older 3.x versions are known to work.
+
+          Please note that the minimum requirement for GDExtension support is 3.1.14.
 
 Building export templates
 -------------------------


### PR DESCRIPTION
Fix #8589

Recommending 3.1.39 as this is our current battle-tested version.