### PR TITLE
Refer to official Godot website for community list, update Discord

### DIFF
--- a/about/introduction.rst
+++ b/about/introduction.rst
@@ -28,8 +28,8 @@ consider checking them out. Otherwise, :ref:`Getting Started <doc_getting_starte
 is a great starting point.
 
 In case you have trouble with one of the tutorials or your project,
-you can find help on the various :ref:`Community channels <doc_community_channels>`,
-especially the Godot `Discord`_ community and
+you can find help on the various `Community channels <https://godotengine.org/community/>`_,
+especially the Godot `Discord <https://discord.gg/bdcfAYM4W9>`_ community and
 `Forum <https://forum.godotengine.org/>`_.
 
 About Godot Engine
@@ -75,11 +75,10 @@ This documentation is organized into several sections:
   It also contains sections intended for advanced users and contributors,
   with information on compiling the engine, contributing to the editor,
   or developing C++ modules.
-- **Community** is dedicated to the life of Godot's community.
-  It points to various community channels like the
-  `Godot Contributors Chat <https://chat.godotengine.org/>`_ and
-  `Discord`_ and contains a list of recommended third-party tutorials and
-  materials outside of this documentation.
+- **Community** is dedicated to the life of Godot's community and contains a list of
+  recommended third-party tutorials and materials outside of this documentation.
+  It also provides details on the Asset Library. It also used to list Godot
+  communities, which are now listed on the `Godot website <https://godotengine.org/community/>`_.
 - Finally, the **Class reference** documents the full Godot API,
   also available directly within the engine's script editor.
   You can find information on all classes, functions, signals and so on here.
@@ -104,5 +103,3 @@ with attribution to "*Juan Linietsky, Ariel Manzur, and the Godot Engine communi
 unless otherwise noted.
 
 *Have fun reading and making games with Godot Engine!*
-
-.. _Discord: https://discord.gg/4JBkykG

--- a/community/channels.rst
+++ b/community/channels.rst
@@ -5,42 +5,8 @@ Community channels
 
 So, where is the Godot community and where can you ask questions and get help?
 
-Note that some of these channels are run and moderated by members of the Godot community or third parties.
-
-A brief overview over these and other channels is also available on the `Godot website <https://godotengine.org/community>`_.
-
-Forums
-------
-
-- `Official Godot Forum <https://forum.godotengine.org/>`_
-- `Community Forum <https://godotforums.org/>`_
-
-Chats
------
-
-- `Godot Contributors Chat <https://chat.godotengine.org/>`_
-- `Discord <https://discord.gg/4JBkykG>`_
-- `Matrix (IRC compatible) <https://matrix.to/#/#godotengine:matrix.org>`_
-- `IRC (#godotengine on Libera.Chat) <https://web.libera.chat/?channels=#godotengine>`_
-
-.. note::
-
-    As of January 2021, core developer chat has moved to the Godot Contributors Chat platform listed above.
-    IRC is less active. Please stick around to get an answer,
-    as it may take several hours for someone to see and answer your questions.
-
-Social networks and other sites
--------------------------------
-
-- `GitHub <https://github.com/godotengine/>`_
-- `Facebook group <https://www.facebook.com/groups/godotengine/>`_
-- `Twitter <https://twitter.com/godotengine>`_
-  (see also the `#GodotEngine <https://twitter.com/hashtag/GodotEngine>`_ hashtag)
-- `Reddit <https://www.reddit.com/r/godot>`_
-- `YouTube <https://www.youtube.com/c/GodotEngineOfficial>`_
-- `Steam <https://steamcommunity.com/app/404790>`_
-- `itch.io <https://godotengine.itch.io/godot>`_
-- `Links <https://links.godotengine.org>`_
+This page used to list the various official and user-supported Godot communities.
+That list is now available on the `Godot website <https://godotengine.org/community>`_.
 
 Language-based communities
 --------------------------

