### PR TITLE
[4.2] Update dependencies in Compiling for Linux/*BSD

### DIFF
--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -33,7 +33,7 @@ required:
 - Development libraries:
 
   - X11, Xcursor, Xinerama, Xi and XRandR.
-  - MesaGL.
+  - Mesa.
   - ALSA.
   - PulseAudio.
 
@@ -67,7 +67,6 @@ Distro-specific one-liners
               libxi-dev \
               libxrandr-dev \
               mesa-dev \
-              libexecinfo-dev \
               eudev-dev \
               alsa-lib-dev \
               pulseaudio-dev
@@ -76,7 +75,7 @@ Distro-specific one-liners
 
         ::
 
-            pacman -S --needed \
+            pacman -Sy --noconfirm --needed \
               scons \
               pkgconf \
               gcc \
@@ -94,7 +93,8 @@ Distro-specific one-liners
 
         ::
 
-            apt-get install \
+            sudo apt-get update
+            sudo apt-get install -y \
               build-essential \
               scons \
               pkg-config \
@@ -102,7 +102,7 @@ Distro-specific one-liners
               libxcursor-dev \
               libxinerama-dev \
               libgl1-mesa-dev \
-              libglu-dev \
+              libglu1-mesa-dev \
               libasound2-dev \
               libpulse-dev \
               libudev-dev \
@@ -113,7 +113,7 @@ Distro-specific one-liners
 
         ::
 
-            dnf install \
+            sudo dnf install -y \
               scons \
               pkgconfig \
               libX11-devel \
@@ -141,7 +141,8 @@ Distro-specific one-liners
               libXcursor \
               libXrandr \
               libXi \
-              xorgproto libGLU \
+              xorgproto \
+              libGLU \
               alsa-lib \
               pulseaudio
 
@@ -149,8 +150,9 @@ Distro-specific one-liners
 
         ::
 
+            emerge --sync
             emerge -an \
-              dev-util/scons \
+              dev-build/scons \
               x11-libs/libX11 \
               x11-libs/libXcursor \
               x11-libs/libXinerama \
@@ -164,10 +166,9 @@ Distro-specific one-liners
 
         ::
 
-            urpmi \
+            sudo urpmi --auto \
               scons \
               task-c++-devel \
-              pkgconfig \
               "pkgconfig(alsa)" \
               "pkgconfig(glu)" \
               "pkgconfig(libpulse)" \
@@ -176,7 +177,19 @@ Distro-specific one-liners
               "pkgconfig(xcursor)" \
               "pkgconfig(xinerama)" \
               "pkgconfig(xi)" \
-              "pkgconfig(xrandr)"
+		      "pkgconfig(xrandr)"
+
+    .. tab:: NetBSD
+
+        ::
+
+            pkg_add \
+              pkg-config \
+              py37-scons
+
+        .. hint::
+
+            For audio support, you can optionally install ``pulseaudio``.
 
     .. tab:: OpenBSD
 
@@ -191,7 +204,7 @@ Distro-specific one-liners
 
         ::
 
-            zypper install \
+            sudo zypper install -y \
               scons \
               pkgconfig \
               libX11-devel \
@@ -206,24 +219,12 @@ Distro-specific one-liners
               gcc-c++ \
               libGLU1
 
-    .. tab:: NetBSD
-
-        ::
-
-            pkg_add \
-              pkg-config \
-              py37-scons
-
-        .. hint::
-
-            For audio support, you can optionally install ``pulseaudio``.
-
     .. tab:: Solus
 
         ::
 
-            eopkg install -c \
-              system.devel \
+            eopkg install -y \
+              -c system.devel \
               scons \
               libxcursor-devel \
               libxinerama-devel \


### PR DESCRIPTION
- `4.2` version of https://github.com/godotengine/godot-docs/pull/9357 with Wayland references removed.

___

- Use `sudo` on distributions that are set up to use it by default.
- Use unattended install-friendly commands (e.g. `-y` switch).
- Mention required commands to run before installing, such as `apt-get update`.
- Fix install commands on some distributions:
  - Alpine no longer packages libexecinfo since 3.17, so it was removed from the list.
  - Solus requires `-c` for `system.devel`.
- Reorder distributions so they're in alphabetical order.
