### PR TITLE
Add note about BackBufferCopy and Control nodes to Screen-reading shaders page

### DIFF
--- a/tutorials/shaders/screen-reading_shaders.rst
+++ b/tutorials/shaders/screen-reading_shaders.rst
@@ -115,6 +115,14 @@ With correct back-buffer copying, the two spheres blend correctly:
     If you plan to instance a scene that uses a material with ``hint_screen_texture``,
     you will need to use a BackBufferCopy node.
 
+.. note::
+
+    Since :ref:`BackBufferCopy <class_BackBufferCopy>` inherits from :ref:`Node2D<class_Node2D>` 
+    (and not :ref:`Control<class_Control>`), anchors and margins won't apply to child 
+    :ref:`Control<class_Control>`-derived nodes. This can be problematic when resizing the window.
+    To avoid this, add :ref:`Control<class_Control>`-derived nodes as *siblings* to the 
+    **BackBufferCopy** node instead of adding them as children.
+
 In 3D, there is less flexibility to solve this particular issue because the
 screen texture is only captured once. Be careful when using the screen texture
 in 3D as it won't capture transparent objects and may capture some opaque


### PR DESCRIPTION
Added note on Control derived nodes, found in the class documentation.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
