### PR TITLE
Update android SDK and Java version [3.6]

### DIFF
--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -33,7 +33,7 @@ Download and install the Android SDK.
     - Android SDK Platform 34
     - Android SDK Command-line Tools (latest)
     - CMake version 3.10.2.4988404
-    - NDK version r26c (26.2.11394342)
+    - NDK version r23c (23.2.8568313)
 
 - You can install it using the `command line tools <https://developer.android.com/studio/#command-tools>`__.
 
@@ -41,7 +41,7 @@ Download and install the Android SDK.
 
 ::
 
-    sdkmanager --sdk_root=<android_sdk_path> "platform-tools" "build-tools;34.0.0" "platforms;android-34" "cmdline-tools;latest" "cmake;3.10.2.4988404" "ndk;26.2.11394342"
+    sdkmanager --sdk_root=<android_sdk_path> "platform-tools" "build-tools;34.0.0" "platforms;android-34" "cmdline-tools;latest" "cmake;3.10.2.4988404" "ndk;23.2.8568313"
 
 .. note::
 

--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -13,10 +13,10 @@ Exporting for Android
 Exporting for Android has fewer requirements than compiling Godot for Android.
 The following steps detail what is needed to set up the Android SDK and the engine.
 
-Install OpenJDK 11
+Install OpenJDK 17
 ------------------
 
-Download and install  `OpenJDK 11 <https://adoptium.net/?variant=openjdk11>`__.
+Download and install  `OpenJDK 17 <https://adoptium.net/?variant=openjdk17>`__.
 
 Download the Android SDK
 ------------------------
@@ -30,7 +30,7 @@ Download and install the Android SDK.
 
     - Android SDK Platform-Tools version 30.0.5 or later
     - Android SDK Build-Tools version 30.0.3
-    - Android SDK Platform 33
+    - Android SDK Platform 34
     - Android SDK Command-line Tools (latest)
     - CMake version 3.10.2.4988404
     - NDK version r23c (23.2.8568313)
@@ -41,7 +41,7 @@ Download and install the Android SDK.
 
 ::
 
-    sdkmanager --sdk_root=<android_sdk_path> "platform-tools" "build-tools;30.0.3" "platforms;android-31" "cmdline-tools;latest" "cmake;3.10.2.4988404" "ndk;21.4.7075529"
+    sdkmanager --sdk_root=<android_sdk_path> "platform-tools" "build-tools;30.0.3" "platforms;android-34" "cmdline-tools;latest" "cmake;3.10.2.4988404" "ndk;21.4.7075529"
 
 .. note::
 

--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -29,11 +29,11 @@ Download and install the Android SDK.
   - Ensure that the `required packages <https://developer.android.com/studio/intro/update#recommended>`__ are installed as well.
 
     - Android SDK Platform-Tools version 30.0.5 or later
-    - Android SDK Build-Tools version 30.0.3
+    - Android SDK Build-Tools version 34.0.0
     - Android SDK Platform 34
     - Android SDK Command-line Tools (latest)
     - CMake version 3.10.2.4988404
-    - NDK version r23c (23.2.8568313)
+    - NDK version r26c (26.2.11394342)
 
 - You can install it using the `command line tools <https://developer.android.com/studio/#command-tools>`__.
 
@@ -41,7 +41,7 @@ Download and install the Android SDK.
 
 ::
 
-    sdkmanager --sdk_root=<android_sdk_path> "platform-tools" "build-tools;30.0.3" "platforms;android-34" "cmdline-tools;latest" "cmake;3.10.2.4988404" "ndk;21.4.7075529"
+    sdkmanager --sdk_root=<android_sdk_path> "platform-tools" "build-tools;34.0.0" "platforms;android-34" "cmdline-tools;latest" "cmake;3.10.2.4988404" "ndk;26.2.11394342"
 
 .. note::
 


### PR DESCRIPTION
- Update Java version from 11 to 17
- Update target SDK from 33 to 34 according to Google's requirements for publishing on the Play Store