### PR TITLE
Recommend `unshaded` render mode for quad in Advanced post-processing

### DIFF
--- a/tutorials/shaders/advanced_postprocessing.rst
+++ b/tutorials/shaders/advanced_postprocessing.rst
@@ -46,6 +46,8 @@ and sets the vertex position in clip space directly.
 .. code-block:: glsl
 
   shader_type spatial;
+  // Prevent the quad from being affected by lighting and fog. This also improves performance.
+  render_mode unshaded, disable_fog;
 
   void vertex() {
     POSITION = vec4(VERTEX.xy, 1.0, 1.0);


### PR DESCRIPTION
This prevents the quad from being affected by lighting and fog, while also improving performance.

- This closes https://github.com/godotengine/godot-docs/issues/9387.
