### PR TITLE
Update Docs for ARM support

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -22,7 +22,7 @@ Platforms
 
 **Can run both the editor and exported projects:**
 
-- Windows (x86, 64-bit and 32-bit).
+- Windows (x86 and ARM, 64-bit and 32-bit).
 - macOS (x86 and ARM, 64-bit only).
 - Linux (x86 and ARM, 64-bit and 32-bit).
 

--- a/about/system_requirements.rst
+++ b/about/system_requirements.rst
@@ -23,9 +23,9 @@ Desktop or laptop PC - Minimum
 .. which can run up to macOS 10.13.
 
 +----------------------+-----------------------------------------------------------------------------------------+
-| **CPU**              | - **Windows:** x86_32 CPU with SSE2 instructions, or any x86_64 CPU                     |
+| **CPU**              | - **Windows:** x86_32 CPU with SSE2 instructions, x86_64 CPU, ARMv8 CPU                 |
 |                      |                                                                                         |
-|                      |   - *Example: Intel Core 2 Duo E8200, AMD Athlon XE BE-2300*                            |
+|                      |   - *Example: Intel Core 2 Duo E8200, AMD Athlon XE BE-2300, Snapdragon X Elite*        |
 |                      |                                                                                         |
 |                      | - **macOS:** x86_64 or ARM CPU (Apple Silicon)                                          |
 |                      |                                                                                         |
@@ -112,40 +112,40 @@ Godot editor on a simple 2D or 3D project:
 Desktop or laptop PC - Recommended
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-+----------------------+-----------------------------------------------------------------------------------------+
-| **CPU**              | - **Windows:** x86_64 CPU with SSE4.2 instructions, with 4 physical cores or more       |
-|                      |                                                                                         |
-|                      |   - *Example: Intel Core i5-6600K, AMD Ryzen 5 1600*                                    |
-|                      |                                                                                         |
-|                      | - **macOS:** x86_64 or ARM CPU (Apple Silicon)                                          |
-|                      |                                                                                         |
-|                      |   - *Example: Intel Core i5-8500, Apple M1*                                             |
-|                      |                                                                                         |
-|                      | - **Linux:** x86_32 CPU with SSE2 instructions, x86_64 CPU, ARMv7 or ARMv8 CPU          |
-|                      |                                                                                         |
-|                      |   - *Example: Intel Core i5-6600K, AMD Ryzen 5 1600, Raspberry Pi 5 with overclocking*  |
-+----------------------+-----------------------------------------------------------------------------------------+
-| **GPU**              | - **Forward+ rendering method:** Dedicated graphics with full Vulkan 1.2 support        |
-|                      |                                                                                         |
-|                      |   - *Example: NVIDIA GeForce GTX 1050 (Pascal), AMD Radeon RX 460 (GCN 4.0)*            |
-|                      |                                                                                         |
-|                      | - **Mobile rendering method:** Dedicated graphics with full Vulkan 1.2 support          |
-|                      |                                                                                         |
-|                      |   - *Example: NVIDIA GeForce GTX 1050 (Pascal), AMD Radeon RX 460 (GCN 4.0)*            |
-|                      |                                                                                         |
-|                      | - **Compatibility rendering method:** Dedicated graphics with full OpenGL 4.6 support   |
-|                      |                                                                                         |
-|                      |   - *Example: NVIDIA GeForce GTX 650 (Kepler), AMD Radeon HD 7750 (GCN 1.0)*            |
-+----------------------+-----------------------------------------------------------------------------------------+
-| **RAM**              | - **Native editor:** 8 GB                                                               |
-|                      | - **Web editor:** 12 GB                                                                 |
-+----------------------+-----------------------------------------------------------------------------------------+
-| **Storage**          | 1.5 GB (used for the executable, project files, all export templates and cache)         |
-+----------------------+-----------------------------------------------------------------------------------------+
-| **Operating system** | - **Native editor:** Windows 10, macOS 10.15,                                           |
-|                      |   Linux distribution released after 2020                                                |
-|                      | - **Web editor:** Latest version of Firefox, Chrome, Edge, Safari, Opera                |
-+----------------------+-----------------------------------------------------------------------------------------+
++----------------------+---------------------------------------------------------------------------------------------+
+| **CPU**              | - **Windows:** x86_64 CPU with SSE4.2 instructions, with 4 physical cores or more, ARMv8 CPU|
+|                      |                                                                                             |
+|                      |   - *Example: Intel Core i5-6600K, AMD Ryzen 5 1600, Snapdragon X Elite*                    |
+|                      |                                                                                             |
+|                      | - **macOS:** x86_64 or ARM CPU (Apple Silicon)                                              |
+|                      |                                                                                             |
+|                      |   - *Example: Intel Core i5-8500, Apple M1*                                                 |
+|                      |                                                                                             |
+|                      | - **Linux:** x86_32 CPU with SSE2 instructions, x86_64 CPU, ARMv7 or ARMv8 CPU              |
+|                      |                                                                                             |
+|                      |   - *Example: Intel Core i5-6600K, AMD Ryzen 5 1600, Raspberry Pi 5 with overclocking*      |
++----------------------+---------------------------------------------------------------------------------------------+
+| **GPU**              | - **Forward+ rendering method:** Dedicated graphics with full Vulkan 1.2 support            |
+|                      |                                                                                             |
+|                      |   - *Example: NVIDIA GeForce GTX 1050 (Pascal), AMD Radeon RX 460 (GCN 4.0)*                |
+|                      |                                                                                             |
+|                      | - **Mobile rendering method:** Dedicated graphics with full Vulkan 1.2 support              |
+|                      |                                                                                             |
+|                      |   - *Example: NVIDIA GeForce GTX 1050 (Pascal), AMD Radeon RX 460 (GCN 4.0)*                |
+|                      |                                                                                             |
+|                      | - **Compatibility rendering method:** Dedicated graphics with full OpenGL 4.6 support       |
+|                      |                                                                                             |
+|                      |   - *Example: NVIDIA GeForce GTX 650 (Kepler), AMD Radeon HD 7750 (GCN 1.0)*                |
++----------------------+---------------------------------------------------------------------------------------------+
+| **RAM**              | - **Native editor:** 8 GB                                                                   |
+|                      | - **Web editor:** 12 GB                                                                     |
++----------------------+---------------------------------------------------------------------------------------------+
+| **Storage**          | 1.5 GB (used for the executable, project files, all export templates and cache)             |
++----------------------+---------------------------------------------------------------------------------------------+
+| **Operating system** | - **Native editor:** Windows 10, macOS 10.15,                                               |
+|                      |   Linux distribution released after 2020                                                    |
+|                      | - **Web editor:** Latest version of Firefox, Chrome, Edge, Safari, Opera                    |
++----------------------+---------------------------------------------------------------------------------------------+
 
 Mobile device (smartphone/tablet) - Recommended
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -208,9 +208,9 @@ Desktop or laptop PC - Minimum
 .. which can run up to macOS 10.13.
 
 +----------------------+-----------------------------------------------------------------------------------------+
