### PR TITLE
Add info for opening demo projects

### DIFF
--- a/getting_started/step_by_step/instancing.rst
+++ b/getting_started/step_by_step/instancing.rst
@@ -58,6 +58,9 @@ Finally, click the Import & Edit button.
 
 .. image:: img/instancing_import_and_edit_button.webp
 
+A window notifying you that the project was last opened in an older Godot version
+may appear, that's not an issue. Click *Ok* to open the project.
+
 The project contains two packed scenes: ``main.tscn``, containing walls against
 which the ball collides, and ``ball.tscn``. The Main scene should open
 automatically. If you're seeing an empty 3D scene instead of the main scene, click the 2D button at the top of the screen.

--- a/tutorials/scripting/singletons_autoload.rst
+++ b/tutorials/scripting/singletons_autoload.rst
@@ -132,6 +132,9 @@ To begin, download the template from here:
 `singleton_autoload_starter.zip <https://github.com/godotengine/godot-docs-project-starters/releases/download/latest-4.x/singleton_autoload_starter.zip>`_
 and open it in Godot.
 
+A window notifying you that the project was last opened in an older Godot version
+may appear, that's not an issue. Click *Ok* to open the project.
+
 The project contains two scenes: ``scene_1.tscn`` and ``scene_2.tscn``. Each
 scene contains a label displaying the scene name and a button with its
 ``pressed()`` signal connected. When you run the project, it starts in


### PR DESCRIPTION
Adds a brief section to the instancing page and singletons page that the demo projects may have been made in an older version of godot but that's fine. Added these since we added a similar warning for the first 3D game project in #9482

Closes #9629
