### PR TITLE
Unify C# naming notes and comments

### DIFF
--- a/getting_started/first_2d_game/03.coding_the_player.rst
+++ b/getting_started/first_2d_game/03.coding_the_player.rst
@@ -407,6 +407,7 @@ Next, add this code to the function:
 
  .. code-tab:: csharp
 
+    // We also specified this function name in PascalCase in the editor's connection window.
     private void OnBodyEntered(Node2D body)
     {
         Hide(); // Player disappears after being hit.

--- a/getting_started/first_2d_game/04.creating_the_enemy.rst
+++ b/getting_started/first_2d_game/04.creating_the_enemy.rst
@@ -117,6 +117,7 @@ to the ``Mob`` and add this code:
 
  .. code-tab:: csharp
 
+    // We also specified this function name in PascalCase in the editor's connection window.
     private void OnVisibleOnScreenNotifier2DScreenExited()
     {
         QueueFree();

--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -168,11 +168,13 @@ the other two timers. ``ScoreTimer`` will increment the score by 1.
 
  .. code-tab:: csharp
 
+    // We also specified this function name in PascalCase in the editor's connection window.
     private void OnScoreTimerTimeout()
     {
         _score++;
     }
 
+    // We also specified this function name in PascalCase in the editor's connection window.
     private void OnStartTimerTimeout()
     {
         GetNode<Timer>("MobTimer").Start();
@@ -219,6 +221,7 @@ Note that a new instance must be added to the scene using ``add_child()``.
 
  .. code-tab:: csharp
 
+    // We also specified this function name in PascalCase in the editor's connection window.
     private void OnMobTimerTimeout()
     {
         // Note: Normally it is best to use explicit types rather than the `var`

--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -199,12 +199,14 @@ signal of ``MessageTimer``, and add the following code to the new functions:
 
  .. code-tab:: csharp
 
+    // We also specified this function name in PascalCase in the editor's connection window.
     private void OnStartButtonPressed()
     {
         GetNode<Button>("StartButton").Hide();
         EmitSignal(SignalName.StartGame);
     }
 
+    // We also specified this function name in PascalCase in the editor's connection window.
     private void OnMessageTimerTimeout()
     {
         GetNode<Label>("Message").Hide();

--- a/getting_started/first_3d_game/03.player_movement_code.rst
+++ b/getting_started/first_3d_game/03.player_movement_code.rst
@@ -6,6 +6,17 @@ Moving the player with code
 It's time to code! We're going to use the input actions we created in the last
 part to move the character.
 
+.. note:: For this project, we will be following the Godot naming conventions.
+
+          - **GDScript**: Classes (nodes) use PascalCase, variables and
+            functions use snake_case, and constants use ALL_CAPS (See
+            :ref:`doc_gdscript_styleguide`).
+
+          - **C#**: Classes, export variables and methods use PascalCase,
+            private fields use _camelCase, local variables and parameters use
+            camelCase (See :ref:`doc_c_sharp_styleguide`). Be careful to type
+            the method names precisely when connecting signals.
+
 Right-click the ``Player`` node and select *Attach Script* to add a new script to
 it. In the popup, set the *Template* to *Empty* before pressing the *Create*
 button. We set it to *Empty* because we want to write our own code for

--- a/getting_started/first_3d_game/04.mob_scene.rst
+++ b/getting_started/first_3d_game/04.mob_scene.rst
@@ -239,7 +239,7 @@ method. This function destroys the instance it's called on.
 
  .. code-tab:: csharp
 
-    // We also specified this function name in PascalCase in the editor's connection window
+    // We also specified this function name in PascalCase in the editor's connection window.
     private void OnVisibilityNotifierScreenExited()
     {
         QueueFree();
@@ -321,7 +321,7 @@ Here is the complete ``Mob.gd`` script for reference.
             Velocity = Velocity.Rotated(Vector3.Up, Rotation.Y);
         }
 
-        // We also specified this function name in PascalCase in the editor's connection window
+        // We also specified this function name in PascalCase in the editor's connection window.
         private void OnVisibilityNotifierScreenExited()
         {
             QueueFree();

--- a/getting_started/first_3d_game/05.spawning_mobs.rst
+++ b/getting_started/first_3d_game/05.spawning_mobs.rst
@@ -244,7 +244,7 @@ Let's code the mob spawning logic. We're going to:
 
  .. code-tab:: csharp
 
-    // We also specified this function name in PascalCase in the editor's connection window
+    // We also specified this function name in PascalCase in the editor's connection window.
     private void OnMobTimerTimeout()
     {
         // Create a new instance of the Mob scene.

--- a/getting_started/first_3d_game/07.killing_player.rst
+++ b/getting_started/first_3d_game/07.killing_player.rst
@@ -94,7 +94,7 @@ a ``die()`` function that helps us put a descriptive label on the code.
         QueueFree();
     }
 
-    // We also specified this function name in PascalCase in the editor's connection window
+    // We also specified this function name in PascalCase in the editor's connection window.
     private void OnMobDetectorBodyEntered(Node3D body)
     {
         Die();
@@ -122,7 +122,7 @@ Get the timer, and stop it, in the ``_on_player_hit()`` function.
 
  .. code-tab:: csharp
 
-    // We also specified this function name in PascalCase in the editor's connection window
+    // We also specified this function name in PascalCase in the editor's connection window.
     private void OnPlayerHit()
     {
         GetNode<Timer>("MobTimer").Stop();

--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -32,6 +32,17 @@ the bar to reflect the change. To do so, in Godot, you would use signals.
 We will now use a signal to make our Godot icon from the previous lesson
 (:ref:`doc_scripting_player_input`) move and stop by pressing a button.
 
+.. note:: For this project, we will be following the Godot naming conventions.
+
+          - **GDScript**: Classes (nodes) use PascalCase, variables and
+            functions use snake_case, and constants use ALL_CAPS (See
+            :ref:`doc_gdscript_styleguide`).
+
+          - **C#**: Classes, export variables and methods use PascalCase,
+            private fields use _camelCase, local variables and parameters use
+            camelCase (See :ref:`doc_c_sharp_styleguide`). Be careful to type
+            the method names precisely when connecting signals.
+
 .. Example
 
 Scene setup
@@ -156,6 +167,7 @@ the ``not`` keyword to invert the value.
 
  .. code-tab:: csharp C#
 
+    // We also specified this function name in PascalCase in the editor's connection window.
     private void OnButtonPressed()
     {
         SetProcess(!IsProcessing());
@@ -221,6 +233,7 @@ Your complete ``sprite_2d.gd`` code should look like the following.
             Position += velocity * (float)delta;
         }
 
+        // We also specified this function name in PascalCase in the editor's connection window.
         private void OnButtonPressed()
         {
             SetProcess(!IsProcessing());
@@ -393,6 +406,7 @@ Here is the complete ``sprite_2d.gd`` file for reference.
             Position += velocity * (float)delta;
         }
 
+        // We also specified this function name in PascalCase in the editor's connection window.
         private void OnButtonPressed()
         {
             SetProcess(!IsProcessing());


### PR DESCRIPTION
Doing this because of discussion in #9048.

Currently there's a note in the first 2D game tutorial about naming, the first 3D game has comments in all of its code for signals, and the signals page in step by step has nothing. This PR makes it so all sections have a note and code comments. The notes are being used in addition to comments since comments can't be translated. Technically we could have the note just in the signals page, since you're supposed to read that before either of the first game tutorials, but I don't think we should assume people won't skim or skip around. Plus if someone's going through these pages over multiple days and not in one day it's good to have reminders.

Closes #9048.