### PR TITLE
Extract remaining changes from setget/annotation update PR's

### DIFF
--- a/tutorials/best_practices/data_preferences.rst
+++ b/tutorials/best_practices/data_preferences.rst
@@ -240,7 +240,7 @@ tree structures.
     class_name TreeNode
 
     var _parent: TreeNode = null
-    var _children: = [] setget
+    var _children := []
 
     func _notification(p_what):
         match p_what:
@@ -283,7 +283,7 @@ Enumerations: int vs. string
 
 Most languages offer an enumeration type option. GDScript is no different, but
 unlike most other languages, it allows one to use either integers or strings for
-the enum values (the latter only when using the ``export`` keyword in GDScript).
+the enum values (the latter only when using the ``@export_enum`` annotation in GDScript).
 The question then arises, "which should one use?"
 
 The short answer is, "whichever you are more comfortable with." This

--- a/tutorials/best_practices/logic_preferences.rst
+++ b/tutorials/best_practices/logic_preferences.rst
@@ -119,7 +119,7 @@ consider:
    in exceptional cases, one may wish not to do this:
 
    1. If the 'imported' class is liable to change, then it should be a property
-      instead, initialized either using an ``export`` or a ``load()`` (and
+      instead, initialized either using an ``@export`` or a ``load()`` (and
       perhaps not even initialized until later).
 
    2. If the script requires a great many dependencies, and one does not wish

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -2061,7 +2061,7 @@ Example::
 
 .. note::
 
-    Unlike ``setget`` in previous Godot versions, the properties setter and getter are **always** called (except as noted below),
+    Unlike ``setget`` in previous Godot versions, ``set`` and ``get`` methods are **always** called (except as noted below),
     even when accessed inside the same class (with or without prefixing with ``self.``). This makes the behavior
     consistent. If you need direct access to the value, use another variable for direct access and make the property
     code use that name.

--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -843,7 +843,7 @@ variables, in that order.
 
 .. note::
 
-    The GDScript compiler evaluates onready variables right before the ``_ready``
+    GDScript evaluates ``@onready`` variables right before the ``_ready``
     callback. You can use that to cache node dependencies, that is to say, to get
     child nodes in the scene that your class relies on. This is what the example
     above shows.


### PR DESCRIPTION
This are the remaining changes, which didn't get already updated in the meantime.
I mainly extracted the changes, I haven't completely checked the validity.

Supersede:

#7008 :
tutorials/best_practices/data_preferences.rst: `var _children: = [] setget` and `using the @export annotation`
tutorials/best_practices/logic_preferences.rst: `using an @export or a load()`

#6634 :
tutorials/best_practices/data_preferences.rst: `var _children: = [] setget`
tutorials/scripting/gdscript/gdscript_basics.rst: `set and get methods are **always**`
tutorials/scripting/gdscript/gdscript_styleguide.rst: `evaluates @onready variables`

#6594 :
tutorials/best_practices/data_preferences.rst: `var _children: = [] setget`
tutorials/scripting/gdscript/gdscript_basics.rst: `set and get methods are **always**`
~~contributing/development/file_formats/gdscript_grammar.rst: `classVarDecl = [ @onready ] [ @export ] "var" IDENTIFIER...`~~