### PR TITLE
Update 3d_gizmos.rst

### DIFF
--- a/tutorials/plugins/editor/3d_gizmos.rst
+++ b/tutorials/plugins/editor/3d_gizmos.rst
@@ -34,7 +34,7 @@ This would be a basic setup:
     extends EditorNode3DGizmoPlugin
 
 
-    func get_name():
+    func _get_gizmo_name():
         return "CustomNode"
 
 


### PR DESCRIPTION
Addresses "Unnamed Gizmo" error when following example code; now overriding _get_gizmo_name function, not get_name. Possible from a typo or legacy-era docs?

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
