### PR TITLE
Style self-links to make them appear only on hover

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -396,6 +396,36 @@ a.btn:hover {
     padding-right: 13px;
 }
 
+/* Style self-links to make them appear only on hover. */
+.classref-method > a[href*="-method-"].reference,
+.classref-property > a[href*="-property-"].reference,
+.classref-signal > a[href*="-signal-"].reference,
+.classref-annotation > a[href*="-annotation-"].reference,
+.classref-themeproperty > a[href*="-theme-"].reference,
+.classref-method > a[href*="-method-"].reference,
+.classref-constructor > a[href*="-constructor-"].reference,
+.classref-operator > a[href*="-operator-"].reference,
+.classref-constant > a[href*="-constant-"].reference,
+.classref-enumeration > a[href^="#enum-"].reference {
+    visibility: hidden;
+    padding-left: 20px;
+    padding-right: 20px;
+}
+.classref-method:hover > a[href*="-method-"].reference,
+.classref-property:hover > a[href*="-property-"].reference,
+.classref-signal:hover > a[href*="-signal-"].reference,
+.classref-annotation:hover > a[href*="-annotation-"].reference,
+.classref-themeproperty:hover > a[href*="-theme-"].reference,
+.classref-method:hover > a[href*="-method-"].reference,
+.classref-constructor:hover > a[href*="-constructor-"].reference,
+.classref-operator:hover > a[href*="-operator-"].reference,
+.classref-constant:hover > a[href*="-constant-"].reference,
+.classref-enumeration:hover > a[href^="#enum-"].reference {
+    visibility: visible;
+    padding-left: 20px;
+    padding-right: 20px;
+}
+
 /* Distinguish class reference page links from "user manual" page links with a class reference badge. */
 
 /* Remove text wrapping so that the badge is always on the same line as the anchor's text. */


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/91537

https://github.com/godotengine/godot-docs/assets/229837/62a11a38-4b1c-4fb3-8b27-2a2679fabff3

On mobile the link appears by tapping on the line of e.g. the method signature (e.g. tapping on the method name).

The implementation is a bit of a hack, but it works. I would have preferred to add an attribute to the self-link to identify it more easily, but I didn't manage to do it with Sphinx (not sure it's possible).