### PR TITLE
Document the possibility to enable custom pretty-printers in GDB

### DIFF
--- a/contributing/development/configuring_an_ide/visual_studio_code.rst
+++ b/contributing/development/configuring_an_ide/visual_studio_code.rst
@@ -112,6 +112,10 @@ To run and debug the project you need to create a new configuration in the ``lau
           "description": "Enable pretty-printing for gdb",
           "text": "-enable-pretty-printing",
           "ignoreFailures": true
+        },
+        {
+            "description": "Load custom pretty-printers for Godot types.",
+            "text": "source ${workspaceRoot}/misc/scripts/godot_gdb_pretty_print.py"
         }
       ],
       "preLaunchTask": "build"


### PR DESCRIPTION
An MR  for adding GDB pretty-printers  for a couple of Godot types was recently merged. They make the GDB debugger variable display more readable, so let's document their existence for developers.
cf. https://github.com/godotengine/godot/pull/91280 