### PR TITLE
Update class_editorplugin.rst

### DIFF
--- a/classes/class_editorplugin.rst
+++ b/classes/class_editorplugin.rst
@@ -185,7 +185,7 @@ Methods
 .. rst-class:: classref-descriptions-group
 
 Signals
--------
+-------     
 
 .. _class_EditorPlugin_signal_main_screen_changed:
 
@@ -1143,7 +1143,7 @@ Optionally, you can specify a shortcut parameter. When pressed, this shortcut wi
 
 |void| **add_custom_type**\ (\ type\: :ref:`String<class_String>`, base\: :ref:`String<class_String>`, script\: :ref:`Script<class_Script>`, icon\: :ref:`Texture2D<class_Texture2D>`\ ) :ref:`🔗<class_EditorPlugin_method_add_custom_type>`
 
-Adds a custom type, which will appear in the list of nodes or resources. An icon can be optionally passed.
+Adds a custom type, which will appear in the list of nodes or resources. An editor error is generated when this function is called without the icon parameter.
 
 When a given node or resource is selected, the base type will be instantiated (e.g. "Node3D", "Control", "Resource"), then the script will be loaded and set to this object.
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

fixes #9555

fixed an error: "icon" parameter in EditorPlugin.add_custom_type is not optional, but documentation says it is.
Removed the line "An icon can be optionally passed." and added this "An editor error is generated when this function is called without the icon parameter."
