### PR TITLE
Document caveats related to GPUParticles3D collision

### DIFF
--- a/tutorials/3d/particles/collision.rst
+++ b/tutorials/3d/particles/collision.rst
@@ -11,10 +11,6 @@ world. If you need particles to collide with the environment, you have to set up
 There are four of them: :ref:`class_GPUParticlesCollisionBox3D`, :ref:`class_GPUParticlesCollisionSphere3D`,
 :ref:`class_GPUParticlesCollisionSDF3D`, and :ref:`class_GPUParticlesCollisionHeightField3D`.
 
-.. note::
-
-   GPU Particle collision is not yet implemented for 2D particle systems.
-
 Common properties
 ~~~~~~~~~~~~~~~~~
 
@@ -175,3 +171,22 @@ level geometry and instead shoot right through it, try setting this property to 
 
 The ``Bake Mask`` property controls which meshes will be considered when the SDF is baked. Only meshes that
 render on the active layers in the bake mask contribute to particle collision.
+
+Troubleshooting
+~~~~~~~~~~~~~~~
+
+For particle collision to work, the particle's :ref:`visibility AABB <doc_3d_particles_properties_draw>`
+must overlap with the collider's AABB. If collisions appear to be not working
+despite colliders being set up, generate an updated visibility AABB by selecting
+the GPUParticles3D node and choosing **GPUParticles3D > Generate Visibility AABB…**
+at the top of the 3D editor viewport.
+
+If the particles move fast and colliders are thin. There are two solutions for this:
+
+- Make the colliders thicker. For instance, if particles cannot get below a
+  solid floor, you could make the collider representing the floor thicker than
+  its actual visual representation. The heightfield collider automatically
+  handles this by design, as heightfields cannot represent "room over room"
+  collision.
+- Increased ``Fixed FPS`` in the GPUParticles3D node, which will perform collision
+  checks more often. This comes at a performance cost, so avoid setting this too high.

--- a/tutorials/3d/particles/properties.rst
+++ b/tutorials/3d/particles/properties.rst
@@ -113,10 +113,21 @@ That's what the ``Interpolate`` property does. It blends particle properties bet
 updates so that even a particle system running at ``10`` FPS appears as smooth as
 running at ``60``.
 
+.. note::
+
+    When using :ref:`particle collision <doc_3d_particles_collision>`, tunneling can occur
+    if the particles move fast and colliders are thin. This can be remedied by increasing
+    ``Fixed FPS`` (at a performance cost).
+
 .. _doc_3d_particles_properties_collision:
 
 Collision properties
 ~~~~~~~~~~~~~~~~~~~~
+
+.. seealso::
+
+    Setting up particle collision requires following further steps described in
+    :ref:`doc_3d_particles_collision`.
 
 The ``Base Size`` property defines each particle's default collision size, which is used
 to check whether a particle is currently colliding with the environment. You would usually want this
@@ -141,7 +152,8 @@ box as small as possible.
 
 One thing to keep in mind when you set a size for the ``Visibility AABB`` is that particles
 that are outside of its bounds disappear instantly when it leaves the camera's field of view.
-This, while not technically a bug, can have a negative effect on the visual experience.
+Particle collision will also not occur outside the ``Visibility AABB``.
+While not technically a bug, this can have a negative effect on the visual experience.
 
 When the ``Local Coords`` property is checked, all particle calculations use the local
 coordinate system to determine things like up and down, gravity, and movement direction.


### PR DESCRIPTION
- Remove incorrect notice about GPUParticles2D not supporting collision. This is supported using LightOccluder2D with SDF generation enabled.

___

- This closes https://github.com/godotengine/godot/issues/93567.
