### PR TITLE
Fix link to import hints

### DIFF
--- a/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.rst
@@ -41,7 +41,7 @@ This import process is customizable using 3 separate interfaces, depending on yo
 - The **Advanced Import Settings** dialog, which can be accessed by double-clicking
   the 3D scene in the FileSystem dock or by clicking the **Advanced…** button in
   the Import dock. This allows you to customize per-object options in Godot.
-- :ref:`Import hints <doc_importing_3d_scenes_import_hints>`, which are special
+- :ref:`Import hints <doc_importing_3d_scenes_node_type_customization>`, which are special
   suffixes added to object names in the 3D modeling software. This allows you to
   customize per-object options in the 3D modeling software.
 
@@ -524,5 +524,3 @@ In inherited scenes, the only limitations for modification are:
   described above.
 
 Other than that, everything is allowed.
-
-.. _doc_importing_3d_scenes_import_hints:


### PR DESCRIPTION
The link for "Import hints", points to a non-existent section

https://github.com/godotengine/godot-docs/blob/18960c556f764e44b840a6746f13603f6a5001c3/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.rst?plain=1#L44


It was moved in this [commit](https://github.com/godotengine/godot-docs/commit/7d9ab84ac187d4319734e7e90e3797276dda3eaf#diff-404435ae1b618b15cdf5008ad8b3700c06304864169c2d8ab19ea2ce84408a35L758-L760) but the reference name `doc_importing_3d_scenes_import_hints` was not updated to `doc_importing_3d_scenes_node_type_customization`

Fixes #9469

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
