### PR TITLE
Update asset library demo URLs to point to Godot 4.x demos

### DIFF
--- a/tutorials/i18n/internationalizing_games.rst
+++ b/tutorials/i18n/internationalizing_games.rst
@@ -23,7 +23,7 @@ translations page before, we recommend you give it a read before reading this
 page.
 
 .. note:: We will be using the official demo as an example; you can
-          `download it from the Asset Library <https://godotengine.org/asset-library/asset/134>`_.
+          `download it from the Asset Library <https://godotengine.org/asset-library/asset/2776>`_.
 
 Configuring the imported translation
 ------------------------------------

--- a/tutorials/inputs/controllers_gamepads_joysticks.rst
+++ b/tutorials/inputs/controllers_gamepads_joysticks.rst
@@ -315,7 +315,7 @@ You can contribute an updated mapping to be included in the next Godot version
 by opening a pull request on the linked repository.
 
 There are many ways to create mappings. One option is to use the mapping wizard
-in the `official Joypads demo <https://godotengine.org/asset-library/asset/140>`__.
+in the `official Joypads demo <https://godotengine.org/asset-library/asset/2785>`__.
 Once you have a working mapping for your controller, you can test it by defining
 the ``SDL_GAMECONTROLLERCONFIG`` environment variable before running Godot:
 

--- a/tutorials/physics/ragdoll_system.rst
+++ b/tutorials/physics/ragdoll_system.rst
@@ -10,7 +10,7 @@ Since version 3.1, Godot supports ragdoll physics. Ragdolls rely on physics simu
 
 In this tutorial, we will be using the Platformer3D demo to set up a ragdoll.
 
-.. note:: You can download the Platformer3D demo on `GitHub <https://github.com/godotengine/godot-demo-projects/tree/master/3d/platformer>`_ or using the `Asset Library <https://godotengine.org/asset-library/asset/125>`_.
+.. note:: You can download the Platformer3D demo on `GitHub <https://github.com/godotengine/godot-demo-projects/tree/master/3d/platformer>`_ or using the `Asset Library <https://godotengine.org/asset-library/asset/2748>`_.
 
 Setting up the ragdoll
 ----------------------

--- a/tutorials/physics/soft_body.rst
+++ b/tutorials/physics/soft_body.rst
@@ -34,7 +34,7 @@ Cloak simulation
 
 Let's make a cloak in the Platformer3D demo.
 
-.. note:: You can download the Platformer3D demo on `GitHub <https://github.com/godotengine/godot-demo-projects/tree/master/3d/platformer>`_ or `the Asset Library <https://godotengine.org/asset-library/asset/125>`_.
+.. note:: You can download the Platformer3D demo on `GitHub <https://github.com/godotengine/godot-demo-projects/tree/master/3d/platformer>`_ or `the Asset Library <https://godotengine.org/asset-library/asset/2748>`_.
 
 Open the ``Player`` scene, add a ``SoftBody`` node and assign a ``PlaneMesh`` to it.
 


### PR DESCRIPTION
- This closes https://github.com/godotengine/godot-demo-projects/issues/1046.
