### PR TITLE
Added openKylin system installation dependencies

### DIFF
--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -219,6 +219,7 @@ Distro-specific one-liners
     .. tab:: openKylin
 
         ::
+
             sudo apt update
             sudo apt install -y \
               python3-pip \

--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -216,6 +216,27 @@ Distro-specific one-liners
               gcc-c++ \
               libGLU1
 
+    .. tab:: openKylin
+
+        ::
+            sudo apt update
+            sudo apt install -y \
+              python3-pip \
+              build-essential \
+              pkg-config \
+              libx11-dev \
+              libxcursor-dev \
+              libxinerama-dev \
+              libgl1-mesa-dev \
+              libglu1-mesa-dev \
+              libasound2-dev \
+              libpulse-dev \
+              libudev-dev \
+              libxi-dev \
+              libxrandr-dev \
+              libwayland-dev
+            sudo pip install scons
+
     .. tab:: Solus
 
         ::


### PR DESCRIPTION
Although openKylin also uses apt as the package manager, compiling the Godot dependent installation on the openKylin system is slightly different, requiring python3-pip to be installed before scons is installed with pip, which makes it easier for Godot developers on the openKylin system to copy commands from the document

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