--- a/contributing/how_to_contribute.rst
+++ b/contributing/how_to_contribute.rst
@@ -3,7 +3,7 @@
 How to contribute
 =================
 
-The Godot Engine is free and open-source. Like any community-driven project, we rely on volunteer contributions. 
+The Godot Engine is free and open-source. Like any community-driven project, we rely on volunteer contributions.
 On this page we want to showcase the various ways you as users can participate - to help you find the right starting place with the skillset you have.
 Because contrary to popular opinion, we need more than just programmers on the project!
 
@@ -13,18 +13,18 @@ Fundraising
 
 - **Donate**
 
-  We created the non-profit `Godot Foundation <https://godot.foundation/>`_ to be able to support the Godot Engine in both matters of finance and administration. 
-  In practice, this means the Foundation hires people to work part-time or full-time on the project. 
+  We created the non-profit `Godot Foundation <https://godot.foundation/>`_ to be able to support the Godot Engine in both matters of finance and administration.
+  In practice, this means the Foundation hires people to work part-time or full-time on the project.
   These jobs include engine development as well as related tasks like code reviews, production management, community & marketing efforts, and more.
 
-  With as little as 5 EUR per month, you can help us keep going strong. 
+  With as little as 5 EUR per month, you can help us keep going strong.
   Currently, we are intending to hire more core developers, as to cover more ground with full-time specialists that supplement and guide volunteer work.
 
   `Join the Development Fund <https://fund.godotengine.org>`_
 
 - **Donation Drives**
   Think about your followers on social media, or other communities you are active in.
-  Use that reach to remind your social environment that even small contributions can make a difference, especially when done by a great number of people at the same time. 
+  Use that reach to remind your social environment that even small contributions can make a difference, especially when done by a great number of people at the same time.
 
   Are you a content creator? Consider adding a link to the `Godot Development Fund <https://fund.godotengine.org>`_ to your descriptions. 
   If you do live streams, perhaps think about organizing a stream with donation incentives.
@@ -32,8 +32,8 @@ Fundraising
 .. - **Buy Official Merch**
 
 - **Publish Godot Games.**
-  You heard right, simply publishing a game #MadeWithGodot can positively impact the well-being of this project. 
-  Your personal success elevates the engine to a viable alternative for other developers, growing the community further. 
+  You heard right, simply publishing a game #MadeWithGodot can positively impact the well-being of this project.
+  Your personal success elevates the engine to a viable alternative for other developers, growing the community further.
   Additionally, it opens the doors for us to approach industry contacts about possible cooperations.
 
 
@@ -49,26 +49,26 @@ Technical contributions
 
 - **Test Development Versions**
   While it is recommended to use the stable releases for your projects, you can help us test dev releases, betas, and release candidates
-  by opening a copy of your project in them and checking what problems this introduces or maybe even solves. 
+  by opening a copy of your project in them and checking what problems this introduces or maybe even solves.
   Make sure to have a backup ready, since this can produce irreversible changes.
 
   Find recent `development versions <https://godotengine.org/download/preview/>`_ directly on our download page, or linked in their own blog posts.
-  
+
 - **Contribute Engine Code (mainly C++)**
-  The engine development is mainly coordinated on our `Contributor RocketChat <https://chat.godotengine.org/>`_, 
+  The engine development is mainly coordinated on our `Contributor RocketChat <https://chat.godotengine.org/>`_,
   so if you are serious about making PRs you should join us there!
 
   Read more about the **technical submission process**: :ref:`doc_first_steps`
 
-  For each subject area of the engine, there is a corresponding team to coordinate the work. 
-  Join the linked chat to get more eyes on your related PR, learn about open todos, or partake in meetings. 
+  For each subject area of the engine, there is a corresponding team to coordinate the work.
+  Join the linked chat to get more eyes on your related PR, learn about open todos, or partake in meetings.
   For some areas, specialists might even be encouraged to step up as maintainer!
   `List of teams <https://godotengine.org/teams/>`_
 
 - **Review Code Contributions**
   All pull requests need to be thoroughly reviewed before they can be merged into the master branch.
   Help us get a headstart by participating in the code review process.
