### PR TITLE
Add more information about VS and VS Code debugging

### DIFF
--- a/getting_started/step_by_step/scripting_languages.rst
+++ b/getting_started/step_by_step/scripting_languages.rst
@@ -53,8 +53,6 @@ now mature, you will find fewer learning resources for it compared to
 GDScript. That's why we recommend C# mainly to users who already have experience
 with the language. 
 
-.. seealso:: To learn more about C#, head to the :ref:`C# basics <doc_c_sharp>` page.
-
 Let's look at each language's features, as well as its pros and cons.
 
 GDScript
@@ -134,6 +132,8 @@ officially supported .NET option.
     platform. To use C# on that platform, consider Godot 3 instead.
     Android and iOS platform support is available as of Godot 4.2, but is
     experimental and :ref:`some limitations apply <doc_c_sharp_platforms>`.
+
+.. seealso:: To learn more about C#, head to the :ref:`C# basics <doc_c_sharp>` page.
 
 C++ via GDExtension
 ~~~~~~~~~~~~~~~~~~~

--- a/getting_started/step_by_step/scripting_languages.rst
+++ b/getting_started/step_by_step/scripting_languages.rst
@@ -51,7 +51,9 @@ For C#, you will need an external code editor like
 `VSCode <https://code.visualstudio.com/>`_ or Visual Studio. While C# support is
 now mature, you will find fewer learning resources for it compared to
 GDScript. That's why we recommend C# mainly to users who already have experience
-with the language.
+with the language. 
+
+.. seealso:: To learn more about C#, head to the :ref:`C# basics <doc_c_sharp>` page.
 
 Let's look at each language's features, as well as its pros and cons.
 

--- a/getting_started/step_by_step/scripting_languages.rst
+++ b/getting_started/step_by_step/scripting_languages.rst
@@ -51,7 +51,7 @@ For C#, you will need an external code editor like
 `VSCode <https://code.visualstudio.com/>`_ or Visual Studio. While C# support is
 now mature, you will find fewer learning resources for it compared to
 GDScript. That's why we recommend C# mainly to users who already have experience
-with the language. 
+with the language.
 
 Let's look at each language's features, as well as its pros and cons.
 

--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -136,14 +136,11 @@ Here is an example ``launch.json``:
 
 For this launch configuration to work, you need to either setup a GODOT4
 environment variable that points to the Godot executable, or replace ``program`` 
-parameter with the path to the Godot executable. On mac or linux, this can be 
-done by adding the following to your .zshrc, .bashrc, or .bash_profile file:
-
-.. code-block:: bash
-    
-    export GODOT4="/Applications/Godot.app/Contents/MacOS/Godot"
+parameter with the path to the Godot executable.
 
 Here is an example ``tasks.json``:
+
+.. code-block:: json
 
     {
         "version": "2.0.0",
@@ -155,15 +152,7 @@ Here is an example ``tasks.json``:
                 "args": [
                     "build"
                 ],
-                "problemMatcher": "$msCompile",
-                "presentation": {
-                    "echo": true,
-                    "reveal": "silent",
-                    "focus": false,
-                    "panel": "shared",
-                    "showReuseMessage": true,
-                    "clear": false
-                }
+                "problemMatcher": "$msCompile"
             }
         ]
     }
@@ -199,9 +188,9 @@ To debug your C# scripts using Visual Studio, open the .sln file that is generat
 after opening the first C# script in the editor.  In the **Debug** menu, go to the 
 **Debug Properties** menu item for your project.  Click the **Create a new profile** 
 button and choose **Executable**.  In the **Executable** field, browse to the path 
-of the C# version of the Godot editor. It must be the path to the main Godot 
-executable, not the 'console' version.  For the **Command Line Arguments** field, 
-type ``--path . --verbose``.  For the **Working Directory**, type a single period, 
+of the C# version of the Godot editor, or type ``%GODOT4%`` if you have created an
+environment variable for the Godot executable path. It must be the path to the main Godot 
+executable, not the 'console' version.  For the **Working Directory**, type a single period, 
 ``.``, meaning the current directory. Also check the **Enable native code debugging** 
 checkbox.  You may now close this window, click downward arrow on the debug profile 
 dropdown, and select your new launch profile.  Hit the green start button, and your 

--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -112,7 +112,7 @@ In Visual Studio Code:
     for the C# tools plugin to work.
 
 To configure a project for debugging, you need a ``tasks.json`` and ``launch.json`` file in
-the ``.vscode`` folder with the necessary configuration. 
+the ``.vscode`` folder with the necessary configuration.
 
 Here is an example ``launch.json``:
 
@@ -135,7 +135,7 @@ Here is an example ``launch.json``:
     }
 
 For this launch configuration to work, you need to either setup a GODOT4
-environment variable that points to the Godot executable, or replace ``program`` 
+environment variable that points to the Godot executable, or replace ``program``
 parameter with the path to the Godot executable.
 
 Here is an example ``tasks.json``:
@@ -184,17 +184,18 @@ In Godot's **Editor → Editor Settings** menu:
           the ``NuGet.Config`` file. When you build your Godot project again,
           the file will be automatically created with default values.
 
