### PR TITLE
Add table of contents to EPUB of docs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -317,3 +317,6 @@ rst_epilog = """
     image_locale="-" if language == "en" else language,
     target_locale="" if language == "en" else "/" + language,
 )
+
+# Needed so the table of contents is created for EPUB
+epub_tocscope = 'includehidden'


### PR DESCRIPTION
This change adds a table of contents to the EPUB version of the docs. I built the docs on my machine and the table shows up in Calibre. There's a lot of warnings during the build about a duplicated ToC entries but everything still works.

Closes #9129, Closes #8584, Closes #8300