### PR TITLE
Fix return type of `EditorImportPlugin._Import`

### DIFF
--- a/classes/class_editorimportplugin.rst
+++ b/classes/class_editorimportplugin.rst
@@ -120,18 +120,18 @@ Below is an example EditorImportPlugin that imports a :ref:`Mesh<class_Mesh>` fr
             };
         }
     
-        public override int _Import(string sourceFile, string savePath, Godot.Collections.Dictionary options, Godot.Collections.Array<string> platformVariants, Godot.Collections.Array<string> genFiles)
+        public override Error _Import(string sourceFile, string savePath, Godot.Collections.Dictionary options, Godot.Collections.Array<string> platformVariants, Godot.Collections.Array<string> genFiles)
         {
             using var file = FileAccess.Open(sourceFile, FileAccess.ModeFlags.Read);
             if (file.GetError() != Error.Ok)
             {
-                return (int)Error.Failed;
+                return Error.Failed;
             }
     
             var mesh = new ArrayMesh();
             // Fill the Mesh with data read in "file", left as an exercise to the reader.
             string filename = $"{savePath}.{_GetSaveExtension()}";
-            return (int)ResourceSaver.Save(mesh, filename);
+            return ResourceSaver.Save(mesh, filename);
         }
     }
 


### PR DESCRIPTION
The following is the currently generated `EditorImportPlugin.cs`:

```csharp
    public virtual Error _Import(string sourceFile, string savePath, Dictionary options, Array<string> platformVariants, Array<string> genFiles)
    {
        return Error.Ok;
    }
```

This fixes the type signature in the documentation's example to match the actual type signature.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
