### PR TITLE
Update class_sprite2d.rst

### DIFF
--- a/classes/class_sprite2d.rst
+++ b/classes/class_sprite2d.rst
@@ -371,7 +371,7 @@ Returns a :ref:`Rect2<class_Rect2>` representing the Sprite2D's boundary in loca
 
 :ref:`bool<class_bool>` **is_pixel_opaque** **(** :ref:`Vector2<class_Vector2>` pos **)** |const|
 
-Returns ``true``, if the pixel at the given position is opaque and ``false`` in other case.
+Returns ``true``, if the pixel at the given position in local coordinates is opaque and ``false`` in other case.
 
 \ **Note:** It also returns ``false``, if the sprite's texture is ``null`` or if the given position is invalid.
 


### PR DESCRIPTION
Clarify that `is_pixel_opaque` function gets position in local coordinates

**DISCLAIMER:** I am sure for 99% it is true because I tried it and see that it use local coords but maybe I am just a fool...

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
