### PR TITLE
Add links to the stable documentation offline builds

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -58,7 +58,7 @@ To browse the documentation offline, you can `download an HTML copy <https://nig
 the top-level ``index.html`` in a web browser.
 
 For mobile devices or e-readers, you can also `download an ePub copy <https://nightly.link/godotengine/godot-docs/workflows/build_offline_docs/master/godot-docs-epub-master.zip>`__
-for offline reading (updated every Monday). Extract the ZIP archive then open
+(`stable <https://nightly.link/godotengine/godot-docs/workflows/build_offline_docs/master/godot-docs-epub-stable.zip>`__) for offline reading (updated every Monday). Extract the ZIP archive then open
 the ``GodotEngine.epub`` file in an e-book reader application.
 
 .. Below is the main table-of-content tree of the documentation website.

--- a/index.rst
+++ b/index.rst
@@ -54,7 +54,7 @@ Offline documentation
 ---------------------
 
 To browse the documentation offline, you can `download an HTML copy <https://nightly.link/godotengine/godot-docs/workflows/build_offline_docs/master/godot-docs-html-master.zip>`__
-for offline reading (updated every Monday). Extract the ZIP archive then open
+(`stable <https://nightly.link/godotengine/godot-docs/workflows/build_offline_docs/master/godot-docs-html-stable.zip>`__) for offline reading (updated every Monday). Extract the ZIP archive then open
 the top-level ``index.html`` in a web browser.
 
 For mobile devices or e-readers, you can also `download an ePub copy <https://nightly.link/godotengine/godot-docs/workflows/build_offline_docs/master/godot-docs-epub-master.zip>`__


### PR DESCRIPTION
Stable documentation is built but not linked on the main page, so I added links to the stable build next to the links for the latest build.
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
