### PR TITLE
Add note on enabling driver input in recording_with_microphone.rst to allow mic recording

### DIFF
--- a/tutorials/audio/recording_with_microphone.rst
+++ b/tutorials/audio/recording_with_microphone.rst
@@ -28,6 +28,8 @@ An ``AudioStreamPlayer`` named ``AudioStreamRecord`` is used for recording.
 
 .. image:: img/record_stream_player.png
 
+.. note:: For microphone recording to work, the following option is turned on **Project Settings -> Audio -> Driver -> Enable Input**. To view this option **Advanced Settings** should be turned on.
+
 .. tabs::
  .. code-tab:: gdscript GDScript
 


### PR DESCRIPTION
I've written a note that tells user to enable the option `Audio -> Driver -> Enable Input` in `Project Settings`. This is disabled by **default** (in the example project provided in doc its enabled). So without this enabled in new projects, microphone recording won't work.