### PR TITLE
Remove incorrect information on script templates

### DIFF
--- a/tutorials/scripting/creating_script_templates.rst
+++ b/tutorials/scripting/creating_script_templates.rst
@@ -39,10 +39,6 @@ the Godot editor. Go to ``Editor > Open Editor Data/Settings Folder`` and it
 will open a folder in your file browser, inside that folder is the
 ``script_templates`` folder.
 
-If no ``script_templates`` is detected, Godot will create a default set of
-built-in templates automatically, so this logic can be used to reset the default
-templates in case you've accidentally overwritten them.
-
 Project-defined templates
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Deleting the script templates folder does not cause new script templates to generate. Closes #9034.