### PR TITLE
Update the default filename of the script

### DIFF
--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -80,7 +80,7 @@ scene dock and select "Attach Script".
 The Attach Node Script window appears. It allows you to select the script's
 language and file path, among other options.
 
-Change the Template field from "Node: Default" to "Object: Empty" to start with a clean file. Leave the
+Change the Template field from "Node: Default" to "Object: Empty" to start with a clean file. Name the file `sprite_2d.gd`, and leave the
 other options set to their default values and click the Create button to create the script.
 
 .. image:: img/scripting_first_script_attach_node_script.webp


### PR DESCRIPTION
Hello,

In the "Creating your first script" tutorial, the docs imply that the default filename of the file should be sprite_2d.gd, but in version 4.2, it is created as Sprite2D.gd as default, with a warning that suggests changing the name of the script. This part can be updated to make the new users (like me!) prompted to change the filename.

I went and added a message for this change, but feel free to edit it if that can be done in a better way.