### PR TITLE
Remove Note from Constants

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1243,12 +1243,6 @@ Assigning a value of an incompatible type will raise an error.
 You can also create constants inside a function, which is useful to name local
 magic values.
 
-.. note::
-
-    Since objects, arrays and dictionaries are passed by reference, constants are "flat".
-    This means that if you declare a constant array or dictionary, it can still
-    be modified afterwards. They can't be reassigned with another value though.
-
 Enums
 ^^^^^
 


### PR DESCRIPTION
From PR [#71051
](https://github.com/godotengine/godot/pull/71051)
Documentation not updated to reflect deep read-only change to const Array and const Dictionary

Remove Note Section describing that Arrays and Dictionaries could be modified after declared constant when that is no longer the case.