### PR TITLE
Fix (C#) Dictionaries in the Scripting/Resources section

### DIFF
--- a/tutorials/scripting/resources.rst
+++ b/tutorials/scripting/resources.rst
@@ -337,7 +337,7 @@ Now, select the :ref:`CharacterBody3D <class_CharacterBody3D>` node which we nam
         [GlobalClass]
         public partial class BotStatsTable : Resource
         {
-            private Godot.Dictionary<string, BotStats> _stats = new Godot.Dictionary<string, BotStats>();
+            private Godot.Collections.Dictionary<string, BotStats> _stats = new Godot.Collections.Dictionary<string, BotStats>();
 
             public BotStatsTable()
             {


### PR DESCRIPTION
…ections.Dictionary<>'

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
