### PR TITLE
Node type customization warning updated to explain suffix options #8950

### DIFF
--- a/tutorials/assets_pipeline/importing_3d_scenes/node_type_customization.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/node_type_customization.rst
@@ -17,7 +17,8 @@ will detect suffixes in object names and will perform actions automatically.
 
 .. warning::
 
-    All the suffixes described below are **case-sensitive**.
+    All the suffixes described below can be used with ``-``, ``$``, and ``_`` and are
+	**case-insensitive**.
 
 Remove nodes (-noimp)
 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Suffix options for resource importing in 3d scenes can actually be used with multiple symbols with different case sensitivity. Pointed in this issue: https://github.com/godotengine/godot-docs/issues/8950
