### PR TITLE
Document baking lightmaps on Android/web editor is not supported

### DIFF
--- a/tutorials/3d/global_illumination/using_lightmap_gi.rst
+++ b/tutorials/3d/global_illumination/using_lightmap_gi.rst
@@ -60,9 +60,6 @@ Visual comparison
    but lower quality visuals. Notice the blurrier sun shadow in the top-right
    corner.
 
-Visual comparison
------------------
-
 Here are some comparisons of how LightmapGI vs. VoxelGI look. Notice that
 lightmaps are more accurate, but also suffer from the fact
 that lighting is on an unwrapped texture, so transitions and resolution may not
@@ -76,6 +73,12 @@ large open worlds without any need for baking.
 
 Setting up
 ----------
+
+.. warning::
+
+    Baking lightmaps in the Android and web editors is not supported due to
+    graphics API limitations on those devices. On Android and web platforms,
+    only *rendering* lightmaps that were baked on a desktop PC is supported.
 
 First of all, before the lightmapper can do anything, the objects to be baked need
 a UV2 layer and a texture size. A UV2 layer is a set of secondary texture coordinates


### PR DESCRIPTION
- `master` version of https://github.com/godotengine/godot-docs/pull/9608.

This also removes a duplicated heading.

- See https://github.com/godotengine/godot/issues/94297.
