### PR TITLE
Update import pages for ufbx in 4.3

### DIFF
--- a/tutorials/assets_pipeline/importing_3d_scenes/available_formats.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/available_formats.rst
@@ -18,9 +18,11 @@ Godot supports the following 3D *scene file formats*:
 - OBJ (Wavefront) format + their MTL material files. This is also
   supported, but pretty limited given the format's limitations (no support for
   pivots, skeletons, animations, UV2, PBR materials, ...).
-- FBX, supported via `FBX2glTF <https://github.com/godotengine/FBX2glTF>`__ integration.
-  This requires installing an external program that links against the proprietary FBX SDK,
-  so we recommend using other formats listed above (if suitable for your workflow).
+- FBX, supported via the `ufbx <https://github.com/ufbx/ufbx>`__ library. The
+  previous import workflow used `FBX2glTF <https://github.com/godotengine/FBX2glTF>`__
+  integration. This requires installing an external program that links against the
+  proprietary FBX SDK, so we recommend using the default ubfx method or other formats
+  listed above (if suitable for your workflow).
 
 Copy the scene file together with the textures and mesh data (if separate) to
 the project repository, then Godot will do a full import when focusing the
@@ -185,24 +187,30 @@ There are 2 ways to use OBJ meshes in Godot:
 Importing FBX files in Godot
 ----------------------------
 
-When opening a project containing FBX scenes, you will see a dialog asking you
-to configure FBX import. Click the link in the dialog to download an FBX2glTF
-binary, then extract the ZIP archive, place the binary anywhere you wish, then
-specify its path in the dialog.
+By default any FBX file added to a Godot project in Godot 4.3 or later will
+use the ufbx import method. Any file that was was added to a project in a
+previous version, such as 4.2, will continue to be imported via the FBX2glTF
+method unless you go into that files import settings, and change the importer
+to  ``ufbx``.
 
 If you keep ``.fbx`` files within your project folder but don't want them to
 be imported by Godot, disable **Filesystem > Import > FBX > Enabled** in the
 advanced Project Settings.
 
-The FBX import process converts to glTF first, so it still uses
+If you want to setup the FBX2glTF workflow, which is generally not recommend
+unless you have a specific reason to use it, you need to download the `FBX2glTF <https://github.com/godotengine/FBX2glTF>`__
+executable, then specify the path to that executable in the editor settings under
+**Filesystem > Import > FBX > FBX2glTFPath**
+
+The FBX2glTF import process converts to glTF first, so it still uses
 Godot's glTF import code. Therefore, the FBX import process is the same
 as the glTF import process, but with an extra step at the beginning.
 
 .. figure:: img/importing_3d_scenes_available_formats_fbx.webp
    :align: center
-   :alt: Diagram explaining the import process for FBX files in Godot
+   :alt: Diagram explaining the import process for FBX files in Godot  via FBX2glTF
 
 .. seealso::
 
-    The full installation process for using FBX in Godot is described on the
+    The full installation process for using FBX2glTF in Godot is described on the
     `FBX import page of the Godot website <https://godotengine.org/fbx-import>`__.

--- a/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.rst
@@ -157,6 +157,21 @@ exported from other tools such as Maya.
   Universal** and **Embed as Uncompressed** keeps the textures embedded in the
   imported scene, with and without VRAM compression respectively.
 
+**FBX**
+
+- **Importer** Which import method is used. ubfx handles fbx files as fbx files.
+  FBX2glTF converts FBX files to glTF on import and requires additonal setup.
+  FBX2glTF is not recommended unless you have a specific rason to use it over
+  ufbx or working with a different file format.
+- **Allow Geometry Helper Nodes** enables or disables geometry helper nodes
+- **Embedded Texture Handling:** Controls how textures embedded within fbx
+  scenes should be handled. **Discard All Textures** will not import any
+  textures, which is useful if you wish to manually set up materials in Godot
+  instead. **Extract Textures** extracts textures to external images, resulting
+  in smaller file sizes and more control over import options. **Embed as Basis
+  Universal** and **Embed as Uncompressed** keeps the textures embedded in the
+  imported scene, with and without VRAM compression respectively.
+
 Using the Advanced Import Settings dialog
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Supersedes #9501. Updates the import pages for ufbx in Godot 4.3. This is the PR that added support: https://github.com/godotengine/godot/pull/81746. The old FBX2glTF method is still usable though. The description for enabling geometry nodes is short because I can't find anything on what those are online.

The page on our website, https://godotengine.org/fbx-import/, should be updated at some point. Though lyumia is already working on a ufbx page here: https://github.com/godotengine/godot-website/pull/852
