### PR TITLE
Fix Visual Studio Code gdb pretty print script path to match the Godot repository

### DIFF
--- a/contributing/development/configuring_an_ide/visual_studio_code.rst
+++ b/contributing/development/configuring_an_ide/visual_studio_code.rst
@@ -115,7 +115,7 @@ To run and debug the project you need to create a new configuration in the ``lau
         },
         {
             "description": "Load custom pretty-printers for Godot types.",
-            "text": "source ${workspaceRoot}/misc/scripts/godot_gdb_pretty_print.py"
+            "text": "source ${workspaceRoot}/misc/utility/godot_gdb_pretty_print.py"
         }
       ],
       "preLaunchTask": "build"


### PR DESCRIPTION
- See https://github.com/godotengine/godot-docs-user-notes/discussions/46#discussioncomment-10367692.

This script is new in 4.3, so this shouldn't be cherry-picked to the `4.2` branch.