### PR TITLE
Document GDScript "when" and clarify pattern guard docs

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -165,6 +165,8 @@ in case you want to take a look under the hood.
 +------------+---------------------------------------------------------------------------------------------------------------------------------------------------+
 | match      | See match_.                                                                                                                                       |
 +------------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+| when       | Used by `pattern guards <Pattern guards_>`_ in ``match`` statements.                                                                              |
++------------+---------------------------------------------------------------------------------------------------------------------------------------------------+
 | break      | Exits the execution of the current ``for`` or ``while`` loop.                                                                                     |
 +------------+---------------------------------------------------------------------------------------------------------------------------------------------------+
 | continue   | Immediately skips to the next iteration of the ``for`` or ``while`` loop.                                                                         |
@@ -1654,10 +1656,10 @@ Basic syntax
 
 ::
 
-    match <expression>:
+    match <test value>:
         <pattern(s)>:
             <block>
-        <pattern(s)> when <guard expression>:
+        <pattern(s)> when <pattern guard>:
             <block>
         <...>
 
@@ -1790,9 +1792,13 @@ The following pattern types are available:
 Pattern guards
 """"""""""""""
 
+A *pattern guard* is an optional condition that follows the pattern list
+and allows you to make additional checks before choosing a ``match`` branch.
+Unlike a pattern, a pattern guard can be an arbitrary expression.
+
 Only one branch can be executed per ``match``. Once a branch is chosen, the rest are not checked.
 If you want to use the same pattern for multiple branches or to prevent choosing a branch with too general pattern,
-you can specify a guard expression after the list of patterns with the ``when`` keyword::
+you can specify a pattern guard after the list of patterns with the ``when`` keyword::
 
     match point:
         [0, 0]:
@@ -1808,9 +1814,9 @@ you can specify a guard expression after the list of patterns with the ``when`` 
         [var x, var y]:
             print("Point (%s, %s)" % [x, y])
 
-- If there is no matching pattern for the current branch, the guard expression
+- If there is no matching pattern for the current branch, the pattern guard
   is **not** evaluated and the patterns of the next branch are checked.
-- If a matching pattern is found, the guard expression is evaluated.
+- If a matching pattern is found, the pattern guard is evaluated.
 
   - If it's true, then the body of the branch is executed and ``match`` ends.
   - If it's false, then the patterns of the next branch are checked.


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-docs/issues/9786.

Adds an entry for "when" to the table, which links to "match".

---

As for potential confusion about "pattern guards" vs "guard expressions":
- In the docs, both phrases only appear on this page. 
- The engine itself has some errors that mention a "pattern guard" with an "expression". The phrase "guard expression" does not appear anywhere in engine error messages.
- The class reference never mentions "guard expressions" or "pattern guards".

So my impression is that you can create a match statement with a "pattern guard" which has an "expression". And you might call that expression a "guard expression", as the current docs section does. But these seem to be terms that are only implicitly defined in a one place in user-facing content, or perhaps terms from another language that are borrowed directly.

I changed the section header from "Pattern guards" to "Pattern guard expressions" so it can be found with `ctrl+f` both ways. Not too attached to that change.

---
I mainly use C#, so a review from a GDScript expert would be appreciated.