### PR TITLE
Modification of the section title of a_better_xr_start_script.rst

### DIFF
--- a/tutorials/xr/a_better_xr_start_script.rst
+++ b/tutorials/xr/a_better_xr_start_script.rst
@@ -192,7 +192,7 @@ it is nicer to exit on failure than to hang the system.
     ...
 
 
-On session begun
+_on_openxr_session_begun
 ----------------
 
 This signal is emitted by OpenXR when our session is setup.
@@ -294,7 +294,7 @@ Not matching the physics update rate will cause stuttering as frames are rendere
 
     ...
 
-On visible state
+_on_openxr_visible_state
 ----------------
 
 This signal is emitted by OpenXR when our game becomes visible but is not focussed.
@@ -363,7 +363,7 @@ If you haven't, you can connect a method to the signal that performs additional 
 
     ...
 
-On focussed state
+_on_openxr_focused_state
 -----------------
 
 This signal is emitted by OpenXR when our game gets focus.
@@ -421,7 +421,7 @@ While handling our signal we will update the focusses state, unpause our node an
 
     ...
 
-On stopping state
+_on_openxr_stopping
 -----------------
 
 This signal is emitted by OpenXR when we enter our stop state.
@@ -459,7 +459,7 @@ For now this method is only a place holder.
     ...
 
 
-On pose recentered
+_on_openxr_pose_recentered
 ------------------
 
 This signal is emitted by OpenXR when the user requests their view to be recentered.

--- a/tutorials/xr/a_better_xr_start_script.rst
+++ b/tutorials/xr/a_better_xr_start_script.rst
@@ -193,7 +193,7 @@ it is nicer to exit on failure than to hang the system.
 
 
 _on_openxr_session_begun
-----------------
+------------------------
 
 This signal is emitted by OpenXR when our session is setup.
 This means the headset has run through setting everything up and is ready to begin receiving content from us.
@@ -295,7 +295,7 @@ Not matching the physics update rate will cause stuttering as frames are rendere
     ...
 
 _on_openxr_visible_state
-----------------
+------------------------
 
 This signal is emitted by OpenXR when our game becomes visible but is not focussed.
 This is a bit of a weird description in OpenXR but it basically means that our game has just started
@@ -364,7 +364,7 @@ If you haven't, you can connect a method to the signal that performs additional 
     ...
 
 _on_openxr_focused_state
------------------
+------------------------
 
 This signal is emitted by OpenXR when our game gets focus.
 This is done at the completion of our startup,
@@ -422,7 +422,7 @@ While handling our signal we will update the focusses state, unpause our node an
     ...
 
 _on_openxr_stopping
------------------
+-------------------
 
 This signal is emitted by OpenXR when we enter our stop state.
 There are some differences between platforms when this happens.
@@ -460,7 +460,7 @@ For now this method is only a place holder.
 
 
 _on_openxr_pose_recentered
-------------------
+--------------------------
 
 This signal is emitted by OpenXR when the user requests their view to be recentered.
 Basically this communicates to your game that the user is now facing forward


### PR DESCRIPTION
## The original section title is somewhat misleading; 
**On session begun** should refer to the **_on_openxr_session_begun** signal in the script code. The same applies to **On visible state**, **On focussed state**, **On stopping state**, and **On pose recentered** (**_on_openxr_visible_state**, **_on_openxr_focused_state**, **_on_openxr_stopping**, **_on_openxr_pose_recentered**).

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
