### PR TITLE
Fix wrong information on NavigationLayers page

### DIFF
--- a/tutorials/navigation/navigation_using_navigationlayers.rst
+++ b/tutorials/navigation/navigation_using_navigationlayers.rst
@@ -3,14 +3,12 @@
 Using NavigationLayers
 ======================
 
-NavigationLayers are an optional feature to further control which navigation meshes are considered in a path query and which regions can be connected.
+NavigationLayers are an optional feature to further control which navigation meshes are considered in a path query.
 They work similar to how physics layers control collision between collision objects or how visual layers control what is rendered to the Viewport.
 
 NavigationLayers can be named in the **ProjectSettings** the same as physics layers or visual layers.
 
 .. image:: img/navigationlayers_naming.png
-
-If two regions have not a single compatible layer they will not be merged by the NavigationServer. See :ref:`doc_navigation_connecting_navmesh` for more information on merging navigation meshes.
 
 If a region has not a single compatible navigation layer with the ``navigation_layers`` parameter of a path query this regions navigation mesh will be skipped in pathfinding.
 See :ref:`doc_navigation_using_navigationpaths` for more information on querying the NavigationServer for paths.
@@ -96,5 +94,4 @@ trigger large scale updates on the NavigationServer.
 
 Changing the navigation layers of NavigationAgent nodes will have an immediate
 effect on the next path query. Changing the navigation layers of
-regions will have an immediate effect on the region but any new region
-connect or disconnect will only be in effect after the next physics frame.
+regions will have an effect after the next NavigationServer sync.

--- a/tutorials/navigation/navigation_using_navigationlinks.rst
+++ b/tutorials/navigation/navigation_using_navigationlinks.rst
@@ -16,7 +16,7 @@ interacting with gameplay objects e.g. ladders, jump pads or teleports.
 :ref:`NavigationLink3D<class_NavigationLink3D>` respectively.
 
 Different NavigationRegions can connect their navigation meshes without the need for a NavigationLink
-as long as they are within navigation map ``edge_connection_margin`` and have compatible ``navigation_layers``.
+as long as they have overlapping edges or edges that are within navigation map ``edge_connection_margin``.
 As soon as the distance becomes too large, building valid connections becomes a problem - a problem that NavigationLinks can solve.
 
 See :ref:`doc_navigation_using_navigationregions` to learn more about the use of navigation regions.


### PR DESCRIPTION
Removes the parts that state that the navigation layers have anything to do with how a navigation map merges the navigation regions or navigation mesh polygons.

Also corrects wrong statement about changing the navigation layers of a region as that change requires a server sync and is not applied immediately.

This can be backported to all Godot 4.0+ version that are still updated as it applies to all versions.

This wrong documentation was done years ago build on a lot of hearsay from developers how they thought the system worked at that time. After learning how it actually functions at least I forgot to correct the page 3 times by now - so lucky number. :sweat: :unamused:

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
