### PR TITLE
Update 03.player_movement_code.rst

### DIFF
--- a/getting_started/first_3d_game/03.player_movement_code.rst
+++ b/getting_started/first_3d_game/03.player_movement_code.rst
@@ -421,7 +421,7 @@ character.
 .. note::
 
     If your preview image does not look like the screenshots above, try deleting the *Camera3D* node. 
-    Set the Rotation X on *CameraPivot* to ``-45`` degrees, then repeat the instructions after creating the *Camera3D* node.
+    Set the X-axis Rotation of *CameraPivot* to ``-45`` degrees, then repeat the instructions after creating the *Camera3D* node.
 
 We can see some empty space around the character due to the perspective
 projection. In this game, we're going to use an orthographic projection instead

--- a/getting_started/first_3d_game/03.player_movement_code.rst
+++ b/getting_started/first_3d_game/03.player_movement_code.rst
@@ -418,6 +418,11 @@ character.
 
 |image9|
 
+.. note::
+
+    If your preview image does not look like the screenshots above, try deleting the *Camera3D* node. 
+    And first set the Rotation X ``-45`` for *CameraPivot*, and then repeat the instructions after creating *Camera3D* node.
+
 We can see some empty space around the character due to the perspective
 projection. In this game, we're going to use an orthographic projection instead
 to better frame the gameplay area and make it easier for the player to read

--- a/getting_started/first_3d_game/03.player_movement_code.rst
+++ b/getting_started/first_3d_game/03.player_movement_code.rst
@@ -421,7 +421,7 @@ character.
 .. note::
 
     If your preview image does not look like the screenshots above, try deleting the *Camera3D* node. 
-    And first set the Rotation X ``-45`` for *CameraPivot*, and then repeat the instructions after creating *Camera3D* node.
+    Set the Rotation X on *CameraPivot* to ``-45`` degrees, then repeat the instructions after creating the *Camera3D* node.
 
 We can see some empty space around the character due to the perspective
 projection. In this game, we're going to use an orthographic projection instead


### PR DESCRIPTION
Hi, while going through the instructions for developing the first 3D game, I encountered the problem that my camera on the preview did not turn -45 degrees relative to the pivot

It took me a while to figure out what I did wrong, and I decided to skip the problem, but later on, according to the guide, we will need a correct preview display

And you can't close your eyes to this problem

For some reason, the pivot did not turn the camera display, but if you delete the node and recreate it, everything will work correctly

Therefore, I think this tip will be useful for beginners

I have LTS version Godot 4.2
C# edition
