### PR TITLE
Build offline version of stable branch

### DIFF
--- a/.github/workflows/build_offline_docs.yml
+++ b/.github/workflows/build_offline_docs.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         branch:
           - master
+          - stable
           - 3.6
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Updates the build offline workflow so an offline version of the stable branch is built. Closes #8744.