### PR TITLE
Fix description of typed resource exports

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_exports.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_exports.rst
@@ -342,7 +342,7 @@ Therefore, if you specify a type derived from Resource such as:
     public AnimationNode AnimationNode { get; set; }
 
 The drop-down menu will be limited to AnimationNode and all
-its inherited classes. Custom resource classes can also be used,
+its derived classes. Custom resource classes can also be used,
 see :ref:`doc_c_sharp_global_classes`.
 
 It must be noted that even if the script is not being run while in the

--- a/tutorials/scripting/gdscript/gdscript_exports.rst
+++ b/tutorials/scripting/gdscript/gdscript_exports.rst
@@ -242,7 +242,7 @@ Therefore, if you specify an extension of Resource such as:
     @export var resource: AnimationNode
 
 The drop-down menu will be limited to AnimationNode and all
-its inherited classes.
+its derived classes.
 
 It must be noted that even if the script is not being run while in the
 editor, the exported properties are still editable. This can be used


### PR DESCRIPTION
`AnimationNode`'s inherited classes are `Resource`, `RefCounted`, and `Object`.

I assume it meant to say "derived classes", or something along the lines of "and all classes which inherit it".

I could change it to the latter instead, if people prefer?
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
