### PR TITLE
Update 02.player_input.rst

### DIFF
--- a/getting_started/first_3d_game/02.player_input.rst
+++ b/getting_started/first_3d_game/02.player_input.rst
@@ -1,4 +1,4 @@
-:article_outdated: True
+:article_outdated: False
 
 .. _doc_first_3d_game_player_scene_and_input:
 


### PR DESCRIPTION
Set :article_outdated to False.

I have followed the tutorial and found no discrepancies between the text or pictures and what I saw when I followed the tutorial using Godot 4.2.

I was told to commit to master last time, but I'm hoping it's right to commit to 4.2 given that this is specifically about the documentation for 4.2? I see that the master version has no :artice_outdated property, so I assume I don't need to target master as well as 4.2, as suggested in the description comments.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