-| **CPU**              | - **Windows:** x86_32 CPU with SSE2 instructions, or any x86_64 CPU                     |
+| **CPU**              | - **Windows:** x86_32 CPU with SSE2 instructions, any x86_64 CPU, ARMv8 CPU             |
 |                      |                                                                                         |
-|                      |  - *Example: Intel Core 2 Duo E8200, AMD Athlon XE BE-2300*                             |
+|                      |  - *Example: Intel Core 2 Duo E8200, AMD Athlon XE BE-2300, Snapdragon X Elite*         |
 |                      |                                                                                         |
 |                      | - **macOS:** x86_64 or ARM CPU (Apple Silicon)                                          |
 |                      |                                                                                         |
@@ -295,40 +295,40 @@ simple 2D or 3D project exported with Godot:
 Desktop or laptop PC - Recommended
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-+----------------------+-----------------------------------------------------------------------------------------+
-| **CPU**              | - **Windows:** x86_64 CPU with SSE4.2 instructions, with 4 physical cores or more       |
-|                      |                                                                                         |
-|                      |  - *Example: Intel Core i5-6600K, AMD Ryzen 5 1600*                                     |
-|                      |                                                                                         |
-|                      | - **macOS:** x86_64 or ARM CPU (Apple Silicon)                                          |
-|                      |                                                                                         |
-|                      |  - *Example: Intel Core i5-8500, Apple M1*                                              |
-|                      |                                                                                         |
-|                      | - **Linux:** x86_32 CPU with SSE2 instructions, x86_64 CPU, ARMv7 or ARMv8 CPU          |
-|                      |                                                                                         |
-|                      |  - *Example: Intel Core i5-6600K, AMD Ryzen 5 1600, Raspberry Pi 5 with overclocking*   |
-+----------------------+-----------------------------------------------------------------------------------------+
-| **GPU**              | - **Forward+ rendering method:** Dedicated graphics with full Vulkan 1.2 support        |
-|                      |                                                                                         |
-|                      |   - *Example: NVIDIA GeForce GTX 1050 (Pascal), AMD Radeon RX 460 (GCN 4.0)*            |
-|                      |                                                                                         |
-|                      | - **Mobile rendering method:** Dedicated graphics with full Vulkan 1.2 support          |
-|                      |                                                                                         |
-|                      |   - *Example: NVIDIA GeForce GTX 1050 (Pascal), AMD Radeon RX 460 (GCN 4.0)*            |
-|                      |                                                                                         |
-|                      | - **Compatibility rendering method:** Dedicated graphics with full OpenGL 4.6 support   |
-|                      |                                                                                         |
-|                      |   - *Example: NVIDIA GeForce GTX 650 (Kepler), AMD Radeon HD 7750 (GCN 1.0)*            |
-+----------------------+-----------------------------------------------------------------------------------------+
-| **RAM**              | - **For native exports:** 4 GB                                                          |
-|                      | - **For web exports:** 8 GB                                                             |
-+----------------------+-----------------------------------------------------------------------------------------+
-| **Storage**          | 150 MB (used for the executable, project files and cache)                               |
-+----------------------+-----------------------------------------------------------------------------------------+
-| **Operating system** | - **For native exports:** Windows 10, macOS 10.15,                                      |
-|                      |   Linux distribution released after 2020                                                |
-|                      | - **For web exports:** Latest version of Firefox, Chrome, Edge, Safari, Opera           |
-+----------------------+-----------------------------------------------------------------------------------------+
++----------------------+---------------------------------------------------------------------------------------------+
+| **CPU**              | - **Windows:** x86_64 CPU with SSE4.2 instructions, with 4 physical cores or more, ARMv8 CPU|
+|                      |                                                                                             |
+|                      |  - *Example: Intel Core i5-6600K, AMD Ryzen 5 1600, Snapdragon X Elite*                     |
+|                      |                                                                                             |
+|                      | - **macOS:** x86_64 or ARM CPU (Apple Silicon)                                              |
+|                      |                                                                                             |
+|                      |  - *Example: Intel Core i5-8500, Apple M1*                                                  |
+|                      |                                                                                             |
+|                      | - **Linux:** x86_32 CPU with SSE2 instructions, x86_64 CPU, ARMv7 or ARMv8 CPU              |
+|                      |                                                                                             |
+|                      |  - *Example: Intel Core i5-6600K, AMD Ryzen 5 1600, Raspberry Pi 5 with overclocking*       |
++----------------------+---------------------------------------------------------------------------------------------+
+| **GPU**              | - **Forward+ rendering method:** Dedicated graphics with full Vulkan 1.2 support            |
+|                      |                                                                                             |
+|                      |   - *Example: NVIDIA GeForce GTX 1050 (Pascal), AMD Radeon RX 460 (GCN 4.0)*                |
+|                      |                                                                                             |
+|                      | - **Mobile rendering method:** Dedicated graphics with full Vulkan 1.2 support              |
+|                      |                                                                                             |
+|                      |   - *Example: NVIDIA GeForce GTX 1050 (Pascal), AMD Radeon RX 460 (GCN 4.0)*                |
+|                      |                                                                                             |
+|                      | - **Compatibility rendering method:** Dedicated graphics with full OpenGL 4.6 support       |
+|                      |                                                                                             |
+|                      |   - *Example: NVIDIA GeForce GTX 650 (Kepler), AMD Radeon HD 7750 (GCN 1.0)*                |
++----------------------+---------------------------------------------------------------------------------------------+
+| **RAM**              | - **For native exports:** 4 GB                                                              |
+|                      | - **For web exports:** 8 GB                                                                 |
++----------------------+---------------------------------------------------------------------------------------------+
+| **Storage**          | 150 MB (used for the executable, project files and cache)                                   |
++----------------------+---------------------------------------------------------------------------------------------+
+| **Operating system** | - **For native exports:** Windows 10, macOS 10.15,                                          |
+|                      |   Linux distribution released after 2020                                                    |
+|                      | - **For web exports:** Latest version of Firefox, Chrome, Edge, Safari, Opera               |
++----------------------+---------------------------------------------------------------------------------------------+
 
 Mobile device (smartphone/tablet) - Recommended
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/contributing/development/compiling/introduction_to_the_buildsystem.rst
+++ b/contributing/development/compiling/introduction_to_the_buildsystem.rst
@@ -446,10 +446,14 @@ platform:
     windows_debug_x86_32.exe
     windows_debug_x86_64_console.exe
     windows_debug_x86_64.exe
+    windows_debug_arm64_console.exe
+    windows_debug_arm64.exe
     windows_release_x86_32_console.exe
     windows_release_x86_32.exe
     windows_release_x86_64_console.exe
     windows_release_x86_64.exe
+    windows_release_arm64_console.exe
+    windows_release_arm64.exe
 
 To create those yourself, follow the instructions detailed for each
 platform in this same tutorial section. Each platform explains how to


### PR DESCRIPTION
Updates the docs for ARM support on Windows in 4.3. Updates the about page, system requirements and intro to the build system. The compiling for windows page is being updated by Bruvzg in #9650. As far as  I can tell no other pages need to be updated for this.