### PR TITLE
document 0, 90, 180, and 270 degree TileMap cell rotations

### DIFF
--- a/classes/class_tilesetatlassource.rst
+++ b/classes/class_tilesetatlassource.rst
@@ -206,10 +206,10 @@ Note: These transformations can be combined to do the equivalent of 0, 90, 180, 
 ::
 
    const rotation_settings = [
-      0,
-      TileSetAtlasSource.TRANSFORM_TRANSPOSE |  TileSetAtlasSource.TRANSFORM_FLIP_H,
-      TileSetAtlasSource.TRANSFORM_FLIP_H    |  TileSetAtlasSource.TRANSFORM_FLIP_V,
-      TileSetAtlasSource.TRANSFORM_TRANSPOSE |  TileSetAtlasSource.TRANSFORM_FLIP_V
+      0,                                                                             #rotate   0
+      TileSetAtlasSource.TRANSFORM_TRANSPOSE |  TileSetAtlasSource.TRANSFORM_FLIP_H, #rotate  90
+      TileSetAtlasSource.TRANSFORM_FLIP_H    |  TileSetAtlasSource.TRANSFORM_FLIP_V, #rotate 180 
+      TileSetAtlasSource.TRANSFORM_TRANSPOSE |  TileSetAtlasSource.TRANSFORM_FLIP_V  #rotate 270
    ]
 
 .. rst-class:: classref-section-separator

--- a/classes/class_tilesetatlassource.rst
+++ b/classes/class_tilesetatlassource.rst
@@ -200,6 +200,18 @@ Represents cell's vertical flip flag. See :ref:`TRANSFORM_FLIP_H<class_TileSetAt
 
 Represents cell's transposed flag. See :ref:`TRANSFORM_FLIP_H<class_TileSetAtlasSource_constant_TRANSFORM_FLIP_H>` for usage.
 
+
+Note: These transformations can be combined to do the equivalent of 0, 90, 180, and 270 degree rotations, as shown below
+
+::
+
+   const rotation_settings = [
+      0,
+      TileSetAtlasSource.TRANSFORM_TRANSPOSE |  TileSetAtlasSource.TRANSFORM_FLIP_H,
+      TileSetAtlasSource.TRANSFORM_FLIP_H    |  TileSetAtlasSource.TRANSFORM_FLIP_V,
+      TileSetAtlasSource.TRANSFORM_TRANSPOSE |  TileSetAtlasSource.TRANSFORM_FLIP_V
+   ]
+
 .. rst-class:: classref-section-separator
 
 ----


### PR DESCRIPTION
Documents how to simulate 0, 90, 180, and 270 degree rotations for tiles