### PR TITLE
Update AnimatedSprite to AnimatedSprite2D in C# example

### DIFF
--- a/tutorials/2d/2d_sprite_animation.rst
+++ b/tutorials/2d/2d_sprite_animation.rst
@@ -101,7 +101,7 @@ released.
 
         public override void _Ready()
         {
-            _animatedSprite = GetNode<AnimatedSprite>("AnimatedSprite");
+            _animatedSprite = GetNode<AnimatedSprite2D>("AnimatedSprite2D");
         }
 
         public override _Process(float _delta)


### PR DESCRIPTION
As of Godot 4, AnimatedSprite does not exist, and AnimatedSprite2D must be used instead.