### PR TITLE
Point user to further reading at end of GDExtension example

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -698,3 +698,7 @@ Next steps
 We hope the above example showed you the basics. You can
 build upon this example to create full-fledged scripts to control nodes in Godot
 using C++.
+
+To learn more about the types and objects you can use, see the following:
+- :ref:`doc_core_types`
+- :ref:`doc_object_class`


### PR DESCRIPTION
Based on a discussion I had [here](https://github.com/godotengine/godot-cpp/issues/1467#issuecomment-2118832190), I thought it would be best to point the reader of the GDExtension C++ example to the location of other existing C++ documentation. 

For someone that is new to the documentation, it might not make sense to look for explanation of the core types in the "Contributing" section. This is something that I myself ran into.