### PR TITLE
Fix typo in "Optimizing 3D performance"

### DIFF
--- a/tutorials/performance/optimizing_3d_performance.rst
+++ b/tutorials/performance/optimizing_3d_performance.rst
@@ -163,7 +163,7 @@ also limit the processing needed to the local area.
 
 There may also be rendering and physics glitches due to floating point error in
 large worlds. This can be resolved using :ref:`doc_large_world_coordinates`.
-If using large world coordinates is an option, you may be able to use techniques
+If using large world coordinates is not an option, you may be able to use techniques
 such as orienting the world around the player (rather than the other way
 around), or shifting the origin periodically to keep things centred around
 ``Vector3(0, 0, 0)``.


### PR DESCRIPTION
From context, it seems like origin shifting is being introduced as an alternative to large world coordinates, but this is not reflected in the actual wording.
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
