### PR TITLE
Add extension support info for web export

### DIFF
--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -57,6 +57,8 @@ If a runnable web export template is available, a button appears between the
 *Stop scene* and *Play edited Scene* buttons in the editor to quickly open the
 game in the default browser for testing.
 
+If your project uses GDExtension **Extension Support** needs to be enabled.
+
 If you plan to use :ref:`VRAM compression <doc_importing_images>` make sure that
 **Vram Texture Compression** is enabled for the targeted platforms (enabling
 both **For Desktop** and **For Mobile** will result in a bigger, but more


### PR DESCRIPTION
States that "extension support" needs to be enabled if a project uses GDExtension. I'm not sure if there's more to add to this or not, that's basically the info people on Discord gave me. If anything else should be added I'll gladly do it. Closes #6970.