### PR TITLE
Remove DevDocs from Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,7 @@ They are meant to be parsed with the [Sphinx](https://www.sphinx-doc.org/) docum
 
 ## Download for offline use
 
-To browse the documentation offline, you can use the mirror of the documentation
-hosted on [DevDocs](https://devdocs.io/godot/). To enable offline browsing on
-DevDocs, you need to:
-
-- Click the three dots in the top-left corner, choose **Preferences**.
-- Enable the desired version of the Godot documentation by checking the box
-  next to it in the sidebar.
-- Click the three dots in the top-left corner, choose **Offline data**.
-- Click the **Install** link next to the Godot documentation.
-
-You can also
+To browse the documentation offline, you can
 [download an HTML copy](https://nightly.link/godotengine/godot-docs/workflows/build_offline_docs/master/godot-docs-html-master.zip)
 for offline reading (updated every Monday). Extract the ZIP archive then open
 the top-level `index.html` in a web browser.


### PR DESCRIPTION
Follow up to PR #8896, didn't realize it was also in the readme file at the time.