### PR TITLE
Fix "make html FILELIST" command in building_the_manual.rst

### DIFF
--- a/contributing/documentation/building_the_manual.rst
+++ b/contributing/documentation/building_the_manual.rst
@@ -166,4 +166,4 @@ You can specify a list of files to build, which can greatly speed up compilation
 
 .. code:: sh
 
-    make FILELIST='classes/class_node.rst classes/class_resource.rst' html
+    make html FILELIST='classes/class_node.rst classes/class_resource.rst'


### PR DESCRIPTION
The command listed in the docs didn't work for me. Correct me if I'm wrong. I only tested on windows, which uses `.\make` instead of `make`.

NOT WORKING: Building with `.\make FILELIST='tutorials/scripting/gdscript/gdscript_basics.rst' html`:
```
Running Sphinx v4.4.0
Build language: en, i18n tag: False
loading translations [en]... done

Sphinx error:
Builder name FILELIST not registered or available through entry point
```
WORKING: Building with ` .\make html FILELIST='tutorials/scripting/gdscript/gdscript_basics.rst`:
```
Running Sphinx v4.4.0
Build language: en, i18n tag: False
loading translations [en]... done
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
....
```