### PR TITLE
Add table of contents to 3.6 EPUB file

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -301,3 +301,6 @@ rst_epilog = """
     image_locale="-" if language == "en" else language,
     target_locale="" if language == "en" else "/" + language,
 )
+
+# Needed so the table of contents is created for EPUB
+epub_tocscope = 'includehidden'


### PR DESCRIPTION
Does what the title says. This change was done for the master and 4.2 branch in #9131.

Closes #9485

EDIT: Build is failing because of spellcheck on unrelated files.