### PR TITLE
Add a note to the vendor plugin info that it no longer needs to be ma…

### DIFF
--- a/tutorials/xr/deploying_to_android.rst
+++ b/tutorials/xr/deploying_to_android.rst
@@ -62,6 +62,12 @@ Enable the **GodotOpenXRVendors** plugin.
 
 .. image:: img/xr_enable_vendors_plugin.webp
 
+.. note::
+    This is no longer required from vendors plugin 2.0.3 onwards as it now uses GDExtension.
+    The plugin will not be shown in this list.
+    You can verify it is installed correctly by checking if the export presets contain
+    the entries described below.
+
 Creating the export presets
 ---------------------------
 You will need to setup a separate export preset for each device, as each device will need its own loader included.


### PR DESCRIPTION
…nually enabled

Backporting @BastiaanOlij note from the master branch (commit #dd4c243) as it also applies to Godot 4.2

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
