### PR TITLE
OpenXR: Add a note about the vendor plugin

### DIFF
--- a/tutorials/xr/deploying_to_android.rst
+++ b/tutorials/xr/deploying_to_android.rst
@@ -62,6 +62,12 @@ Enable the **GodotOpenXRVendors** plugin.
 
 .. image:: img/xr_enable_vendors_plugin.webp
 
+.. note::
+    This is no longer required from vendors plugin 2.0.3 onwards as it now uses GDExtension.
+    The plugin will not be shown in this list.
+    You can verify it is installed correctly by checking if the export presets contain
+    the entries described below.
+
 Creating the export presets
 ---------------------------
 You will need to setup a separate export preset for each device, as each device will need its own loader included.


### PR DESCRIPTION
For a few versions the vendor plugin needed to be enabled but now that it has been rewritten to GDExtensions this is no longer the case.

I though of removing the section all together but seeing this info is features in a fair amount of places, I thought a note would be more communicative so people know this is no longer needed.