### PR TITLE
Update getting_started/step_by_step/scripting_player_input.rst

### DIFF
--- a/getting_started/step_by_step/scripting_player_input.rst
+++ b/getting_started/step_by_step/scripting_player_input.rst
@@ -82,11 +82,10 @@ Finally, we use the ``direction`` as a multiplier when we update the node's
 Comment out the lines ``var velocity = Vector2.UP.rotated(rotation) * speed`` and ``position += velocity * delta`` like this:
 
 .. tabs::
-
  .. code-tab:: gdscript GDScript
 
     #var velocity = Vector2.UP.rotated(rotation) * speed
-	
+
     #position += velocity * delta
 
  .. code-tab:: csharp C#


### PR DESCRIPTION
Hi!
Was following the Godot docs to learn a bit and found this bit that didn't make sense. Opened the code and realized that something wasn't rendering, so here's a small fix.

Page in question: https://docs.godotengine.org/en/stable/getting_started/step_by_step/scripting_player_input.html

* Removed a space that cause code block to not render

<img width="1207" alt="Screenshot 2024-03-17 at 1 42 43 PM" src="https://github.com/godotengine/godot-docs/assets/6665607/e0dab506-12c2-4aae-862e-6351bd2a5fdc">

Cheers!

