### PR TITLE
Fixed out of date binding syntax for `Signal.connect`

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -2337,7 +2337,7 @@ character's name in the binds array argument::
         var character_node = get_node('Character')
         var battle_log_node = get_node('UserInterface/BattleLog')
 
-        character_node.health_changed.connect(battle_log_node._on_Character_health_changed, [character_node.name])
+        character_node.health_changed.connect(battle_log_node._on_Character_health_changed.bind(character_node.name))
 
 Our ``BattleLog`` node receives each element in the binds array as an extra argument::
 


### PR DESCRIPTION
fixes godotengine/godot-docs#9236

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
