### PR TITLE
Fix typo in 2D transform tutorial

### DIFF
--- a/tutorials/2d/2d_transforms.rst
+++ b/tutorials/2d/2d_transforms.rst
@@ -98,7 +98,7 @@ the following order:
 
  .. code-tab:: csharp
 
-    var screenCord = GetViewport().GetScreenTransform() * GetGlobalTransformWithCanvas() * localPos;
+    var screenCoord = GetViewport().GetScreenTransform() * GetGlobalTransformWithCanvas() * localPos;
 
 Keep in mind, however, that it is generally not desired to work with screen coordinates. The
 recommended approach is to simply work in Canvas coordinates


### PR DESCRIPTION
Change `screenCord` to `screenCoord`

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
