### PR TITLE
Audio Streams Tutorial: change outdated reference to AudioStreamRandomPitch

### DIFF
--- a/tutorials/audio/audio_streams.rst
+++ b/tutorials/audio/audio_streams.rst
@@ -21,8 +21,9 @@ loaded as AudioStreams and placed inside an AudioStreamPlayer. You can find
 information on supported formats and differences in :ref:`doc_importing_audio_samples`.
 
 There are other types of AudioStreams, such as :ref:`AudioStreamRandomizer<class_AudioStreamRandomizer>`.
-This one picks a different sound from a list of streams each time it's played back.
-This can be helpful for adding variation to sounds that are played back often.
+This one picks a different audio stream from a list of streams each time it's played
+back, and applies random pitch and volume shifting. This can be helpful for adding
+variation to sounds that are played back often.
 
 AudioStreamPlayer
 -----------------

--- a/tutorials/audio/audio_streams.rst
+++ b/tutorials/audio/audio_streams.rst
@@ -20,10 +20,9 @@ many places, but is most commonly loaded from the filesystem. Audio files can be
 loaded as AudioStreams and placed inside an AudioStreamPlayer. You can find
 information on supported formats and differences in :ref:`doc_importing_audio_samples`.
 
-There are other types of AudioStreams, such as AudioStreamRandomPitch.
-This one makes a random adjustment to the sound's pitch every time it's
-played back. This can be helpful for adding variation to sounds that are
-played back often.
+There are other types of AudioStreams, such as :ref:`AudioStreamRandomizer<class_AudioStreamRandomizer>`.
+This one picks a different sound from a list of streams each time it's played back.
+This can be helpful for adding variation to sounds that are played back often.
 
 AudioStreamPlayer
 -----------------


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
AudioStreamRandomPitch is no longer supported in Godot 4. I would like to replace the example to a reference to the AudioStreamRandomizer node instead.