### PR TITLE
Change "Editor > Convert Icons With Editor Theme" to "Editor > Convert Colors With Editor Theme"

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -214,7 +214,7 @@ don't have one, you can grab the default one from the engine and save it in your
 .. tip::
 
     SVG images that are used as custom node icons should have the
-    **Editor > Scale With Editor Scale** and **Editor > Convert Icons With Editor Theme**
+    **Editor > Scale With Editor Scale** and **Editor > Convert Colors With Editor Theme**
     :ref:`import options <doc_importing_images_editor_import_options>` enabled. This allows
     icons to follow the editor's scale and theming settings if the icons are designed with
     the same color palette as Godot's own icons.


### PR DESCRIPTION

That's what the option is actually called https://docs.godotengine.org/en/stable/tutorials/assets_pipeline/importing_images.html#doc-importing-images-editor-import-options

Also are you sure png icons should be 16x16? I created a 16x16 icon and it was only half as big as it had to be. However, I'm using a 4K screen with 200% application scaling, so this might just be because of that.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
