### PR TITLE
Add missing Ctrl-click equivalents for MacOS.

### DIFF
--- a/getting_started/introduction/learning_new_features.rst
+++ b/getting_started/introduction/learning_new_features.rst
@@ -56,7 +56,7 @@ A class reference's page tells you:
           <https://github.com/godotengine/godot-docs/issues>`_ GitHub repository
           to report it.
 
-You can Ctrl-click any underlined text like the name of a class, property,
+You can Ctrl-click (Cmd-click on MacOS) any underlined text like the name of a class, property,
 method, signal, or constant to jump to it.
 
 Learning to think like a programmer

--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -245,7 +245,7 @@ our sprite's rotation every frame. Here, ``rotation`` is a property inherited
 from the class ``Node2D``, which ``Sprite2D`` extends. It controls the rotation
 of our node and works with radians.
 
-.. tip:: In the code editor, you can ctrl-click on any built-in property or
+.. tip:: In the code editor, you can Ctrl-click (Cmd-click on MacOS) on any built-in property or
          function like ``position``, ``rotation``, or ``_process`` to open the
          corresponding documentation in a new tab.
 


### PR DESCRIPTION
I found two occurrences of Ctrl-click shortcut in the documentation that did not have equivalent instructions for MacOS - which is Cmd-click.

This commit adds information about the Cmd-click instruction for MacOS to follow the pattern for other keyboard shortcuts.