### PR TITLE
Update the names of the export binaries

### DIFF
--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -345,10 +345,14 @@ and named like this (even for \*BSD which is seen as "Linux/X11" by Godot):
 
 ::
 
-    linux_x11_32_debug
-    linux_x11_32_release
-    linux_x11_64_debug
-    linux_x11_64_release
+    linux_debug.arm32
+    linux_debug.arm64
+    linux_debug.x86_32
+    linux_debug.x86_64
+    linux_release.arm32
+    linux_release.arm64
+    linux_release.x86_32
+    linux_release.x86_64
 
 However, if you are writing your custom modules or custom C++ code, you
 might instead want to configure your binaries as custom export templates

--- a/contributing/development/compiling/compiling_for_windows.rst
+++ b/contributing/development/compiling/compiling_for_windows.rst
@@ -410,18 +410,22 @@ with the following flags:
 
 If you plan on replacing the standard export templates, copy these to the
 following location, replacing ``<version>`` with the version identifier
-(such as ``3.1.1.stable`` or ``3.2.dev``):
+(such as ``4.2.1.stable`` or ``4.3.dev``):
 
 .. code-block:: none
 
-    %USERPROFILE%\AppData\Roaming\Godot\templates\<version>\
+    %APPDATA%\Godot\export_templates\<version>\
 
 With the following names::
 
-    windows_32_debug.exe
-    windows_32_release.exe
-    windows_64_debug.exe
-    windows_64_release.exe
+    windows_debug_x86_32_console.exe
+    windows_debug_x86_32.exe
+    windows_debug_x86_64_console.exe
+    windows_debug_x86_64.exe
+    windows_release_x86_32_console.exe
+    windows_release_x86_32.exe
+    windows_release_x86_64_console.exe
+    windows_release_x86_64.exe
 
 However, if you are using custom modules or custom engine code, you
 may instead want to configure your binaries as custom export templates

--- a/contributing/development/compiling/introduction_to_the_buildsystem.rst
+++ b/contributing/development/compiling/introduction_to_the_buildsystem.rst
@@ -422,20 +422,34 @@ platform:
 
     android_debug.apk
     android_release.apk
-    web_debug.zip
-    web_release.zip
-    linux_server_32
-    linux_server_64
-    linux_x11_32_debug
-    linux_x11_32_release
-    linux_x11_64_debug
-    linux_x11_64_release
+    android_source.zip
+    ios.zip
+    linux_debug.arm32
+    linux_debug.arm64
+    linux_debug.x86_32
+    linux_debug.x86_64
+    linux_release.arm32
+    linux_release.arm64
+    linux_release.x86_32
+    linux_release.x86_64
     macos.zip
     version.txt
-    windows_32_debug.exe
-    windows_32_release.exe
-    windows_64_debug.exe
-    windows_64_release.exe
+    web_debug.zip
+    web_dlink_debug.zip
+    web_dlink_nothreads_debug.zip
+    web_dlink_nothreads_release.zip
+    web_dlink_release.zip
+    web_nothreads_debug.zip
+    web_nothreads_release.zip
+    web_release.zip
+    windows_debug_x86_32_console.exe
+    windows_debug_x86_32.exe
+    windows_debug_x86_64_console.exe
+    windows_debug_x86_64.exe
+    windows_release_x86_32_console.exe
+    windows_release_x86_32.exe
+    windows_release_x86_64_console.exe
+    windows_release_x86_64.exe
 
 To create those yourself, follow the instructions detailed for each
 platform in this same tutorial section. Each platform explains how to


### PR DESCRIPTION
The names/paths of the export binaries were outdated in a couple of places. This fixes that.