### PR TITLE
Correct dictionary re-allocation from "quadratic" to "exponential"

### DIFF
--- a/tutorials/best_practices/data_preferences.rst
+++ b/tutorials/best_practices/data_preferences.rst
@@ -129,7 +129,7 @@ the expense of memory and some minor operational efficiency.
 
     - HashMaps maintain gaps of unused memory interspersed in the table
       on purpose to reduce hash collisions and maintain the speed of
-      accesses. This is why it constantly increases in size quadratically by
+      accesses. This is why it constantly increases in size exponentially by
       powers of 2.
 
 As one might be able to tell, Dictionaries specialize in tasks that Arrays


### PR DESCRIPTION
In the section under `Data preference`,  regarding dictionary resizing, it says that the size increases "quadratically".

But the size doubles each time, so this should be exponential instead.