### PR TITLE
Adding a next steps page to the XR documentation

### DIFF
--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -19,6 +19,7 @@ Some tutorials mentioned below provide more advanced tutorials, e.g. on 3D or sh
 Video tutorials
 ---------------
 
+- `Bastiaan Olij <https://www.youtube.com/BastiaanOlij>`_ (3D, AR and VR, GDScript)
 - `BornCG <https://www.youtube.com/playlist?list=PLda3VoSoc_TTp8Ng3C57spnNkOw3Hm_35>`_ (2D and 3D, GDScript)
 - `Clear Code <https://www.youtube.com/watch?v=nAh_Kx5Zh5Q>`_ (2D, GDScript, Programming Basics)
 - `FencerDevLog <https://www.youtube.com/@FencerDevLog>`_ (2D, 3D, GDScript, Shaders)
@@ -30,11 +31,14 @@ Video tutorials
 - `Gwizz <https://www.youtube.com/@Gwizz1027>`_ (2D, GDScript)
 - `Godotneers <https://www.youtube.com/@godotneers>`_ (2D, Shaders, GDScript)
 - `HeartBeast <https://www.youtube.com/@uheartbeast>`_ (2D, GDScript)
+- `Malcolm Nixon <https://youtube.com/@MalcolmAnixon>`_ (AR and VR, GDScript)
+- `Muddy Wolf <https://www.youtube.com/@MuddyWolf>`_ (2D, 3D and VR, GDSCript)
 - `KidsCanCode <https://www.youtube.com/channel/UCNaPQ5uLX5iIEHUCLmfAgKg/playlists>`__ (2D and 3D, GDScript)
 - `Maker Tech <https://www.youtube.com/@MakerTech/>`_ (2D, GDScript)
 - `Pigdev <https://www.youtube.com/@pigdev>`_ (2D, GDScript)
 - `Queble <https://www.youtube.com/@queblegamedevelopment4143>`_ (2D, GDScript)
 - `Quiver <https://quiver.dev/>`_ (2D, GDScript)
+- `Snopek Games <https://www.youtube.com/@SnopekGames>`_ (3D, networked multiplayer, AR and VR, GDScript)
 
 Text tutorials
 --------------
@@ -49,7 +53,6 @@ Text tutorials
 Devlogs
 -------
 
-- `Bastiaan Olij (AR & VR) <https://www.youtube.com/channel/UCrbLJYzJjDf2p-vJC011lYw/videos>`_
 - `bitbrain <https://www.youtube.com/@bitbraindev>`_
 - `DevDuck (2D) <https://www.youtube.com/@devduck/videos>`_
 

--- a/tutorials/xr/index.rst
+++ b/tutorials/xr/index.rst
@@ -16,9 +16,8 @@ Basic Tutorial
    setting_up_xr
    deploying_to_android
    a_better_xr_start_script
-   introducing_xr_tools
-   basic_xr_locomotion
    ar_passthrough
+   xr_next_steps
 
 Advanced topics
 ---------------
@@ -32,3 +31,13 @@ Advanced topics
    xr_room_scale
    openxr_composition_layers
    openxr_hand_tracking
+
+Godot XR Tools
+--------------
+
+.. toctree::
+   :maxdepth: 1
+   :name: godot-xr-tools
+
+   introducing_xr_tools
+   basic_xr_locomotion

--- a/tutorials/xr/xr_next_steps.rst
+++ b/tutorials/xr/xr_next_steps.rst
@@ -1,0 +1,24 @@
+.. _doc_xr_next_steps:
+
+Where to go from here
+=====================
+
+Now that we have the basics covered there are several options to look at for your XR game dev journey:
+
+* You can take a look at the :ref:`Advanced topics <openxr-advanced-topics>` section.
+* You can look at a number of `XR demos here <https://github.com/godotengine/godot-demo-projects/tree/master/xr>`_.
+* You can find 3rd party tutorials on our :ref:`Tutorials and resources <doc_community_tutorials>` page.
+
+XR Toolkits
+-----------
+
+There are various XR toolkits available that implement more complex XR logic ready for you to use.
+We have a :Ref:`small introduction to Godot XR Tools <godot-xr-tools>` that you can look at,
+a toolkit developed by core contributors of Godot.
+
+There are more toolkits available for Godot:
+
+* `Godot XR handtracking toolkit <https://github.com/RevolNoom/godot_xr_handtracking>`_ (GDScript)
+* `Godot XR Kit <https://github.com/patrykkalinowski/godot-xr-kit>`_ (GDScript)
+* `Godot XR Tools <https://github.com/godotvr/godot-xr-tools>`_ (GDScript)
+* `NXR <https://github.com/stumpynub/NXR>`_ (C#)


### PR DESCRIPTION
This PR reshuffles some of the entries in the XR manual pages and adds a "next steps" page to the basic tutorial section.
The main reason for the change came out of a discussion during the XR meeting of 14 June 2024 where the topic came up that Godot XR Tools, while maintained by core Godot developers, isn't the only toolkit available, and is only currently usable for XR developers who stick to GDScript.

We wanted a place to point out other frameworks that exist. I've added 3 that i'm aware off but I know there is at least a 3rd for which I don't (yet) have a link. 

I've also updated the `Tutorials and resources` page to include links to a few youtubers that do Godot XR content. I was actually surprised to find myself in the devlog section while I mainly focus on tutorials.