### PR TITLE
Fix link written in md syntax instead of rst

### DIFF
--- a/tutorials/platform/android/android_plugin.rst
+++ b/tutorials/platform/android/android_plugin.rst
@@ -363,7 +363,7 @@ developers / users intend to run the Godot Editor. Not doing so may prevent deve
 users from writing code that accesses the plugin from within the Godot Editor.
 
 This may involve creating dummy plugins for the host OS just so the API is published to the
-editor. You can use the [godot-cpp-template](https://github.com/godotengine/godot-cpp-template)
+editor. You can use the `godot-cpp-template <https://github.com/godotengine/godot-cpp-template>`__
 github template for reference on how to do so.
 
 Godot crashes upon load


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

This link is written in markdown instead of restructuredtext syntax

https://docs.godotengine.org/en/stable/tutorials/platform/android/android_plugin.html#support-using-the-gdextension-functionality-in-the-godot-editor
