### PR TITLE
Add `thirdparty` as linter exception

### DIFF
--- a/_tools/codespell-ignore.txt
+++ b/_tools/codespell-ignore.txt
@@ -5,3 +5,4 @@ que
 raison
 uint
 implementors
+thirdparty


### PR DESCRIPTION
Fails on paths in the engine repo etc.

Seems to have been introduced by changes upstream as this only appeared recently

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
