### PR TITLE
Add description of TIME to shaders, add label to global uniform header

### DIFF
--- a/tutorials/shaders/shader_reference/canvas_item_shader.rst
+++ b/tutorials/shaders/shader_reference/canvas_item_shader.rst
@@ -50,24 +50,26 @@ Global built-ins
 
 Global built-ins are available everywhere, including custom functions.
 
-+-------------------+----------------------------------------------------------------------------------------+
-| Built-in          | Description                                                                            |
-+===================+========================================================================================+
-| in float **TIME** | Global time since the engine has started, in seconds (always positive).                |
-|                   | It's subject to the rollover setting (which is 3,600 seconds by default).              |
-|                   | It's not affected by :ref:`time_scale<class_Engine_property_time_scale>`               |
-|                   | or pausing, but you can define a global shader uniform to add a "scaled"               |
-|                   | ``TIME`` variable if desired.                                                          |
-+-------------------+----------------------------------------------------------------------------------------+
-| in float **PI**   | A ``PI`` constant (``3.141592``).                                                      |
-|                   | A ration of circle's circumference to its diameter and amount of radians in half turn. |
-+-------------------+----------------------------------------------------------------------------------------+
-| in float **TAU**  | A ``TAU`` constant (``6.283185``).                                                     |
-|                   | An equivalent of ``PI * 2`` and amount of radians in full turn.                        |
-+-------------------+----------------------------------------------------------------------------------------+
-| in float **E**    | An ``E`` constant (``2.718281``).                                                      |
-|                   | Euler's number and a base of the natural logarithm.                                    |
-+-------------------+----------------------------------------------------------------------------------------+
++-------------------+-----------------------------------------------------------------------------------------+
+| Built-in          | Description                                                                             |
++===================+=========================================================================================+
+| in float **TIME** | Global time since the engine has started, in seconds. It repeats after every 3,600      |
+|                   | seconds (which can  be changed with the                                                 |
+|                   | :ref:`rollover<class_ProjectSettings_property_rendering/limits/time/time_rollover_secs>`|
+|                   | setting). It's not affected by :ref:`time_scale<class_Engine_property_time_scale>` or   |
+|                   | pausing. If you need  a ``TIME`` variable that can be scaled or paused, add your own    |
+|                   | :ref:`global shader uniform<doc_shading_language_global_uniforms>` and update it each   |
+|                   | frame.                                                                                  |      
++-------------------+-----------------------------------------------------------------------------------------+
+| in float **PI**   | A ``PI`` constant (``3.141592``).                                                       |
+|                   | A ration of circle's circumference to its diameter and amount of radians in half turn.  |
++-------------------+-----------------------------------------------------------------------------------------+
+| in float **TAU**  | A ``TAU`` constant (``6.283185``).                                                      |
+|                   | An equivalent of ``PI * 2`` and amount of radians in full turn.                         |
++-------------------+-----------------------------------------------------------------------------------------+
+| in float **E**    | An ``E`` constant (``2.718281``).                                                       |
+|                   | Euler's number and a base of the natural logarithm.                                     |
++-------------------+-----------------------------------------------------------------------------------------+
 
 Vertex built-ins
 ^^^^^^^^^^^^^^^^

--- a/tutorials/shaders/shader_reference/fog_shader.rst
+++ b/tutorials/shaders/shader_reference/fog_shader.rst
@@ -35,7 +35,13 @@ Global built-ins are available everywhere, including in custom functions.
 +---------------------------------+-----------------------------------------------------------------------------------------+
 | Built-in                        | Description                                                                             |
 +=================================+=========================================================================================+
-| in float **TIME**               | Global time, in seconds.                                                                |
+| in float **TIME**               | Global time since the engine has started, in seconds. It repeats after every 3,600      |
+|                                 | seconds (which can  be changed with the                                                 |
+|                                 | :ref:`rollover<class_ProjectSettings_property_rendering/limits/time/time_rollover_secs>`|
+|                                 | setting). It's not affected by :ref:`time_scale<class_Engine_property_time_scale>` or   |
+|                                 | pausing. If you need  a ``TIME`` variable that can be scaled or paused, add your own    |
+|                                 | :ref:`global shader uniform<doc_shading_language_global_uniforms>` and update it each   |
+|                                 | frame.                                                                                  | 
 +---------------------------------+-----------------------------------------------------------------------------------------+
 | in float **PI**                 | A ``PI`` constant (``3.141592``).                                                       |
 |                                 | A ratio of a circle's circumference to its diameter and amount of radians in half turn. |

