### PR TITLE
Update import pages for ufbx in 4.3

### DIFF
--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -19,6 +19,7 @@ Some tutorials mentioned below provide more advanced tutorials, e.g. on 3D or sh
 Video tutorials
 ---------------
 
+- `Bastiaan Olij <https://www.youtube.com/BastiaanOlij>`_ (3D, AR and VR, GDScript)
 - `BornCG <https://www.youtube.com/playlist?list=PLda3VoSoc_TTp8Ng3C57spnNkOw3Hm_35>`_ (2D and 3D, GDScript)
 - `Clear Code <https://www.youtube.com/watch?v=nAh_Kx5Zh5Q>`_ (2D, GDScript, Programming Basics)
 - `FencerDevLog <https://www.youtube.com/@FencerDevLog>`_ (2D, 3D, GDScript, Shaders)
@@ -30,11 +31,14 @@ Video tutorials
 - `Gwizz <https://www.youtube.com/@Gwizz1027>`_ (2D, GDScript)
 - `Godotneers <https://www.youtube.com/@godotneers>`_ (2D, Shaders, GDScript)
 - `HeartBeast <https://www.youtube.com/@uheartbeast>`_ (2D, GDScript)
+- `Malcolm Nixon <https://youtube.com/@MalcolmAnixon>`_ (AR and VR, GDScript)
+- `Muddy Wolf <https://www.youtube.com/@MuddyWolf>`_ (2D, 3D and VR, GDSCript)
 - `KidsCanCode <https://www.youtube.com/channel/UCNaPQ5uLX5iIEHUCLmfAgKg/playlists>`__ (2D and 3D, GDScript)
 - `Maker Tech <https://www.youtube.com/@MakerTech/>`_ (2D, GDScript)
 - `Pigdev <https://www.youtube.com/@pigdev>`_ (2D, GDScript)
 - `Queble <https://www.youtube.com/@queblegamedevelopment4143>`_ (2D, GDScript)
 - `Quiver <https://quiver.dev/>`_ (2D, GDScript)
+- `Snopek Games <https://www.youtube.com/@SnopekGames>`_ (3D, networked multiplayer, AR and VR, GDScript)
 
 Text tutorials
 --------------
@@ -49,7 +53,6 @@ Text tutorials
 Devlogs
 -------
 
-- `Bastiaan Olij (AR & VR) <https://www.youtube.com/channel/UCrbLJYzJjDf2p-vJC011lYw/videos>`_
 - `bitbrain <https://www.youtube.com/@bitbraindev>`_
 - `DevDuck (2D) <https://www.youtube.com/@devduck/videos>`_
 

--- a/tutorials/assets_pipeline/importing_3d_scenes/available_formats.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/available_formats.rst
@@ -18,9 +18,11 @@ Godot supports the following 3D *scene file formats*:
 - OBJ (Wavefront) format + their MTL material files. This is also
   supported, but pretty limited given the format's limitations (no support for
   pivots, skeletons, animations, UV2, PBR materials, ...).
-- FBX, supported via `FBX2glTF <https://github.com/godotengine/FBX2glTF>`__ integration.
-  This requires installing an external program that links against the proprietary FBX SDK,
-  so we recommend using other formats listed above (if suitable for your workflow).
+- FBX, supported via the `ufbx <https://github.com/ufbx/ufbx>`__ library. The
+  previous import workflow used `FBX2glTF <https://github.com/godotengine/FBX2glTF>`__
+  integration. This requires installing an external program that links against the
+  proprietary FBX SDK, so we recommend using the default ubfx method or other formats
+  listed above (if suitable for your workflow).
 
 Copy the scene file together with the textures and mesh data (if separate) to
 the project repository, then Godot will do a full import when focusing the
@@ -185,24 +187,30 @@ There are 2 ways to use OBJ meshes in Godot:
 Importing FBX files in Godot
 ----------------------------
 
-When opening a project containing FBX scenes, you will see a dialog asking you
-to configure FBX import. Click the link in the dialog to download an FBX2glTF
-binary, then extract the ZIP archive, place the binary anywhere you wish, then
-specify its path in the dialog.
+By default any FBX file added to a Godot project in Godot 4.3 or later will
+use the ufbx import method. Any file that was was added to a project in a
+previous version, such as 4.2, will continue to be imported via the FBX2glTF
+method unless you go into that files import settings, and change the importer
+to  ``ufbx``.
 
 If you keep ``.fbx`` files within your project folder but don't want them to
 be imported by Godot, disable **Filesystem > Import > FBX > Enabled** in the
 advanced Project Settings.
 
