### PR TITLE
Update certain example code snippets to use the new syntax

### DIFF
--- a/contributing/development/core_and_modules/custom_godot_servers.rst
+++ b/contributing/development/core_and_modules/custom_godot_servers.rst
@@ -483,7 +483,7 @@ Here is the GDScript sample code:
 
     func _ready():
         print("Start debugging")
-        HilbertHotel.connect("occupy_room", self, "_print_occupy_room")
+        HilbertHotel.occupy_room.connect(_print_occupy_room)
         var rid = HilbertHotel.create_bus()
         OS.delay_msec(2000)
         HilbertHotel.create_bus()

--- a/tutorials/navigation/navigation_introduction_2d.rst
+++ b/tutorials/navigation/navigation_introduction_2d.rst
@@ -131,7 +131,7 @@ It uses the NavigationServer2D and a NavigationAgent2D for path movement.
         navigation_agent.target_desired_distance = 4.0
 
         # Make sure to not await during _ready.
-        call_deferred("actor_setup")
+        actor_setup.call_deferred()
 
     func actor_setup():
         # Wait for the first physics frame so the NavigationServer can sync.

--- a/tutorials/navigation/navigation_introduction_3d.rst
+++ b/tutorials/navigation/navigation_introduction_3d.rst
@@ -132,7 +132,7 @@ It uses the NavigationServer3D and a NavigationAgent3D for path movement.
         navigation_agent.target_desired_distance = 0.5
 
         # Make sure to not await during _ready.
-        call_deferred("actor_setup")
+        actor_setup.call_deferred()
 
     func actor_setup():
         # Wait for the first physics frame so the NavigationServer can sync.

--- a/tutorials/navigation/navigation_using_navigationservers.rst
+++ b/tutorials/navigation/navigation_using_navigationservers.rst
@@ -97,7 +97,7 @@ Afterwards the function waits for the next physics frame before continuing with 
     func _ready():
         # Use call deferred to make sure the entire scene tree nodes are setup
         # else await on 'physics_frame' in a _ready() might get stuck.
-        call_deferred("custom_setup")
+        custom_setup.call_deferred()
 
     func custom_setup():
 

--- a/tutorials/performance/thread_safe_apis.rst
+++ b/tutorials/performance/thread_safe_apis.rst
@@ -30,7 +30,7 @@ Interacting with the active scene tree is **NOT** thread-safe. Make sure to use 
     # Unsafe:
     node.add_child(child_node)
     # Safe:
-    node.call_deferred("add_child", child_node)
+    node.add_child.call_deferred(child_node)
 
 However, creating scene chunks (nodes in tree arrangement) outside the active tree is fine. This way, parts of a scene can be built or instantiated in a thread, then added in the main thread:
 
@@ -39,7 +39,7 @@ However, creating scene chunks (nodes in tree arrangement) outside the active tr
     var enemy_scene = load("res://enemy_scene.scn")
     var enemy = enemy_scene.instantiate()
     enemy.add_child(weapon) # Set a weapon.
-    world.call_deferred("add_child", enemy)
+    world.add_child.call_deferred(enemy)
 
 Still, this is only really useful if you have **one** thread loading data.
 Attempting to load or create scene chunks from multiple threads may work, but you risk

--- a/tutorials/scripting/singletons_autoload.rst
+++ b/tutorials/scripting/singletons_autoload.rst
@@ -205,7 +205,7 @@ current scene and replace it with the requested one.
         # The solution is to defer the load to a later time, when
         # we can be sure that no code from the current scene is running:
 
-        call_deferred("_deferred_goto_scene", path)
+        _deferred_goto_scene.call_deferred(path)
 
 
     func _deferred_goto_scene(path):


### PR DESCRIPTION
Update certain example code snippets that still use the legacy syntax of `call_deferred` and `connect`. The changes are :
- Replace `Object.call_deferred` to `Callable.call_deferred`
- Replace `Object.connect` to `Signal.connect`