### PR TITLE
Fix typo in class name

### DIFF
--- a/tutorials/2d/2d_sprite_animation.rst
+++ b/tutorials/2d/2d_sprite_animation.rst
@@ -101,7 +101,7 @@ released.
 
         public override void _Ready()
         {
-            _animatedSprite = GetNode<AnimatedSprite>("AnimatedSprite");
+            _animatedSprite = GetNode<AnimatedSprite2D>("AnimatedSprite2D");
         }
 
         public override _Process(float _delta)


### PR DESCRIPTION
Change AnimatedSprite to AnimatedSprite2D. This is already fixed in the latest documentation but since I was following the stable(4.2) version I noticed it.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
