### PR TITLE
Change description for get_unix_time_from_system for clarity regarding Unix Epoch and UTC

### DIFF
--- a/classes/class_time.rst
+++ b/classes/class_time.rst
@@ -25,7 +25,7 @@ This class conforms with as many of the ISO 8601 standards as possible. All date
 
 Conversion methods assume "the same timezone", and do not handle timezone conversions or DST automatically. Leap seconds are also not handled, they must be done manually if desired. Suffixes such as "Z" are not handled, you need to strip them away manually.
 
-When getting time information from the system, the time can either be in the local timezone or UTC depending on the ``utc`` parameter. However, the :ref:`get_unix_time_from_system<class_Time_method_get_unix_time_from_system>` method always returns the time in UTC.
+When getting time information from the system, the time can either be in the local timezone or UTC depending on the ``utc`` parameter. However, the :ref:`get_unix_time_from_system<class_Time_method_get_unix_time_from_system>` method always returns the seconds passed since the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time), which is in UTC.
 
 \ **Important:** The ``_from_system`` methods use the system clock that the user can manually set. **Never use** this method for precise time calculation since its results are subject to automatic adjustments by the user or the operating system. **Always use** :ref:`get_ticks_usec<class_Time_method_get_ticks_usec>` or :ref:`get_ticks_msec<class_Time_method_get_ticks_msec>` for precise time calculation instead, since they are guaranteed to be monotonic (i.e. never decrease).
 
@@ -507,7 +507,7 @@ Converts the given Unix timestamp to an ISO 8601 time string (HH:MM:SS).
 
 :ref:`Dictionary<class_Dictionary>` **get_time_zone_from_system**\ (\ ) |const|
 
-Returns the current time zone as a dictionary of keys: ``bias`` and ``name``. 
+Returns the current time zone as a dictionary of keys: ``bias`` and ``name``.
 
 - ``bias`` is the offset from UTC in minutes, since not all time zones are multiples of an hour from UTC.
 
@@ -559,7 +559,7 @@ Converts the given ISO 8601 date and/or time string to a Unix timestamp. The str
 
 :ref:`float<class_float>` **get_unix_time_from_system**\ (\ ) |const|
 
-Returns the current Unix timestamp in seconds based on the system time in UTC. This method is implemented by the operating system and always returns the time in UTC.
+Returns the current Unix timestamp in seconds based on the system time. The Unix timestamp is the number of seconds passed since 00:00:00 UTC on 1 January 1970, the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time). It is always in UTC.
 
 \ **Note:** Unlike other methods that use integer timestamps, this method returns the timestamp as a :ref:`float<class_float>` for sub-second precision.
 

--- a/classes/class_time.rst
+++ b/classes/class_time.rst
@@ -25,7 +25,7 @@ This class conforms with as many of the ISO 8601 standards as possible. All date
 
 Conversion methods assume "the same timezone", and do not handle timezone conversions or DST automatically. Leap seconds are also not handled, they must be done manually if desired. Suffixes such as "Z" are not handled, you need to strip them away manually.
 
-When getting time information from the system, the time can either be in the local timezone or UTC depending on the ``utc`` parameter. However, the :ref:`get_unix_time_from_system<class_Time_method_get_unix_time_from_system>` method always returns the seconds passed since the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time), which is in UTC.
+When getting time information from the system, the time can either be in the local timezone or UTC depending on the ``utc`` parameter. However, the :ref:`get_unix_time_from_system<class_Time_method_get_unix_time_from_system>` method always returns the seconds passed since the `Unix epoch <https://en.wikipedia.org/wiki/Unix_time>`_, which is in UTC.
 
 \ **Important:** The ``_from_system`` methods use the system clock that the user can manually set. **Never use** this method for precise time calculation since its results are subject to automatic adjustments by the user or the operating system. **Always use** :ref:`get_ticks_usec<class_Time_method_get_ticks_usec>` or :ref:`get_ticks_msec<class_Time_method_get_ticks_msec>` for precise time calculation instead, since they are guaranteed to be monotonic (i.e. never decrease).
 
@@ -559,7 +559,7 @@ Converts the given ISO 8601 date and/or time string to a Unix timestamp. The str
 
 :ref:`float<class_float>` **get_unix_time_from_system**\ (\ ) |const|
 
-Returns the current Unix timestamp in seconds based on the system time. The Unix timestamp is the number of seconds passed since 00:00:00 UTC on 1 January 1970, the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time). It is always in UTC.
+Returns the current Unix timestamp in seconds based on the system time. The Unix timestamp is the number of seconds passed since 00:00:00 UTC on 1 January 1970, the `Unix epoch <https://en.wikipedia.org/wiki/Unix_time>`_. It is always in UTC.
 
 \ **Note:** Unlike other methods that use integer timestamps, this method returns the timestamp as a :ref:`float<class_float>` for sub-second precision.
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
This fixes the issue #9080 