### PR TITLE
Fix 4.0 RTD build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,10 @@ sphinx-copybutton==0.5.1
 sphinx-notfound-page==0.8.3
 # Adds Open Graph tags in the HTML `<head>` tag.
 sphinxext-opengraph==0.7.5
+
+# These get pulled in by Sphinx, we need to pin these as higher versions require Sphinx 5.0+.
+sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-devhelp==1.0.2


### PR DESCRIPTION
Manual cherrypick of https://github.com/godotengine/godot-docs/pull/8763 to 4.0.