-  
+
   To get started, chose any `open pull request <https://github.com/godotengine/godot/pulls>`_ and reference our **style guide**: :ref:`doc_pr_review_guidelines`
 
 - **Write Plugins (GDScript, C#, & more)**
@@ -78,33 +78,33 @@ Technical contributions
 
 - **Demo projects (GDScript, C#, and making Assets)**
   We provide new users with `demo projects <https://github.com/godotengine/godot-demo-projects/>`_ so they can quickly test new features or get familiar with the engine in the first place.
-  At industry events, we might even exhibit these demo projects to showcase what Godot can do! 
+  At industry events, we might even exhibit these demo projects to showcase what Godot can do!
   Help improve existing projects or supply your own to be added to the pool, and join the `demo channel <https://chat.godotengine.org/channel/demo-content>`_ in the Contributor RocketChat to talk about it.
 
 - **Documentation**
-  The documentation is one of the most essential parts of any tech project, yet the need to document new features and substantial changes often gets overlooked. 
+  The documentation is one of the most essential parts of any tech project, yet the need to document new features and substantial changes often gets overlooked.
   Join the `documentation team <https://chat.godotengine.org/channel/documentation>`_ to improve the Godot Engine with your technical writing skills.
 
 - **Translations (spoken languages other than English)**
-  Are you interested in making the Godot Engine more accessible to non-English speakers? 
+  Are you interested in making the Godot Engine more accessible to non-English speakers?
   Contribute to our `community-translations <https://hosted.weblate.org/projects/godot-engine/godot/>`_.
 
 Community support
 -----------------
 
 - **Call for Moderators**
-  With a community of our size, we need people to step up as volunteer moderators in all kinds of places. 
+  With a community of our size, we need people to step up as volunteer moderators in all kinds of places.
   These teams are organized by the Godot Foundation, but would not function without the dedication of active community members like you.
 
-  Have a look around your favorite community platform and you might come across open application calls. 
+  Have a look around your favorite community platform and you might come across open application calls.
 
 - **Answer tech-support questions**
-  With many new people discovering the Godot Engine recently, the need for peer-to-peer tech-support has never been greater. 
-  Be it on the `Forum <https://forum.godotengine.org/>`_, our `subreddit <https://www.reddit.com/r/godot/>`_, or on `Discord <https://discord.gg/bdcfAYM4W9>`_, you can always brighten someone's day by helping them get their personal projects back on track.
+  With many new people discovering the Godot Engine recently, the need for peer-to-peer tech-support has never been greater.
+  See the `Godot website <https://godotengine.org/community>`_ for a list of official and user-supported Godot communities.
 
 - **Create tutorials & more**
-  How did you get started with the Godot Engine? 
+  How did you get started with the Godot Engine?
   Chances are you looked for learning materials outside of what the documentation provides.
   Without content creators covering the game development process, there would not be this big of a community today.
   Therefore it seemed only right to mention them in a page about important contributions to the project.
-  
+


### PR DESCRIPTION
We keep a list of official and non-official communities on the Godot website at https://godotengine.org/community/ and in the Godot documentation at https://docs.godotengine.org/en/stable/community/channels.html.

This has the usual downsides of maintaining the same information in multiple places, mostly that they won't stay in sync. The docs one has grown badly outdated, and the Discord info also wasn't updated.

Seeing as the website is at this point the canonical listing, and as we're at a point where edits to this list should only be made with consideration of the Foundation, not by docs PRs and merges by the docs team, it in my opinion makes sense to just refer to the website.

I would have completely removed the docs page, but limited redirect functionality on RTD currently makes that tricky without breaking old links, which would be bad form. We can de-emphasize and link directly to the website where we can for now.

I've also updated the Discord link to the official one.