### PR TITLE
Fix redirect to new contribution guidelines

### DIFF
--- a/_tools/redirects/redirects.csv
+++ b/_tools/redirects/redirects.csv
@@ -14,7 +14,6 @@ source,destination
 /community/contributing/docs_writing_guidelines.html,/contributing/documentation/docs_writing_guidelines.html
 /community/contributing/editor_and_docs_localization.html,/contributing/documentation/editor_and_docs_localization.html
 /community/contributing/index.html,/contributing/ways_to_contribute.html
-/community/contributing/ways_to_contribute.html,/contributing/how_to_contribute.html
 /community/contributing/pr_workflow.html,/contributing/workflow/pr_workflow.html
 /community/contributing/testing_pull_requests.html,/contributing/workflow/testing_pull_requests.html
 /community/contributing/updating_the_class_reference.html,/contributing/documentation/updating_the_class_reference.html
@@ -31,6 +30,7 @@ source,destination
 /contributing/development/core_and_modules/introduction_to_godot_development.html,/contributing/development/core_and_modules/index.html
 /contributing/doc_and_l10n_guidelines.html,/community/contributing/doc_and_l10n_guidelines.html
 /contributing/updating_the_class_reference.html,/community/contributing/updating_the_class_reference.html
+/contributing/ways_to_contribute.html,/contributing/how_to_contribute.html
 /development/compiling/compiling_for_android.html,/contributing/development/compiling/compiling_for_android.html
 /development/compiling/compiling_for_ios.html,/contributing/development/compiling/compiling_for_ios.html
 /development/compiling/compiling_for_linuxbsd.html,/contributing/development/compiling/compiling_for_linuxbsd.html


### PR DESCRIPTION
Follow-up to:
* https://github.com/godotengine/godot-docs/pull/9609

The added redirect was from the old location, instead of the new one
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
