### PR TITLE
[Documentation>Runtime file loading and saving] Removed a single space that shouldn't be there

### DIFF
--- a/tutorials/io/runtime_file_loading_and_saving.rst
+++ b/tutorials/io/runtime_file_loading_and_saving.rst
@@ -47,7 +47,7 @@ filesystem for reading and writing:
 
 ::
 
-     func save_file(content):
+    func save_file(content):
         var file = FileAccess.open("/path/to/file.txt", FileAccess.WRITE)
         file.store_string(content)
 


### PR DESCRIPTION
There was 5 spaces on the start of that line which caused 1 space to appear on the Godot documentation before "func". it triggered my OCD so here I am. Thanks