### PR TITLE
Fix typo in node_alternatives.rst

### DIFF
--- a/tutorials/best_practices/node_alternatives.rst
+++ b/tutorials/best_practices/node_alternatives.rst
@@ -50,7 +50,7 @@ your project's features.
 
    - **Example:** Scripts, PackedScene (for scene files), and other types like
      each of the :ref:`AudioEffect <class_AudioEffect>` classes. Each of these
-     can be save and loaded, therefore they extend from Resource.
+     can be saved and loaded, therefore they extend from Resource.
 
    - **Advantages:** Much has
      :ref:`already been said <doc_resources>`


### PR DESCRIPTION
Fixed a typo in the best_practices/node_alternatives section

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
