### PR TITLE
Fix wrong lines of code in the "Using NavigationMaps" page

### DIFF
--- a/tutorials/navigation/navigation_using_navigationmaps.rst
+++ b/tutorials/navigation/navigation_using_navigationmaps.rst
@@ -64,7 +64,7 @@ Navigation regions and avoidance agents can only be part of a single navigation 
 
     func _ready() -> void:
         var new_navigation_map: RID = NavigationServer2D.map_create()
-        NavigationServer2D.map_set_active(true)
+        NavigationServer2D.map_set_active(new_navigation_map, true)
 
  .. code-tab:: gdscript 3D GDScript
 
@@ -72,7 +72,7 @@ Navigation regions and avoidance agents can only be part of a single navigation 
 
     func _ready() -> void:
         var new_navigation_map: RID = NavigationServer3D.map_create()
-        NavigationServer3D.map_set_active(true)
+        NavigationServer3D.map_set_active(new_navigation_map, true)
 
 .. note::
 


### PR DESCRIPTION
NavigationServer2D and 3D's `map_set_active()` method [takes two arguments](https://docs.godotengine.org/en/stable/classes/class_navigationserver3d.html#class-navigationserver3d-method-map-set-active), the map RID and the boolean that makes the map active/inactive. The docs only contained the boolean, resulting in wrong code.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
