### PR TITLE
Document the `--export-additional-pack` command-line option

### DIFF
--- a/tutorials/editor/command_line_tutorial.rst
+++ b/tutorials/editor/command_line_tutorial.rst
@@ -201,6 +201,9 @@ given build type.
 | ``--export-pack <preset> <path>``                                | |editor| Like ``--export-release``, but only export the game pack for the given preset. The ``<path>`` extension determines whether it will be in PCK   |
 |                                                                  | or ZIP format.                                                                                                                                          |
 +------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``--export-additional-pack <preset> <path>``                     | |editor| Like ``--export-pack``, but excludes data that's only relevant for a main pack, such as the project icon, splash screen, among other things.   |
+|                                                                  | The ``<path>`` extension determines whether it will be in PCK or ZIP format.                                                                            |
++------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
 | ``--convert-3to4 [<max_file_kb>] [<max_line_size>]``             | |editor| Convert project from Godot 3.x to Godot 4.x.                                                                                                   |
 +------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+
 | ``--validate-conversion-3to4 [<max_file_kb>] [<max_line_size>]`` | |editor| Show what elements will be renamed when converting project from Godot 3.x to Godot 4.x.                                                        |
@@ -411,6 +414,13 @@ To export only a PCK file, use the ``--export-pack`` option followed by the
 preset name and output path, with the file extension, instead of
 ``--export-release`` or ``--export-debug``. The output path extension determines
 the package's format, either PCK or ZIP.
+
+To export a PCK file for something like a patch, mod or DLC, use the
+``--export-additional-pack`` option followed by the preset name and output path,
+with the file extension. The output path extension determines the package's
+format, either PCK or ZIP. This kind of pack will exclude project data that's
+only relevant for main pack files, such as project icon, splash screen, among
+other things.
 
 .. warning::
 

--- a/tutorials/export/exporting_projects.rst
+++ b/tutorials/export/exporting_projects.rst
@@ -199,6 +199,15 @@ When doing so, the export preset name must still be specified on the command lin
 
     godot --export-pack "Windows Desktop" some_name.pck
 
+You can also configure it to export an *additional* PCK/ZIP file, meaning a
+non-main pack file, which will exclude any project data that's only relevant for
+the main pack file, such as the project icon, splash screen, among other things.
+These packs may be better suited for things like a patch, mod or DLC.
+
+.. code-block:: shell
+
+    godot --export-additional-pack "Windows Desktop" some_name.pck
+
 It is often useful to combine the ``--export`` flag with the ``--path``
 flag, so that you do not need to ``cd`` to the project folder before running
 the command:


### PR DESCRIPTION
This updates `command_line_tutorial.rst` as well as `exporting_projects.rst` with the new `--export-additional-pack` option introduced in godotengine/godot#89928.

_(Marking this as draft until the corresponding PR is merged.)_