### PR TITLE
Release policy: Bump 4.3 ETA to June

### DIFF
--- a/about/release_policy.rst
+++ b/about/release_policy.rst
@@ -82,7 +82,7 @@ on GitHub.
 +--------------+----------------------+--------------------------------------------------------------------------+
 | **Version**  | **Release date**     | **Support level**                                                        |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 4.3    | April 2024           | |unstable| *Development.* Receives new features, usability and           |
+| Godot 4.3    | June 2024            | |unstable| *Development.* Receives new features, usability and           |
 | (`master`)   | (estimate)           | performance improvements, as well as bug fixes, while under development. |
 +--------------+----------------------+--------------------------------------------------------------------------+
 | Godot 4.2    | November 2023        | |supported| Receives fixes for bugs and security issues, as well as      |


### PR DESCRIPTION
We're close to beta, but not started yet, so it's definitely not releasing in April. A release in May is plausible, but I don't want to make too optimistic promises, so let's communicate June as a more realistic estimate.