### PR TITLE
Update Python code style guidelines regarding usage of `ruff`

### DIFF
--- a/contributing/development/code_style_guidelines.rst
+++ b/contributing/development/code_style_guidelines.rst
@@ -267,35 +267,34 @@ Python
 Godot's SCons buildsystem is written in Python, and various scripts included
 in the source tree are also using Python.
 
-For those, we follow the `Black style guide <https://github.com/psf/black#the-black-code-style>`__.
-Blacken your Python changes using `Black <https://pypi.org/project/black/>`__.
+For those, we use the `Ruff linter and code formatter <https://docs.astral.sh/ruff/>`__.
 
-Using black locally
+Using ruff locally
 ~~~~~~~~~~~~~~~~~~~
 
-First of all, you will need to install Black. Black requires Python 3.7+ to run.
+First of all, you will need to install Ruff. Ruff requires Python 3.7+ to run.
 
 Installation
 ^^^^^^^^^^^^
 
-Here's how to install black:
+Here's how to install ruff:
 
 ::
 
-    pip3 install black --user
+    pip3 install ruff --user
 
 
-You then have different possibilities to apply black to your changes:
+You then have different possibilities to apply ruff to your changes:
 
 Manual usage
 ^^^^^^^^^^^^
 
-You can apply ``black`` manually to one or more files with the following
+You can apply ``ruff`` manually to one or more files with the following
 command:
 
 ::
 
-    black -l 120 <path/to/file(s)>
+    ruff -l 120 <path/to/file(s)>
 
 - ``-l 120`` means that the allowed number of characters per line is 120.
   This number was agreed upon by the developers.
@@ -307,8 +306,8 @@ Pre-commit hook
 ~~~~~~~~~~~~~~~
 
 For ease of use, we provide hooks for Git with the `pre-commit <https://pre-commit.com/>`__
-Python framework that will run ``black`` automatically on all your commits with the 
-correct version of ``black``.
+Python framework that will run ``ruff`` automatically on all your commits with the
+correct version of ``ruff``.
 To set up:
 
 ::
@@ -319,7 +318,7 @@ To set up:
 
 You can also run the hook manually with ``pre-commit run``.
 
-.. note:: 
+.. note::
 
     Previously, we supplied a hook in the folder ``misc/hooks``. If you copied the
     script manually, these hooks should still work, but symlinks will be broken.
@@ -331,8 +330,8 @@ Editor integration
 ^^^^^^^^^^^^^^^^^^
 
 Many IDEs or code editors have beautifier plugins that can be configured to run
-black automatically, for example, each time you save a file. For details, you can
-check `Black editor integration <https://github.com/psf/black#editor-integration>`__.
+ruff automatically, for example, each time you save a file. For details, you can
+check `Ruff Integrations <https://docs.astral.sh/ruff/integrations/>`__.
 
 Comment style guide
 -------------------


### PR DESCRIPTION
- Depends on https://github.com/godotengine/godot/pull/90457.
- This PR replaces all mentions of `black` formatter (which is being replaced by the PR mentioned above) with `ruff`.
- The `contributing/development/code_style_guidelines.rst` file seems to be out of date regarding removal of hand-written pre-commit hooks introduced by https://github.com/godotengine/godot/pull/88866 - I borrowed a few relevant changes from https://github.com/godotengine/godot-docs/pull/9094 in the hopes that future merge conflicts aren't too painful.
