### PR TITLE
Mention that signals are first-class types since Godot 4.0 in Using signals

### DIFF
--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -25,9 +25,17 @@ For example, you might have a life bar on the screen that represents the
 player's health. When the player takes damage or uses a healing potion, you want
 the bar to reflect the change. To do so, in Godot, you would use signals.
 
-.. note:: As mentioned in the introduction, signals are Godot's version of the
-          observer pattern. You can learn more about it here:
-          https://gameprogrammingpatterns.com/observer.html
+Like methods (:ref:`class_callable`), signals are a first-class type since Godot
+4.0. This means you can pass them around as method arguments directly without
+having to pass them as strings, which allows for better autocompletion and is
+less error-prone. See the :ref:`class_signal` class reference for a list of
+what you can do with the Signal type directly.
+
+.. seealso::
+
+    As mentioned in the introduction, signals are Godot's version of the
+    observer pattern. You can learn more about it in
+    `Game Programming Patterns <https://gameprogrammingpatterns.com/observer.html>`__.
 
 We will now use a signal to make our Godot icon from the previous lesson
 (:ref:`doc_scripting_player_input`) move and stop by pressing a button.
@@ -42,8 +50,6 @@ We will now use a signal to make our Godot icon from the previous lesson
             private fields use _camelCase, local variables and parameters use
             camelCase (See :ref:`doc_c_sharp_styleguide`). Be careful to type
             the method names precisely when connecting signals.
-
-.. Example
 
 Scene setup
 -----------
@@ -139,10 +145,10 @@ methods "_on_node_name_signal_name". Here, it'll be "_on_button_pressed".
    toggle the mode in the window's bottom-right by clicking the Advanced
    button.
 
-.. note:: 
+.. note::
 
-    If you are using an external editor (such as VS Code) this 
-    automatic code generation might not work. In this case you need to to connect 
+    If you are using an external editor (such as VS Code) this
+    automatic code generation might not work. In this case you need to to connect
     the signal via code as explained in the next section.
 
 Click the Connect button to complete the signal connection and jump to the


### PR DESCRIPTION
- See https://github.com/godotengine/godot-docs/pull/9460.

This is also an opportunity to link to the Signal class reference.