### PR TITLE
Fix project structure diagram in gdextension docs system docs

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_docs_system.rst
+++ b/tutorials/scripting/gdextension/gdextension_docs_system.rst
@@ -18,6 +18,8 @@ XML files (one per class) to document the exposed constructors, properties, meth
     We are assuming you are using the project files explained in the :ref:`GDExtension C++ Example <doc_gdextension_cpp_example>`
     with the following structure:
 
+.. code-block:: none
+
     gdextension_cpp_example/  # GDExtension directory
     |
     +--demo/                  # game example/demo to test the extension


### PR DESCRIPTION
Fixes the messed up project structure diagram

<details>
<summary><h3>Before</h3></summary>

<img width="838" alt="image" src="https://github.com/user-attachments/assets/37ecd1e0-6fa0-424a-8647-9e67b78cde6d">
</details>
<details>
<summary><h3>After</h3></summary>

<img width="655" alt="image" src="https://github.com/user-attachments/assets/b5cc1fa3-de89-4d29-9d7b-921fc51ccbc9">

</details>
