### PR TITLE
Fix compile error in advanced_postprocessing.rst

### DIFF
--- a/tutorials/shaders/advanced_postprocessing.rst
+++ b/tutorials/shaders/advanced_postprocessing.rst
@@ -47,7 +47,7 @@ and sets the vertex position in clip space directly.
 
   shader_type spatial;
   // Prevent the quad from being affected by lighting and fog. This also improves performance.
-  render_mode unshaded, disable_fog;
+  render_mode unshaded, fog_disabled;
 
   void vertex() {
     POSITION = vec4(VERTEX.xy, 1.0, 1.0);


### PR DESCRIPTION
The shader from this page would not compile on 4.3.
Now it uses `fog_disabled` instead of `disable_fog`.
