### PR TITLE
Add section on working with collections in C#

### DIFF
--- a/tutorials/scripting/cross_language_scripting.rst
+++ b/tutorials/scripting/cross_language_scripting.rst
@@ -173,25 +173,22 @@ If that's impossible, you'll see the following error: ``Invalid call. Nonexisten
 
 Receiving C# collections from GDScript
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-When passing or returning collections from C# methods, types from the `System.Collections` and `System.Collections.Generic` namespaces are not compatible with Godot's marshalling system. For example:
+When passing or returning collections from C# methods, types from the `System.Collections` and `System.Collections.Generic` namespaces are not compatible with Godot's marshalling system. For example, this method will not be visible to GDScript, and Godot will throw the "Invalid call" error:
 
 .. code-block:: csharp
 
-    // These methods will not be visible to GDScript, and Godot will throw the "Invalid call" error
     public System.Collections.Generic.List<string> GetStrings() { ... }
 
-To ensure your collections can be used in GDScript, use Godot's collection types from the `Godot.Collections` namespace. The types in your collection also must be :ref:`Variant-compatible <c_sharp_variant_compatible_types>`:
+To ensure your collections can be used in GDScript, use Godot's collection types from the `Godot.Collections` namespace. The types in your collection also must be :ref:`Variant-compatible <c_sharp_variant_compatible_types>`. This method *will* be visible to GDScript:
 
 .. code-block:: csharp
 
-    // This method can be called from GDScript
     public Godot.Collections.Array<string> GetStrings() { ... }
 
-Alternatively, you can use raw arrays, which are also compatible with the marshalling system.
+Alternatively, you can use raw arrays, which are also compatible with the marshalling system. This method will also be visible to GDScript:
 
 .. code-block:: csharp
 
-    // This method can be called from GDScript
     public string[] GetStrings() { ... }
 
 

--- a/tutorials/scripting/cross_language_scripting.rst
+++ b/tutorials/scripting/cross_language_scripting.rst
@@ -178,7 +178,7 @@ When passing or returning collections from C# methods, types from the `System.Co
 .. code-block:: csharp
 
     // These methods will not be visible to GDScript, and Godot will throw the "Invalid call" error
-    public List<string> GetStrings() { ... }
+    public System.Collections.Generic.List<string> GetStrings() { ... }
 
 To ensure your collections can be used in GDScript, use Godot's collection types from the `Godot.Collections` namespace:
 

--- a/tutorials/scripting/cross_language_scripting.rst
+++ b/tutorials/scripting/cross_language_scripting.rst
@@ -195,6 +195,8 @@ Alternatively, you can use raw arrays, which are also compatible with the marsha
     public string[] GetStrings() { ... }
 
 
+For more details on how to choose the right C# collection for your use case, see :ref:`C# collections<doc_c_sharp_collections>`.
+
 Calling GDScript methods from C#
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tutorials/scripting/cross_language_scripting.rst
+++ b/tutorials/scripting/cross_language_scripting.rst
@@ -171,6 +171,30 @@ If that's impossible, you'll see the following error: ``Invalid call. Nonexisten
     my_csharp_node.PrintArray(["a", "b", "c"]) # a, b, c
     my_csharp_node.PrintArray([1, 2, 3]) # 1, 2, 3
 
+Receiving C# collections from GDScript
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When passing or returning collections from C# methods, types from the `System.Collections` and `System.Collections.Generic` namespaces are not compatible with Godot's marshalling system. For example:
+
+.. code-block:: csharp
+
+    // These methods will not be visible to GDScript, and Godot will throw the "Invalid call" error
+    public List<string> GetStrings() { ... }
+
+To ensure your collections can be used in GDScript, use Godot's collection types from the `Godot.Collections` namespace:
+
+.. code-block:: csharp
+
+    // This method can be called from GDScript
+    public Godot.Collections.Array<string> GetStrings() { ... }
+
+Alternatively, you can use raw arrays, which are also compatible with the marshalling system.
+
+.. code-block:: csharp
+
+    // This method can be called from GDScript
+    public string[] GetStrings() { ... }
+
+
 Calling GDScript methods from C#
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tutorials/scripting/cross_language_scripting.rst
+++ b/tutorials/scripting/cross_language_scripting.rst
@@ -180,7 +180,7 @@ When passing or returning collections from C# methods, types from the `System.Co
     // These methods will not be visible to GDScript, and Godot will throw the "Invalid call" error
     public System.Collections.Generic.List<string> GetStrings() { ... }
 
-To ensure your collections can be used in GDScript, use Godot's collection types from the `Godot.Collections` namespace:
+To ensure your collections can be used in GDScript, use Godot's collection types from the `Godot.Collections` namespace. The types in your collection also must be :ref:`Variant-compatible <c_sharp_variant_compatible_types>`:
 
 .. code-block:: csharp
 


### PR DESCRIPTION
Clarified that for passing collections, use Godot's collections (or raw arrays) instead of C#'s provided collections as these currently don't work with the marshaller
