### PR TITLE
Fix button description

### DIFF
--- a/getting_started/first_2d_game/03.coding_the_player.rst
+++ b/getting_started/first_2d_game/03.coding_the_player.rst
@@ -247,7 +247,7 @@ the ``_process`` function (make sure it's not indented under the `else`):
         Using this value ensures that your movement will remain consistent even
         if the frame rate changes.
 
-Click "Play Scene" (:kbd:`F6`, :kbd:`Cmd + R` on macOS) and confirm you can move
+Click "Run Current Scene" (:kbd:`F6`, :kbd:`Cmd + R` on macOS) and confirm you can move
 the player around the screen in all directions.
 
 .. warning:: If you get an error in the "Debugger" panel that says


### PR DESCRIPTION
makes it so the "play current scene" button is referred to as the "play current scene" button since that's what the tooltip says. Closes #9276.