### PR TITLE
Add Sickhead to porting support list

### DIFF
--- a/tutorials/platform/consoles.rst
+++ b/tutorials/platform/consoles.rst
@@ -81,7 +81,7 @@ Following is the list of providers:
   Switch porting and publishing of Godot games.
 - `Seaven Studio <https://www.seaven-studio.com/>`_ offers
   Switch, Xbox One, Xbox Series, PlayStation 4 & PlayStation 5 porting of Godot games.
-
+- `Sickhead Games <https://www.sickhead.com>`_ offers console porting to Nintendo Switch, PlayStation 4, PlayStation 5, Xbox One, and Xbox Series X/S for Godot games.
 
 If your company offers porting, or porting *and* publishing services for Godot games,
 feel free to


### PR DESCRIPTION
Hi.

I'm Tom Spilman from Sickhead.

We just shipped Until Then for PS5 using our private branch of Godot 4 for PS platforms.

  https://store.playstation.com/en-us/concept/10004486/

We would like to be added to the console porting support list.