### PR TITLE
Clarify per-instance uniforms are not supported in the Compatibility renderer

### DIFF
--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -1018,6 +1018,10 @@ Per-instance uniforms
 
     Per-instance uniforms are only available in ``spatial`` (3D) shaders.
 
+.. note::
+
+    Per-instance uniforms are not supported when using the Compatibility renderer.
+
 Sometimes, you want to modify a parameter on each node using the material. As an
 example, in a forest full of trees, when you want each tree to have a slightly
 different color that is editable by hand. Without per-instance uniforms, this


### PR DESCRIPTION
Source: https://github.com/godotengine/godot/blob/655e93d5846b2ef8ebb7d22c8878f51b8f22b312/servers/rendering/shader_language.cpp#L8364-L8371

The restriction to `spatial` shaders will probably be lifted eventually, so I made a separate note.