### PR TITLE
Fix website highlight of text

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -668,6 +668,7 @@ footer {
 }
 
 .wy-body-for-nav {
+    position: relative;
     background-color: var(--content-wrap-background-color);
 }
 


### PR DESCRIPTION
Fixes #4790
Supersedes #8903 

This PR adds `position: relative;` to `.wy-body-for-nav`, which is the parent element of `.wy-grid-for-nav` which has `position: absolute;`. The fact that the parent didn't have `relative` as position made the glitch appear depending on the circumstances.

![image](https://github.com/godotengine/godot-docs/assets/270928/5f2ce7e3-20a8-4792-ba85-2b6c907b0a70)
