### PR TITLE
Update docs page introduction_to_3d to accurately explain Transform3D

### DIFF
--- a/tutorials/3d/introduction_to_3d.rst
+++ b/tutorials/3d/introduction_to_3d.rst
@@ -28,7 +28,7 @@ node for everything 3D.
 
 Node3Ds have a local transform, which is relative to the parent
 node (as long as the parent node is also of **or inherits from** the type
-Node3D). This transform can be accessed as a 4×3
+Node3D). This transform can be accessed as a 3×4
 :ref:`Transform3D <class_Transform3D>`, or as 3 :ref:`Vector3 <class_Vector3>`
 members representing location, Euler rotation (X, Y and Z angles) and
 scale.


### PR DESCRIPTION
As mentioned in Issue #8904, a Transform3D is a 3x4 matrix, not a 4x3. This simply updates line 35 in introduction_to_3d.rst to match.

edit: I did not mean to try to merge 99 commits, I only wanted to request merge the one that I was making, and I'm afraid that I messed up.
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
