### PR TITLE
Branch docs version 4.3

### DIFF
--- a/.github/workflows/sync_class_ref.yml
+++ b/.github/workflows/sync_class_ref.yml
@@ -2,15 +2,10 @@ name: Sync Class Reference
 
 on:
   workflow_dispatch:
-  # Scheduled updates only run on the default/master branch.
-  schedule:
-    # Run it at night (European time) every Saturday.
-    # The offset is there to try and avoid the high load times.
-    - cron: '15 3 * * 6'
 
 # Make sure jobs cannot overlap.
 concurrency:
-  group: classref-sync-ci-master
+  group: classref-sync-ci-4.3
   cancel-in-progress: true
 
 jobs:
@@ -18,7 +13,7 @@ jobs:
     name: Update class reference files based on the engine revision
     runs-on: ubuntu-latest
     env:
-      engine_rev: 'master'
+      engine_rev: '4.3'
 
     steps:
       - name: Checkout the documentation repository

--- a/conf.py
+++ b/conf.py
@@ -88,7 +88,7 @@ author = "Juan Linietsky, Ariel Manzur and the Godot community"
 
 # Version info for the project, acts as replacement for |version| and |release|
 # The short X.Y version
-version = os.getenv("READTHEDOCS_VERSION", "latest")
+version = os.getenv("READTHEDOCS_VERSION", "4.3")
 # The full version, including alpha/beta/rc tags
 release = version
 
@@ -179,7 +179,7 @@ html_context = {
     "display_github": not is_i18n,  # Integrate GitHub
     "github_user": "godotengine",  # Username
     "github_repo": "godot-docs",  # Repo name
-    "github_version": "master",  # Version
+    "github_version": "4.3",  # Version
     "conf_py_path": "/",  # Path in the checkout to the docs root
     "godot_inject_language_links": True,
     "godot_docs_supported_languages": list(supported_languages.keys()),
@@ -193,7 +193,7 @@ html_context = {
     "godot_title_prefix": "" if on_rtd else "(DEV) ",
     # Set this to `True` when in the `latest` branch to clearly indicate to the reader
     # that they are not reading the `stable` documentation.
-    "godot_is_latest": True,
+    "godot_is_latest": False,
     "godot_version": "4.3",
     # Enables a banner that displays the up-to-date status of each article.
     "godot_show_article_status": True,

--- a/index.rst
+++ b/index.rst
@@ -1,6 +1,6 @@
 :allow_comments: False
 
-Godot Docs – *master* branch
+Godot Docs – *4.3* branch
 ============================
 
 .. only:: not i18n


### PR DESCRIPTION
🎉 

Godot 4.3 docs branch created starting from https://github.com/godotengine/godot-docs/commit/d3f3c4fa3c4e9d830b2f5827e8398c7e688baaec.