### PR TITLE
C#: Remove references to `GODOT_SERVER` and `GODOT_HTML5` defines

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_features.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_features.rst
@@ -102,10 +102,6 @@ Preprocessor defines
 Godot has a set of defines that allow you to change your C# code
 depending on the environment you are compiling to.
 
-.. note:: If you created your project before Godot 3.2, you have to modify
-          or regenerate your `csproj` file to use this feature
-          (compare ``<DefineConstants>`` with a new 3.2+ project).
-
 Examples
 ~~~~~~~~
 
@@ -115,10 +111,7 @@ For example, you can change code based on the platform:
 
         public override void _Ready()
         {
-    #if GODOT_SERVER
-            // Don't try to load meshes or anything, this is a server!
-            LaunchServer();
-    #elif GODOT_32 || GODOT_MOBILE || GODOT_WEB
+    #if (GODOT_32 || GODOT_MOBILE || GODOT_WEB)
             // Use simple objects when running on less powerful systems.
             SpawnSimpleObjects();
     #else
@@ -167,7 +160,7 @@ Full list of defines
 * One of ``GODOT_64`` or ``GODOT_32`` is defined depending on if the architecture is 64-bit or 32-bit.
 
 * One of ``GODOT_LINUXBSD``, ``GODOT_WINDOWS``, ``GODOT_OSX``,
-  ``GODOT_ANDROID``, ``GODOT_IOS``, ``GODOT_HTML5``, or ``GODOT_SERVER``
+  ``GODOT_ANDROID``, ``GODOT_IOS``, ``GODOT_WEB``
   depending on the OS. These names may change in the future.
   These are created from the ``get_name()`` method of the
   :ref:`OS <class_OS>` singleton, but not every possible OS


### PR DESCRIPTION
- The `GODOT_SERVER` preprocessor define is no longer available in Godot 4, since the dedicated server platform was removed.
    - Closes https://github.com/godotengine/godot/issues/94414/.
    - https://github.com/godotengine/godot/pull/49074.
- Replaced a reference to `GODOT_HTML5` with `GODOT_WEB` since that platform was also renamed in Godot 4.
    - https://github.com/godotengine/godot/pull/65023.
- Remove note about `<DefineConstants>` that only really applies to Godot 3.
