### PR TITLE
Clarified godot-cpp example directory snapshot to indicate where compiled binaries should go

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -412,6 +412,7 @@ Here is another overview to check the correct file structure:
     |   +--bin/
     |       |
     |       +--gdexample.gdextension
+    |       +--libgdexample.windows.template_debug.x86_64.dll # and/or all the other builds you compiled
     |
     +--godot-cpp/             # C++ bindings
     |


### PR DESCRIPTION
When following the godot-cpp tutorial, I ran in to a small confusion regarding the intended directory structure. The tutorial says to create the gdextension file to look something like this:

```
[configuration]

entry_symbol = "example_library_init"
compatibility_minimum = "4.1"

[libraries]

macos.debug = "res://bin/libgdexample.macos.template_debug.framework"
macos.release = "res://bin/libgdexample.macos.template_release.framework"
windows.debug.x86_32 = "res://bin/libgdexample.windows.template_debug.x86_32.dll"
windows.release.x86_32 = "res://bin/libgdexample.windows.template_release.x86_32.dll"
windows.debug.x86_64 = "res://bin/libgdexample.windows.template_debug.x86_64.dll"
windows.release.x86_64 = "res://bin/libgdexample.windows.template_release.x86_64.dll"
linux.debug.x86_64 = "res://bin/libgdexample.linux.template_debug.x86_64.so"
linux.release.x86_64 = "res://bin/libgdexample.linux.template_release.x86_64.so"
linux.debug.arm64 = "res://bin/libgdexample.linux.template_debug.arm64.so"
linux.release.arm64 = "res://bin/libgdexample.linux.template_release.arm64.so"
linux.debug.rv64 = "res://bin/libgdexample.linux.template_debug.rv64.so"
linux.release.rv64 = "res://bin/libgdexample.linux.template_release.rv64.so"
android.debug.x86_64 = "res://bin/libgdexample.android.template_debug.x86_64.so"
android.release.x86_64 = "res://bin/libgdexample.android.template_release.x86_64.so"
android.debug.arm64 = "res://bin/libgdexample.android.template_debug.arm64.so"
android.release.arm64 = "res://bin/libgdexample.android.template_release.arm64.so"
```

and then later shows what the directory should look like at this point with this snapshot:

```
gdextension_cpp_example/
|
+--demo/                  # game example/demo to test the extension
|   |
|   +--main.tscn
|   |
|   +--bin/
|       |
|       +--gdexample.gdextension
|
+--godot-cpp/             # C++ bindings
|
+--src/                   # source code of the extension we are building
|   |
|   +--register_types.cpp
|   +--register_types.h
|   +--gdexample.cpp
|   +--gdexample.h
```

I was confused because the snapshot only showed gdexample.gdextension in the bin folder, but really, the intention is for the bin folder to also have your compiled extension in it at this point. This PR is just a one-line change that makes the bin folder now look like

```
    |   +--bin/
    |       |
    |       +--gdexample.gdextension
    |       +--libgdexample.windows.template_debug.x86_64.dll # and/or all the other builds you compiled
```

I'm happy to reword this slightly if needed, but I do think this addition would clarify the tutorial.
