### PR TITLE
Cross-language - Add examples to reference Nodes in scene tree (by path)

### DIFF
--- a/tutorials/scripting/cross_language_scripting.rst
+++ b/tutorials/scripting/cross_language_scripting.rst
@@ -80,6 +80,7 @@ Getting C# nodes in scene tree from GDScript
 Getting nodes - using C# code - from GDScript is pretty straightforward
 
 .. code-block:: gdscript
+
     var MyCSharpNode = get_node("PathTo/MyCSharpNode")
 
 Getting GDScript nodes in scene tree from C#
@@ -88,7 +89,8 @@ Getting GDScript nodes in scene tree from C#
 As C# is statically typed, accessing GDScript Nodes requires just an extra step and use
 the :ref:`GodotObject <class_Object>` type
 
-.. code-bloc:: csharp
+.. code-block:: csharp
+
     GodotObject myGDScriptNode = GetNode<GodotObject>("PathTo/MyGDScriptNode");
 
 Instantiating nodes

--- a/tutorials/scripting/cross_language_scripting.rst
+++ b/tutorials/scripting/cross_language_scripting.rst
@@ -72,7 +72,7 @@ The following two scripts will be used as references throughout this page.
     }
 
 Getting nodes from the scene tree by path
------------------------------------
+-----------------------------------------
 
 Getting C# nodes in scene tree from GDScript
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tutorials/scripting/cross_language_scripting.rst
+++ b/tutorials/scripting/cross_language_scripting.rst
@@ -71,6 +71,26 @@ The following two scripts will be used as references throughout this page.
         }
     }
 
+Getting nodes from the scene tree by path
+-----------------------------------
+
+Getting C# nodes in scene tree from GDScript
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Getting nodes - using C# code - from GDScript is pretty straightforward
+
+.. code-block:: gdscript
+    var MyCSharpNode = get_node("PathTo/MyCSharpNode")
+
+Getting GDScript nodes in scene tree from C#
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As C# is statically typed, accessing GDScript Nodes requires just an extra step and use
+the :ref:`GodotObject <class_Object>` type
+
+.. code-bloc:: csharp
+    GodotObject myGDScriptNode = GetNode<GodotObject>("PathTo/MyGDScriptNode");
+
 Instantiating nodes
 -------------------
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Added an example to reference Nodes in the scene tree using cross-language scripts, which in C# is not immediate
