### PR TITLE
Update 04.mob_scene.rst

### DIFF
--- a/getting_started/first_3d_game/04.mob_scene.rst
+++ b/getting_started/first_3d_game/04.mob_scene.rst
@@ -216,9 +216,6 @@ Leaving the screen
 We still have to destroy the mobs when they leave the screen. To do so, we'll
 connect our :ref:`VisibleOnScreenNotifier3D <class_VisibleOnScreenNotifier3D>` node's ``screen_exited`` signal to the ``Mob``.
 
-Head back to the 3D viewport by clicking on the *3D* label at the top of the
-editor. You can also press :kbd:`Ctrl + F2` (:kbd:`Alt + 2` on macOS).
-
 |image8|
 
 Select the :ref:`VisibleOnScreenNotifier3D <class_VisibleOnScreenNotifier3D>` node and on the right side of the interface,
@@ -230,7 +227,7 @@ Connect the signal to the ``Mob``
 
 |image10|
 
-This will take you back to the script editor and add a new function for you,
+This will add a new function for you in your mob script,
 ``_on_visible_on_screen_notifier_3d_screen_exited()``. From it, call the ``queue_free()``
 method. This function destroy the instance it's called on.
 


### PR DESCRIPTION
Removed an unnecessary instruction. The tutorial calls for the user to return to the 3D viewport to select the VisibleOnScreenNotifier3D and connect its screen_exited signal to the mob script. It then says this will return you to the script. Since these actions happen in the scene dock and inspector dock, there is no need to change from Script mode to 3D mode in the viewport.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