--- a/tutorials/shaders/shader_reference/particle_shader.rst
+++ b/tutorials/shaders/shader_reference/particle_shader.rst
@@ -55,19 +55,25 @@ Global built-ins
 
 Global built-ins are available everywhere, including custom functions.
 
-+-------------------+----------------------------------------------------------------------------------------+
-| Built-in          | Description                                                                            |
-+===================+========================================================================================+
-| in float **TIME** | Global time, in seconds.                                                               |
-+-------------------+----------------------------------------------------------------------------------------+
-| in float **PI**   | A ``PI`` constant (``3.141592``).                                                      |
-|                   | A ration of circle's circumference to its diameter and amount of radians in half turn. |
-+-------------------+----------------------------------------------------------------------------------------+
-| in float **TAU**  | A ``TAU`` constant (``6.283185``).                                                     |
-|                   | An equivalent of ``PI * 2`` and amount of radians in full turn.                        |
-+-------------------+----------------------------------------------------------------------------------------+
-| in float **E**    | An ``E`` constant (``2.718281``). Euler's number and a base of the natural logarithm.  |
-+-------------------+----------------------------------------------------------------------------------------+
++-------------------+-----------------------------------------------------------------------------------------+
+| Built-in          | Description                                                                             |
++===================+=========================================================================================+
+| in float **TIME** | Global time since the engine has started, in seconds. It repeats after every 3,600      |
+|                   | seconds (which can  be changed with the                                                 |
+|                   | :ref:`rollover<class_ProjectSettings_property_rendering/limits/time/time_rollover_secs>`|
+|                   | setting). It's not affected by :ref:`time_scale<class_Engine_property_time_scale>` or   |
+|                   | pausing. If you need  a ``TIME`` variable that can be scaled or paused, add your own    |
+|                   | :ref:`global shader uniform<doc_shading_language_global_uniforms>` and update it each   |
+|                   | frame.                                                                                  | 
++-------------------+-----------------------------------------------------------------------------------------+
+| in float **PI**   | A ``PI`` constant (``3.141592``).                                                       |
+|                   | A ration of circle's circumference to its diameter and amount of radians in half turn.  |
++-------------------+-----------------------------------------------------------------------------------------+
+| in float **TAU**  | A ``TAU`` constant (``6.283185``).                                                      |
+|                   | An equivalent of ``PI * 2`` and amount of radians in full turn.                         |
++-------------------+-----------------------------------------------------------------------------------------+
+| in float **E**    | An ``E`` constant (``2.718281``). Euler's number and a base of the natural logarithm.   |
++-------------------+-----------------------------------------------------------------------------------------+
 
 Start and Process built-ins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -966,6 +966,8 @@ The syntax also supports subgroups (it's not mandatory to declare the base group
 
     group_uniforms MyGroup.MySubgroup;
 
+.. _doc_shading_language_global_uniforms:
+
 Global uniforms
 ~~~~~~~~~~~~~~~
 

--- a/tutorials/shaders/shader_reference/sky_shader.rst
+++ b/tutorials/shaders/shader_reference/sky_shader.rst
@@ -154,7 +154,13 @@ There are 4 ``LIGHTX`` lights, accessed as ``LIGHT0``, ``LIGHT1``, ``LIGHT2``, a
 +---------------------------------+--------------------------------------------------------------------------------------------------------------------------+
 | Built-in                        | Description                                                                                                              |
 +=================================+==========================================================================================================================+
-| in float **TIME**               | Global time, in seconds.                                                                                                 |
+| in float **TIME**               | Global time since the engine has started, in seconds. It repeats after every 3,600                                       |
+|                                 | seconds (which can  be changed with the                                                                                  |
+|                                 | :ref:`rollover<class_ProjectSettings_property_rendering/limits/time/time_rollover_secs>`                                 |
+|                                 | setting). It's not affected by :ref:`time_scale<class_Engine_property_time_scale>` or                                    |
+|                                 | pausing. If you need  a ``TIME`` variable that can be scaled or paused, add your own                                     |
+|                                 | :ref:`global shader uniform<doc_shading_language_global_uniforms>` and update it each                                    |
+|                                 | frame.                                                                                                                   |                          
 +---------------------------------+--------------------------------------------------------------------------------------------------------------------------+
 | in vec3 **POSITION**            | Camera position in world space                                                                                           |
 +---------------------------------+--------------------------------------------------------------------------------------------------------------------------+

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -96,19 +96,25 @@ Global built-ins
 
 Global built-ins are available everywhere, including custom functions.
 
-+-------------------+----------------------------------------------------------------------------------------+
-| Built-in          | Description                                                                            |
-+===================+========================================================================================+
-| in float **TIME** | Global time, in seconds.                                                               |
-+-------------------+----------------------------------------------------------------------------------------+
-| in float **PI**   | A ``PI`` constant (``3.141592``).                                                      |
-|                   | A ration of circle's circumference to its diameter and amount of radians in half turn. |
-+-------------------+----------------------------------------------------------------------------------------+
-| in float **TAU**  | A ``TAU`` constant (``6.283185``).                                                     |
-|                   | An equivalent of ``PI * 2`` and amount of radians in full turn.                        |
-+-------------------+----------------------------------------------------------------------------------------+
-| in float **E**    | An ``E`` constant (``2.718281``). Euler's number and a base of the natural logarithm.  |
-+-------------------+----------------------------------------------------------------------------------------+
++-------------------+-----------------------------------------------------------------------------------------+
+| Built-in          | Description                                                                             |
++===================+=========================================================================================+
+| in float **TIME** | Global time since the engine has started, in seconds. It repeats after every 3,600      |
+|                   | seconds (which can  be changed with the                                                 |
+|                   | :ref:`rollover<class_ProjectSettings_property_rendering/limits/time/time_rollover_secs>`|
+|                   | setting). It's not affected by :ref:`time_scale<class_Engine_property_time_scale>` or   |
+|                   | pausing. If you need  a ``TIME`` variable that can be scaled or paused, add your own    |
+|                   | :ref:`global shader uniform<doc_shading_language_global_uniforms>` and update it each   |
+|                   | frame.                                                                                  | 
++-------------------+-----------------------------------------------------------------------------------------+
+| in float **PI**   | A ``PI`` constant (``3.141592``).                                                       |
+|                   | A ration of circle's circumference to its diameter and amount of radians in half turn.  |
++-------------------+-----------------------------------------------------------------------------------------+
+| in float **TAU**  | A ``TAU`` constant (``6.283185``).                                                      |
+|                   | An equivalent of ``PI * 2`` and amount of radians in full turn.                         |
++-------------------+-----------------------------------------------------------------------------------------+
+| in float **E**    | An ``E`` constant (``2.718281``). Euler's number and a base of the natural logarithm.   |
++-------------------+-----------------------------------------------------------------------------------------+
 
 Vertex built-ins
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Added/changed description of TIME in CanvasItem, Fog, Particle, Sky, and Spatial shader pages. Description now links to other relevant docs pages. Added a label to the global uniform header of shading_languge.rst, so it can be cross referenced from elsewhere.



I made some changes in addition to simply copying the existing description from CanvasItem shaders to the other pages.

I wrote for a user is new-ish to shaders, notices that ``TIME`` does not exactly match CPU time behavior, and finds any of the shader pages. Ideally they can come away the exact behavior of the built-in ``TIME`` uniform, as well as a way to make their own if need be. I based this on my interactions with users in various discords who asked about ``TIME``.

New description which appears on each shader page:
> Global time since the engine has started, in seconds. It repeats after every 3,600 seconds (which can  be changed with the ``rollover`` setting). It's not affected by ``time_scale`` or pausing. If you need  a ``TIME`` variable that can be scaled or paused, add your own ``global shader uniform`` and update it each frame.

Old description, from the CanvasItem shader page: 
> Global time since the engine has started, in seconds (always positive). It's subject to the rollover setting (which is 3,600 seconds by default). It's not affected by ``time_scale`` or pausing, but you can define a global shader uniform to add a "scaled" ``TIME`` variable if desired.

Changes:
- Now links to the [rollover setting](https://docs.godotengine.org/en/latest/classes/class_projectsettings.html#class-projectsettings-property-rendering-limits-time-time-rollover-secs) in project settings.
- Now links to the [global shader uniform](https://docs.godotengine.org/en/latest/tutorials/shaders/shader_reference/shading_language.html#global-uniforms) documentation. A label is added to the global uniform header in that docs page. I may have gotten the preferred syntax wrong for this.
- Uses more active language for the sentence about adding your own ``TIME`` uniform.
- Clarifies that the value *repeats* rather than merely "being subject to" the rollover setting.
- Emphasizes the default value of 3,600 seconds first, because a user finding this page is unlikely to have changed that value.
- No longer mentions that the value is "always positive". If this is necessary, I would suggest "always in the range of 0 to 3,600" or "always in the range of 0 to ``rollover``".

If any of these changes break docs style, or are otherwise too much, I can revert to more minimal changes.