### PR TITLE
change shrink to enlarge in "Your first 3D game" tutorial

### DIFF
--- a/getting_started/first_3d_game/02.player_input.rst
+++ b/getting_started/first_3d_game/02.player_input.rst
@@ -67,7 +67,7 @@ The sphere's wireframe appears below the character.
 |image3|
 
 It will be the shape the physics engine uses to collide with the environment, so
-we want it to better fit the 3D model. Shrink it a bit by dragging the orange
+we want it to better fit the 3D model. Make it a bit larger by dragging the orange
 dot in the viewport. My sphere has a radius of about ``0.8`` meters.
 
 Then, move the collision shape up so its bottom roughly aligns with the grid's plane.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
This fixes an issue mentioned in #6744. In Godot 4, it seems the default size of a spherical collision shape changed from `1` to `0.5`, therefore, the size needs to be increased rather than reduced to get to the final size of `0.8`.