### PR TITLE
update editing pages online instructions in contributing_to_the_documentation.rst

### DIFF
--- a/contributing/documentation/contributing_to_the_documentation.rst
+++ b/contributing/documentation/contributing_to_the_documentation.rst
@@ -81,19 +81,28 @@ and to log in to use it. Once logged in, you can propose change like so:
 
 1. Click the **Edit on GitHub** button.
 
-2. On the GitHub page you're taken to, click the pencil icon in the top-right
-   corner near the **Raw**, **Blame**, and **Delete** buttons. It has the
-   tooltip "Fork this project and edit the file".
+2. On the GitHub page you're taken to, make sure the current branch is "master".
+   Click the pencil icon in the top-right corner
+   near the **Raw**, **Blame**, and **Delete** buttons.
+   It has the tooltip "Fork this project and edit the file".
 
 3. Edit the text in the text editor.
 
-4. At the bottom of the web page, summarize the changes you made and click the
-   button **Propose file change**. Make sure to replace the placeholder "Update file.rst"
-   by a short, but clear one-line description, as this is the commit title.
+4. Click "Commit changes...", summarize the changes you made
+   and make sure to replace the placeholder "Update file.rst" by a short,
+   but clear one-line description, as this is the commit title.
+   Click the button **Propose changes**.
 
 5. On the following screens, click the **Create pull request** button until you
    see a message like *Username wants to merge 1 commit into godotengine:master
    from Username:patch-1*.
+
+.. note::
+
+   If there are more commits than your own in the pull request
+   it is likely that your branch was created using the wrong origin,
+   due to "master" not being the current branch in step 2.
+   You will need to rebase your branch to "master" or create a new branch.
 
 Another contributor will review your changes and merge them into the docs if
 they're good. They may also make changes or ask you to do so before merging.


### PR DESCRIPTION
Added some instructions to avoid the pitfalls that I ran into when creating #9826

Updated the instructions to accurately describe the current GitHub UI (screenshot references below)
![github_commit_screenshot](https://github.com/user-attachments/assets/052daafb-03d3-48da-b80b-4508e73dffae)
![github_commit_dialog_screenshot](https://github.com/user-attachments/assets/de3dea4a-1a82-478b-85e2-a19da0b3462a)

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
