### PR TITLE
Update Resources tutorial to mention and use the GlobalClass annotation for C#

### DIFF
--- a/tutorials/scripting/resources.rst
+++ b/tutorials/scripting/resources.rst
@@ -333,6 +333,7 @@ Now, select the :ref:`CharacterBody3D <class_CharacterBody3D>` node which we nam
       .. code-tab:: csharp
 
         using Godot;
+
         [GlobalClass]
         public partial class BotStatsTable : Resource
         {

--- a/tutorials/scripting/resources.rst
+++ b/tutorials/scripting/resources.rst
@@ -208,6 +208,9 @@ It should appear in your file tab with the full name ``bot_stats.tres``.
 Without a script, it's useless, so let's add some data and logic!
 Attach a script to it named ``bot_stats.gd`` (or just create a new script, and then drag it to it).
 
+.. note::
+    If you're using C#, you need to annoate your Resource class with the ``[GlobalClass]`` annotation for it to show up in the create resource GUI.
+
 .. tabs::
   .. code-tab:: gdscript GDScript
 
@@ -232,6 +235,7 @@ Attach a script to it named ``bot_stats.gd`` (or just create a new script, and t
 
         namespace ExampleProject
         {
+            [GlobalClass]
             public partial class BotStats : Resource
             {
                 [Export]
@@ -329,7 +333,7 @@ Now, select the :ref:`CharacterBody3D <class_CharacterBody3D>` node which we nam
       .. code-tab:: csharp
 
         using Godot;
-
+        [GlobalClass]
         public partial class BotStatsTable : Resource
         {
             private Godot.Dictionary<string, BotStats> _stats = new Godot.Dictionary<string, BotStats>();
@@ -384,6 +388,7 @@ Now, select the :ref:`CharacterBody3D <class_CharacterBody3D>` node which we nam
 
         public partial class MyNode : Node
         {
+            [GlobalClass]
             public partial class MyResource : Resource
             {
                 [Export]

--- a/tutorials/scripting/resources.rst
+++ b/tutorials/scripting/resources.rst
@@ -209,7 +209,7 @@ Without a script, it's useless, so let's add some data and logic!
 Attach a script to it named ``bot_stats.gd`` (or just create a new script, and then drag it to it).
 
 .. note::
-    If you're using C#, you need to annoate your Resource class with the ``[GlobalClass]`` annotation for it to show up in the create resource GUI.
+    If you're using C#, you need to annotate your Resource class with the ``[GlobalClass]`` attribute for it to show up in the create resource GUI.
 
 .. tabs::
   .. code-tab:: gdscript GDScript


### PR DESCRIPTION

The previous version of this page didn't mention using the `[GlobalClass]` annotation. Following this tutorial results in the user not finding their resource in the Create a new resource menu without any understanding as to why

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
