### PR TITLE
Update C++ example to use version 4.2

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -363,7 +363,7 @@ loaded for each platform and the entry function for the module. It is called ``g
     [configuration]
 
     entry_symbol = "example_library_init"
-    compatibility_minimum = "4.2"
+    compatibility_minimum = "4.1"
 
     [libraries]
 

--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -35,7 +35,7 @@ of Godot. GDExtensions will not work in older versions of Godot (only Godot 4 an
 .. note::
     To use `GDExtension <https://godotengine.org/article/introducing-gd-extensions>`__
     you need to use the godot-cpp branch that matches the version of Godot that you are
-    targeting. For example, if you're targeting Godot 4.1, use the ``4.1`` branch,
+    targeting. For example, if you're targeting Godot 4.2, use the ``4.2`` branch,
     which is what is shown through out this tutorial.
 
     The ``master`` branch is the development branch which is updated regularly
@@ -59,7 +59,7 @@ a Git submodule:
     mkdir gdextension_cpp_example
     cd gdextension_cpp_example
     git init
-    git submodule add -b 4.1 https://github.com/godotengine/godot-cpp
+    git submodule add -b 4.2 https://github.com/godotengine/godot-cpp
     cd godot-cpp
     git submodule update --init
 
@@ -69,7 +69,7 @@ Alternatively, you can also clone it to the project folder:
 
     mkdir gdextension_cpp_example
     cd gdextension_cpp_example
-    git clone -b 4.1 https://github.com/godotengine/godot-cpp
+    git clone -b 4.2 https://github.com/godotengine/godot-cpp
 
 .. note::
 
@@ -332,7 +332,7 @@ build files in a subsequent tutorial.
 
     This ``SConstruct`` file was written to be used with the latest ``godot-cpp``
     master, you may need to make small changes using it with older versions or
-    refer to the ``SConstruct`` file in the Godot 4.0 documentation.
+    refer to the ``SConstruct`` file in the Godot 4.2 documentation.
 
 Once you've downloaded the ``SConstruct`` file, place it in your GDExtension folder
 structure alongside ``godot-cpp``, ``src`` and ``demo``, then run:
@@ -363,7 +363,7 @@ loaded for each platform and the entry function for the module. It is called ``g
     [configuration]
 
     entry_symbol = "example_library_init"
-    compatibility_minimum = "4.1"
+    compatibility_minimum = "4.2"
 
     [libraries]
 

--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -36,7 +36,7 @@ of Godot. GDExtensions will not work in older versions of Godot (only Godot 4 an
     To use `GDExtension <https://godotengine.org/article/introducing-gd-extensions>`__
     you need to use the godot-cpp branch that matches the version of Godot that you are
     targeting. For example, if you're targeting Godot 4.1, use the ``4.1`` branch. Throughout
-    this tutorial we use ``4.x`,` which will need to be replaced with the version of Godot you
+    this tutorial we use ``4.x``, which will need to be replaced with the version of Godot you
     are targeting.
 
     The ``master`` branch is the development branch which is updated regularly

--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -35,16 +35,17 @@ of Godot. GDExtensions will not work in older versions of Godot (only Godot 4 an
 .. note::
     To use `GDExtension <https://godotengine.org/article/introducing-gd-extensions>`__
     you need to use the godot-cpp branch that matches the version of Godot that you are
-    targeting. For example, if you're targeting Godot 4.2, use the ``4.2`` branch,
-    which is what is shown through out this tutorial.
+    targeting. For example, if you're targeting Godot 4.1, use the ``4.1`` branch. Throughout
+    this tutorial we use ``4.x`,` which will need to be replaced with the version of Godot you
+    are targeting.
 
     The ``master`` branch is the development branch which is updated regularly
     to work with Godot's ``master`` branch.
 
 .. warning::
     Our long-term goal is that GDExtensions targeting an earlier version of Godot will work
-    in later minor versions, but not vice-versa. For example, a GDExtension targeting Godot 4.2
-    should work just fine in Godot 4.3, but one targeting Godot 4.3 won't work in Godot 4.2.
+    in later minor versions, but not vice-versa. For example, a GDExtension targeting Godot 4.1
+    should work just fine in Godot 4.2, but one targeting Godot 4.2 won't work in Godot 4.1.
 
     However, GDExtension is currently *experimental*, which means that we may break compatibility
     in order to fix major bugs or include critical features. For example, GDExtensions created
@@ -59,7 +60,7 @@ a Git submodule:
     mkdir gdextension_cpp_example
     cd gdextension_cpp_example
     git init
-    git submodule add -b 4.2 https://github.com/godotengine/godot-cpp
+    git submodule add -b 4.x https://github.com/godotengine/godot-cpp
     cd godot-cpp
     git submodule update --init
 
@@ -69,7 +70,7 @@ Alternatively, you can also clone it to the project folder:
 
     mkdir gdextension_cpp_example
     cd gdextension_cpp_example
-    git clone -b 4.2 https://github.com/godotengine/godot-cpp
+    git clone -b 4.x https://github.com/godotengine/godot-cpp
 
 .. note::
 
@@ -332,7 +333,7 @@ build files in a subsequent tutorial.
 
     This ``SConstruct`` file was written to be used with the latest ``godot-cpp``
     master, you may need to make small changes using it with older versions or
-    refer to the ``SConstruct`` file in the Godot 4.2 documentation.
+    refer to the ``SConstruct`` file in the Godot 4.x documentation.
 
 Once you've downloaded the ``SConstruct`` file, place it in your GDExtension folder
 structure alongside ``godot-cpp``, ``src`` and ``demo``, then run:


### PR DESCRIPTION
I was going through the C++ GDExtension tutorial and noticed that in some places it references 4.0 and in others it references 4.1.

This PR updates it to reference 4.2 everywhere.

It looks like something similar was done on the `4.2` docs branch, but never made it into master. https://github.com/godotengine/godot-docs/tree/1ef005b81b6baa190522bae37fd0fe96ff04b654