### PR TITLE
Update outdated call to `ImmediateMesh.surface_clear`

### DIFF
--- a/tutorials/3d/procedural_geometry/immediatemesh.rst
+++ b/tutorials/3d/procedural_geometry/immediatemesh.rst
@@ -78,7 +78,7 @@ The example code below draws a single triangle in the ``_ready()`` function.
 The ImmediateMesh can also be used across frames. Each time you call
 ``surface_begin()`` and ``surface_end()``, you are adding a new surface to the
 ImmediateMesh. If you want to recreate the mesh from scratch each frame, call
-``surface_clear()`` before calling ``surface_begin()``.
+``clear_surfaces()`` before calling ``surface_begin()``.
 
 .. tabs::
   .. code-tab:: gdscript GDScript


### PR DESCRIPTION
The function "surface_clear" does not exist as of 4.2.2. "clear_surfaces" does however.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
