### PR TITLE
Clarify `production=yes` SCons option in Compiling for Linux/*BSD

### DIFF
--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -266,14 +266,15 @@ Manager.
     would not build.
     For RISC-V architecture devices, use the Clang compiler instead of the GCC compiler.
 
-.. note:: If you are compiling Godot for production use, then you can
-          make the final executable smaller and faster by adding the
-          SCons options ``target=template_release production=yes``.
+.. tip:: If you are compiling Godot for production use, you can
+         make the final executable smaller and faster by adding the
+         SCons option ``production=yes``. This enables additional compiler
+         optimizations and link-time optimization.
 
-          If you are compiling Godot with GCC, you can make the binary
-          even smaller and faster by adding the SCons option ``lto=full``.
-          As link-time optimization is a memory-intensive process,
-          this will require about 7 GB of available RAM while compiling.
+         LTO takes some time to run and requires about 7 GB of available RAM
+         while compiling. If you're running out of memory with the above option,
+         use ``production=yes lto=none`` or ``production=yes lto=thin`` for a
+         lightweight but less effective form of LTO.
 
 .. note:: If you want to use separate editor settings for your own Godot builds
           and official releases, you can enable

--- a/contributing/development/compiling/compiling_for_windows.rst
+++ b/contributing/development/compiling/compiling_for_windows.rst
@@ -159,14 +159,15 @@ your CPU architecture, but this can be overridden using ``arch=x86_64`` or
 This executable file contains the whole engine and runs without any
 dependencies. Running it will bring up the Project Manager.
 
-.. note:: If you are compiling Godot for production use, then you can
-          make the final executable smaller and faster by adding the
-          SCons option ``target=template_release``.
+.. tip:: If you are compiling Godot for production use, you can
+         make the final executable smaller and faster by adding the
+         SCons option ``production=yes``. This enables additional compiler
+         optimizations and link-time optimization.
 
-          If you are compiling Godot with MinGW, you can make the binary
-          even smaller and faster by adding the SCons option ``lto=full``.
-          As link-time optimization is a memory-intensive process,
-          this will require about 7 GB of available RAM while compiling.
+         LTO takes some time to run and requires about 7 GB of available RAM
+         while compiling. If you're running out of memory with the above option,
+         use ``production=yes lto=none`` or ``production=yes lto=thin`` for a
+         lightweight but less effective form of LTO.
 
 .. note:: If you want to use separate editor settings for your own Godot builds
           and official releases, you can enable
@@ -203,7 +204,7 @@ To compile Godot with Direct3D 12 support you need at least the following:
               ./update_mesa.sh
               scons
 
-             If you are buildng with MinGW, add ``use_mingw=yes`` to the ``scons``
+             If you are building with MinGW, add ``use_mingw=yes`` to the ``scons``
              command, you can also specify build architecture using ``arch={architecture}``.
 
              Mesa static library should be built using the same compiler you are


### PR DESCRIPTION
- This closes https://github.com/godotengine/godot-docs/issues/8969.
