### PR TITLE
Update requiered JDK version (3.6)

### DIFF
--- a/tutorials/export/exporting_basics.rst
+++ b/tutorials/export/exporting_basics.rst
@@ -336,7 +336,7 @@ Before you can export your project for Android, you must download the following
 software:
 
 * Android SDK: https://developer.android.com/studio/
-* Open JDK (**version 8 is required**, more recent versions won't work): https://adoptopenjdk.net/index.html
+* Open JDK (**version 11 is required**, more recent versions won't work): https://adoptopenjdk.net/index.html
 
 When you run Android Studio for the first time, click on **Configure -> SDK Manager**
 and install **Android SDK Platform Tools**. This installs the ``adb``


### PR DESCRIPTION
Godot 3.6 uses OpenJDK 11 now, the Android page in the exporting section correctly lists this. Closes #8617.