### PR TITLE
Fix false positives in codespell CI and fix reported typos

### DIFF
--- a/.github/workflows/build_offline_docs.yml
+++ b/.github/workflows/build_offline_docs.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Install dependencies
         run: |
           sudo pip3 install -r requirements.txt
-          sudo pip3 install codespell
           sudo apt update
           sudo apt install parallel libwebp7
 

--- a/_tools/codespell-ignore.txt
+++ b/_tools/codespell-ignore.txt
@@ -6,3 +6,5 @@ raison
 uint
 implementors
 thirdparty
+inout
+findn

--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -394,7 +394,7 @@ There are two solutions:
 - Follow `these instructions <https://github.com/ivmai/libatomic_ops#installation-and-usage>`__ to configure, build, and
   install ``libatomic_ops``. Then, copy ``/usr/lib/libatomic_ops.a`` to ``/usr/lib/libatomic.a``, or create a soft link
   to ``libatomic_ops`` by command ``ln -s /usr/lib/libatomic_ops.a /usr/lib/libatomic.a``. The soft link can ensure the
-  latest ``libatomic_ops`` will be used without the need to copy it everytime when it is updated.
+  latest ``libatomic_ops`` will be used without the need to copy it every time when it is updated.
 
 Using mold for faster development
 ---------------------------------
@@ -406,7 +406,7 @@ As of January 2023, mold is not readily available in Linux distribution
 repositories, so you will have to install its binaries manually.
 
 - Download mold binaries from its `releases page <https://github.com/rui314/mold/releases/latest>`__.
-- Extract the ``.tar.gz`` file, then move the extraced folder to a location such as ``.local/share/mold``.
+- Extract the ``.tar.gz`` file, then move the extracted folder to a location such as ``.local/share/mold``.
 - Add ``$HOME/.local/share/mold/bin`` to your user's ``PATH`` environment variable.
   For example, you can add the following line at the end of your ``$HOME/.bash_profile`` file:
 

--- a/contributing/development/compiling/compiling_for_windows.rst
+++ b/contributing/development/compiling/compiling_for_windows.rst
@@ -93,7 +93,7 @@ The tutorial will assume from now on that you placed the source code in
 
     For Windows Defender, hit the :kbd:`Windows` key, type "Windows Security"
     then hit :kbd:`Enter`. Click on **Virus & threat protection** on the left
-    panel. Under **Virus & threat protection settings** click on **Mange Settings**
+    panel. Under **Virus & threat protection settings** click on **Manage Settings**
     and scroll down to **Exclusions**. Click **Add or remove exclusions** then
     add the Godot source folder.
 

--- a/contributing/development/compiling/index.rst
+++ b/contributing/development/compiling/index.rst
@@ -13,7 +13,7 @@ setup compiling the engine for your current platform should be as easy as runnin
 
 But you will probably need to use at least some of the available options to configure
 the build to match your specific needs, be it a custom engine fork, a lightweight build
-stripped of extra modules, or an executable targetting engine development.
+stripped of extra modules, or an executable targeting engine development.
 
 The articles below should help you navigate configuration options available, as well as
 prerequisites required to compile Godot exactly the way you need.

--- a/contributing/development/compiling/introduction_to_the_buildsystem.rst
+++ b/contributing/development/compiling/introduction_to_the_buildsystem.rst
@@ -397,7 +397,7 @@ For the folders accelerated by this option, multiple ``.cpp`` files are
 compiled in each translation unit, so headers can be shared between multiple
 files, which can dramatically decrease build times.
 
-To peform an SCU build, use the ``scu_build=yes`` SCons option.
+To perform an SCU build, use the ``scu_build=yes`` SCons option.
 
 .. note:: When developing a Pull Request using SCU builds, be sure to make a
           regular build prior to submitting the PR. This is because SCU builds

--- a/contributing/development/core_and_modules/scripting_development.rst
+++ b/contributing/development/core_and_modules/scripting_development.rst
@@ -14,7 +14,7 @@ Annotation guidelines
     compilation details because these are often inconsistent between annotations
 
 Create annotations for modifiers that act on the script or its code.
-Addionally, create annotations for behavior that is specific to the Godot
+Additionally, create annotations for behavior that is specific to the Godot
 engine and editor; if the primary purpose is to affect the way that the engine
 or editor treats or interacts with the script, implement the token as an
 annotation.

--- a/tutorials/3d/global_illumination/using_lightmap_gi.rst
+++ b/tutorials/3d/global_illumination/using_lightmap_gi.rst
@@ -400,7 +400,7 @@ but doing so will increase bake times significantly.
 
 To combat noise without increasing bake times too much, a denoiser can be used.
 A denoiser is an algorithm that runs on the final baked lightmap, detects patterns of
-noise and softens them while attempting to best preseve detail.
+noise and softens them while attempting to best preserve detail.
 Godot offers two denoising algorithms:
 
 JNLM (Non-Local Means with Joint Filtering)

--- a/tutorials/plugins/editor/inspector_plugins.rst
+++ b/tutorials/plugins/editor/inspector_plugins.rst
@@ -192,7 +192,7 @@ You can display your custom widget in two ways. Use just the default ``add_child
 method to display it to the right of the property name, and use ``add_child()``
 followed by ``set_bottom_editor()`` to position it below the name.
 
-.. FIXME: The second tab has the C# lexer for hightlighting disabled for now, as the provided code causes errors.
+.. FIXME: The second tab has the C# lexer for highlighting disabled for now, as the provided code causes errors.
 
 .. tabs::
  .. code-tab:: gdscript GDScript


### PR DESCRIPTION
- Don't install codespell when building offline docs as it's not needed in that workflow.
