### PR TITLE
Remove unnecessary opinion about languages.

### DIFF
--- a/tutorials/i18n/internationalizing_games.rst
+++ b/tutorials/i18n/internationalizing_games.rst
@@ -6,9 +6,7 @@ Internationalizing games
 Introduction
 ------------
 
-Sería excelente que el mundo hablara solo un idioma (It would be great if the
-world spoke only one language). Unfortunately for
-us developers, that is not the case. While indie or niche games usually
+While indie or niche games usually
 do not need localization, games targeting a more massive market
 often require localization. Godot offers many tools to make this process
 more straightforward, so this tutorial is more like a collection of


### PR DESCRIPTION
Removing this unnecessary opinion about languages in the `Internationalizing games` section. Since it can be a controversial opinion (it can trigger anti-colonialism folks, or language lovers for that matter), I propose to just remove it.

I understand it is there just as a funny comment, but to be honest, it always shocks me when I see it, and doesn't add any value to the documentation. I also believe that the docs should be as neutral as possible, and this is the main reason why I opened the PR.
