### PR TITLE
Add "Using System;" line to default C# script

### DIFF
--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -101,6 +101,7 @@ the following line of code:
  .. code-tab:: csharp C#
 
     using Godot;
+    using System;
 
     public partial class MySprite2D : Sprite2D
     {


### PR DESCRIPTION
This line appears in the default created script, but was missing the section showing what we should expect to see.
