### PR TITLE
Fix funding link to be an external link

### DIFF
--- a/contributing/how_to_contribute.rst
+++ b/contributing/how_to_contribute.rst
@@ -20,7 +20,7 @@ Fundraising
   With as little as 5 EUR per month, you can help us keep going strong. 
   Currently, we are intending to hire more core developers, as to cover more ground with full-time specialists that supplement and guide volunteer work.
 
-  `Join the Development Fund <fund.godotengine.org>`_
+  `Join the Development Fund <https://fund.godotengine.org>`_
 
 - **Donation Drives**
   Think about your followers on social media, or other communities you are active in.


### PR DESCRIPTION
The link on the live documentation was leading to a "Page not found" error. You can see this interaction by visiting the page [here](https://docs.godotengine.org/en/stable/contributing/how_to_contribute.html) and clicking the funding link. I made this change from master and am merging to master but let me know if it should be from another branch, perhaps 4.3 for the RC cycle.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
