### PR TITLE
Link to stable offline documentation downloads on homepage

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -51,11 +51,11 @@ into your language, or talk to us on the ``#documentation`` channel on the
 Offline documentation
 ---------------------
 
-To browse the documentation offline, you can `download an HTML copy <https://nightly.link/godotengine/godot-docs/workflows/build_offline_docs/master/godot-docs-html-master.zip>`__
+To browse the documentation offline, you can `download an HTML copy <https://nightly.link/godotengine/godot-docs/workflows/build_offline_docs/master/godot-docs-html-stable.zip>`__
 for offline reading (updated every Monday). Extract the ZIP archive then open
 the top-level ``index.html`` in a web browser.
 
-For mobile devices or e-readers, you can also `download an ePub copy <https://nightly.link/godotengine/godot-docs/workflows/build_offline_docs/master/godot-docs-epub-master.zip>`__
+For mobile devices or e-readers, you can also `download an ePub copy <https://nightly.link/godotengine/godot-docs/workflows/build_offline_docs/master/godot-docs-epub-stable.zip>`__
 for offline reading (updated every Monday). Extract the ZIP archive then open
 the ``GodotEngine.epub`` file in an e-book reader application.
 


### PR DESCRIPTION
Now that offline downloads for the `stable` branch are built on CI, we can link to it on the homepage.

Remember to synchronize `stable` with `4.2` after merging this PR.

- See https://github.com/godotengine/godot-docs/issues/9419.