### PR TITLE
Clarify how to enable post-import script

### DIFF
--- a/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.rst
@@ -395,6 +395,8 @@ The ``_post_import(scene: Node)`` function takes the imported scene as argument
 (the parameter is actually the root node of the scene). The scene that will
 finally be used **must** be returned (even if the scene can be entirely different).
 
+To use your script, locate the script in the import tab's "Path" option under the "Import Script" category.
+
 Using animation libraries
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Add the step how to enable post-import script in import configurations tutorial.
Page: [Import configuration / Using import scripts for automation](https://docs.godotengine.org/en/4.2/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.html#doc-importing-3d-scenes-import-script)
The tutorial makes sense if you're reading the whole page (there's mention how import scripts work somewhere on that page), but if you find anchor directly to the section about import scripts, it's missing this crucial bit of information. I actually got stumped for a moment with this, I thought the script has to be added via EditorPlugin or something.