### PR TITLE
Add pre-cond command to install Godot using Scoop on Windows

### DIFF
--- a/tutorials/editor/command_line_tutorial.rst
+++ b/tutorials/editor/command_line_tutorial.rst
@@ -245,6 +245,9 @@ available in the ``PATH``:
 
  .. code-tab:: sh Windows
 
+    # Add "Extras" bucket
+    scoop bucket add extras
+
     # Standard editor:
     scoop install godot
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Added `scoop bucket add extras` in the editor command line tutorial because scoop cannot find Godot without the command before.