### PR TITLE
Marking outdated tutorial pages as outdated

### DIFF
--- a/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
@@ -1,5 +1,7 @@
 .. _doc_your_first_spatial_shader:
 
+:article_outdated: True
+
 Your first 3D shader
 ====================
 

--- a/tutorials/shaders/your_first_shader/your_second_3d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_second_3d_shader.rst
@@ -1,5 +1,7 @@
 .. _doc_your_second_spatial_shader:
 
+:article_outdated: True
+
 Your second 3D shader
 =====================
 


### PR DESCRIPTION

See #8077 which reports that the 3D shader tutorials are out-of-date, and people spend time trying to figure out why their results don't look like the tutorials'.  The tutorials need to be updated, but in the meantime, this will potentially save users the headache of not knowing why their results don't match the tutorial results.