### PR TITLE
Fix codespell path and spelling errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Linter checks
         run: |
           bash _tools/format.sh
-          codespell -I _tools/codespell-ignore.txt -x _tools/codespell-ignore-lines.txt -S tutorials/i18n/locales.rst {about,community,development,getting_started,tutorials}/**/*.rst
+          codespell -I _tools/codespell-ignore.txt -x _tools/codespell-ignore-lines.txt -S tutorials/i18n/locales.rst {about,community,contributing,getting_started,tutorials}/**/*.rst
 
       # Use dummy builder to improve performance as we don't need the generated HTML in this workflow.
       - name: Sphinx build

--- a/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.rst
@@ -160,7 +160,7 @@ exported from other tools such as Maya.
 **FBX**
 
 - **Importer** Which import method is used. ubfx handles fbx files as fbx files.
-  FBX2glTF converts FBX files to glTF on import and requires additonal setup.
+  FBX2glTF converts FBX files to glTF on import and requires additional setup.
   FBX2glTF is not recommended unless you have a specific rason to use it over
   ufbx or working with a different file format.
 - **Allow Geometry Helper Nodes** enables or disables geometry helper nodes

--- a/tutorials/scripting/c_sharp/c_sharp_global_classes.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_global_classes.rst
@@ -83,7 +83,7 @@ will let you create and load instances of this type easily.
 
 .. warning::
 
-    The Godot editor will hide these custom classes with names that beging with the prefix
+    The Godot editor will hide these custom classes with names that begin with the prefix
     "Editor" in the 'Create New Node' or 'Create New Scene' dialog windows. The classes 
     are available for instantiation at runtime via their class names, but are 
     automatically hidden by the editor windows along with the built-in editor nodes used 

--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -348,11 +348,12 @@ When building for iOS, package the module as a static `.xcframework`, you can us
 following commands to do so:
 
 ::
+
     # compile simulator and device modules
     scons arch=universal ios_simulator=yes platform=ios target=<target>
     scons arch=arm64 ios_simulator=no platform=ios target=<target>
 
-    # assembe xcframeworks
+    # assemble xcframeworks
     xcodebuild -create-xcframework -library demo/bin/libgdexample.ios.<target>.a -library demo/bin/libgdexample.ios.<target>.simulator.a -output demo/bin/libgdexample.ios.<target>.xcframework
     xcodebuild -create-xcframework -library godot-cpp/bin/libgodot-cpp.ios.<target>.arm64.a -library godot-cpp/bin/libgodot-cpp.ios.<target>.universal.simulator.a  -output demo/bin/libgodot-cpp.ios.<target>.xcframework
 

--- a/tutorials/troubleshooting.rst
+++ b/tutorials/troubleshooting.rst
@@ -83,7 +83,7 @@ in the Editor Settings (**Network > Debug > Remote Port**). The default is
 
 On Windows, when loading the project for the first time after the PC is turned on,
 Windows Defender will cause the filesystem cache validation on project startup
-to take significantly longer. This is especially noticable in projects with a
+to take significantly longer. This is especially noticeable in projects with a
 large number of files. Consinder adding the project folder to the list of exclusions
 by going to Virus & threat protection > Virus & threat protection settings >
 Add or remove exclusions.


### PR DESCRIPTION
- Replace `development` with `contributing` in codespell path
- Fix spelling errors
- Fix indentation of bash commands in gdextension docs

I don't know why github ci doesn't detect this problems, but using codespell locally does.