### PR TITLE
Add note for hosting asset icons on GitHub

### DIFF
--- a/community/asset_library/submitting_to_assetlib.rst
+++ b/community/asset_library/submitting_to_assetlib.rst
@@ -180,8 +180,7 @@ is required in the submission form here as well.
 
 .. note::
 
-    If you are hosting your repository with GitHub you can host the icon within the repo.
-    You must provide a url in the form `https://raw.githubusercontent.com/<user>/<project>/<branch>/Icon.png`.
+    For icons hosted on GitHub, URLs must be provided in the form of `https://raw.githubusercontent.com/<user>/<project>/<branch>/Icon.png`.
 
 * **License**:
     The license under which you are distributing the asset. The list

--- a/community/asset_library/submitting_to_assetlib.rst
+++ b/community/asset_library/submitting_to_assetlib.rst
@@ -178,6 +178,11 @@ is required in the submission form here as well.
     The **icon** must be square (1:1 aspect ratio). It should have a minimum
     resolution of 128×128 pixels.
 
+.. note::
+
+    If you are hosting your repository with GitHub you can host the icon within the repo.
+    You must provide a url in the form `https://raw.githubusercontent.com/<user>/<project>/<branch>/Icon.png`.
+
 * **License**:
     The license under which you are distributing the asset. The list
     includes a variety of free and open source software licenses, such as GPL


### PR DESCRIPTION
The asset submission validator will reject a url that ends with a query string such as `?raw=1`. Providing the icon url without the query string passes validation but the image will not load causing:

```
This asset has been rejected. Reason: The icon link must be a direct link. For icons hosted on GitHub, the link must start with "raw.githubusercontent.com", not "github.com". See this article for more information: https://docs.godotengine.org/en/latest/community/asset_library/submitting_to_assetlib.html 
```

The required information is listed as a note under Requirements rather than under the relevant Icon section where it is pertinent..

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
