### PR TITLE
Update Cross-compiling for iOS on Linux

### DIFF
--- a/contributing/development/compiling/cross-compiling_for_ios_on_linux.rst
+++ b/contributing/development/compiling/cross-compiling_for_ios_on_linux.rst
@@ -25,94 +25,60 @@ Requirements
 ------------
 
 - `XCode with the iOS SDK <https://developer.apple.com/download/all/?q=Xcode>`__
-  (a dmg image, for newer versions a **xip** file is going to be downloaded.
-  You must be logged into an Apple ID to download Xcode.)
+  (you must be logged into an Apple ID to download Xcode).
 - `Clang >= 3.5 <https://clang.llvm.org>`__ for your development
   machine installed and in the ``PATH``. It has to be version >= 3.5
   to target ``arm64`` architecture.
-- `Fuse <https://github.com/libfuse/libfuse>`__ for mounting and unmounting
-  the dmg image.
-- `darling-dmg <https://github.com/darlinghq/darling-dmg>`__, which
-  needs to be built from source. The procedure for that is explained
-  below.
+- `xar <https://mackyle.github.io/xar/>`__ and `pbzx <https://github.com/NiklasRosenstein/pbzx>`__
+  (required to extract the ``.xip`` archive Xcode comes in).
 
-    - For newer versions you should download `xar <https://mackyle.github.io/xar/>`__
-      and `pbzx <https://github.com/NiklasRosenstein/pbzx>`__.
-    - For building darling-dmg, you'll need the development packages of
-      the following libraries: fuse, icu, openssl, zlib, bzip2.
-    - For building xar and pbzx you may want to follow
-      `this guide <https://gist.github.com/phracker/1944ce190e01963c550566b749bd2b54>`__.
+  - For building xar and pbzx, you may want to follow
+    `this guide <https://gist.github.com/phracker/1944ce190e01963c550566b749bd2b54>`__.
 
 - `cctools-port <https://github.com/tpoechtrager/cctools-port>`__
   for the needed build tools. The procedure for building is quite
   peculiar and is described below.
 
-    - This also has some extra dependencies: automake, autogen, libtool.
+  - This also has some extra dependencies: automake, autogen, libtool.
 
 Configuring the environment
 ---------------------------
 
-darling-dmg
-~~~~~~~~~~~
-
-Clone the repository on your machine:
-
-::
-
-    $ git clone https://github.com/darlinghq/darling-dmg.git
-
-Build it:
-
-::
-
-    $ cd darling-dmg
-    $ mkdir build
-    $ cd build
-    $ cmake .. -DCMAKE_BUILD_TYPE=Release
-    $ make -j 4  # The number is the amount of cores your processor has, for faster build
-    $ cd ../..
-
 Preparing the SDK
 ~~~~~~~~~~~~~~~~~
 
-Mount the XCode image:
+Extract the Xcode ``.xip`` file you downloaded from Apple's developer website:
 
 ::
 
-    $ mkdir xcode
-    $ ./darling-dmg/build/darling-dmg /path/to/Xcode_7.1.1.dmg xcode
-    [...]
-    Everything looks OK, disk mounted
+    mkdir xcode
+    xar -xf /path/to/Xcode_X.x.xip -C xcode
+    pbzx -n Content | cpio -i
 
-
-For newer versions you should extract the **xip** file:
-
-::
-
-    $ mkdir xcode
-    $ xar -xf /path/to/Xcode_X.x.xip -C xcode
-    $ pbzx -n Content | cpio -i
     [...]
     ######### Blocks
 
-Note that for the commands below, you may need to replace the version (`X.x`) with whatever iOS SDK version you're using.
+Note that for the commands below, you will need to replace the version (``x.x``)
+with whatever iOS SDK version you're using. If you don't know your iPhone SDK
+version, you can see the JSON file inside of
+``Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs``.
 
 Extract the iOS SDK:
 
 ::
 
-    $ # If you don't know your iPhone SDK version you can see the json file inside of Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs
-    $ mkdir -p iPhoneSDK/iPhoneOSX.x.sdk
-    $ cp -r xcode/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/* iPhoneSDK/iPhoneOSX.x.sdk
-    $ cp -r xcode/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/* iPhoneSDK/iPhoneOSX.x.sdk/usr/include/c++
-    $ fusermount -u xcode  # unmount the image
+    export IOS_SDK_VERSION="x.x"
+    mkdir -p iPhoneSDK/iPhoneOS${IOS_SDK_VERSION}.sdk
+    cp -r xcode/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/* iPhoneSDK/iPhoneOS${IOS_SDK_VERSION}.sdk
+    cp -r xcode/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/* iPhoneSDK/iPhoneOS${IOS_SDK_VERSION}.sdk/usr/include/c++
+    fusermount -u xcode
 
-Pack the SDK:
+Pack the SDK so that cctools can use it:
 
 ::
 
-    $ cd iPhoneSDK
-    $ tar -cf - * | xz -9 -c - > iPhoneOSX.x.sdk.tar.xz
+    cd iPhoneSDK
+    tar -cf - * | xz -9 -c - > iPhoneOS${IOS_SDK_VERSION}.sdk.tar.xz
 
 Toolchain
 ~~~~~~~~~
@@ -121,9 +87,9 @@ Build cctools:
 
 ::
 
-    $ git clone https://github.com/tpoechtrager/cctools-port.git
-    $ cd cctools-port/usage_examples/ios_toolchain
-    $ ./build.sh /path/iPhoneOSX.x.sdk.tar.xz arm64
+    git clone https://github.com/tpoechtrager/cctools-port.git
+    cd cctools-port/usage_examples/ios_toolchain
+    ./build.sh /path/iPhoneOS${IOS_SDK_VERSION}.sdk.tar.xz arm64
 
 Copy the tools to a nicer place. Note that the SCons scripts for
 building will look under ``usr/bin`` inside the directory you provide
@@ -132,11 +98,11 @@ to the following commands:
 
 ::
 
-    $ mkdir -p /home/user/iostoolchain/usr
-    $ cp -r target/bin /home/user/iostoolchain/usr/
+    mkdir -p "$HOME/iostoolchain/usr"
+    cp -r target/bin "$HOME/iostoolchain/usr/"
 
 Now you should have the iOS toolchain binaries in
-``/home/user/iostoolchain/usr/bin``.
+``$HOME/iostoolchain/usr/bin``.
 
 Compiling Godot for iPhone
 --------------------------
@@ -151,11 +117,11 @@ environment variable defined to anything.
 
 ::
 
-    $ export OSXCROSS_IOS=anything
+    export OSXCROSS_IOS="anything"
 
 Now you can compile for iPhone using SCons like the standard Godot
 way, with some additional arguments to provide the correct paths:
 
 ::
 
-    $ scons -j 4 platform=ios arch=arm64 target=template_release IOS_SDK_PATH="/path/to/iPhoneSDK" IOS_TOOLCHAIN_PATH="/path/to/iostoolchain" ios_triple="arm-apple-darwin11-"
+    scons platform=ios arch=arm64 target=template_release IOS_SDK_PATH="/path/to/iPhoneSDK" IOS_TOOLCHAIN_PATH="/path/to/iostoolchain" ios_triple="arm-apple-darwin11-"


### PR DESCRIPTION
- Update link to Xcode download. Mention that it requires being logged into an Apple ID for the page to be visible.
- Remove DMG method as Xcode has been distributed in XIP archives since 2016.
- Update page formatting to make copying commands easier and use variables when possible.

For Windows users, it should be possible to follow these steps on WSL but I haven't tested. It might be worth adding a note on this if someone can get it to work there.
