### PR TITLE
Explanation for printraw() behaviour

### DIFF
--- a/classes/class_@globalscope.rst
+++ b/classes/class_@globalscope.rst
@@ -6521,7 +6521,7 @@ Prints one or more arguments to strings in the best way possible to standard err
 
 |void| **printraw**\ (\ ...\ ) |vararg|
 
-Prints one or more arguments to strings in the best way possible to the OS terminal. Unlike :ref:`print<class_@GlobalScope_method_print>`, no newline is automatically added at the end.
+Prints one or more arguments to strings in the best way possible to the OS terminal (NOTE: The OS terminal is NOT the Editor's Console, the output can be seen using "Godot_version_console.exe"). Unlike :ref:`print<class_@GlobalScope_method_print>`, no newline is automatically added at the end.
 
 
 .. tabs::


### PR DESCRIPTION
changed line 6524 to include:

(NOTE: The OS terminal is NOT the Editor's Console, the output can be seen using "Godot_version_console.exe")

This is in reference to the issue 89323: https://github.com/godotengine/godot/issues/89323

Target Branch: `master`
