### PR TITLE
2D movement overview - Click-and-move - use actions

### DIFF
--- a/tutorials/2d/2d_movement.rst
+++ b/tutorials/2d/2d_movement.rst
@@ -231,7 +231,7 @@ on the screen will cause the player to move to the target location.
     var target = position
 
     func _input(event):
-        #use is_action_just_pressed to only accept single taps as input
+        #use is_action_just_pressed to only accept single taps as input instead of mouse drags
         if event.is_action_pressed("click"):
 		    target = get_global_mouse_position()
 

--- a/tutorials/2d/2d_movement.rst
+++ b/tutorials/2d/2d_movement.rst
@@ -232,7 +232,7 @@ on the screen will cause the player to move to the target location.
 
     func _input(event):
         # Use is_action_pressed to only accept single taps as input instead of mouse drags.
-        if event.is_action_pressed("click"):
+        if event.is_action_pressed(&"click"):
             target = get_global_mouse_position()
 
     func _physics_process(delta):

--- a/tutorials/2d/2d_movement.rst
+++ b/tutorials/2d/2d_movement.rst
@@ -231,9 +231,9 @@ on the screen will cause the player to move to the target location.
     var target = position
 
     func _input(event):
-        if event is InputEventMouseButton:
-            if event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-                target = get_global_mouse_position()
+        #use is_action_just_pressed to only accept single taps as input
+        if event.is_action_pressed("click"):
+		    target = get_global_mouse_position()
 
     func _physics_process(delta):
         velocity = position.direction_to(target) * speed

--- a/tutorials/2d/2d_movement.rst
+++ b/tutorials/2d/2d_movement.rst
@@ -254,12 +254,9 @@ on the screen will cause the player to move to the target location.
 
         public override void _Input(InputEvent @event)
         {
-            if (@event is InputEventMouseButton eventMouseButton)
+            if (Input.IsActionPressed("click"))
             {
-                if (eventMouseButton.ButtonIndex == MouseButton.Left && eventMouseButton.Pressed)
-                {
-                    _target = GetGlobalMousePosition();
-                }
+                _target = GetGlobalMousePosition();
             }
         }
 

--- a/tutorials/2d/2d_movement.rst
+++ b/tutorials/2d/2d_movement.rst
@@ -254,7 +254,8 @@ on the screen will cause the player to move to the target location.
 
         public override void _Input(InputEvent @event)
         {
-            if (Input.IsActionPressed("click"))
+            // Use IsActionPressed to only accept single taps as input instead of mouse drags.
+            if (@event.IsActionPressed("click"))
             {
                 _target = GetGlobalMousePosition();
             }


### PR DESCRIPTION
Changed the code sample for the `Click-and-move` section of the `2D movement overview` page to use Actions instead of the InputEvent, to match the [sample](https://github.com/godotengine/godot-docs-project-starters/blob/master/src/2d_movement_starter/click_and_move.gd).