### PR TITLE
Add note around mob velocity to direct users to next section

### DIFF
--- a/getting_started/first_2d_game/04.creating_the_enemy.rst
+++ b/getting_started/first_2d_game/04.creating_the_enemy.rst
@@ -122,7 +122,9 @@ to the ``Mob`` and add this code:
         QueueFree();
     }
 
-This completes the `Mob` scene.
+This completes the `Mob` scene. If you test it now you will see that it is still
+not moving. We will create velocity for it when we know where it is coming from on 
+screen.
 
 With the player and enemies ready, in the next part, we'll bring them together
 in a new scene. We'll make enemies spawn randomly around the game board and move


### PR DESCRIPTION
The idea of mob completion often creates an expectation of movement. Note to encourage users to test and move on to next section

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
