### PR TITLE
Specified that get_floor_normal() does not return the surface normal

### DIFF
--- a/classes/class_characterbody3d.rst
+++ b/classes/class_characterbody3d.rst
@@ -502,7 +502,7 @@ Returns the floor's collision angle at the last collision point according to ``u
 
 :ref:`Vector3<class_Vector3>` **get_floor_normal**\ (\ ) |const|
 
-Returns the surface normal of the floor at the last collision point. Only valid after calling :ref:`move_and_slide<class_CharacterBody3D_method_move_and_slide>` and when :ref:`is_on_floor<class_CharacterBody3D_method_is_on_floor>` returns ``true``.
+Returns the collision normal of the floor at the last collision point. Only valid after calling :ref:`move_and_slide<class_CharacterBody3D_method_move_and_slide>` and when :ref:`is_on_floor<class_CharacterBody3D_method_is_on_floor>` returns ``true``. Note that this is not always the same as the surface normal.
 
 .. rst-class:: classref-item-separator
 


### PR DESCRIPTION
Specified that get_floor_normal() does not return the surface normal, but rather the collision normal.

Also see https://github.com/godotengine/godot-proposals/issues/8324

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
