### PR TITLE
Document behavior of modulo operator

### DIFF
--- a/tutorials/scripting/evaluating_expressions.rst
+++ b/tutorials/scripting/evaluating_expressions.rst
@@ -44,7 +44,7 @@ The following operators are available:
 | Division (``/``)       | Performs and integer division if both operands are integers.                        |
 |                        | If at least one of them is a floating-point number, returns a floating-point value. |
 +------------------------+-------------------------------------------------------------------------------------+
-| Remainder (``%``)      | Returns the remainder of an integer division.                                       |
+| Remainder (``%``)      | Returns the remainder of an integer division (modulo).                              |
 |                        | The result will always have the sign of the dividend.                               |
 +------------------------+-------------------------------------------------------------------------------------+
 

--- a/tutorials/scripting/evaluating_expressions.rst
+++ b/tutorials/scripting/evaluating_expressions.rst
@@ -45,6 +45,7 @@ The following operators are available:
 |                        | If at least one of them is a floating-point number, returns a floating-point value. |
 +------------------------+-------------------------------------------------------------------------------------+
 | Modulo (``%``)         | Returns the remainder of an integer division.                                       |
+|                        | The result will always have the sign of the dividend.                               |
 +------------------------+-------------------------------------------------------------------------------------+
 
 Spaces around operators are optional. Also, keep in mind the usual

--- a/tutorials/scripting/evaluating_expressions.rst
+++ b/tutorials/scripting/evaluating_expressions.rst
@@ -44,7 +44,7 @@ The following operators are available:
 | Division (``/``)       | Performs and integer division if both operands are integers.                        |
 |                        | If at least one of them is a floating-point number, returns a floating-point value. |
 +------------------------+-------------------------------------------------------------------------------------+
-| Modulo (``%``)         | Returns the remainder of an integer division.                                       |
+| Remainder (``%``)      | Returns the remainder of an integer division.                                       |
 |                        | The result will always have the sign of the dividend.                               |
 +------------------------+-------------------------------------------------------------------------------------+
 


### PR DESCRIPTION
Different languages and contexts have different default behaviors for modulo where one or both operands are negative. "The remainder of an integer division" is underspecified. As such, clarification is in order.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
