### PR TITLE
Update release policy info on 4.1

### DIFF
--- a/about/release_policy.rst
+++ b/about/release_policy.rst
@@ -200,8 +200,8 @@ While Godot contributors aren't working under any deadlines, we strive to
 publish minor releases relatively frequently.
 
 In particular, after the very length release cycle for 4.0, we are pivoting to
-a faster paced development workflow, with the 4.1 release expected within late
-Q2 / early Q3 2023.
+a faster paced development workflow, 4.1 released 4 months after 4.0, and 4.2
+released 4 months after 4.1
 
 Frequent minor releases will enable us to ship new features faster (possibly
 as experimental), get user feedback quickly, and iterate to improve those


### PR DESCRIPTION
4.1 has been released so that section needed updating. Closes #9056.