### PR TITLE
Update required SDK version on "compiling w/ .NET"

### DIFF
--- a/contributing/development/compiling/compiling_with_dotnet.rst
+++ b/contributing/development/compiling/compiling_with_dotnet.rst
@@ -8,7 +8,7 @@ Compiling with .NET
 Requirements
 ------------
 
-- `.NET SDK 6.0+ <https://dotnet.microsoft.com/download>`_
+- `.NET SDK 8.0+ <https://dotnet.microsoft.com/download>`_
 
   You can use ``dotnet --info`` to check which .NET SDK versions are installed.
 


### PR DESCRIPTION
Hi 🙂 

This one goes with godotengine/godot#91079 in spirit, but could be merged any time. We're currently requiring at least SDK 7 to build some of the C# projects, so saying 6+ is already outdated.