### PR TITLE
Patched a minor typo in visual_studio_code.rst

### DIFF
--- a/contributing/development/configuring_an_ide/visual_studio_code.rst
+++ b/contributing/development/configuring_an_ide/visual_studio_code.rst
@@ -154,7 +154,7 @@ To run and debug the project you need to create a new configuration in the ``lau
 
 The name under ``program`` depends on your build configuration,
 e.g. ``godot.linuxbsd.editor.dev.x86_64`` for 64-bit LinuxBSD platform with
-``platform=editor`` and ``dev_build=yes``.
+``target=editor`` and ``dev_build=yes``.
 
 Configuring Intellisense
 ------------------------


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

I just found this minor typo.
I checked the [buildsystem doc](https://docs.godotengine.org/en/latest/contributing/development/compiling/introduction_to_the_buildsystem.html) to be sure