### PR TITLE
Update android SDK version [3.x]

### DIFF
--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -30,7 +30,7 @@ Download and install the Android SDK.
 
     - Android SDK Platform-Tools version 30.0.5 or later
     - Android SDK Build-Tools version 30.0.3
-    - Android SDK Platform 31
+    - Android SDK Platform 33
     - Android SDK Command-line Tools (latest)
     - CMake version 3.10.2.4988404
     - NDK version r23c (23.2.8568313)


### PR DESCRIPTION
Updates the android SDK version for 3.x. It was changed to 33 in 3.5.3, release notes for that version are [here](https://godotengine.org/article/maintenance-release-godot-3-5-3/). Closes #8822, Closes #7111