### PR TITLE
Add warnings for classes named "Editor" in GDscript and C# pages, class_name keyword/global class attribute

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_global_classes.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_global_classes.rst
@@ -80,3 +80,11 @@ will let you create and load instances of this type easily.
 .. image:: img/globalclasses_exportedproperty1.webp
 
 .. image:: img/globalclasses_exportedproperty2.webp
+
+.. warning::
+
+    The Godot editor will hide these custom classes with names that beging with the prefix
+    "Editor" in the 'Create New Node' or 'Create New Scene' dialog windows. The classes 
+    are available for instantiation at runtime via their class names, but are 
+    automatically hidden by the editor windows along with the built-in editor nodes used 
+    by the Godot editor.

--- a/tutorials/scripting/c_sharp/c_sharp_global_classes.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_global_classes.rst
@@ -88,3 +88,4 @@ will let you create and load instances of this type easily.
     are available for instantiation at runtime via their class names, but are 
     automatically hidden by the editor windows along with the built-in editor nodes used 
     by the Godot editor.
+    

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1838,6 +1838,14 @@ If you want to use ``extends`` too, you can keep both on the same line::
     and this includes arrays and dictionaries. This is in the spirit of thread safety,
     since scripts can be initialized in separate threads without the user knowing.
 
+.. warning::
+
+    The Godot editor will hide these custom classes with names that beging with the prefix
+    "Editor" in the 'Create New Node' or 'Create New Scene' dialog windows. The classes 
+    are available for instantiation at runtime via their class names, but are 
+    automatically hidden by the editor windows along with the built-in editor nodes used 
+    by the Godot editor.
+
 Inheritance
 ^^^^^^^^^^^
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
Currently classes with the "Editor" prefix in their names are hidden in the Godot editor. This documents that behavior.