-The FBX import process converts to glTF first, so it still uses
+If you want to setup the FBX2glTF workflow, which is generally not recommend
+unless you have a specific reason to use it, you need to download the `FBX2glTF <https://github.com/godotengine/FBX2glTF>`__
+executable, then specify the path to that executable in the editor settings under
+**Filesystem > Import > FBX > FBX2glTFPath**
+
+The FBX2glTF import process converts to glTF first, so it still uses
 Godot's glTF import code. Therefore, the FBX import process is the same
 as the glTF import process, but with an extra step at the beginning.
 
 .. figure:: img/importing_3d_scenes_available_formats_fbx.webp
    :align: center
-   :alt: Diagram explaining the import process for FBX files in Godot
+   :alt: Diagram explaining the import process for FBX files in Godot vis FBX2glTF
 
 .. seealso::
 
-    The full installation process for using FBX in Godot is described on the
+    The full installation process for using FBX2glTF in Godot is described on the
     `FBX import page of the Godot website <https://godotengine.org/fbx-import>`__.

--- a/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.rst
@@ -157,6 +157,21 @@ exported from other tools such as Maya.
   Universal** and **Embed as Uncompressed** keeps the textures embedded in the
   imported scene, with and without VRAM compression respectively.
 
+**FBX**
+
+- **Importer** Which import method is used. ubfx handles fbx files as fbx files.
+  FBX2glTF converts FBX files to glTF on import and requires additonal setup.
+  FBX2glTF is not recommended unless you have a specific rason to use it over
+  ufbx or working with a different file format.
+- **Allow Geometry Helper Nodes** enables or disables geometry helper nodes
+- **Embedded Texture Handling:** Controls how textures embedded within fbx
+  scenes should be handled. **Discard All Textures** will not import any
+  textures, which is useful if you wish to manually set up materials in Godot
+  instead. **Extract Textures** extracts textures to external images, resulting
+  in smaller file sizes and more control over import options. **Embed as Basis
+  Universal** and **Embed as Uncompressed** keeps the textures embedded in the
+  imported scene, with and without VRAM compression respectively.
+
 Using the Advanced Import Settings dialog
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tutorials/xr/index.rst
+++ b/tutorials/xr/index.rst
@@ -16,9 +16,8 @@ Basic Tutorial
    setting_up_xr
    deploying_to_android
    a_better_xr_start_script
-   introducing_xr_tools
-   basic_xr_locomotion
    ar_passthrough
+   xr_next_steps
 
 Advanced topics
 ---------------
@@ -32,3 +31,13 @@ Advanced topics
    xr_room_scale
    openxr_composition_layers
    openxr_hand_tracking
+
+Godot XR Tools
+--------------
+
+.. toctree::
+   :maxdepth: 1
+   :name: godot-xr-tools
+
+   introducing_xr_tools
+   basic_xr_locomotion

--- a/tutorials/xr/xr_next_steps.rst
+++ b/tutorials/xr/xr_next_steps.rst
@@ -1,0 +1,24 @@
+.. _doc_xr_next_steps:
+
+Where to go from here
+=====================
+
+Now that we have the basics covered there are several options to look at for your XR game dev journey:
+
+* You can take a look at the :ref:`Advanced topics <openxr-advanced-topics>` section.
+* You can look at a number of `XR demos here <https://github.com/godotengine/godot-demo-projects/tree/master/xr>`_.
+* You can find 3rd party tutorials on our :ref:`Tutorials and resources <doc_community_tutorials>` page.
+
+XR Toolkits
+-----------
+
+There are various XR toolkits available that implement more complex XR logic ready for you to use.
+We have a :Ref:`small introduction to Godot XR Tools <godot-xr-tools>` that you can look at,
+a toolkit developed by core contributors of Godot.
+
+There are more toolkits available for Godot:
+
+* `Godot XR handtracking toolkit <https://github.com/RevolNoom/godot_xr_handtracking>`_ (GDScript)
+* `Godot XR Kit <https://github.com/patrykkalinowski/godot-xr-kit>`_ (GDScript)
+* `Godot XR Tools <https://github.com/godotvr/godot-xr-tools>`_ (GDScript)
+* `NXR <https://github.com/stumpynub/NXR>`_ (C#)


### PR DESCRIPTION
Updates the import pages for ufbx in Godot 4.3. This is the PR that added support: https://github.com/godotengine/godot/pull/81746. The old FBX2glTF method is still usable though. The description for enabling geometry nodes is short because I can't find anything on what those are online.

The page on our website, https://godotengine.org/fbx-import/, should be updated at some point. Though lyumia is already working on a ufbx page here: https://github.com/godotengine/godot-website/pull/852