### PR TITLE
Update CSG note with info on reliability

### DIFF
--- a/tutorials/3d/csg_tools.rst
+++ b/tutorials/3d/csg_tools.rst
@@ -15,7 +15,9 @@ Interior environments can be created by using inverted primitives.
 
 .. note:: The CSG nodes in Godot are mainly intended for prototyping. There is
           no built-in support for UV mapping or editing 3D polygons (though
-          extruded 2D polygons can be used with the CSGPolygon3D node).
+          extruded 2D polygons can be used with the CSGPolygon3D node). In
+          addition CSG can't reliably create meshes made up of multiple nodes
+          without holes.
 
           If you're looking for an easy to use level design tool for a project,
           you may want to use `Qodot <https://github.com/QodotPlugin/Qodot>`__


### PR DESCRIPTION
CSG can't reliably create meshes made up of multiple nodes without holes in them. See discussion in https://github.com/godotengine/godot/issues/58637. Closes #8767.