### PR TITLE
Fix hashing context example

### DIFF
--- a/classes/class_hashingcontext.rst
+++ b/classes/class_hashingcontext.rst
@@ -42,6 +42,8 @@ The :ref:`HashType<enum_HashingContext_HashType>` enum shows the supported hashi
         # Update the context after reading each chunk.
         while not file.get_position() < file.get_len():
             var remaining = file.get_len() - file.get_position()
+            if remaining > CHUNK_SIZE:
+                remaining = CHUNK_SIZE
             ctx.update(file.get_buffer(min(remaining, CHUNK_SIZE)))
         # Get the computed hash.
         var res = ctx.finish()
@@ -65,8 +67,12 @@ The :ref:`HashType<enum_HashingContext_HashType>` enum shows the supported hashi
         // Open the file to hash.
         using var file = FileAccess.Open(path, FileAccess.ModeFlags.Read);
         // Update the context after reading each chunk.
-        while (!file.EofReached())
+        while (file.GetPosition() < file.GetLength())
         {
+            int remaining = file.GetLen() - file.GetPosition();
+            if (remaining > ChunkSize) {
+                remaining = ChunkSize;
+            }
             ctx.Update(file.GetBuffer(ChunkSize));
         }
         // Get the computed hash.

--- a/classes/class_hashingcontext.rst
+++ b/classes/class_hashingcontext.rst
@@ -40,8 +40,9 @@ The :ref:`HashType<enum_HashingContext_HashType>` enum shows the supported hashi
         # Open the file to hash.
         var file = FileAccess.open(path, FileAccess.READ)
         # Update the context after reading each chunk.
-        while not file.eof_reached():
-            ctx.update(file.get_buffer(CHUNK_SIZE))
+        while not file.get_position() < file.get_len():
+            var remaining = file.get_len() - file.get_position()
+            ctx.update(file.get_buffer(min(remaining, CHUNK_SIZE)))
         # Get the computed hash.
         var res = ctx.finish()
         # Print the result as hex string and array.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
The example function produces invalid hashes for files that aren't a multiple of `CHUNK_SIZE` bytes in size

Fixes two issues:

+ replaces use of `eof_reached()` who's docs say to use `file.get_position() < file.get_len()` instead when looping
+ uses remaining number of bytes instead of `CHUNK_SIZE` if `CHUNK_SIZE` would be too large