### PR TITLE
Replace old `--export` flag with `--export-release`

### DIFF
--- a/tutorials/export/exporting_projects.rst
+++ b/tutorials/export/exporting_projects.rst
@@ -167,13 +167,13 @@ Exporting from the command line
 -------------------------------
 
 In production, it is useful to automate builds, and Godot supports this
-with the ``--export`` and ``--export-debug`` command line parameters.
+with the ``--export-release`` and ``--export-debug`` command line parameters.
 Exporting from the command line still requires an export preset to define
 the export parameters. A basic invocation of the command would be:
 
 .. code-block:: shell
 
-    godot --export "Windows Desktop" some_name.exe
+    godot --export-release "Windows Desktop" some_name.exe
 
 This will export to ``some_name.exe``, assuming there is a preset
 called "Windows Desktop" and the template can be found. (The export preset name
@@ -199,13 +199,13 @@ When doing so, the export preset name must still be specified on the command lin
 
     godot --export-pack "Windows Desktop" some_name.pck
 
-It is often useful to combine the ``--export`` flag with the ``--path``
+It is often useful to combine the ``--export-release`` flag with the ``--path``
 flag, so that you do not need to ``cd`` to the project folder before running
 the command:
 
 .. code-block:: shell
 
-    godot --path /path/to/project --export "Windows Desktop" some_name.exe
+    godot --path /path/to/project --export-release "Windows Desktop" some_name.exe
 
 .. seealso::
 


### PR DESCRIPTION
I used the docs to export my project with `--export` flag and was greeted with `The Godot 3 --export option was changed to more explicit --export-release / --export-debug / --export-pack options.`.

This commit updates the documentation to reflect the changed flag.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
