### PR TITLE
Ubuntu APT oneliner to install system builtin alternatives

### DIFF
--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -437,22 +437,53 @@ you may not be able to use system libraries for everything due to bugs in the
 system library packages (or in the build system, as this feature is less
 tested).
 
-To compile Godot with system libraries, install these dependencies *on top* of the ones
+To compile Godot with system libraries, install these dependencies **on top** of the ones
 listed in the :ref:`doc_compiling_for_linuxbsd_oneliners`:
 
-+------------------+-----------------------------------------------------------------------------------------------------------+
-| **Fedora**       | ::                                                                                                        |
-|                  |                                                                                                           |
-|                  |     sudo dnf install embree3-devel enet-devel glslang-devel graphite2-devel harfbuzz-devel libicu-devel \ |
-|                  |         libsquish-devel libtheora-devel libvorbis-devel libwebp-devel libzstd-devel mbedtls-devel \       |
-|                  |         miniupnpc-devel                                                                                   |
-+------------------+-----------------------------------------------------------------------------------------------------------+
-| **Ubuntu**       | ::                                                                                                        |
-|                  |                                                                                                           |
-|                  |     sudo apt install libembree-dev libenet-dev libfreetype-dev libpng-dev zlib1g-dev libgraphite2-dev \   |
-|                  |         libharfbuzz-dev libogg-dev libtheora-dev libvorbis-dev libwebp-dev libmbedtls-dev \               |
-|                  |         libminiupnpc-dev libpcre2-dev libzstd-dev libsquish-dev libicu-dev                                |
-+------------------+-----------------------------------------------------------------------------------------------------------+
+.. tabs::
+
+    .. tab:: Debian/Ubuntu
+
+        ::
+
+            sudo apt-get update
+            sudo apt-get install -y \
+              libembree-dev \
+              libenet-dev \
+              libfreetype-dev \
+              libpng-dev \
+              zlib1g-dev \
+              libgraphite2-dev \
+              libharfbuzz-dev \
+              libogg-dev \
+              libtheora-dev \
+              libvorbis-dev \
+              libwebp-dev \
+              libmbedtls-dev \
+              libminiupnpc-dev \
+              libpcre2-dev \
+              libzstd-dev \
+              libsquish-dev \
+              libicu-dev
+
+    .. tab:: Fedora
+
+        ::
+
+            sudo dnf install -y \
+              embree3-devel \
+              enet-devel \
+              glslang-devel \
+              graphite2-devel \
+              harfbuzz-devel \
+              libicu-devel \
+              libsquish-devel \
+              libtheora-devel \
+              libvorbis-devel \
+              libwebp-devel \
+              libzstd-devel \
+              mbedtls-devel \
+              miniupnpc-devel
 
 After installing all required packages, use the following command to build Godot:
 
@@ -462,6 +493,10 @@ After installing all required packages, use the following command to build Godot
 ::
 
     scons platform=linuxbsd builtin_embree=no builtin_enet=no builtin_freetype=no builtin_graphite=no builtin_harfbuzz=no builtin_libogg=no builtin_libpng=no builtin_libtheora=no builtin_libvorbis=no builtin_libwebp=no builtin_mbedtls=no builtin_miniupnpc=no builtin_pcre2=no builtin_zlib=no builtin_zstd=no
+
+On Debian stable, you will need to remove `builtin_embree=no` as the system-provided
+Embree version is too old to work with Godot's latest `master` branch
+(which requires Embree 4).
 
 You can view a list of all built-in libraries that have system alternatives by
 running ``scons -h``, then looking for options starting with ``builtin_``.

--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -447,6 +447,12 @@ listed in the :ref:`doc_compiling_for_linuxbsd_oneliners`:
 |                  |         libsquish-devel libtheora-devel libvorbis-devel libwebp-devel libzstd-devel mbedtls-devel \       |
 |                  |         miniupnpc-devel                                                                                   |
 +------------------+-----------------------------------------------------------------------------------------------------------+
+| **Ubuntu**       | ::                                                                                                        |
+|                  |                                                                                                           |
+|                  |     sudo apt install libembree-dev libenet-dev libfreetype-dev libpng-dev zlib1g-dev libgraphite2-dev \   |
+|                  |         libharfbuzz-dev libogg-dev libtheora-dev libvorbis-dev libwebp-dev libmbedtls-dev \               |
+|                  |         libminiupnpc-dev libpcre2-dev libzstd-dev libsquish-dev libicu-dev                                |
++------------------+-----------------------------------------------------------------------------------------------------------+
 
 After installing all required packages, use the following command to build Godot:
 


### PR DESCRIPTION
Might work on Debian, not sure - tested on Ubuntu 24.04 LTS

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
