### PR TITLE
Update compiling_with_script_encryption_key.rst

### DIFF
--- a/contributing/development/compiling/compiling_with_script_encryption_key.rst
+++ b/contributing/development/compiling/compiling_with_script_encryption_key.rst
@@ -52,7 +52,7 @@ Step by step
    that way you can minimize the risk of exposing the key.
 
 2. Set this key as environment variable in the console that you will use to
-   compile Godot, like this:
+   compile Godot (in Windows you may have to run terminal or Powershell as admin), like this:
 
    .. tabs::
     .. code-tab:: bash Linux/macOS


### PR DESCRIPTION
Adding in the compiling a PCK with encryption. It may be necessary to note, that when adding the env var to Windows with command prompt, terminal, or Powershell, it might require being ran as admin. Not doing this can lead the the engine unable to unencrypt the PCK at runtime.
