### PR TITLE
Document PackedVector4Array

### DIFF
--- a/_extensions/gdscript.py
+++ b/_extensions/gdscript.py
@@ -358,6 +358,7 @@ class GDScriptLexer(RegexLexer):
                         "PackedVector2iArray",
                         "PackedVector3Array",
                         "PackedVector3iArray",
+                        "PackedVector4Array",
                         "PackedColorArray",
                         "null",
                         "void",

--- a/tutorials/scripting/c_sharp/c_sharp_collections.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_collections.rst
@@ -85,6 +85,7 @@ GDScript                C#
 ``PackedStringArray``   ``string[]``
 ``PackedVector2Array``  ``Vector2[]``
 ``PackedVector3Array``  ``Vector3[]``
+``PackedVector4Array``  ``Vector4[]``
 ``PackedColorArray``    ``Color[]``
 ======================  ==============================================================
 

--- a/tutorials/scripting/c_sharp/c_sharp_variant.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_variant.rst
@@ -129,6 +129,7 @@ Variant.Type             C# Type
 ``PackedStringArray``    ``string[]``
 ``PackedVector2Array``   ``Godot.Vector2[]``
 ``PackedVector3Array``   ``Godot.Vector3[]``
+``PackedVector4Array``   ``Godot.Vector4[]``
 ``PackedColorArray``     ``Godot.Color[]``
 =======================  ===========================================================
 

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -895,6 +895,7 @@ arrays. They are therefore only recommended to use for large data sets:
 - :ref:`PackedStringArray <class_PackedStringArray>`: An array of strings.
 - :ref:`PackedVector2Array <class_PackedVector2Array>`: An array of :ref:`Vector2 <class_Vector2>` values.
 - :ref:`PackedVector3Array <class_PackedVector3Array>`: An array of :ref:`Vector3 <class_Vector3>` values.
+- :ref:`PackedVector4Array <class_PackedVector4Array>`: An array of :ref:`Vector4 <class_Vector4>` values.
 - :ref:`PackedColorArray <class_PackedColorArray>`: An array of :ref:`Color <class_Color>` values.
 
 :ref:`Dictionary <class_Dictionary>`


### PR DESCRIPTION
This type was added in Godot 4.3.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/61#discussioncomment-10492602.
