### PR TITLE
Update method name in object_class.rst

### DIFF
--- a/contributing/development/core_and_modules/object_class.rst
+++ b/contributing/development/core_and_modules/object_class.rst
@@ -57,7 +57,7 @@ Registering as virtual is the same but it can't be instanced.
 
 .. code-block:: cpp
 
-    ClassDB::register_virtual_class<MyCustomClass>()
+    ClassDB::register_abstract_class<MyCustomClass>()
 
 Object-derived classes can override the static function
 ``static void _bind_methods()``. When one class is registered, this


### PR DESCRIPTION
`register_virtual_class()` changed to `register_abstract_class()` in [2022](https://github.com/godotengine/godot/commit/6f51eca1e3045571ccc68414a922e8b0229111f0#diff-f94cd5be526d3d95f0e3e7dd0f2c7a6c6205ad2f94aa96ef4165c2bb0051938cL172-R174)  

Documentation page: https://docs.godotengine.org/en/stable/contributing/development/core_and_modules/object_class.html#registering-an-object  

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
