### PR TITLE
Add tip for zooming in the bezier curve editor

### DIFF
--- a/tutorials/animation/animation_track_types.rst
+++ b/tutorials/animation/animation_track_types.rst
@@ -72,7 +72,14 @@ editor, click the curve icon to the right of the animation track.
 .. image:: img/bezier_curve_icon.webp
 
 In the editor, keys are represented by filled diamonds and the outlined
-diamonds connected to them by a line control curve's shape.
+diamonds connected to them by a line control curve's shape. 
+
+.. tip::
+
+    For better precision while manually working with curves, you might want to alter
+    the zoom levels of the editor. You can do this with your mouse wheel, or using
+    the track on the bottom right of the editor to zoom in on the time axis, 
+    or with :kbd:`Ctrl + Alt + Mouse wheel` to zoom in the values range of the animation.
 
 .. image:: img/bezier_curves.webp
 

--- a/tutorials/animation/animation_track_types.rst
+++ b/tutorials/animation/animation_track_types.rst
@@ -72,7 +72,7 @@ editor, click the curve icon to the right of the animation track.
 .. image:: img/bezier_curve_icon.webp
 
 In the editor, keys are represented by filled diamonds and the outlined
-diamonds connected to them by a line control curve's shape. 
+diamonds connected to them by a line control curve's shape.
 
 .. tip::
 

--- a/tutorials/animation/animation_track_types.rst
+++ b/tutorials/animation/animation_track_types.rst
@@ -77,9 +77,9 @@ diamonds connected to them by a line control curve's shape.
 .. tip::
 
     For better precision while manually working with curves, you might want to alter
-    the zoom levels of the editor. You can do this with your mouse wheel, or using
-    the track on the bottom right of the editor to zoom in on the time axis, 
-    or with :kbd:`Ctrl + Alt + Mouse wheel` to zoom in the values range of the animation.
+    the zoom levels of the editor. The slider on the bottom right of the editor can be used to
+    zoom in and out on the time axis, you can also do that with :kbd:`Ctrl + Shift + Mouse wheel`.
+    Using :kbd:`Ctrl + Alt + Mouse wheel` will zoom in and out on the Y axis
 
 .. image:: img/bezier_curves.webp
 


### PR DESCRIPTION
After spending quite a bit of time trying to figure out how to scale the Y axis of the Bezier curve navigator (and getting my answer from Discord) I decided to do my first contribution to the docs by adding a tip to the animation tutorial.
ESL, so very open to grammatical corrections. 