### PR TITLE
Fixed copy-paste error on Decals distance fade

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -291,7 +291,7 @@ Rendering
 - Does not rely on run-time mesh generation. This means decals can be used on
   complex skinned meshes with no performance penalty, even if the decal moves every frame.
 - Support for nearest, bilinear, trilinear or anisotropic texture filtering (configured globally).
-- Optional distance fade system to fade distant lights and their shadows, improving performance.
+- Optional distance fade system to fade distant decals, improving performance.
 - When using the Forward+ backend (default on desktop), decals are
   rendered with clustered forward optimizations to decrease their individual cost.
   Clustered rendering also lifts any limits on the number of decals that can be used on a mesh.


### PR DESCRIPTION
Decals distance fade (in list of features) was referring to lights and their shadows, should be decals. Was likely copy-pasted from the lights section.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
