### PR TITLE
Update NavigationAgent doc with new simplify_path property

### DIFF
--- a/tutorials/navigation/navigation_using_navigationagents.rst
+++ b/tutorials/navigation/navigation_using_navigationagents.rst
@@ -28,6 +28,7 @@ The result of the pathfinding can be influenced with the following properties.
 - The ``pathfinding_algorithm`` controls how the pathfinding travels through the navigation mesh polygons in the path search.
 - The ``path_postprocessing`` sets if or how the raw path corridor found by the pathfinding is altered before it is returned.
 - The ``path_metadata_flags`` enable the collection of additional path point meta data returned by the path.
+- The ``simplify_path`` and ``simplify_epsilon`` properties can be used to remove less critical points from the path.
 
 .. warning::
 


### PR DESCRIPTION
Mentions the new `simplify_path` and `simplify_epsilon` properties on the NavigationAgents added in Godot 4.3.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
