### PR TITLE
Remove article before plural noun in autoloads_versus_internal_nodes.rst

### DIFF
--- a/tutorials/best_practices/autoloads_versus_internal_nodes.rst
+++ b/tutorials/best_practices/autoloads_versus_internal_nodes.rst
@@ -87,7 +87,7 @@ limitation of static functions is that they can't reference member variables,
 non-static functions or ``self``.
 
 Since Godot 4.1, GDScript also supports ``static`` variables using ``static var``.
-This means you can now share a variables across instances of a class without
+This means you can now share variables across instances of a class without
 having to create a separate autoload.
 
 Still, autoloaded nodes can simplify your code for systems with a wide scope. If


### PR DESCRIPTION
A plural noun shouldn't be preceded by an indefinite article [butte.edu/departments/cas/tipsheets/grammar/articles](https://www.butte.edu/departments/cas/tipsheets/grammar/articles.html).

Fixed origin mistake from #9826.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
