### PR TITLE
Add tip and warning about TileMap build-in navigation

### DIFF
--- a/tutorials/2d/using_tilemaps.rst
+++ b/tutorials/2d/using_tilemaps.rst
@@ -81,6 +81,15 @@ Navigation
 - **Navigation Visible** Whether or not the TileMapLayer's navigation meshes are
   visible. If set to default then it depends on the show navigation debug settings.
 
+.. tip::
+
+    TileMap built-in navigation has many practical limitations that result in inferior pathfinding performance and pathfollowing quality.
+
+    After designing the TileMap consider baking it to a more optimized navigation mesh (and disabling the TileMap NavigationLayer) using a :ref:`NavigationRegion2D <class_NavigationRegion2D>` or the :ref:`NavigationServer2D <class_NavigationServer2D>`. See :ref:`doc_navigation_using_navigationmeshes` for additional information.
+
+.. warning::
+    2D navigation meshes can not be "layered" or stacked on top of each other like visuals or physic shapes. Attempting to stack navigation meshes on the same navigation map will result in merge and logical errors that break the pathfinding.
+
 You can reorder layers by drag-and-dropping their node in the Scene tab. You can
 also switch between which TileMapLayer node you're working on by using the buttons
 in the top right corner of the TileMap editor.


### PR DESCRIPTION
- Adds a tip to TileMap navigation section that informs users to prefer baking the TileMap navigation.
- Adds a warning that 2D navigation meshes can not overlap.

I don't think this big warning block is too much considering that basically every single TileMap user gets this wrong and the TileMap and its editor does a very poor job informing users about all the TileMap specific navigation related constrains and issues.

New users spend a lot of time trying to make the ill-designed TileMapLayer feature work until they are deeply frustated with it (you can't "layer" navigation meshes). Only then they start to ask or read the navigation documentation. I hope by placing it more prominently inside the TileMap doc that this information reaches more users before that frustation happens.

![tilemap_nav_warning](https://github.com/user-attachments/assets/59bafad6-6eb3-4d4e-a798-d41c4ad4e6c3)

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
