### PR TITLE
Update first_look_at_the_editor.rst

### DIFF
--- a/getting_started/introduction/first_look_at_the_editor.rst
+++ b/getting_started/introduction/first_look_at_the_editor.rst
@@ -144,11 +144,10 @@ Godot comes with a built-in class reference.
 You can search for information about a class, method, property, constant, or
 signal by any one of the following methods:
 
-* Pressing :kbd:`F1` (or :kbd:`Opt + Space` on macOS, or :kbd:`fn + F1` for laptops with a :kbd:`fn` key) anywhere in the editor.
+* Pressing :kbd:`F1` (or :kbd:`⌥ Option + Space` on macOS, or :kbd:`fn + F1` for laptops with a :kbd:`fn` key) anywhere in the editor.
 * Clicking the "Search Help" button in the top-right of the Script main screen.
 * Clicking on the Help menu and Search Help.
-* Clicking while pressing the :kbd:`Ctrl` key on a class name, function name,
-  or built-in variable in the script editor.
+* :kbd:`Ctrl + Click` (:kbd:`⌘ Command + Click` on macOS) on a class name, function name, or built-in variable in the script editor.
 
 
 .. image:: img/editor_intro_search_help_button.webp

--- a/getting_started/introduction/first_look_at_the_editor.rst
+++ b/getting_started/introduction/first_look_at_the_editor.rst
@@ -144,10 +144,10 @@ Godot comes with a built-in class reference.
 You can search for information about a class, method, property, constant, or
 signal by any one of the following methods:
 
-* Pressing :kbd:`F1` (or :kbd:`⌥ Option + Space` on macOS, or :kbd:`fn + F1` for laptops with a :kbd:`fn` key) anywhere in the editor.
+* Pressing :kbd:`F1` (or :kbd:`Opt + Space` on macOS, or :kbd:`fn + F1` for laptops with a :kbd:`fn` key) anywhere in the editor.
 * Clicking the "Search Help" button in the top-right of the Script main screen.
 * Clicking on the Help menu and Search Help.
-* :kbd:`Ctrl + Click` (:kbd:`⌘ Command + Click` on macOS) on a class name, function name, or built-in variable in the script editor.
+* :kbd:`Ctrl + Click` (:kbd:`Cmd + Click` on macOS) on a class name, function name, or built-in variable in the script editor.
 
 
 .. image:: img/editor_intro_search_help_button.webp


### PR DESCRIPTION
Updating macOS shortcuts and cleaning up the click shortcut.
* Clarified clicking on keywords help function shortcuts.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
