### PR TITLE
[Manual] Clarify use of `delta` with `move_and_slide`

### DIFF
--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -429,7 +429,9 @@ without writing much code.
 
 .. warning:: ``move_and_slide()`` automatically includes the timestep in its
              calculation, so you should **not** multiply the velocity vector
-             by ``delta``.
+             by ``delta``. This does **not** apply to ``gravity`` as it is an
+             acceleration and is time dependent, and needs to be scaled by
+             ``delta``.
 
 For example, use the following code to make a character that can walk along
 the ground (including slopes) and jump when standing on the ground:


### PR DESCRIPTION
Added details to clarify that while `velocity` should not be multiplied by `delta`, `gravity` still should.

* Closes: https://github.com/godotengine/godot-docs/issues/9009

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
