### PR TITLE
Change misleading comment in 'Your first 3D game'

### DIFF
--- a/getting_started/first_3d_game/06.jump_and_squash.rst
+++ b/getting_started/first_3d_game/06.jump_and_squash.rst
@@ -241,7 +241,11 @@ With this code, if no collisions occurred on a given frame, the loop won't run.
             # We get one of the collisions with the player
             var collision = get_slide_collision(index)
 
-            # If the collision is with ground
+            # If there are duplicate collisions with a mob in a single frame
+            # the mob will be deleted after the first collision, and a second call to 
+            # get_collider will return null, leading to a null pointer when calling 
+            # collision.get_collider().is_in_group("mob").
+            # This block of code prevents processing duplicate collisions.
             if collision.get_collider() == null:
                 continue
 


### PR DESCRIPTION
On the collision processing code (Chapter 6 - Jumping and squashing monsters) there is a misleading comment saying that the collision.get_collider() == null has the purpose of checking for a collision with the ground, while the purpose is to prevent a null pointer that happens when there are multiple collisions with a mob in a single frame.

This addresses the following open issue: https://github.com/godotengine/godot-docs/issues/9355