### PR TITLE
Update PhysicsServer2D naming for C# in ray-casting.rst

### DIFF
--- a/tutorials/physics/ray-casting.rst
+++ b/tutorials/physics/ray-casting.rst
@@ -63,7 +63,7 @@ Use the following code in 2D:
     public override void _PhysicsProcess(double delta)
     {
         var spaceRid = GetWorld2D().Space;
-        var spaceState = Physics2DServer.SpaceGetDirectState(spaceRid);
+        var spaceState = PhysicsServer2D.SpaceGetDirectState(spaceRid);
     }
 
 Or more directly:


### PR DESCRIPTION
Current C# documentation refers to "Physics2DServer", but the actual name should be PhysicsServer2D.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
