### PR TITLE
Changed Autoload to Globals -> Autoload in Getting Started

### DIFF
--- a/getting_started/first_3d_game/08.score_and_replay.rst
+++ b/getting_started/first_3d_game/08.score_and_replay.rst
@@ -324,7 +324,7 @@ game.
 Save the scene as ``music_player.tscn``.
 
 We have to register it as an autoload. Head to the *Project -> Project
-Settings…* menu and click on the *Autoload* tab.
+Settings…* menu and click on the *Globals -> Autoload* tab.
 
 In the *Path* field, you want to enter the path to your scene. Click the folder
 icon to open the file browser and double-click on ``music_player.tscn``. Then,


### PR DESCRIPTION
Since the Autoload tab is under Globals, I updated the documentation to reflect its new position.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
