### PR TITLE
Mention that the NavigationMesh border_size only works along xz-axis

### DIFF
--- a/tutorials/navigation/navigation_using_navigationmeshes.rst
+++ b/tutorials/navigation/navigation_using_navigationmeshes.rst
@@ -255,6 +255,10 @@ parts so that only the intended chunk size is left.
 
     The baking bounds need to be large enough to include a reasonable amount of source geometry from all the neighboring chunks.
 
+.. warning::
+
+    In 3D the functionality of the border size is limited to the xz-axis.
+
 Navigation mesh baking common problems
 --------------------------------------
 


### PR DESCRIPTION
Adds a warning that the NavigationMesh `border_size` property only works along xz-axis as a limitation of the Recast third-party baking library.

This is because the border_size offset was developed for tile baking with the Recast tile mesh. This tile mesh never supported  verticality, you never can or could use it to bake level "voxel" chunks.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
