### PR TITLE
Fix outdated _CLASS_ script template description.

### DIFF
--- a/tutorials/scripting/creating_script_templates.rst
+++ b/tutorials/scripting/creating_script_templates.rst
@@ -203,7 +203,7 @@ Base placeholders
 +==========================+====================================================+
 | ``_BINDINGS_NAMESPACE_`` | The name of the Godot namespace (used in C# only). |
 +--------------------------+----------------------------------------------------+
-| ``_CLASS_``              | The name of the new class (used in C# only).       |
+| ``_CLASS_``              | The name of the new class.                         |
 +--------------------------+----------------------------------------------------+
 | ``_BASE_``               | The base type a new script inherits from.          |
 +--------------------------+----------------------------------------------------+


### PR DESCRIPTION
_CLASS_ works in gdscript as well, so remove the `(used in C# only)` note.