### PR TITLE
Compiling: Min versions are now SCons 3.1.2 and GCC 9

### DIFF
--- a/contributing/development/compiling/compiling_for_android.rst
+++ b/contributing/development/compiling/compiling_for_android.rst
@@ -27,7 +27,7 @@ Requirements
 For compiling under Windows, Linux or macOS, the following is required:
 
 - `Python 3.6+ <https://www.python.org/downloads/>`_.
-- `SCons 3.0+ <https://scons.org/pages/download.html>`_ build system.
+- `SCons 3.1.2+ <https://scons.org/pages/download.html>`_ build system.
 - `Android SDK <https://developer.android.com/studio/#command-tools>`_
   (command-line tools are sufficient).
 

--- a/contributing/development/compiling/compiling_for_ios.rst
+++ b/contributing/development/compiling/compiling_for_ios.rst
@@ -14,7 +14,7 @@ Requirements
 ------------
 
 - `Python 3.6+ <https://www.python.org/downloads/macos/>`_.
-- `SCons 3.0+ <https://scons.org/pages/download.html>`_ build system.
+- `SCons 3.1.2+ <https://scons.org/pages/download.html>`_ build system.
 - `Xcode <https://apps.apple.com/us/app/xcode/id497799835>`_.
 
 If you are building the ``master`` branch:

--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -16,19 +16,9 @@ Requirements
 For compiling under Linux or other Unix variants, the following is
 required:
 
-- GCC 7+ or Clang 6+.
-
+- GCC 9+ or Clang 6+.
 - `Python 3.6+ <https://www.python.org/downloads/>`_.
-
-- `SCons 3.0+ <https://scons.org/pages/download.html>`_ build system.
-
-  .. note::
-
-      If your distribution uses Python 2 by default, or you are using a version of SCons prior to 3.1.2,
-      you will need to change the version of Python that SCons uses by changing the shebang
-      (the first line) of the SCons script file to ``#! /usr/bin/python3``.
-      Use the command ``which scons`` to find the location of the SCons script file.
-
+- `SCons 3.1.2+ <https://scons.org/pages/download.html>`_ build system.
 - pkg-config (used to detect the development libraries listed below).
 - Development libraries:
 

--- a/contributing/development/compiling/compiling_for_macos.rst
+++ b/contributing/development/compiling/compiling_for_macos.rst
@@ -16,7 +16,7 @@ Requirements
 For compiling under macOS, the following is required:
 
 - `Python 3.6+ <https://www.python.org/downloads/macos/>`_.
-- `SCons 3.0+ <https://scons.org/pages/download.html>`_ build system.
+- `SCons 3.1.2+ <https://scons.org/pages/download.html>`_ build system.
 - `Xcode <https://apps.apple.com/us/app/xcode/id497799835>`_
   (or the more lightweight Command Line Tools for Xcode).
 - `Vulkan SDK <https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.dmg>`_

--- a/contributing/development/compiling/compiling_for_web.rst
+++ b/contributing/development/compiling/compiling_for_web.rst
@@ -17,7 +17,7 @@ To compile export templates for the Web, the following is required:
 
 - `Emscripten 3.1.39+ <https://emscripten.org>`__.
 - `Python 3.6+ <https://www.python.org/>`__.
-- `SCons 3.0+ <https://scons.org/pages/download.html>`__ build system.
+- `SCons 3.1.2+ <https://scons.org/pages/download.html>`__ build system.
 
 .. seealso:: To get the Godot source code for compiling, see
              :ref:`doc_getting_source`.

--- a/contributing/development/compiling/compiling_for_windows.rst
+++ b/contributing/development/compiling/compiling_for_windows.rst
@@ -25,7 +25,7 @@ For compiling under Windows, the following is required:
   **Important:** When using MinGW to compile the ``master`` branch, you need GCC 9 or later.
 - `Python 3.6+ <https://www.python.org/downloads/windows/>`_.
   **Make sure to enable the option to add Python to the ``PATH`` in the installer.**
-- `SCons 3.0+ <https://scons.org/pages/download.html>`_ build system. Using the
+- `SCons 3.1.2+ <https://scons.org/pages/download.html>`_ build system. Using the
   latest release is recommended, especially for proper support of recent Visual
   Studio releases.
 


### PR DESCRIPTION
- Follow up to https://github.com/godotengine/godot/pull/91833
- Follow up to https://github.com/godotengine/godot/pull/92043

I kept things simple for this PR, but for the future I think we should refactor the docs a bit to reduce duplication regarding how to set up SCons. I would also suggest we tell users to install the latest available SCons version through `pip`, as opposed to advising using distro packages, homebrew, MacPorts, etc. Those can still be mentioned as options but maybe without detailed instructions on how to use them.

The detailed instructions should just be for `pip install scons` and can go in the "Introduction to the buildsystem" page so we don't have to repeat it everywhere.

Note: Not relevant to cherry-pick, we didn't backport the above PRs for now.