### PR TITLE
Fix meaning of "scons" by itself in Introduction to the Buildsystem

### DIFF
--- a/contributing/development/compiling/introduction_to_the_buildsystem.rst
+++ b/contributing/development/compiling/introduction_to_the_buildsystem.rst
@@ -12,16 +12,16 @@ that compiling Godot from source can be as simple as running::
 
     scons
 
-This produces an *export template* for your current platform, operating system, and architecture.
-An export template is a build of the engine that is used for running exported projects. To build
-the *editor* instead you can run the following command::
+This produces an editor build for your current platform, operating system, and architecture.
+You can change what gets built by specifying a target, a platform, and/or an architecture.
+For example, to build an export template used for running exported games, you can run::
 
-    scons target=editor
+    scons target=template_release
 
-If you plan to debug or develop the engine, then you might want to add another option to the command::
+If you plan to debug or develop the engine, then you might want to enable the ``dev_build``
+option to enable dev-only debugging code::
 
     scons dev_build=yes
-    scons target=editor dev_build=yes
 
 Following sections in the article will explain these and other universal options in more detail. But
 before you can compile Godot, you need to install a few prerequisites. Please refer to the platform


### PR DESCRIPTION
The current docs state this:
<img width="700" alt="Screenshot 2024-05-11 at 6 00 22 PM" src="https://github.com/godotengine/godot-docs/assets/1646875/650473be-520a-4c04-8e79-c7a1b1ba7ac5">

This is just wrong. If you run `scons` by itself, you get an editor build:

```
% scons          
scons: Reading SConscript files ...
Automatically detected platform: macos
Auto-detected 10 CPU cores available for build parallelism. Using 9 cores by default. You can override it with the -j argument.
Building for macOS 11.0+.
MoltenVK found at: /Users/aaronfranke/.local/share/VulkanSDK/1.3.275.0/macOS/lib/MoltenVK.xcframework
Building for platform "macos", architecture "arm64", target "editor".
```