### PR TITLE
Update list of spatial shader render modes for Godot 4.4

### DIFF
--- a/tutorials/assets_pipeline/importing_images.rst
+++ b/tutorials/assets_pipeline/importing_images.rst
@@ -426,9 +426,12 @@ displayed correctly:
 
 - In 2D, a :ref:`class_CanvasItemMaterial` will need to be created and
   configured to use the **Premul Alpha** blend mode on CanvasItems that use this
-  texture.
-- In 3D, there is no support for premultiplied alpha blend mode yet, so this
-  option is only suited for 2D.
+  texture. In :ref:`custom canvas item shaders <doc_canvas_item_shader>`,
+  ``render_mode blend_premul_alpha;`` should be used.
+- In 3D, a :ref:`class_BaseMaterial3D` will need to be created and configured
+  to use the **Premul Alpha** blend mode on materials that use this texture.
+  In :ref:`custom spatial shaders <doc_spatial_shader>`,
+  ``render_mode blend_premul_alpha;`` should be used.
 
 Process > Normal Map Invert Y
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- Related to https://github.com/godotengine/godot/pull/95004.

This also improves the documentation for existing render modes.

- This closes https://github.com/godotengine/godot/issues/95102
 and closes https://github.com/godotengine/godot-docs/issues/10522.
- See https://github.com/godotengine/godot-docs/pull/9690.