### PR TITLE
Fix DotNet EditorInterface singleton usage

### DIFF
--- a/tutorials/plugins/editor/making_main_screen_plugins.rst
+++ b/tutorials/plugins/editor/making_main_screen_plugins.rst
@@ -92,7 +92,7 @@ Add five extra methods such that the script looks like this:
 
         public override Texture2D _GetPluginIcon()
         {
-            return EditorInterface.GetEditorTheme().GetIcon("Node", "EditorIcons");
+            return EditorInterface.Singleton.GetEditorTheme().GetIcon("Node", "EditorIcons");
         }
     }
     #endif
@@ -210,7 +210,7 @@ Here is the full plugin script:
         {
             MainPanelInstance = (Control)MainPanel.Instantiate();
             // Add the main panel to the editor's main viewport.
-            EditorInterface.GetEditorMainScreen().AddChild(MainPanelInstance);
+            EditorInterface.Singleton.GetEditorMainScreen().AddChild(MainPanelInstance);
             // Hide the main panel. Very much required.
             _MakeVisible(false);
         }
@@ -244,7 +244,7 @@ Here is the full plugin script:
         public override Texture2D _GetPluginIcon()
         {
             // Must return some kind of Texture for the icon.
-            return EditorInterface.GetEditorTheme().GetIcon("Node", "EditorIcons");
+            return EditorInterface.Singleton.GetEditorTheme().GetIcon("Node", "EditorIcons");
         }
     }
     #endif


### PR DESCRIPTION
See issue https://github.com/godotengine/godot-docs/issues/9626.

---
**Your Godot version:**
4.3, 4.2

**Issue description:**

Compile error using C# on godot-demo-projects:plugins:main_screen
https://github.com/DamienFremont/godot-demo-projects/tree/master/plugins/addons/main_screen

Plugin script should be using `EditorInterface.singleton.` instead of `EditorInterface.`

**URL to the documentation page:**
https://docs.godotengine.org/en/latest/tutorials/plugins/editor/making_main_screen_plugins.html

**Fix + PR:**
https://github.com/godotengine/godot-docs/pull/9627

**Test project**
https://github.com/DamienFremont/godot-demo-projects/tree/fix-docs-dotnet-editorinterface-singleton-usage/plugins

**Screenshots:**

![20240720_170834-Zoomit Zoom Window](https://github.com/user-attachments/assets/2226d908-611f-47e6-828c-db1d1ca404e9)

![20240720_170647-Window](https://github.com/user-attachments/assets/d66c5f20-e6ef-4f03-b366-e30bbf10eb85)

![20240720_170700-Window](https://github.com/user-attachments/assets/7c54202c-29c7-4fd1-b2ae-0a5e5fdb9441)
