### PR TITLE
Fix dead links in the documentation

### DIFF
--- a/about/faq.rst
+++ b/about/faq.rst
@@ -11,7 +11,7 @@ Frequently asked questions
 What can I do with Godot? How much does it cost? What are the license terms?
 ----------------------------------------------------------------------------
 
-Godot is `Free and open source Software <https://en.wikipedia.org/wiki/Free_and_open source_software>`_
+Godot is `Free and open source Software <https://en.wikipedia.org/wiki/Free_and_open_source_software>`_
 available under the `OSI-approved <https://opensource.org/licenses/MIT>`_ MIT license. This means it is
 free as in "free speech" as well as in "free beer."
 

--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -62,4 +62,3 @@ Resources
 - `awesome-godot: A curated list of free/libre plugins, scripts and add-ons <https://github.com/godotengine/awesome-godot>`_
 - `Godot Asset Library <https://godotengine.org/asset-library/asset>`_
 - `Godot Shaders: A community-driven shader library <https://godotshaders.com/>`_
-- `Zeef Godot Engine: A curated directory of resources by Andre Schmitz <https://godot-engine.zeef.com/andre.antonio.schmitz>`_

--- a/contributing/development/compiling/compiling_for_windows.rst
+++ b/contributing/development/compiling/compiling_for_windows.rst
@@ -317,7 +317,7 @@ Cross-compiling for Windows from other operating systems
 --------------------------------------------------------
 
 If you are a Linux or macOS user, you need to install
-`MinGW-w64 <https://mingw-w64.org/doku.php>`__, which typically comes in 32-bit
+`MinGW-w64 <https://www.mingw-w64.org/>`__, which typically comes in 32-bit
 and 64-bit variants. The package names may differ based on your distribution,
 here are some known ones:
 

--- a/contributing/development/compiling/cross-compiling_for_ios_on_linux.rst
+++ b/contributing/development/compiling/cross-compiling_for_ios_on_linux.rst
@@ -24,8 +24,9 @@ described here and cross-compiling the binary.
 Requirements
 ------------
 
-- `XCode with the iOS SDK <https://developer.apple.com/xcode/download>`__
-  (a dmg image, for newer versions a **xip** file is going to be downloaded.)
+- `XCode with the iOS SDK <https://developer.apple.com/download/all/?q=Xcode>`__
+  (a dmg image, for newer versions a **xip** file is going to be downloaded.
+  You must be logged into an Apple ID to download Xcode.)
 - `Clang >= 3.5 <https://clang.llvm.org>`__ for your development
   machine installed and in the ``PATH``. It has to be version >= 3.5
   to target ``arm64`` architecture.

--- a/contributing/documentation/docs_image_guidelines.rst
+++ b/contributing/documentation/docs_image_guidelines.rst
@@ -67,7 +67,7 @@ have cropping built in it's not always easy to get something precise. And while
 Krita is designed as a painting program the cropping tool gives you pixel precision
 by default. Of course, feel free to use a different program you are familiar with.
 
-If you've never used Krita before download it from the `official Krita website <https://krita.org/en/download/krita-desktop/>`_,
+If you've never used Krita before download it from the `official Krita website <https://krita.org/en/download/>`_,
 on Linux you may also be able to download it from your distributions repository,
 flathub is also an option. Once it's installed on your computer open Krita then
 open the image you want to crop. This button on the left panel is the crop tool.

--- a/tutorials/3d/3d_antialiasing.rst
+++ b/tutorials/3d/3d_antialiasing.rst
@@ -116,7 +116,7 @@ AMD FidelityFX Super Resolution 2.2 (FSR2)
 ------------------------------------------
 
 Since Godot 4.2, there is built-in support for
-`AMD FidelityFX Super Resolution <https://www.amd.com/en/technologies/fidelityfx-super-resolution>`__
+`AMD FidelityFX Super Resolution <https://www.amd.com/en/products/graphics/technologies/fidelityfx/super-resolution.html>`__
 2.2. This is an :ref:`upscaling method <doc_resolution_scaling>`
 compatible with all recent GPUs from any vendor. FSR2 is normally designed to
 improve performance by lowering the internal 3D rendering resolution,

--- a/tutorials/assets_pipeline/importing_3d_scenes/model_export_considerations.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/model_export_considerations.rst
@@ -39,10 +39,12 @@ Exporting textures separately
 
 While textures can be exported with a model in certain file formats, such as glTF 2.0, you can also export them
 separately. Godot uses PBR (physically based rendering) for its materials, so if a texturing program can export PBR
-textures they can work in Godot. This includes the `Substance suite <https://www.substance3d.com/>`__,
+textures, they can work in Godot. This includes the `Substance suite <https://www.adobe.com/creativecloud/3d-ar.html>`__,
 `ArmorPaint (open source) <https://armorpaint.org/>`__, and `Material Maker (open source) <https://github.com/RodZill4/material-maker>`__.
 
-.. note:: For more information on Godot's materials, see :ref:`doc_standard_material_3d`.
+.. seealso::
+
+    For more information on Godot's materials, see :ref:`doc_standard_material_3d`.
 
 Exporting considerations
 ------------------------


### PR DESCRIPTION
Command used:

```bash
lychee **/*.rst --github-token="..." --accept="100..=103,200..=299,429"
```

429 error codes were allowed due to a high number of false positives, even with a GitHub token specified.
