### PR TITLE
Remove confusing sentence for changing scenes

### DIFF
--- a/tutorials/scripting/change_scenes_manually.rst
+++ b/tutorials/scripting/change_scenes_manually.rst
@@ -4,8 +4,8 @@ Change scenes manually
 ======================
 
 Sometimes it helps to have more control over how one swaps scenes around.
-As mentioned above, a :ref:`Viewport <class_Viewport>`'s child nodes
-will render to the image it generates. This holds true even for nodes outside
+A :ref:`Viewport <class_Viewport>`'s child nodes will render to the image
+it generates, this holds true even for nodes outside
 of the "current" scene. Autoloads fall into this category, but so do
 scenes which one instances and adds to the tree at runtime:
 


### PR DESCRIPTION
Removes a sentence that references a page that doesn't exist, there's no mention of viewport on the previous page. I even checked the doc branch from when this page and sentence was added (3.1), and there was nothing about viewport in the previous page back then. Closes #8846.