### PR TITLE
bone_map property not available to post import scripts

### DIFF
--- a/tutorials/assets_pipeline/retargeting_3d_skeletons.rst
+++ b/tutorials/assets_pipeline/retargeting_3d_skeletons.rst
@@ -47,6 +47,9 @@ With the Skeleton node selected, first set up a new :ref:`class_bonemap` and :re
 Godot has a preset called :ref:`class_skeletonprofilehumanoid` for humanoid models.
 This tutorial proceeds with the assumption that you are using :ref:`class_skeletonprofilehumanoid`.
 
+..note:: You cannot load a bone_map with import scripts. :ref:`class_bonemap` is not accessible outside of the UI. In order to
+         map the bones with an import script, you must load the bone map file into an array and assign the bones one at a time.
+
 .. note:: If you need a profile that is different from :ref:`class_skeletonprofilehumanoid`, you can export
           a :ref:`class_skeletonprofile` from the editor by selecting a Skeleton3D and using the **Skeleton3D** menu in the 3D viewport's toolbar.
 


### PR DESCRIPTION
You cannot load a bone_map with import scripts. :ref:`class_bonemap` is not accessible outside of the UI. In order to map the bones with an import script, you must load the bone map file into an array and assign the bones one at a time.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
