### PR TITLE
Remove reference of ``vertex`` in particle shaders

### DIFF
--- a/tutorials/shaders/introduction_to_shaders.rst
+++ b/tutorials/shaders/introduction_to_shaders.rst
@@ -70,7 +70,7 @@ are seven different processor functions.
    :ref:`spatial shaders <doc_spatial_shader>`.
 
 4. The ``start()`` function runs for every particle in a particle system once
-   when the particle is first spawned. Used in 
+   when the particle is first spawned. Used in
    :ref:`particles shaders <doc_particle_shader>`.
 
 5. The ``process()`` function runs for every particle in a particle system for
@@ -139,8 +139,7 @@ Vertex processor
 ^^^^^^^^^^^^^^^^
 
 The ``vertex()`` processing function is called once for every vertex in
-``spatial`` and ``canvas_item`` shaders. For ``particles`` shaders, it is called
-once for every particle.
+``spatial`` and ``canvas_item`` shaders.
 
 Each vertex in your world's geometry has properties like a position and color.
 The function modifies those values and passes them to the fragment function. You


### PR DESCRIPTION
Removes the reference of vertex function for particle shaders from the Introduction to shaders. As of 4.0 there is only ``start`` and ``process`` functions.
