### PR TITLE
Fix ImmediateMesh being referred to as a node when it is not

### DIFF
--- a/tutorials/3d/procedural_geometry/surfacetool.rst
+++ b/tutorials/3d/procedural_geometry/surfacetool.rst
@@ -4,7 +4,7 @@ Using the SurfaceTool
 =====================
 
 The :ref:`SurfaceTool <class_surfacetool>` provides a useful interface for constructing geometry.
-The interface is similar to the :ref:`ImmediateMesh <class_ImmediateMesh>` node. You
+The interface is similar to the :ref:`ImmediateMesh <class_ImmediateMesh>` class. You
 set each per-vertex attribute (e.g. normal, uv, color) and then when you add a vertex it
 captures the attributes.
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
