### PR TITLE
Improve Compiling for Android and Compiling for iOS docs

### DIFF
--- a/contributing/development/compiling/compiling_for_android.rst
+++ b/contributing/development/compiling/compiling_for_android.rst
@@ -32,8 +32,8 @@ For compiling under Windows, Linux or macOS, the following is required:
   (command-line tools are sufficient).
 
    - Required SDK components will be automatically installed.
-   - On Linux,
-      **do not use an Android SDK provided by your distribution's repositories as it will often be outdated**.
+   - On Linux, **do not use an Android SDK provided by your distribution's repositories** as it will often be outdated.
+   - On macOS, **do not use an Android SDK provided by Homebrew** as it will not be installed in a unified location.
 
 - Gradle (will be downloaded and installed automatically if missing).
 - JDK 17 (either OpenJDK or Oracle JDK).
@@ -55,6 +55,14 @@ Setting up the buildsystem
    SDK. If you downloaded the Android command-line tools, this would be
    the folder where you extracted the contents of the ZIP archive.
 
+    -  Windows: Press :kbd:`Windows + R`, type "control system",
+       then click on **Advanced system settings** in the left pane,
+       then click on **Environment variables** on the window that appears.
+
+    -  Linux or macOS: Add the text ``export ANDROID_HOME="/path/to/android-sdk"``
+       to your ``.bashrc`` or ``.zshrc`` where ``/path/to/android-sdk`` points to
+       the root of the SDK directories.
+
 -  Install the necessary SDK components in this folder:
 
     -  Accept the SDK component licenses by running the following command
@@ -70,13 +78,14 @@ Setting up the buildsystem
 
         cmdline-tools/latest/bin/sdkmanager --sdk_root=<android_sdk_path> "platform-tools" "build-tools;34.0.0" "platforms;android-34" "cmdline-tools;latest" "cmake;3.10.2.4988404" "ndk;23.2.8568313"
 
-.. seealso::   To set the environment variable on Windows, press :kbd:`Windows + R`, type
-            "control system", then click on **Advanced system settings** in the left
-            pane, then click on **Environment variables** on the window that appears.
+-  After setting up the SDK and environment variables, be sure to
+   **restart your terminal** to apply the changes. If you are using
+   an IDE with an integrated terminal, you need to restart the IDE.
 
-.. seealso::   To set the environment variable on Linux or macOS, use
-            ``export ANDROID_HOME=/path/to/android-sdk`` where ``/path/to/android-sdk`` points to
-            the root of the SDK directories.
+-  Run ``scons platform=android``. If this fails, go back and check the steps.
+   If you completed the setup correctly, the NDK will begin downloading.
+   If you are trying to compile GDExtension, you need to first compile
+   the engine to download the NDK, then you can compile GDExtension.
 
 Building the export templates
 -----------------------------

--- a/contributing/development/compiling/compiling_for_ios.rst
+++ b/contributing/development/compiling/compiling_for_ios.rst
@@ -16,6 +16,10 @@ Requirements
 - `Python 3.6+ <https://www.python.org/downloads/macos/>`_.
 - `SCons 3.1.2+ <https://scons.org/pages/download.html>`_ build system.
 - `Xcode <https://apps.apple.com/us/app/xcode/id497799835>`_.
+    - Launch Xcode once and install iOS support. If you have already launched
+      Xcode and need to install iOS support, go to *Xcode -> Settings... -> Platforms*.
+    - Go to *Xcode -> Settings... -> Locations -> Command Line Tools* and select
+      an installed version. Even if one is already selected, re-select it.
 
 If you are building the ``master`` branch:
 


### PR DESCRIPTION
Android:
* Mention that macOS users should not use Homebrew (I was not able to get it to work, but the command line tools SDK from the android.com website works perfectly).
* Mention that you need to restart your terminal.
* Mention that you need to compile the engine first before you can compile GDExtension in order to get the NDK.
* Organize instructions, convert environment variable "See Also" blocks into items on the bulleted list.

iOS:
* Mention how to set up Xcode. It's not enough to just install it, you need to install iOS libraries and select which version you want to use for the command line tools.