### PR TITLE
Add missing comma in navigation_using_navigationobstacles.rst

### DIFF
--- a/tutorials/navigation/navigation_using_navigationobstacles.rst
+++ b/tutorials/navigation/navigation_using_navigationobstacles.rst
@@ -25,7 +25,7 @@ Obstacles and navigation mesh
 
    Navigation obstacles affecting navigation mesh baking.
 
-For navigation mesh baking obstacles can be used to discard parts of all other source geometry inside the obstacle shape.
+For navigation mesh baking, obstacles can be used to discard parts of all other source geometry inside the obstacle shape.
 
 This can be used to stop navigation meshes being baked in unwanted places,
 e.g. inside "solid" geometry like thick walls or on top of other geometry that should not be included for gameplay like roofs.


### PR DESCRIPTION
Added a comma to clarify the subject of the sentence.

Currently:
"For navigation mesh baking obstacles can be used to discard parts of all other source geometry inside the obstacle shape."

A comma after "baking" would clarify that the sentence is talking about navigation obstacles.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
