### PR TITLE
Add CSharp code example for SetShaderParameter()

### DIFF
--- a/tutorials/shaders/your_first_shader/your_first_2d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_first_2d_shader.rst
@@ -197,10 +197,17 @@ You can change uniforms from code using the function ``set_shader_parameter()``
 which is called on the node's material resource. With a Sprite2D node, the
 following code can be used to set the ``blue`` uniform.
 
-::
+.. tabs::
+ 
+ .. code-tab:: gdscript
 
   var blue_value = 1.0
   material.set_shader_parameter("blue", blue_value)
+
+ .. code-tab:: csharp
+  
+  var blueValue = 1.0;
+  ((ShaderMaterial)Material).SetShaderParameter("blue", blueValue);
 
 Note that the name of the uniform is a string. The string must match exactly
 with how it is written in the shader, including spelling and case.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Added an example for changing shader parameters during runtime in C#.  Code completion in an IDE doesn't help point you in the right direction unless you cast the Material as a ShaderMaterial.
