### PR TITLE
Update GDExtension tutorial with the hot reload feature

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -365,6 +365,7 @@ loaded for each platform and the entry function for the module. It is called ``g
 
     entry_symbol = "example_library_init"
     compatibility_minimum = "4.1"
+    reloadable = true
 
     [libraries]
 
@@ -388,6 +389,8 @@ loaded for each platform and the entry function for the module. It is called ``g
 This file contains a ``configuration`` section that controls the entry function of the module.
 You should also set the minimum compatible Godot version with ``compatability_minimum``,
 which prevents older version of Godot from trying to load your extension.
+The ``reloadable`` flag enables automatic reloading of your extension by the editor every time you recompile it,
+without needing to restart the editor. This only works if you compile your extension in debug mode (default).
 
 The ``libraries`` section is the important bit: it tells Godot the location of the
 dynamic library in the project's filesystem for each supported platform. It will


### PR DESCRIPTION
Although the tutorial assumed the hot reload feature, it wasn't enabled in the example config file. Also it didn't mention that it only works if it's compiled in debug mode.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
