### PR TITLE
Document that hint_color is now source_color

### DIFF
--- a/tutorials/migrating/upgrading_to_godot_4.rst
+++ b/tutorials/migrating/upgrading_to_godot_4.rst
@@ -519,6 +519,7 @@ Some notable renames you will need to perform in shaders are:
 - Texture filter and repeat modes are now set on individual uniforms, rather
   than the texture files themselves.
 - ``hint_albedo`` is now ``source_color``.
+- ``hint_color`` is now ``source_color``.
 - :ref:`Built in matrix variables were renamed. <doc_spatial_shader>`
 - Particles shaders no longer use the ``vertex()`` processor function. Instead
   they use ``start()`` and ``process()``.


### PR DESCRIPTION
Does what the title says for the Godot 3 to Godot 4 doc page. I double checked the [shader page ](https://docs.godotengine.org/en/4.0/tutorials/shaders/shader_reference/shading_language.html)to make sure ``hint_color`` and ``hint_albedo`` are both ``source_color`` now and that's what it looks like. Closes #8451.