### PR TITLE
Update README.md with contributors image

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,9 @@ At the exception of the `classes/` folder, all the content of this repository is
 See [LICENSE.txt](/LICENSE.txt) for details.
 
 The files in the `classes/` folder are derived from [Godot's main source repository](https://github.com/godotengine/godot) and are distributed under the MIT license, with the same authors as above.
+
+## Contributors
+
+[![Contributors image](https://contrib.rocks/image?repo=godotengine/godot-docs&max=2000&columns=15)](https://github.com/godotengine/godot-docs/graphs/contributors)
+
+Made with [contrib.rocks](https://contrib.rocks).


### PR DESCRIPTION
The image will be always accurate with github contributors page

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
