### PR TITLE
docs: typo in  `spatial_shader.rst`

### DIFF
--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -254,7 +254,7 @@ these properties, and if you don't write to them, Godot will optimize away the c
 | in vec4 **FRAGCOORD**                  | Coordinate of pixel center in screen space. ``xy`` specifies position in window, ``z``           |
 |                                        | specifies fragment depth if ``DEPTH`` is not used. Origin is lower-left.                         |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
-| in bool **FRONT_FACING**               | ``true`` if current face if front face.                                                          |
+| in bool **FRONT_FACING**               | ``true`` if current face is front face.                                                          |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
 | in vec3 **VIEW**                       | Normalized vector from fragment position to camera (in view space). This is the same for both    |
 |                                        | perspective and orthogonal cameras.                                                              |

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -254,7 +254,7 @@ these properties, and if you don't write to them, Godot will optimize away the c
 | in vec4 **FRAGCOORD**                  | Coordinate of pixel center in screen space. ``xy`` specifies position in window, ``z``           |
 |                                        | specifies fragment depth if ``DEPTH`` is not used. Origin is lower-left.                         |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
-| in bool **FRONT_FACING**               | ``true`` if current face is front face.                                                          |
+| in bool **FRONT_FACING**               | ``true`` if current face is front facing.                                                        |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
 | in vec3 **VIEW**                       | Normalized vector from fragment position to camera (in view space). This is the same for both    |
 |                                        | perspective and orthogonal cameras.                                                              |


### PR DESCRIPTION
Not 100% sure if this is a typo, but looks like one. Thank you.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
