### PR TITLE
Fix comment directive to prevent webpage display

### DIFF
--- a/contributing/how_to_contribute.rst
+++ b/contributing/how_to_contribute.rst
@@ -74,8 +74,9 @@ Technical contributions
 - **Write Plugins (GDScript, C#, & more)**
   Community addons are not directly included in the core engine download or repository, yet they provide essential quality of life upgrades for your fellow game developers.
   Upload your plugins to the `Godot Asset Library <https://godotengine.org/asset-library/asset>`_ to make them available to others.
-  .. update to talk about Asset Store later
 
+  ..
+    update to talk about Asset Store later
 - **Demo projects (GDScript, C#, and making Assets)**
   We provide new users with `demo projects <https://github.com/godotengine/godot-demo-projects/>`_ so they can quickly test new features or get familiar with the engine in the first place.
   At industry events, we might even exhibit these demo projects to showcase what Godot can do! 


### PR DESCRIPTION
`..` immediately following paragraph text at the same indentation is interpreted as a continuation of that text, as seen on the website:

https://docs.godotengine.org/en/stable/contributing/how_to_contribute.html#technical-contributions

> Upload your plugins to the Godot Asset Library to make them available to others. .. update to talk about Asset Store later

I feel the intent was still clear, but it does look a bit weird at the moment.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
