### PR TITLE
Fix indented text captured by tabs group directive

### DIFF
--- a/getting_started/first_3d_game/06.jump_and_squash.rst
+++ b/getting_started/first_3d_game/06.jump_and_squash.rst
@@ -286,7 +286,7 @@ With this code, if no collisions occurred on a given frame, the loop won't run.
         }
     }
 
- That's a lot of new functions. Here's some more information about them.
+That's a lot of new functions. Here's some more information about them.
 
 The functions ``get_slide_collision_count()`` and ``get_slide_collision()`` both come from
 the :ref:`CharacterBody3D <class_CharacterBody3D>` class and are related to


### PR DESCRIPTION
This paragraph has a leading space which causes it to be captured by the previous tabs directive

As a result, this paragraph gets hidden by sphinx-tabs client code as it tries to hide every child inside `.sphinx-tabs.container`

![Screenshot 2024-06-14 224253](https://github.com/godotengine/godot-docs/assets/458691/d1d46d48-a41c-4568-92c7-3f0d4a1fc755)
