### PR TITLE
Update TileMap node with Layer postfix in using_tilemaps.rst

### DIFF
--- a/tutorials/2d/using_tilemaps.rst
+++ b/tutorials/2d/using_tilemaps.rst
@@ -108,9 +108,9 @@ of the editor:
 
 .. figure:: img/using_tilemaps_open_tilemap_editor.webp
    :align: center
-   :alt: Opening the TileMap panel at the bottom of the editor. The TileMap node must be selected first.
+   :alt: Opening the TileMap panel at the bottom of the editor. The TileMapLayer node must be selected first.
 
-   Opening the TileMap panel at the bottom of the editor. The TileMap node must be selected first.
+   Opening the TileMap panel at the bottom of the editor. The TileMapLayer node must be selected first.
 
 Selecting tiles to use for painting
 -----------------------------------
@@ -127,7 +127,7 @@ layer you wish to paint on:
 .. tip::
 
     In the 2D editor, the layers you aren't currently editing from the same
-    TileMap node will appear grayed out while in the TileMap editor. You can
+    TileMapLayer node will appear grayed out while in the TileMap editor. You can
     disable this behavior by clicking the icon next to the layer selection menu
     (**Highlight Selected TileMap Layer** tooltip).
 
@@ -404,7 +404,7 @@ Rectangle or Bucket Fill painting modes.
 Handling tile connections automatically using terrains
 ------------------------------------------------------
 
-To use terrains, the TileMap node must feature at least one terrain set and a
+To use terrains, the TileMapLayer node must feature at least one terrain set and a
 terrain within this terrain set. See
 :ref:`doc_using_tilesets_creating_terrain_sets` if you haven't created a terrain
 set for the TileSet yet.


### PR DESCRIPTION
There are a mix of references between TileMap and TileMapLayer nodes but if I've understood correctly it should just reference the latter. "TileMap editor" references seem correct however.
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
