### PR TITLE
Add link to `godot-proposals` in the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,6 +5,10 @@ contact_links:
     url: https://godotengine.org/community
     about: Please ask for technical support on one of the other community channels, not here.
 
+  - name: Godot proposals
+    url: https://github.com/godotengine/godot-proposals
+    about: Please submit engine feature proposals on the Godot proposals repository, not here.
+
   - name: Main Godot repository
     url: https://github.com/godotengine/godot
     about: Report engine bugs on the main Godot repository


### PR DESCRIPTION
To reduce confusion over where to propose enhancements to the engine itself

Seen more confusion over this lately so like my earlier addition for where to report engine bugs I thought this would be a useful addition

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
