### PR TITLE
Typo fix

### DIFF
--- a/tutorials/export/exporting_for_dedicated_servers.rst
+++ b/tutorials/export/exporting_for_dedicated_servers.rst
@@ -96,7 +96,7 @@ option is currently inherited, you must tick the box next to it first.
 - **Strip Visuals:** Export this resource, with visual files (textures and materials)
   replaced by placeholder classes. Placeholder classes store the image size
   (as it's sometimes used to position elements in a 2D scene), but nothing else.
-- **Keep:** Export this resource as usual, with visual files interact.
+- **Keep:** Export this resource as usual, with visual files intact.
 - **Remove:** The file is not included in the PCK. This is useful to ignore
   scenes and resources that only the client needs. If you do so, make sure the
   server doesn't reference these client-only scenes and resources in any way.


### PR DESCRIPTION
> Keep: Export this resource as usual, with visual files interact.

I believe this note is supposed to say `intact`, not `interact`, talking about export presets for visual resources. [link](https://docs.godotengine.org/en/stable/tutorials/export/exporting_for_dedicated_servers.html#doc-exporting-for-dedicated-servers)

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
