### PR TITLE
Fix "change_scene_to_*" behavior description

### DIFF
--- a/tutorials/scripting/change_scenes_manually.rst
+++ b/tutorials/scripting/change_scenes_manually.rst
@@ -44,7 +44,7 @@ access and integrity.
 1. **We can delete the existing scene.**
    :ref:`SceneTree.change_scene_to_file() <class_SceneTree_method_change_scene_to_file>` and
    :ref:`SceneTree.change_scene_to_packed() <class_SceneTree_method_change_scene_to_packed>`
-   will delete the current scene immediately. Developers can also delete the
+   will queue the current scene for deletion. Developers can also delete the
    main scene though. Assuming the root node's name is "Main", one could do
    ``get_node("/root/Main").free()`` to delete the whole scene.
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
Fix the "change_scene_to_*" method behavior description as in the source [file](https://github.com/godotengine/godot/blob/master/scene/main/scene_tree.cpp#L521) the scene change is flushed during the end of the current frame.