-To debug your C# scripts using Visual Studio, open the .sln file that is generated 
-after opening the first C# script in the editor.  In the **Debug** menu, go to the 
-**Debug Properties** menu item for your project.  Click the **Create a new profile** 
-button and choose **Executable**.  In the **Executable** field, browse to the path 
+To debug your C# scripts using Visual Studio, open the .sln file that is generated
+after opening the first C# script in the editor. In the **Debug** menu, go to the
+**Debug Properties** menu item for your project. Click the **Create a new profile**
+button and choose **Executable**. In the **Executable** field, browse to the path
 of the C# version of the Godot editor, or type ``%GODOT4%`` if you have created an
-environment variable for the Godot executable path. It must be the path to the main Godot 
-executable, not the 'console' version.  For the **Working Directory**, type a single period, 
-``.``, meaning the current directory. Also check the **Enable native code debugging** 
-checkbox.  You may now close this window, click downward arrow on the debug profile 
-dropdown, and select your new launch profile.  Hit the green start button, and your 
+environment variable for the Godot executable path. It must be the path to the main Godot
+executable, not the 'console' version. For the **Working Directory**, type a single period,
+``.``, meaning the current directory. Also check the **Enable native code debugging**
+checkbox. You may now close this window, click downward arrow on the debug profile
+dropdown, and select your new launch profile. Hit the green start button, and your
 game will begin playing in debug mode.
+
 
 Creating a C# script
 --------------------

--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -112,11 +112,63 @@ In Visual Studio Code:
     for the C# tools plugin to work.
 
 To configure a project for debugging, you need a ``tasks.json`` and ``launch.json`` file in
-the ``.vscode`` folder with the necessary configuration. An example configuration can be
-found `here <https://github.com/godotengine/godot-csharp-vscode/issues/43#issuecomment-1258321229>`__ .
-In the ``launch.json`` file, make sure the ``program`` parameter in the relevant configuration points to your Godot executable, either by
-changing it to the path of the executable or by defining a ``GODOT4`` environment variable that points to the
-executable. Now, when you start the debugger in Visual Studio Code, your Godot project will run.
+the ``.vscode`` folder with the necessary configuration. 
+
+Here is an example ``launch.json``:
+
+.. code-block:: json
+
+    {
+        "version": "0.2.0",
+        "configurations": [
+            {
+                "name": "Play",
+                "type": "coreclr",
+                "request": "launch",
+                "preLaunchTask": "build",
+                "program": "${env:GODOT4}",
+                "args": [],
+                "cwd": "${workspaceFolder}",
+                "stopAtEntry": false,
+            }
+        ]
+    }
+
+For this launch configuration to work, you need to either setup a GODOT4
+environment variable that points to the Godot executable, or replace ``program`` 
+parameter with the path to the Godot executable. On mac or linux, this can be 
+done by adding the following to your .zshrc, .bashrc, or .bash_profile file:
+
+.. code-block:: bash
+    
+    export GODOT4="/Applications/Godot.app/Contents/MacOS/Godot"
+
+Here is an example ``tasks.json``:
+
+    {
+        "version": "2.0.0",
+        "tasks": [
+            {
+                "label": "build",
+                "command": "dotnet",
+                "type": "process",
+                "args": [
+                    "build"
+                ],
+                "problemMatcher": "$msCompile",
+                "presentation": {
+                    "echo": true,
+                    "reveal": "silent",
+                    "focus": false,
+                    "panel": "shared",
+                    "showReuseMessage": true,
+                    "clear": false
+                }
+            }
+        ]
+    }
+
+Now, when you start the debugger in Visual Studio Code, your Godot project will run.
 
 Visual Studio (Windows only)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -142,6 +194,18 @@ In Godot's **Editor → Editor Settings** menu:
           In a file explorer window, go to ``%AppData%\NuGet``. Rename or delete
           the ``NuGet.Config`` file. When you build your Godot project again,
           the file will be automatically created with default values.
+
+To debug your C# scripts using Visual Studio, open the .sln file that is generated 
+after opening the first C# script in the editor.  In the **Debug** menu, go to the 
+**Debug Properties** menu item for your project.  Click the **Create a new profile** 
+button and choose **Executable**.  In the **Executable** field, browse to the path 
+of the C# version of the Godot editor. It must be the path to the main Godot 
+executable, not the 'console' version.  For the **Command Line Arguments** field, 
+type ``--path . --verbose``.  For the **Working Directory**, type a single period, 
+``.``, meaning the current directory. Also check the **Enable native code debugging** 
+checkbox.  You may now close this window, click downward arrow on the debug profile 
+dropdown, and select your new launch profile.  Hit the green start button, and your 
+game will begin playing in debug mode.
 
 Creating a C# script
 --------------------


### PR DESCRIPTION
Added instructions in the C# section on how to setup debugging in Visual Studio. When I first tried Godot a few weeks ago, I gave up as soon as I thought there was no debugging support yet. I think if you support C#, you really need to make it easy for people to be able to figure out how to debug their code. This is an amended version of a prior pull request