### PR TITLE
Add Youtube Bacon and Games to video tutorials

### DIFF
--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -19,6 +19,7 @@ Some tutorials mentioned below provide more advanced tutorials, e.g. on 3D or sh
 Video tutorials
 ---------------
 
+- `Bacon and Games <https://www.youtube.com/@baconandgames>`_ (2D, GDScript)
 - `Bastiaan Olij <https://www.youtube.com/BastiaanOlij>`_ (3D, AR and VR, GDScript)
 - `BornCG <https://www.youtube.com/playlist?list=PLda3VoSoc_TTp8Ng3C57spnNkOw3Hm_35>`_ (2D and 3D, GDScript)
 - `Clear Code <https://www.youtube.com/watch?v=nAh_Kx5Zh5Q>`_ (2D, GDScript, Programming Basics)


### PR DESCRIPTION
Adds a link to Bacon and Games videos on Youtube to the community/tutorials document.

Sean posts regular video with Godot tutorials, feature explanations, along with engine and editor tips.
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
