### PR TITLE
Update compiling_for_macos.rst with double precision app bundling example.

### DIFF
--- a/contributing/development/compiling/compiling_for_macos.rst
+++ b/contributing/development/compiling/compiling_for_macos.rst
@@ -152,6 +152,14 @@ with the following commands (assuming a universal build, otherwise replace the
     cp bin/godot.macos.template_debug.universal macos_template.app/Contents/MacOS/godot_macos_debug.universal
     chmod +x macos_template.app/Contents/MacOS/godot_macos*
 
+For a binary compiled with double precision, (for example `scons platform=macos arch=arm64 precision=double`) the following will work:
+
+    cp -r misc/dist/macos_tools.app ./Godot.app
+    mkdir -p Godot.app/Contents/MacOS
+    cp bin/godot.macos.editor.double.arm64 Godot.app/Contents/MacOS/Godot
+    chmod +x Godot.app/Contents/MacOS/Godot
+    codesign --force --timestamp --options=runtime --entitlements misc/dist/macos/editor.entitlements -s - Godot.app
+
 .. note::
 
     If you are building the ``master`` branch, you also need to include support


### PR DESCRIPTION
Add full app bundling cmd for mac silicon + double precision binary, tested on M1 air Sonoma 14.2.1.  The other bundle cmd did not work for me with `universal` swapped for `arm64`.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
