### PR TITLE
Change call from empty to is_empty in RNG tutorial

### DIFF
--- a/tutorials/math/random_number_generation.rst
+++ b/tutorials/math/random_number_generation.rst
@@ -422,7 +422,7 @@ ends up empty. When that happens, you reinitialize it to its default value::
 
 
     func get_fruit():
-        if _fruits.empty():
+        if _fruits.is_empty():
             # Fill the fruits array again and shuffle it.
             _fruits = _fruits_full.duplicate()
             _fruits.shuffle()


### PR DESCRIPTION
The `empty` method was renamed to `is_empty` somewhere between 3.x and 4.x so the code in the tutorial just needed to be brought up to date.

This was brought to light by ill13 in the Godot Discord server on the #beginner-2 channel noticing an error when running that code:

  https://discord.com/channels/212250894228652034/762480166248513577/1218050947385786438

There are no other instances of a call to `empty` in the repo.