### PR TITLE
Update gdscript_styleguide.rst

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -707,7 +707,7 @@ are constants:
         FIRE,
     }
 
-Write enums with each item on its own line. This allows adding documentation comments abve each item
+Write enums with each item on its own line. This allows adding documentation comments above each item
 more easily, and also makes for cleaner diffs in version control when items are added or removed.
 
 **Good**:


### PR DESCRIPTION
fixes typo

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
