### PR TITLE
Fix NOTIFICATION_WM_GO_BACK_REQUEST documentation

### DIFF
--- a/classes/class_node.rst
+++ b/classes/class_node.rst
@@ -971,7 +971,7 @@ Implemented on desktop platforms.
 
 Notification received from the OS when a go back request is sent (e.g. pressing the "Back" button on Android).
 
-Implemented only on iOS.
+Implemented only on Android.
 
 .. _class_Node_constant_NOTIFICATION_WM_SIZE_CHANGED:
 


### PR DESCRIPTION
I double checked that this is only implemented on Android by going through the godot codebase https://github.com/search?q=repo%3Agodotengine%2Fgodot+WINDOW_EVENT_GO_BACK_REQUEST&type=code