### PR TITLE
Add ThinkWithGames youtube link

### DIFF
--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -35,6 +35,7 @@ Video tutorials
 - `Pigdev <https://www.youtube.com/@pigdev>`_ (2D, GDScript)
 - `Queble <https://www.youtube.com/@queblegamedevelopment4143>`_ (2D, GDScript)
 - `Quiver <https://quiver.dev/>`_ (2D, GDScript)
+- `ThinkWithGames <https://www.youtube.com/@ThinkWithGames>`_ (2D, Shaders, Tilemap, GDScript)
 
 Text tutorials
 --------------


### PR DESCRIPTION
Adds a link to the ThinkWithGames youtube channe in the "Video tutorials" section. (This is my youtube channel)