### PR TITLE
Remove confusing end of sentence from the_profiler.rst documentation

### DIFF
--- a/tutorials/scripting/debug/the_profiler.rst
+++ b/tutorials/scripting/debug/the_profiler.rst
@@ -28,7 +28,7 @@ game and report back to the debugger, so it's off by default.
 
 To begin profiling, click on the **Start** button in the top-left. Run your game
 and data will start appearing. You can also start profiling at any time before
-or during gameplay, depending on if you want.
+or during gameplay.
 
 .. note::
 


### PR DESCRIPTION
Cut off the end of a sentence that doesn't make sense:

"You can also start profiling at any time before or during gameplay, depending on if you want."

It seems like removing the "depending on if you want." improves clarity of the documentation.


Re-opened this: https://github.com/godotengine/godot-docs/pull/9874 but targeting the correct branch.
