### PR TITLE
Clarify where to report engine bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,3 +4,7 @@ contact_links:
   - name: Godot community channels
     url: https://godotengine.org/community
     about: Please ask for technical support on one of the other community channels, not here.
+
+  - name: Main Godot repository
+    url: https://github.com/godotengine/godot
+    about: Report engine bugs on the main Godot repository


### PR DESCRIPTION
Makes it clearer that this is for bugs in the documentation, not general bugs, and helps redirecting
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
