### PR TITLE
Add more tool script info and add a section

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -96,7 +96,7 @@ editor, and it must inherit from :ref:`class_EditorPlugin`.
 .. warning::
 
     In addition to the EditorPlugin script, any other GDScript that your plugin uses
-    must *also* be a tool. Any GDScript without ``@tool`` imported into the editor
+    must *also* be a tool. Any GDScript without ``@tool`` used by the editor
     will act like an empty file!
 
 It's important to deal with initialization and clean-up of resources.

--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -105,18 +105,20 @@ Here is how a ``_process()`` function might look for you:
         // Code to execute both in editor and in game.
     }
 
-.. note::
+Important information
+---------------------
 
-    Modifications in the editor are permanent. For example, in the following
-    case, when we remove the script, the node will keep its rotation. Be careful
-    to avoid making unwanted modifications.
+Any other GDScript that your tool script uses must *also* be a tool. Any
+GDScript without ``@tool`` used by the editor will act like an empty file!
 
-.. note::
+Extending a ``@tool`` script does not automatically make the extending script
+a ``@tool``. Omitting ``@tool`` from the extending script will disable tool
+behavior from the super class. Therefore the extending script should also
+specify the ``@tool`` annotation.
 
-    Extending a ``@tool`` script does not automatically make the extending script
-    a ``@tool``. Omitting ``@tool`` from the extending script will disable tool
-    behavior from the super class. Therefore the extending script should also
-    specify the ``@tool`` annotation.
+Modifications in the editor are permanent. For example, in the next
+section when we remove the script, the node will keep its rotation. Be careful
+to avoid making unwanted modifications.
 
 Try ``@tool`` out
 -----------------


### PR DESCRIPTION
Adds that any script a tool script interacts with must also be a tool script. Instead of creating another note in this section I've combined that info with the two existing notes. Having three back to back would be excessive. Closes #8692