### PR TITLE
[Contributing] Improve list of classes disabled by `disable_advanced_gui`

### DIFF
--- a/contributing/development/compiling/optimizing_for_size.rst
+++ b/contributing/development/compiling/optimizing_for_size.rst
@@ -165,30 +165,34 @@ TextEdit or GraphEdit. They can be disabled using a build flag:
 
 This is everything that will be disabled:
 
-- FileDialog
-- PopupMenu
-- Tree
-- TextEdit
-- CodeEdit
-- SyntaxHighlighter
-- CodeHighlighter
-- TreeItem
-- OptionButton
-- SpinBox
-- ColorPicker
-- ColorPickerButton
-- RichTextlabel
-- RichTextEffect
-- CharFXTransform
-- AcceptDialog
-- ConfirmationDialog
-- MarginContainer
-- SubViewportContainer
-- SplitContainer
-- HSplitContainer
-- VSplitContainer
-- GraphNode
-- GraphEdit
+- :ref:`class_AcceptDialog`
+- :ref:`class_CharFXTransform`
+- :ref:`class_CodeEdit`
+- :ref:`class_CodeHighlighter`
+- :ref:`class_ColorPickerButton`
+- :ref:`class_ColorPicker`
+- :ref:`class_ConfirmationDialog`
+- :ref:`class_FileDialog`
+- :ref:`class_GraphEdit`
+- :ref:`class_GraphElement`
+- :ref:`class_GraphFrame`
+- :ref:`class_GraphNode`
+- :ref:`class_HSplitContainer`
+- :ref:`class_MenuBar`
+- :ref:`class_MenuButton`
+- :ref:`class_OptionButton`
+- :ref:`class_PopupMenu` (will make all popup menus unavailable in code for classes that use them,
+  like :ref:`class_LineEdit`, even though those classes are still available)
+- :ref:`class_RichTextEffect`
+- :ref:`class_RichTextLabel`
+- :ref:`class_SpinBox`
+- :ref:`class_SplitContainer`
+- :ref:`class_SubViewportContainer`
+- :ref:`class_SyntaxHighlighter`
+- :ref:`class_TextEdit`
+- :ref:`class_TreeItem`
+- :ref:`class_Tree`
+- :ref:`class_VSplitContainer`
 
 Disabling unwanted modules
 --------------------------


### PR DESCRIPTION
As per:
* https://github.com/godotengine/godot/pull/94513

Only relevant for 4.4, can make a dedicated one for 4.3 and older with the style improvements though

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
