### PR TITLE
Add commas to sentence in using_tilemaps.rst

### DIFF
--- a/tutorials/2d/using_tilemaps.rst
+++ b/tutorials/2d/using_tilemaps.rst
@@ -126,9 +126,9 @@ layer you wish to paint on:
 
 .. tip::
 
-    In the 2D editor, the layers you aren't currently editing from the same
-    TileMap node will appear grayed out while in the TileMap editor. You can
-    disable this behavior by clicking the icon next to the layer selection menu
+    In the 2D editor, the layers you aren't currently editing,
+    from the same TileMap node, will appear grayed out while in the TileMap editor.
+    You can disable this behavior by clicking the icon next to the layer selection menu
     (**Highlight Selected TileMap Layer** tooltip).
 
 You can skip the above step if you haven't created additional layers, as the


### PR DESCRIPTION
Will conflict with #9870. Could be changed to parentheses instead of commas.
I got confused when reading the sentence because "the layers you aren't currently editing from" all flow together but then what's left of sentence doesn't make sense "the same TileMap node will appear grayed out while in the TileMap editor". Hope the extra commas will help with the flow.
Another solution would be to rephrase it as "In the 2D editor, the layers from the same TileMap node that you aren't currently editing will appear grayed out while in the TileMap editor." or something along those lines.
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
