### PR TITLE
Clarify and add to C# API general differences

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -212,6 +212,8 @@ class reference pages for
 
     *"Cannot find class XXX for script res://XXX.cs"*
 
+.. _doc_c_sharp_general_differences:
+
 General differences between C# and GDScript
 -------------------------------------------
 

--- a/tutorials/scripting/c_sharp/c_sharp_differences.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_differences.rst
@@ -8,8 +8,22 @@ This is a (incomplete) list of API differences between C# and GDScript.
 General differences
 -------------------
 
-As explained in the :ref:`doc_c_sharp`, C# generally uses ``PascalCase`` instead
-of the ``snake_case`` used in GDScript and C++.
+As explained in :ref:`doc_c_sharp_general_differences`, ``PascalCase`` is used
+to access Godot APIs in C# instead of the ``snake_case`` used by GDScript and
+C++. Where possible, fields and getters/setters have been converted to
+properties. In general, the C# Godot API strives to be as idiomatic as is
+reasonably possible. See the :ref:`doc_c_sharp_styleguide`, which we encourage
+you to also use for your own C# code.
+
+In GDScript, the setters/getters of a property can be called directly, although
+this is not encouraged. In C#, only the property is defined. For example, to
+translate the GDScript code ``x.set_name("Friend")`` to C#, write
+``x.Name = "Friend";``.
+
+A C# IDE will provide intellisense, which is extremely useful when figuring out
+renamed C# APIs. The built-in Godot script editor has no support for C#
+intellisense, and it also doesn't provide many other C# development tools that
+are considered essential. See :ref:`doc_c_sharp_setup_external_editor`.
 
 Global scope
 ------------


### PR DESCRIPTION
First, make the link back to the C# basics page more specific. This gets past the setup sections and maybe even gets new eyes on the Gotchas section and other warnings just below it.

Here's my logic for the rest:

* Explain more specifically that PascalCase is how the APIs are accessed. This whole paragraph has been misinterpreted by a few people in the Godot C# help Discord channel:
  * As a casual note about general C# style,
  * As a requirement that their custom class methods/properties must be PascalCase.
* Copy over the rest of that C# basics section. It doesn't seem right to me to be *less* detailed on the more specific page. (I would skip this link because I assume I'm already reading the detailed page.)
* Explicitly mention that C# doesn't include the setters/getters that GDScript is able to call. This can make things hard to find, especially if you're coming from Godot 3.x GDScript -> Godot 4.x C#, and especially if that means you're trying to use the Godot editor for C#--no intellisense. (I've had to point this out to a number of people trying to translate GDScript.)
* On that note: add a note about how nice intellisense is in dealing with the general differences. I was thinking this might seem a *little* out of place... but really it's quite important to effectively use the C# API. I tried my best with the tone, but I'm not totally sure it's ok in this context.