### PR TITLE
Remove already completed step from 06.heads_up_display.rst

### DIFF
--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -273,8 +273,7 @@ with the changing score:
     ``_ready()`` if you haven't already, otherwise
     your game will start automatically.
 
-Now you're ready to play! Click the "Play the Project" button. You will be asked
-to select a main scene, so choose ``main.tscn``.
+Now you're ready to play! Click the "Play the Project" button.
 
 Removing old creeps
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This was done at the end of the previous page, i.e. https://github.com/godotengine/godot-docs/blob/master/getting_started/first_2d_game/05.the_main_game_scene.rst?plain=1#L282-L287
(Replaces #9676 )