### PR TITLE
Add hyphens to adjective phrases

### DIFF
--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -88,14 +88,14 @@ Credits screen
 
 Include the above license text somewhere in the credits screen. It can be at the
 bottom after showing the rest of the credits. Most large studios use this
-approach with open source licenses.
+approach with open-source licenses.
 
 Licenses screen
 ^^^^^^^^^^^^^^^
 
 Some games have a special menu (often in the settings) to display licenses.
 This menu is typically accessed with a button called **Third-party Licenses**
-or **Open Source Licenses**.
+or **Open-source Licenses**.
 
 Output log
 ^^^^^^^^^^
@@ -147,7 +147,7 @@ Godot itself contains software written by
 `third parties <https://github.com/godotengine/godot/blob/master/thirdparty/README.md>`_,
 which is compatible with, but not covered by Godot's MIT license.
 
-Many of these dependencies are distributed under permissive open source licenses
+Many of these dependencies are distributed under permissive open-source licenses
 which require attribution by explicitly citing their copyright statement and
 license text in the final product's documentation.
 

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -11,7 +11,7 @@ Frequently asked questions
 What can I do with Godot? How much does it cost? What are the license terms?
 ----------------------------------------------------------------------------
 
-Godot is `Free and open source Software <https://en.wikipedia.org/wiki/Free_and_open_source_software>`_
+Godot is `Free and open-source Software <https://en.wikipedia.org/wiki/Free_and_open-source_software>`_
 available under the `OSI-approved <https://opensource.org/licenses/MIT>`_ MIT license. This means it is
 free as in "free speech" as well as in "free beer."
 
@@ -62,7 +62,7 @@ being the default. Official macOS builds support Apple Silicon natively as well 
 Some users also report building and using Godot successfully on ARM-based
 systems with Linux, like the Raspberry Pi.
 
-The Godot team can't provide an open source console export due to the licensing
+The Godot team can't provide an open-source console export due to the licensing
 terms imposed by console manufacturers. Regardless of the engine you use,
 though, releasing games on consoles is always a lot of work. You can read more
 about :ref:`doc_consoles`.
@@ -93,7 +93,7 @@ way of developing your games.
 Note that C# support is still relatively new, and as such, you may encounter
 some issues along the way. C# support is also currently missing on the web
 platform. Our friendly and hard-working development community is always
-ready to tackle new problems as they arise, but since this is an open source
+ready to tackle new problems as they arise, but since this is an open-source
 project, we recommend that you first do some due diligence yourself. Searching
 through discussions on
 `open issues <https://github.com/godotengine/godot/issues?q=is%3Aopen+is%3Aissue+label%3Atopic%3Adotnet>`__
@@ -127,7 +127,7 @@ the dimensionality of issues, and allows the developers of the engine to focus o
 bugs and improving features related to the engine core, rather than spending a lot of time
 trying to get a small set of incremental features working across a large set of languages.
 
-Since Godot is an open source project, it was imperative from the start to prioritize a
+Since Godot is an open-source project, it was imperative from the start to prioritize a
 more integrated and seamless experience over attracting additional users by supporting
 more familiar programming languages, especially when supporting those more familiar
 languages would result in a worse experience. We understand if you would rather use
@@ -178,7 +178,7 @@ your 3D modeling software, and how to import them for Godot in the
 Will [insert closed SDK such as FMOD, GameWorks, etc.] be supported in Godot?
 -----------------------------------------------------------------------------
 
-The aim of Godot is to create a free and open source MIT-licensed engine that
+The aim of Godot is to create a free and open-source MIT-licensed engine that
 is modular and extendable. There are no plans for the core engine development
 community to support any third-party, closed-source/proprietary SDKs, as integrating
 with these would go against Godot's ethos.
@@ -191,7 +191,7 @@ To see how support for your SDK of choice could still be provided, look at the
 Plugins question below.
 
 If you know of a third-party SDK that is not supported by Godot but that offers
-free and open source integration, consider starting the integration work yourself.
+free and open-source integration, consider starting the integration work yourself.
 Godot is not owned by one person; it belongs to the community, and it grows along
 with ambitious community contributors like you.
 
@@ -397,7 +397,7 @@ should upgrade depends on your project's circumstances. See
 I would like to contribute! How can I get started?
 --------------------------------------------------
 
-Awesome! As an open source project, Godot thrives off of the innovation and
+Awesome! As an open-source project, Godot thrives off of the innovation and
 the ambition of developers like you.
 
 The best way to start contributing to Godot is by using it and reporting
@@ -456,7 +456,7 @@ in the Project Settings to decrease CPU and GPU usage.
 
 Check out `Material Maker <https://github.com/RodZill4/material-maker>`__ and
 `Pixelorama <https://github.com/Orama-Interactive/Pixelorama>`__ for examples of
-open source applications made with Godot.
+open-source applications made with Godot.
 
 .. _doc_faq_use_godot_as_library:
 

--- a/about/introduction.rst
+++ b/about/introduction.rst
@@ -18,7 +18,7 @@ Introduction
         GD.Print("Hello world!");
     }
 
-Welcome to the official documentation of **Godot Engine**, the free and open source
+Welcome to the official documentation of **Godot Engine**, the free and open-source
 community-driven 2D and 3D game engine! Behind this mouthful, you will find a
 powerful yet user-friendly tool that you can use to develop any kind of game,
 for any platform and with no usage restriction whatsoever.

--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -631,10 +631,10 @@ Windowing and OS integration
 - Execute commands in a blocking or non-blocking manner (including running
   multiple instances of the same project).
 - Open file paths and URLs using default or custom protocol handlers (if registered on the system).
-- Parse custom command line arguments.
+- Parse custom command-line arguments.
 - Any Godot binary (editor or exported project) can be
   :ref:`used as a headless server <doc_exporting_for_dedicated_servers>`
-  by starting it with the ``--headless`` command line argument.
+  by starting it with the ``--headless`` command-line argument.
   This allows running the engine without a GPU or display server.
 
 Mobile
@@ -651,7 +651,7 @@ XR support (AR and VR)
 
    - Including support for popular desktop headsets like the Valve Index, WMR headsets, and Quest over Link.
 
-- Support for :ref:`Android based headsets <doc_deploying_to_android>` using OpenXR through a plugin.
+- Support for :ref:`Android-based headsets <doc_deploying_to_android>` using OpenXR through a plugin.
 
   - Including support for popular stand alone headsets like the Meta Quest 1/2/3 and Pro, Pico 4, Magic Leap 2, and Lynx R1.
 
@@ -753,7 +753,7 @@ Miscellaneous
   project with synchronized audio and perfect frame pacing.
 - :ref:`Low-level access to servers <doc_using_servers>` which allows bypassing
   the scene tree's overhead when needed.
-- :ref:`Command line interface <doc_command_line_tutorial>` for automation.
+- :ref:`Command-line interface <doc_command_line_tutorial>` for automation.
 
    - Export and deploy projects using continuous integration platforms.
    - `Shell completion scripts <https://github.com/godotengine/godot/tree/master/misc/dist/shell>`__

--- a/community/asset_library/submitting_to_assetlib.rst
+++ b/community/asset_library/submitting_to_assetlib.rst
@@ -184,7 +184,7 @@ is required in the submission form here as well.
 
 * **License**:
     The license under which you are distributing the asset. The list
-    includes a variety of free and open source software licenses, such as GPL
+    includes a variety of free and open-source software licenses, such as GPL
     (v2 and v3), MIT, BSD and Boost Software License. You can visit `OpenSource.org <https://opensource.org>`_
     for a detailed description of each of the listed licenses.
 * **Description**:

--- a/community/asset_library/what_is_assetlib.rst
+++ b/community/asset_library/what_is_assetlib.rst
@@ -15,7 +15,7 @@ as paid, commercial ones. In addition, often times such assets are distributed
 under non-free, proprietary licenses, limiting what you can do with them.
 
 The Asset Library is different - all assets are distributed free of charge, and under
-a host of open source licenses (such as the MIT license, the GPL, and the Boost Software License).
+a host of open-source licenses (such as the MIT license, the GPL, and the Boost Software License).
 This makes the AssetLib more similar to the software repositories of a Linux distribution.
 
 This set of pages will cover how to use the AssetLib (both from inside Godot, and on the

--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -12,7 +12,7 @@ Where to start
 
 The Godot video tutorials by `GDQuest <https://www.youtube.com/channel/UCxboW7x0jZqFdvMdCFKTMsQ/playlists>`_ are well-regarded in the community and often recommended as a gentle introduction to beginners.
 
-GDQuest's *Learn GDScript From Zero* is a free and open source interactive tutorial for absolute beginners to learn to program with Godot's GDScript language. It is available as a `desktop application <https://gdquest.itch.io/learn-godot-gdscript>`_  or `in the browser <https://gdquest.github.io/learn-gdscript>`_.
+GDQuest's *Learn GDScript From Zero* is a free and open-source interactive tutorial for absolute beginners to learn to program with Godot's GDScript language. It is available as a `desktop application <https://gdquest.itch.io/learn-godot-gdscript>`_  or `in the browser <https://gdquest.github.io/learn-gdscript>`_.
 
 Some tutorials mentioned below provide more advanced tutorials, e.g. on 3D or shaders.
 

--- a/contributing/development/best_practices_for_engine_contributors.rst
+++ b/contributing/development/best_practices_for_engine_contributors.rst
@@ -179,7 +179,7 @@ they'll need to do* in the future?
 .. image:: img/best_practices6.png
 
 The answer to this question is that, to ensure users still can do what they want
-to do, we need to give them access to a *low level API* that they can use to
+to do, we need to give them access to a *low-level API* that they can use to
 achieve what they want, even if it's more work for them because it means
 reimplementing some logic that already exists.
 
@@ -219,7 +219,7 @@ is always the advised one.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Not every problem has a simple solution and, many times, the right choice is to
-use a third party library to solve the problem.
+use a third-party library to solve the problem.
 
 As Godot requires to be shipped in a large amount of platforms, we can't
 link libraries dynamically. Instead, we bundle them in our source tree.

--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -288,7 +288,7 @@ projects in an automated manner, use the normal build::
 
     scons platform=linuxbsd target=editor
 
-And then use the ``--headless`` command line argument::
+And then use the ``--headless`` command-line argument::
 
     ./bin/godot.linuxbsd.editor.x86_64 --headless
 

--- a/contributing/development/compiling/compiling_for_macos.rst
+++ b/contributing/development/compiling/compiling_for_macos.rst
@@ -98,7 +98,7 @@ projects in an automated manner, use the normal build::
 
     scons platform=macos target=editor
 
-And then use the ``--headless`` command line argument::
+And then use the ``--headless`` command-line argument::
 
     ./bin/godot.macos.editor.x86_64 --headless
 

--- a/contributing/development/compiling/getting_source.rst
+++ b/contributing/development/compiling/getting_source.rst
@@ -26,7 +26,7 @@ In general, you need to install ``git`` and/or one of the various GUI clients.
 Afterwards, to get the latest development version of the Godot source code
 (the unstable ``master`` branch), you can use ``git clone``.
 
-If you are using the ``git`` command line client, this is done by entering
+If you are using the ``git`` command-line client, this is done by entering
 the following in a terminal:
 
 ::

--- a/contributing/development/compiling/introduction_to_the_buildsystem.rst
+++ b/contributing/development/compiling/introduction_to_the_buildsystem.rst
@@ -346,7 +346,7 @@ line option, both overriding the default build configuration:
 
     scons profile=path/to/custom.py
 
-.. note:: Build options set from the file can be overridden by the command line
+.. note:: Build options set from the file can be overridden by the command-line
           options.
 
 It's also possible to override the options conditionally:

--- a/contributing/development/configuring_an_ide/code_blocks.rst
+++ b/contributing/development/configuring_an_ide/code_blocks.rst
@@ -3,7 +3,7 @@
 Code::Blocks
 ============
 
-`Code::Blocks <https://codeblocks.org/>`_ is a free, open source, cross platform IDE.
+`Code::Blocks <https://codeblocks.org/>`_ is a free, open-source, cross-platform IDE.
 
 Creating a new project
 ----------------------

--- a/contributing/development/configuring_an_ide/kdevelop.rst
+++ b/contributing/development/configuring_an_ide/kdevelop.rst
@@ -3,7 +3,7 @@
 KDevelop
 ========
 
-`KDevelop <https://www.kdevelop.org>`_ is a free, open source IDE for all desktop platforms.
+`KDevelop <https://www.kdevelop.org>`_ is a free, open-source IDE for all desktop platforms.
 
 Importing the project
 ---------------------

--- a/contributing/development/configuring_an_ide/qt_creator.rst
+++ b/contributing/development/configuring_an_ide/qt_creator.rst
@@ -3,7 +3,7 @@
 Qt Creator
 ==========
 
-`Qt Creator <https://doc.qt.io/qtcreator/index.html>`_ is a free, open source IDE for all desktop platforms.
+`Qt Creator <https://doc.qt.io/qtcreator/index.html>`_ is a free, open-source IDE for all desktop platforms.
 
 Importing the project
 ---------------------
@@ -85,8 +85,8 @@ Debugging the project
    :figclass: figure-w480
    :align: center
 
-To learn more about command line arguments, refer to the
-:ref:`command line tutorial <doc_command_line_tutorial>`.
+To learn more about command-line arguments, refer to the
+:ref:`command-line tutorial <doc_command_line_tutorial>`.
 
 Code style configuration
 ------------------------

--- a/contributing/development/configuring_an_ide/visual_studio.rst
+++ b/contributing/development/configuring_an_ide/visual_studio.rst
@@ -54,8 +54,8 @@ Project Manager opens a project, the initial process is terminated and the debug
 .. figure:: img/vs_3_debug_command_line.webp
    :align: center
 
-To learn more about command line arguments, refer to the
-:ref:`command line tutorial <doc_command_line_tutorial>`.
+To learn more about command-line arguments, refer to the
+:ref:`command-line tutorial <doc_command_line_tutorial>`.
 
 Even if you start the project without a debugger attached it can still be connected to the running
 process using **Debug > Attach to Process...** menu.

--- a/contributing/development/configuring_an_ide/visual_studio_code.rst
+++ b/contributing/development/configuring_an_ide/visual_studio_code.rst
@@ -69,7 +69,7 @@ To run and debug the project you need to create a new configuration in the ``lau
 .. figure:: img/vscode_1_create_launch.json.png
    :align: center
 
-- Select **C++ (GDB/LLDB)**. There may be another platform specific option here. If selected,
+- Select **C++ (GDB/LLDB)**. There may be another platform-specific option here. If selected,
   adjust the configuration example provided accordingly.
 - Within the ``launch.json`` file find the ``"configurations"`` array and add a new section to it:
 

--- a/contributing/development/configuring_an_ide/xcode.rst
+++ b/contributing/development/configuring_an_ide/xcode.rst
@@ -57,7 +57,7 @@ Importing the project
 
 - Add the Godot source to the project by dragging and dropping it into the project file browser.
 - Select **Create groups** for the **Added folders** option and check *only*
-  your command line indexing target in the **Add to targets** section.
+  your command-line indexing target in the **Add to targets** section.
 
 .. figure:: img/xcode_6_after_add_godot_source_to_project.webp
    :figclass: figure-w480

--- a/contributing/development/core_and_modules/2d_coordinate_systems.rst
+++ b/contributing/development/core_and_modules/2d_coordinate_systems.rst
@@ -104,7 +104,7 @@ effects of each of them.
     *Viewport's* :ref:`canvas transform <class_Viewport_property_canvas_transform>` and the
     *CanvasLayer's* :ref:`follow viewport scale <class_CanvasLayer_property_follow_viewport_scale>`
     and can be used, if :ref:`enabled <class_CanvasLayer_property_follow_viewport_enabled>`, to
-    achieve a pseudo 3D effect. It affects the same child nodes as the *CanvasLayer transform*.
+    achieve a pseudo-3D effect. It affects the same child nodes as the *CanvasLayer transform*.
 
 - **Viewport canvas transform**
     The :ref:`canvas transform <class_Viewport_property_canvas_transform>` affects all

--- a/contributing/development/core_and_modules/common_engine_methods_and_macros.rst
+++ b/contributing/development/core_and_modules/common_engine_methods_and_macros.rst
@@ -21,7 +21,7 @@ Print text
     print_line("There are", 123, "nodes");
 
     // Prints a message to standard output, but only when the engine
-    // is started with the `--verbose` command line argument.
+    // is started with the `--verbose` command-line argument.
     print_verbose("Message");
 
     // Prints a rich-formatted message using BBCode to standard output.

--- a/contributing/development/core_and_modules/internal_rendering_architecture.rst
+++ b/contributing/development/core_and_modules/internal_rendering_architecture.rst
@@ -229,7 +229,7 @@ driver, as most graphics drivers on desktop don't support OpenGL ES.
 WebGL 2.0 is used for web exports.
 
 It is possible to use the use of OpenGL ES 3.0 directly on desktop platforms
-using the ``--rendering-driver opengl3_es`` command line argument, although this
+using the ``--rendering-driver opengl3_es`` command-line argument, although this
 will only work on graphics drivers that feature native OpenGL ES support (such
 as Mesa).
 

--- a/contributing/development/debugging/index.rst
+++ b/contributing/development/debugging/index.rst
@@ -40,8 +40,8 @@ only the ``-e`` option is required.
     $ gdb godot
     > run -e
 
-You can learn more about these launch options and other command line arguments
-in the :ref:`command line tutorial <doc_command_line_tutorial>`.
+You can learn more about these launch options and other command-line arguments
+in the :ref:`command-line tutorial <doc_command_line_tutorial>`.
 
 If you're using a code editor or an IDE to debug Godot, check out our
 :ref:`configuration guides <doc_configuring_an_ide>`, which cover the setup

--- a/contributing/development/debugging/using_cpp_profilers.rst
+++ b/contributing/development/debugging/using_cpp_profilers.rst
@@ -45,14 +45,14 @@ Benchmarking startup/shutdown times
 -----------------------------------
 
 If you're looking into optimizing Godot's startup/shutdown performance,
-you can tell the profiler to use the ``--quit`` command line option on the Godot binary.
+you can tell the profiler to use the ``--quit`` command-line option on the Godot binary.
 This will exit Godot just after it finished starting.
 The ``--quit`` option works with ``--editor``, ``--project-manager`` or
 ``--path <path to project directory>`` (which runs a project directly).
 
 .. seealso::
 
-    See :ref:`doc_command_line_tutorial` for more command line arguments
+    See :ref:`doc_command_line_tutorial` for more command-line arguments
     supported by Godot.
 
 Profiler-specific instructions
@@ -88,9 +88,9 @@ HotSpot
 .. image:: img/cpp_profiler_hotspot_welcome.png
 
 - In the next window, specify the path to the Godot binary that includes debug symbols.
-- Specify command line arguments to run a specific project, with or without the editor.
+- Specify command-line arguments to run a specific project, with or without the editor.
 - The path to the working directory can be anything if an absolute path is used
-  for the ``--path`` command line argument. Otherwise, it must be set to that
+  for the ``--path`` command-line argument. Otherwise, it must be set to that
   the relative path to the project is valid.
 - Make sure **Elevate Privileges** is checked if you have administrative privileges.
   While not essential for profiling Godot, this will ensure all events can be captured.
@@ -136,7 +136,7 @@ Xcode Instruments
 .. image:: img/cpp_profiler_xcode_menu.png
 
 - In the Time Profiler window, click on the **Target** menu, select **Choose target...**
-  and specify the path to the Godot binary, command line arguments and environment variables
+  and specify the path to the Godot binary, command-line arguments and environment variables
   in the next window.
 
 .. image:: img/cpp_profiler_time_profiler.png

--- a/contributing/development/debugging/vulkan/vulkan_validation_layers.rst
+++ b/contributing/development/debugging/vulkan/vulkan_validation_layers.rst
@@ -22,7 +22,7 @@ don't need to reboot after installing the SDK, but you may need to close and
 reopen your current terminal.
 
 After installing the Vulkan SDK, run Godot with the ``--gpu-validation``
-:ref:`command line argument <doc_command_line_tutorial>`. You can also specify
+:ref:`command-line argument <doc_command_line_tutorial>`. You can also specify
 ``--gpu-abort`` which will make Godot quit as soon as a validation error happens.
 This can prevent your system from freezing if a validation error occurs.
 
@@ -49,7 +49,7 @@ reopen your current terminal.
 
 After installing the Vulkan SDK, run a Godot binary that was compiled with
 ``use_volk=yes`` SCons option. Specify the ``--gpu-validation``
-:ref:`command line argument <doc_command_line_tutorial>`.
+:ref:`command-line argument <doc_command_line_tutorial>`.
 You can also specify ``--gpu-abort`` which will make Godot quit as soon
 as a validation error happens. This can prevent your system from freezing
 if a validation error occurs.
@@ -125,7 +125,7 @@ You don't need to reboot after installing the validation layers, but you may
 need to close and reopen your current terminal.
 
 After installing the package, run Godot with the ``--gpu-validation``
-:ref:`command line argument <doc_command_line_tutorial>`. You can also specify
+:ref:`command-line argument <doc_command_line_tutorial>`. You can also specify
 ``--gpu-abort`` which will make Godot quit as soon as a validation error happens.
 This can prevent your system from freezing if a validation error occurs.
 

--- a/contributing/development/editor/creating_icons.rst
+++ b/contributing/development/editor/creating_icons.rst
@@ -12,7 +12,7 @@ Creating icons
 ~~~~~~~~~~~~~~
 
 To create new icons, you first need a vector graphics editor installed.
-For instance, you can use the open source `Inkscape <https://inkscape.org/>`_ editor.
+For instance, you can use the open-source `Inkscape <https://inkscape.org/>`_ editor.
 
 Clone the ``godot`` repository containing all the editor icons:
 

--- a/contributing/documentation/docs_image_guidelines.rst
+++ b/contributing/documentation/docs_image_guidelines.rst
@@ -133,7 +133,7 @@ if multiple outlines on an image are needed, red should be avoided. The second s
 is that all outlines and arrow lines should be 2 pixels wide.
 
 Finally, some images might require text to differentiate multiple parts of an image.
-There are no strict requirements other than use an easy to read non fancy font. As for
+There are no strict requirements other than use an easy to read non-fancy font. As for
 color the yellow color from before should also be used, but black or other colors can
 be used if appropriate. For example, if yellow blends into the image, or if there are
 multiple outlines in multiple colors.

--- a/contributing/documentation/editor_and_docs_localization.rst
+++ b/contributing/documentation/editor_and_docs_localization.rst
@@ -20,7 +20,7 @@ These resources include:
    available both online and in the editor (ca. 200,000 words).
 
 To manage translations, we use the GNU gettext file format (``PO`` files), and
-the open source `Weblate <https://weblate.org>`__ web-based localization
+the open-source `Weblate <https://weblate.org>`__ web-based localization
 platform, which allows easy collaboration of many contributors to complete the
 translation for the various components, and keep them up to date. Click the bold
 links above to access each resource on Weblate.

--- a/contributing/workflow/first_steps.rst
+++ b/contributing/workflow/first_steps.rst
@@ -6,7 +6,7 @@ Contributing code
 The possibility to study, use, modify and redistribute modifications of the
 engine's source code are the fundamental rights that
 Godot's `MIT <https://tldrlegal.com/license/mit-license>`_ license grants you,
-making it `free and open source software <https://en.wikipedia.org/wiki/Free_and_open-source_software>`_.
+making it `free and open-source software <https://en.wikipedia.org/wiki/Free_and_open-source_software>`_.
 
 As such, everyone is entitled to modify
 `Godot's source code <https://github.com/godotengine/godot>`_, and send those
@@ -49,7 +49,7 @@ All pull requests must go through a review process before being accepted.
 Depending on the scope of the changes, it may take some time for a maintainer
 responsible for the modified part of the engine to provide their review.
 We value all of our contributors and ask them to be patient in the meantime,
-as it is expected that in an open source project like Godot, there is going to be
+as it is expected that in an open-source project like Godot, there is going to be
 way more contributions than people validating them.
 
 To make sure that your time and efforts aren't wasted, it is recommended to vet the idea

--- a/contributing/workflow/pr_workflow.rst
+++ b/contributing/workflow/pr_workflow.rst
@@ -97,7 +97,7 @@ To clone your fork from GitHub, use the following command:
 
     $ git clone https://github.com/USERNAME/godot
 
-.. note:: In our examples, the "$" character denotes the command line prompt
+.. note:: In our examples, the "$" character denotes the command-line prompt
           on typical UNIX shells. It is not part of the command and should
           not be typed.
 

--- a/getting_started/first_3d_game/02.player_input.rst
+++ b/getting_started/first_3d_game/02.player_input.rst
@@ -51,7 +51,7 @@ You can rename it to ``Character``.
 
 .. note::
 
-    The ``.glb`` files contain 3D scene data based on the open source glTF 2.0
+    The ``.glb`` files contain 3D scene data based on the open-source glTF 2.0
     specification. They're a modern and powerful alternative to a proprietary format
     like FBX, which Godot also supports. To produce these files, we designed the
     model in `Blender 3D <https://www.blender.org/>`__ and exported it to glTF.

--- a/getting_started/introduction/first_look_at_the_editor.rst
+++ b/getting_started/introduction/first_look_at_the_editor.rst
@@ -141,7 +141,7 @@ auto-completion, and built-in code reference.
 
 .. image:: img/editor_intro_workspace_script.webp
 
-Finally, the **Asset Library** is a library of free and open source add-ons, scripts,
+Finally, the **Asset Library** is a library of free and open-source add-ons, scripts,
 and assets to use in your projects.
 
 .. image:: img/editor_intro_workspace_assetlib.webp

--- a/getting_started/introduction/godot_design_philosophy.rst
+++ b/getting_started/introduction/godot_design_philosophy.rst
@@ -104,7 +104,7 @@ manage states and transitions visually.*
 Open source
 -----------
 
-Godot offers a fully open source codebase under the **MIT license**.
+Godot offers a fully open-source codebase under the **MIT license**.
 This means all the technologies that ship with it have to be Free
 (as in freedom) as well.
 For the most part, they're developed from the ground up by contributors.

--- a/getting_started/introduction/introduction_to_godot.rst
+++ b/getting_started/introduction/introduction_to_godot.rst
@@ -21,7 +21,7 @@ on desktop or mobile, as well as on the web.
 You can also create console games with it, although you either need strong
 programming skills or a developer to port the game for you.
 
-.. note:: The Godot team can't provide an open source console export due to the
+.. note:: The Godot team can't provide an open-source console export due to the
           licensing terms imposed by console manufacturers. Regardless of the
           engine you use, though, releasing games on consoles is always a lot of
           work. You can read more on that here: :ref:`doc_consoles`.
@@ -31,7 +31,7 @@ What can the engine do?
 
 Godot was initially developed in-house by an Argentinian game studio. Its
 development started in 2001, and the engine was rewritten and improved
-tremendously since its open source release in 2014.
+tremendously since its open-source release in 2014.
 
 Some examples of games created with Godot include Ex-Zodiac and Helms of Fury.
 
@@ -39,7 +39,7 @@ Some examples of games created with Godot include Ex-Zodiac and Helms of Fury.
 
 .. image:: img/introduction_helms_of_fury.jpg
 
-As for applications, the open source pixel art drawing program Pixelorama is
+As for applications, the open-source pixel art drawing program Pixelorama is
 powered by Godot, and so is the voxel RPG creator RPG in a box.
 
 .. image:: img/introduction_rpg_in_a_box.png

--- a/index.rst
+++ b/index.rst
@@ -26,7 +26,7 @@ Godot Docs – *master* branch
             of the sidebar.
 
 Welcome to the official documentation of `Godot Engine <https://godotengine.org>`__,
-the free and open source community-driven 2D and 3D game engine! If you are new
+the free and open-source community-driven 2D and 3D game engine! If you are new
 to this documentation, we recommend that you read the
 :ref:`introduction page <doc_about_intro>` to get an overview of what this
 documentation has to offer.
@@ -37,7 +37,7 @@ for your topic of interest. You can also use the search function in the top-left
 Get involved
 ------------
 
-Godot Engine is an open source project developed by a community of volunteers.
+Godot Engine is an open-source project developed by a community of volunteers.
 The documentation team can always use your feedback and help to improve the
 tutorials and class reference. If you don't understand something, or cannot find
 what you are looking for in the docs, help us make the documentation better

--- a/tutorials/2d/2d_lights_and_shadows.rst
+++ b/tutorials/2d/2d_lights_and_shadows.rst
@@ -296,7 +296,7 @@ typically created with manual editing, using the diffuse texture as a base.
 .. tip::
 
     If you don't have normal or specular maps for your sprites, you can generate
-    them using the free and open source `Laigter <https://azagaya.itch.io/laigter>`__
+    them using the free and open-source `Laigter <https://azagaya.itch.io/laigter>`__
     tool.
 
 To set up normal maps and/or specular maps on a 2D node, create a new

--- a/tutorials/2d/2d_transforms.rst
+++ b/tutorials/2d/2d_transforms.rst
@@ -8,7 +8,7 @@ Introduction
 
 This is an overview of the 2D transforms going on for nodes from the
 moment they draw their content locally to the time they are drawn onto
-the screen. This overview discusses very low level details of the engine.
+the screen. This overview discusses very low-level details of the engine.
 
 The goal of this tutorial is to teach a way for feeding input events to the
 Input with a position in the correct coordinate system.

--- a/tutorials/2d/custom_drawing_in_2d.rst
+++ b/tutorials/2d/custom_drawing_in_2d.rst
@@ -613,7 +613,7 @@ Drawing text
 ^^^^^^^^^^^^
 
 While using the :ref:`Label <class_Label>` Node is the most common way to add
-text to your application, the low level `_draw` function includes functionality
+text to your application, the low-level `_draw` function includes functionality
 to add text to your custom Node drawing. We will use it to add the name "GODOT"
 under the robot head.
 
@@ -844,7 +844,7 @@ It will look somewhat like this when run:
 
 Please note that ``_mouth_width`` is a user defined property like any other
 and it or any other used as a drawing argument can be animated using more
-standard and high level methods such as a :ref:`Tween<class_Tween>` or an
+standard and high-level methods such as a :ref:`Tween<class_Tween>` or an
 :ref:`AnimationPlayer<class_AnimationPlayer>` Node. The only difference is
 that a ``queue_redraw()`` call is needed to apply those changes so they get
 shown on screen.

--- a/tutorials/3d/global_illumination/using_lightmap_gi.rst
+++ b/tutorials/3d/global_illumination/using_lightmap_gi.rst
@@ -445,7 +445,7 @@ If hardware acceleration is not available, OIDN will fall back to multithreaded
 CPU-based denoising. To confirm whether GPU-based denoising is working, use a
 GPU utilization monitor while baking lightmaps and look at the GPU utilization
 percentage and VRAM utilization while the denoising step is shown in the Godot
-editor. The ``nvidia-smi`` command line tool can be useful for this.
+editor. The ``nvidia-smi`` command-line tool can be useful for this.
 
 OIDN is not included with Godot due to its relatively large download size. You
 can download precompiled OIDN binary packages from its

--- a/tutorials/3d/introduction_to_3d.rst
+++ b/tutorials/3d/introduction_to_3d.rst
@@ -316,7 +316,7 @@ Manually authored models (using 3D modeling software)
 -----------------------------------------------------
 
 .. FIXME: Needs update to properly description Godot 3.x workflow
-   (used to reference a non existing doc_importing_3d_meshes importer).
+   (used to reference a non-existing doc_importing_3d_meshes importer).
 
 It is possible to import 3D models in Godot created in external tools.
 Depending on the format, you can import entire scenes (exactly as they look in 

--- a/tutorials/3d/variable_rate_shading.rst
+++ b/tutorials/3d/variable_rate_shading.rst
@@ -107,7 +107,7 @@ For custom viewports, the VRS mode and texture must be set manually to the
     On unsupported hardware, there is no visual difference when variable rate
     shading is enabled. You can check whether hardware supports variable rate
     shading by running the editor or project with the ``--verbose``
-    :ref:`command line argument <doc_command_line_tutorial>`.
+    :ref:`command-line argument <doc_command_line_tutorial>`.
 
 Creating a VRS density map
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -167,7 +167,7 @@ However, there is no benefit to using a VRS density map that is larger than the
 viewport resolution divided by the GPU's *tile size*. The tile size is what
 determines the smallest area of pixels where the shading density can be changed
 separately from other tiles. On most GPUs, this tile size is 8×8 pixels. You can
-view the tile size by running Godot with the ``--verbose`` command line
+view the tile size by running Godot with the ``--verbose`` command-line
 argument, as it's printed in the VRS debugging information.
 
 Therefore, sticking to a relatively low resolution such as 256×256 (square) or

--- a/tutorials/animation/creating_movies.rst
+++ b/tutorials/animation/creating_movies.rst
@@ -109,7 +109,7 @@ or relative to the project root.
 Once you've configured and enabled Movie Maker mode, it will be automatically used
 when running the project from the editor.
 
-Command line usage
+Command-line usage
 ^^^^^^^^^^^^^^^^^^
 
 Movie Maker can also be enabled from the :ref:`command line <doc_command_line_tutorial>`:
@@ -121,7 +121,7 @@ Movie Maker can also be enabled from the :ref:`command line <doc_command_line_tu
 If the output path is relative, then it is **relative to the project folder**,
 not the current working directory. In the above example, the file will be
 written to ``/path/to/your_project/output.avi``. This behavior is similar to the
-``--export-release`` command line argument.
+``--export-release`` command-line argument.
 
 Since Movie Maker's output resolution is set by the viewport size, you can
 adjust the window size on startup to override it if the project uses the
@@ -144,7 +144,7 @@ without having to edit the Project Settings:
 
 .. note::
 
-    The ``--write-movie`` and ``--fixed-fps`` command line arguments are both available
+    The ``--write-movie`` and ``--fixed-fps`` command-line arguments are both available
     in exported projects. Movie Maker mode cannot be toggled while the project is running,
     but you can use the :ref:`OS.execute() <class_OS_method_execute>` method to
     run a second instance of the exported project that will record a video file.
@@ -248,7 +248,7 @@ Quitting Movie Maker mode
 
 To safely quit a project that is using Movie Maker mode, use the X button at the
 top of the window, or call ``get_tree().quit()`` in a script. You can also use
-the ``--quit-after N`` command line argument where ``N`` is the number of frames
+the ``--quit-after N`` command-line argument where ``N`` is the number of frames
 to render before quitting.
 
 Pressing :kbd:`F8` (:kbd:`Cmd + .` on macOS) or pressing :kbd:`Ctrl + C` on the
@@ -375,7 +375,7 @@ Converting AVI video to MP4
 
 While some platforms such as YouTube support uploading the AVI file directly, many
 others will require a conversion step beforehand. `HandBrake <https://handbrake.fr/>`__
-(GUI) and `FFmpeg <https://ffmpeg.org/>`__ (CLI) are popular open source tools
+(GUI) and `FFmpeg <https://ffmpeg.org/>`__ (CLI) are popular open-source tools
 for this purpose. FFmpeg has a steeper learning curve, but it's more powerful.
 
 The command below converts an AVI video to an MP4 (H.264) video with a Constant

--- a/tutorials/animation/playing_videos.rst
+++ b/tutorials/animation/playing_videos.rst
@@ -182,7 +182,7 @@ maximize the quality of the output Ogg Theora video, but this can require a lot
 of disk space.
 
 `HandBrake <https://handbrake.fr/>`__
-(GUI) and `FFmpeg <https://ffmpeg.org/>`__ (CLI) are popular open source tools
+(GUI) and `FFmpeg <https://ffmpeg.org/>`__ (CLI) are popular open-source tools
 for this purpose. FFmpeg has a steeper learning curve, but it's more powerful.
 
 Here are example FFmpeg commands to convert an MP4 video to Ogg Theora. Since

--- a/tutorials/editor/command_line_tutorial.rst
+++ b/tutorials/editor/command_line_tutorial.rst
@@ -1,6 +1,6 @@
 .. _doc_command_line_tutorial:
 
-Command line tutorial
+Command-line tutorial
 =====================
 
 .. highlight:: shell
@@ -20,11 +20,11 @@ suitable for this workflow.
     ``.app`` bundle (which is a *folder*, not a file). To run a Godot binary
     from a terminal on macOS, you have to ``cd`` to the folder where the Godot
     application bundle is located, then run ``Godot.app/Contents/MacOS/Godot``
-    followed by any command line arguments. If you've renamed the application
+    followed by any command-line arguments. If you've renamed the application
     bundle from ``Godot`` to another name, make sure to edit this command line
     accordingly.
 
-Command line reference
+Command-line reference
 ----------------------
 
 .. |release| image:: img/template_release.svg
@@ -37,8 +37,8 @@ Command line reference
 - |debug| Available in editor builds and debug export templates only.
 - |editor| Only available in editor builds.
 
-Note that unknown command line arguments have no effect whatsoever. The engine
-will **not** warn you when using a command line argument that doesn't exist with a
+Note that unknown command-line arguments have no effect whatsoever. The engine
+will **not** warn you when using a command-line argument that doesn't exist with a
 given build type.
 
 **General options**
@@ -46,7 +46,7 @@ given build type.
 +----------------------------+-----------------------------------------------------------------------------+
 | Command                    | Description                                                                 |
 +----------------------------+-----------------------------------------------------------------------------+
-| ``-h``, ``--help``         | |release| Display the list of command line options.                         |
+| ``-h``, ``--help``         | |release| Display the list of command-line options.                         |
 +----------------------------+-----------------------------------------------------------------------------+
 | ``--version``              | |release| Display the version string.                                       |
 +----------------------------+-----------------------------------------------------------------------------+
@@ -371,7 +371,7 @@ Debugging
 ---------
 
 Catching errors in the command line can be a difficult task because they
-scroll quickly. For this, a command line debugger is provided by adding
+scroll quickly. For this, a command-line debugger is provided by adding
 ``-d``. It works for running either the game or a single scene.
 
 ::
@@ -392,7 +392,7 @@ especially useful for continuous integration setups.
 
 .. note::
 
-    Using the ``--headless`` command line argument is **required** on platforms
+    Using the ``--headless`` command-line argument is **required** on platforms
     that do not have GPU access (such as continuous integration). On platforms
     with GPU access, ``--headless`` prevents a window from spawning while the
     project is exporting.

--- a/tutorials/editor/managing_editor_features.rst
+++ b/tutorials/editor/managing_editor_features.rst
@@ -11,7 +11,7 @@ Introduction
 In certain situations, it may be desirable to limit what features can be used
 in the Godot editor. For example, a UI designer on a team who doesn't need to
 see 3D features, or an educator slowly introducing features to students. Godot
-has a built in system called "feature profiles" to do this.
+has a built-in system called "feature profiles" to do this.
 
 With feature profiles, major features and nodes can be hidden from the editor.
 This only hides parts of the interface and does not actually remove support for

--- a/tutorials/editor/project_manager.rst
+++ b/tutorials/editor/project_manager.rst
@@ -94,7 +94,7 @@ When the folder path is correct, you'll see a green checkmark.
 Downloading demos and templates
 -------------------------------
 
-From the **Asset Library** tab you can download open source project
+From the **Asset Library** tab you can download open-source project
 templates and demos from the :ref:`Asset Library <toc-learn-features-assetlib>` to help
 you get started faster.
 

--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -43,10 +43,10 @@ Download and install the Android SDK.
     - CMake version 3.10.2.4988404
     - NDK version r23c (23.2.8568313)
 
-- Alternatively, you can install the Android SDK with the `sdkmanager` command line tool.
+- Alternatively, you can install the Android SDK with the `sdkmanager` command-line tool.
 
-  - Install the command line tools package using these `instructions <https://developer.android.com/tools/sdkmanager>`__.
-  - Once the command line tools are installed, run the following `sdkmanager` command to complete the setup process:
+  - Install the command-line tools package using these `instructions <https://developer.android.com/tools/sdkmanager>`__.
+  - Once the command-line tools are installed, run the following `sdkmanager` command to complete the setup process:
 
 ::
 

--- a/tutorials/export/exporting_for_dedicated_servers.rst
+++ b/tutorials/export/exporting_for_dedicated_servers.rst
@@ -8,7 +8,7 @@ have a GPU or display server available, you'll need to run Godot with the ``head
 display server and ``Dummy`` :ref:`audio driver <class_ProjectSettings_property_audio/driver/driver>`.
 
 Since Godot 4.0, this can be done by running a Godot binary on any platform with
-the ``--headless`` command line argument, or running a project exported as
+the ``--headless`` command-line argument, or running a project exported as
 dedicated server. You do not need to use a specialized server binary anymore,
 unlike Godot 3.x.
 
@@ -238,7 +238,7 @@ main scene (or an autoload)'s ``_ready()`` method:
         // command-line argument.
     }
 
-If you wish to use a custom command line argument, this can be done by adding
+If you wish to use a custom command-line argument, this can be done by adding
 the following code snippet in your main scene (or an autoload)'s ``_ready()``
 method:
 

--- a/tutorials/export/exporting_for_ios.rst
+++ b/tutorials/export/exporting_for_ios.rst
@@ -136,13 +136,13 @@ xcode-select points at wrong SDK location
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 xcode-select is a tool that comes with Xcode and among other things points at iOS SDKs on your Mac.
-If you have Xcode installed, opened it, agreed to the license agreement, and installed the command line tools, 
+If you have Xcode installed, opened it, agreed to the license agreement, and installed the command-line tools, 
 xcode-select should point at the right location for the iPhone SDK. 
 If it somehow doesn't, Godot will fail exporting to iOS with an error that may look like this:
 
 ::
 
-    MSB3073: The command ""clang" <LOTS OF PATHS AND COMMAND LINE ARGUMENTS HERE>
+    MSB3073: The command ""clang" <LOTS OF PATHS AND COMMAND-LINE ARGUMENTS HERE>
     "/Library/Developer/CommandLineTools/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk"" exited with code 1.
 
 In this case, Godot is trying to find the ``Platforms`` folder containing the iPhone SDK inside the 

--- a/tutorials/export/exporting_for_macos.rst
+++ b/tutorials/export/exporting_for_macos.rst
@@ -33,7 +33,7 @@ To notarize an app, you **must** have a valid `Apple Developer ID Certificate <h
 If you have an Apple Developer ID Certificate and exporting from macOS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Install `Xcode <https://developer.apple.com/xcode/>`__ command line tools and open Xcode at least once or run the ``sudo xcodebuild -license accept`` command to accept license agreement.
+Install `Xcode <https://developer.apple.com/xcode/>`__ command-line tools and open Xcode at least once or run the ``sudo xcodebuild -license accept`` command to accept license agreement.
 
 To sign exported app
 ^^^^^^^^^^^^^^^^^^^^
@@ -99,7 +99,7 @@ Signing Options
 +------------------------------+---------------------------------------------------------------------------------------------------+
 | Certificate Password         | Password for the certificate file. [2]_                                                           |
 +------------------------------+---------------------------------------------------------------------------------------------------+
-| Custom Options               | Array of command line arguments passed to the code signing tool.                                  |
+| Custom Options               | Array of command-line arguments passed to the code signing tool.                                  |
 +------------------------------+---------------------------------------------------------------------------------------------------+
 
 .. [1] This option is visible only when signing with Xcode codesign.

--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -150,7 +150,7 @@ player to click, tap or press a key/button to enable audio, for instance when di
 Networking
 ~~~~~~~~~~
 
-Low level networking is not implemented due to lacking support in browsers.
+Low-level networking is not implemented due to lacking support in browsers.
 
 Currently, only :ref:`HTTP client <doc_http_client_class>`,
 :ref:`HTTP requests <doc_http_request_class>`,

--- a/tutorials/export/exporting_pcks.rst
+++ b/tutorials/export/exporting_pcks.rst
@@ -75,7 +75,7 @@ process will build that type of file for the chosen platform.
        interfaces, expect modders to install Godot Engine, and then also expect
        those modders to conform to the documentation's defined API when building
        mod content for the game (so that it will work). Users would then use
-       Godot's built in exporting tools to create a PCK file, as detailed
+       Godot's built-in exporting tools to create a PCK file, as detailed
        above.
     2. The developer uses Godot to build a GUI tool for adding their exact API
        content to a project. This Godot tool must either run on a tools-enabled

--- a/tutorials/export/exporting_projects.rst
+++ b/tutorials/export/exporting_projects.rst
@@ -141,7 +141,7 @@ select every scene or resource you want to export.
     ``.git`` from being included in the exported PCK file.
 
 Below the list of resources are two filters that can be setup. The first allows
-non resource files such as ``.txt``, ``.json`` and ``.csv`` to be exported with
+non-resource files such as ``.txt``, ``.json`` and ``.csv`` to be exported with
 the project. The second filter can be used to exclude every file of a certain
 type without manually deselecting every one. For example, ``.png`` files.
 
@@ -167,7 +167,7 @@ Exporting from the command line
 -------------------------------
 
 In production, it is useful to automate builds, and Godot supports this
-with the ``--export-release`` and ``--export-debug`` command line parameters.
+with the ``--export-release`` and ``--export-debug`` command-line parameters.
 Exporting from the command line still requires an export preset to define
 the export parameters. A basic invocation of the command would be:
 

--- a/tutorials/export/running_on_macos.rst
+++ b/tutorials/export/running_on_macos.rst
@@ -122,7 +122,7 @@ When you run the app for the first time, the following dialog is displayed:
 
 To run this app, you can ad-hoc sign it yourself:
 
-* Install ``Xcode`` for the App Store, start it and confirm command line tools installation.
+* Install ``Xcode`` for the App Store, start it and confirm command-line tools installation.
 
 * Open ``Terminal.app`` (press :kbd:`Cmd + Space` and enter ``Terminal``).
 

--- a/tutorials/i18n/localization_using_gettext.rst
+++ b/tutorials/i18n/localization_using_gettext.rst
@@ -37,7 +37,7 @@ Disadvantages
 Installing gettext tools
 ------------------------
 
-The command line gettext tools are required to perform maintenance operations,
+The command-line gettext tools are required to perform maintenance operations,
 such as updating message files. Therefore, it's strongly recommended to
 install them.
 

--- a/tutorials/math/vectors_advanced.rst
+++ b/tutorials/math/vectors_advanced.rst
@@ -363,7 +363,7 @@ Code should be something like this:
         }
 
 As you can see, planes are quite useful, and this is the tip of the
-iceberg. You might be wondering what happens with non convex polygons.
+iceberg. You might be wondering what happens with non-convex polygons.
 This is usually just handled by splitting the concave polygon into
 smaller convex polygons, or using a technique such as BSP (which is not
 used much nowadays).

--- a/tutorials/migrating/upgrading_to_godot_4.rst
+++ b/tutorials/migrating/upgrading_to_godot_4.rst
@@ -381,7 +381,7 @@ table to find its new name.
     :kbd:`Ctrl + Shift + R` while the script editor is open. However, be careful
     as the Replace in Files dialog doesn't offer any way to undo a replacement.
     Use version control to commit your upgrade work regularly.
-    Command line tools such as `sd <https://github.com/chmln/sd>`__ can also be used
+    Command-line tools such as `sd <https://github.com/chmln/sd>`__ can also be used
     if you need something more flexible than the editor's Replace in Files dialog.
 
     If using C#, remember to search for outdated API usage with PascalCase
@@ -521,7 +521,7 @@ Some notable renames you will need to perform in shaders are:
   than the texture files themselves.
 - ``hint_albedo`` is now ``source_color``.
 - ``hint_color`` is now ``source_color``.
-- :ref:`Built in matrix variables were renamed. <doc_spatial_shader>`
+- :ref:`Built-in matrix variables were renamed. <doc_spatial_shader>`
 - Particles shaders no longer use the ``vertex()`` processor function. Instead
   they use ``start()`` and ``process()``.
 

--- a/tutorials/networking/high_level_multiplayer.rst
+++ b/tutorials/networking/high_level_multiplayer.rst
@@ -97,7 +97,7 @@ for full IPv6 support.
 Initializing the network
 ------------------------
 
-High level networking in Godot is managed by the :ref:`SceneTree <class_SceneTree>`.
+High-level networking in Godot is managed by the :ref:`SceneTree <class_SceneTree>`.
 
 Each node has a ``multiplayer`` property, which is a reference to the ``MultiplayerAPI`` instance configured for it
 by the scene tree. Initially, every node is configured with the same default ``MultiplayerAPI`` object.

--- a/tutorials/networking/websocket.rst
+++ b/tutorials/networking/websocket.rst
@@ -161,4 +161,4 @@ This will print (when a client connects) something similar to this:
 Advanced chat demo
 ^^^^^^^^^^^^^^^^^^
 
-A more advanced chat demo which optionally uses the multiplayer mid-level abstraction and a high level multiplayer demo are available in the `godot demo projects <https://github.com/godotengine/godot-demo-projects>`_ under `networking/websocket_chat` and `networking/websocket_multiplayer`.
+A more advanced chat demo which optionally uses the multiplayer mid-level abstraction and a high-level multiplayer demo are available in the `godot demo projects <https://github.com/godotengine/godot-demo-projects>`_ under `networking/websocket_chat` and `networking/websocket_multiplayer`.

--- a/tutorials/performance/using_servers.rst
+++ b/tutorials/performance/using_servers.rst
@@ -5,7 +5,7 @@
 Optimization using Servers
 ==========================
 
-Engines like Godot provide increased ease of use thanks to their high level constructs and features.
+Engines like Godot provide increased ease of use thanks to their high-level constructs and features.
 Most of them are accessed and used via the :ref:`Scene System<doc_scene_tree>`. Using nodes and
 resources simplifies project organization and asset management in complex games.
 
@@ -21,7 +21,7 @@ with signals, so no polling is required). Still, sometimes it can be. For exampl
 tens of thousands of instances for something that needs to be processed every frame can be a bottleneck.
 
 This type of situation makes programmers regret they are using a game engine and wish they could go
-back to a more handcrafted, low level implementation of game code.
+back to a more handcrafted, low-level implementation of game code.
 
 Still, Godot is designed to work around this problem.
 

--- a/tutorials/performance/vertex_animation/animating_thousands_of_fish.rst
+++ b/tutorials/performance/vertex_animation/animating_thousands_of_fish.rst
@@ -11,7 +11,7 @@ static mesh instancing.
 
 In Godot, this can be accomplished with a custom :ref:`Shader <class_Shader>` and
 a :ref:`MultiMeshInstance3D <class_MultiMeshInstance3D>`. Using the following technique you
-can render thousands of animated objects, even on low end hardware.
+can render thousands of animated objects, even on low-end hardware.
 
 We will start by animating one fish. Then, we will see how to extend that animation to
 thousands of fish.

--- a/tutorials/physics/ray-casting.rst
+++ b/tutorials/physics/ray-casting.rst
@@ -11,7 +11,7 @@ custom shaped object) and checking what it hits. This enables complex
 behaviors, AI, etc. to take place. This tutorial will explain how to
 do this in 2D and 3D.
 
-Godot stores all the low level game information in servers, while the
+Godot stores all the low-level game information in servers, while the
 scene is only a frontend. As such, ray casting is generally a
 lower-level task. For simple raycasts, nodes like
 :ref:`RayCast3D <class_RayCast3D>` and :ref:`RayCast2D <class_RayCast2D>`
@@ -24,7 +24,7 @@ so a way to do this by code must exist.
 Space
 -----
 
-In the physics world, Godot stores all the low level collision and
+In the physics world, Godot stores all the low-level collision and
 physics information in a *space*. The current 2d space (for 2D Physics)
 can be obtained by accessing
 :ref:`CanvasItem.get_world_2d().space <class_CanvasItem_method_get_world_2d>`.

--- a/tutorials/platform/consoles.rst
+++ b/tutorials/platform/consoles.rst
@@ -8,7 +8,7 @@ Console porting process
 
 In order to develop for consoles in Godot, you need access to the console SDK and
 export templates for it. These export templates need to be developed either by
-yourself or someone hired to do it, or provided by a third party company.
+yourself or someone hired to do it, or provided by a third-party company.
 
 Currently, the only console Godot officially supports is Steam Deck (through the
 official Linux export templates).
@@ -16,10 +16,10 @@ official Linux export templates).
 The reason other consoles are not officially supported are:
 
 - To develop for consoles, one must be licensed as a company.
-  As an open source project, Godot has no legal structure to provide console ports.
+  As an open-source project, Godot has no legal structure to provide console ports.
 - Console SDKs are secret and covered by non-disclosure agreements.
   Even if we could get access to them, we could not publish the platform-specific
-  code under an open source license.
+  code under an open-source license.
 
 As explained, however, it is possible to port your games to consoles thanks to
 services provided by third-party companies.

--- a/tutorials/platform/ios/plugins_for_ios.rst
+++ b/tutorials/platform/ios/plugins_for_ios.rst
@@ -490,7 +490,7 @@ On success:
 ``show_game_center``
 ~~~~~~~~~~~~~~~~~~~~
 
-Displays the built in Game Center overlay showing leaderboards,
+Displays the built-in Game Center overlay showing leaderboards,
 achievements, and challenges.
 
 Parameters

--- a/tutorials/platform/web/customizing_html5_shell.rst
+++ b/tutorials/platform/web/customizing_html5_shell.rst
@@ -18,7 +18,7 @@ Some use-cases where customizing the default page is useful include:
 - Adding a click-to-play button so that games can be started in the fullscreen mode;
 - Loading some extra files before the engine starts, making them available in
   the project file system as soon as possible;
-- Passing custom command line arguments, e.g. ``-s`` to start a ``MainLoop`` script.
+- Passing custom command-line arguments, e.g. ``-s`` to start a ``MainLoop`` script.
 
 The default HTML page is available in the Godot Engine repository at
 `/misc/dist/html/full-size.html <https://github.com/godotengine/godot/blob/master/misc/dist/html/full-size.html>`__

--- a/tutorials/platform/web/html5_shell_classref.rst
+++ b/tutorials/platform/web/html5_shell_classref.rst
@@ -283,9 +283,9 @@ Properties
 
    .. js:attribute:: args
 
-      The arguments to be passed as command line arguments on startup.
+      The arguments to be passed as command-line arguments on startup.
 
-      See :ref:`command line tutorial <doc_command_line_tutorial>`.
+      See :ref:`command-line tutorial <doc_command_line_tutorial>`.
 
       **Note**: :js:meth:`startGame <Engine.prototype.startGame>` will always add the ``--main-pack`` argument.
 

--- a/tutorials/rendering/jitter_stutter.rst
+++ b/tutorials/rendering/jitter_stutter.rst
@@ -201,7 +201,7 @@ done with caution.
 .. tip::
 
     On any Godot project, you can use the ``--disable-vsync``
-    :ref:`command line argument <doc_command_line_tutorial>` to forcibly disable V-Sync.
+    :ref:`command-line argument <doc_command_line_tutorial>` to forcibly disable V-Sync.
     Since Godot 4.2, ``--max-fps <fps>`` can also be used to set a FPS limit
     (``0`` is unlimited). These arguments can be used at the same time.
 

--- a/tutorials/scripting/debug/overview_of_debugging_tools.rst
+++ b/tutorials/scripting/debug/overview_of_debugging_tools.rst
@@ -109,7 +109,7 @@ Customize Run Instances...
 ++++++++++++++++++++++++++
 
 This opens a dialog allowing you to tell Godot to run multiple instances of the
-game at once, and to specify the command line arguments for each instance. This
+game at once, and to specify the command-line arguments for each instance. This
 is especially useful when building and debugging multiplayer games.
 
 .. image:: img/customize_run_instances.webp
@@ -187,7 +187,7 @@ Tags" unless you select "Enabled" under "Override Main Tags".
     when combining the `Main Run Args` and `Launch Arguments`.
 
     If you place `-- one two three` in the "Main Run Args" and `-- four five
-    six` in the "Launch Arguments" then the final command line arguments will be
+    six` in the "Launch Arguments" then the final command-line arguments will be
     `one two three -- four five six`. This is because the `--` is repeated in
     the "Launch Arguments".
 

--- a/tutorials/scripting/scene_tree.rst
+++ b/tutorials/scripting/scene_tree.rst
@@ -32,11 +32,11 @@ level and when making games in Godot, writing your own MainLoop seldom makes sen
 SceneTree
 ---------
 
-One of the ways to explain how Godot works is that it's a high level
-game engine over a low level middleware.
+One of the ways to explain how Godot works is that it's a high-level
+game engine over a low-level middleware.
 
 The scene system is the game engine, while the :ref:`OS <class_OS>`
-and servers are the low level API.
+and servers are the low-level API.
 
 The scene system provides its own main loop to OS,
 :ref:`SceneTree <class_SceneTree>`.

--- a/tutorials/shaders/compute_shaders.rst
+++ b/tutorials/shaders/compute_shaders.rst
@@ -143,7 +143,7 @@ careful not to read from an index larger than the size of the buffer.
 
 Finally, we write the ``main`` function which is where all the logic happens. We
 access a position in the storage buffer using the ``gl_GlobalInvocationID``
-built in variables. ``gl_GlobalInvocationID`` gives you the global unique ID for
+built-in variables. ``gl_GlobalInvocationID`` gives you the global unique ID for
 the current invocation.
 
 To continue, write the code above into your newly created ``compute_example.glsl``

--- a/tutorials/shaders/custom_postprocessing.rst
+++ b/tutorials/shaders/custom_postprocessing.rst
@@ -50,7 +50,7 @@ For this demo, we will use this :ref:`Sprite <class_Sprite2D>` of a sheep.
 
 Assign a new :ref:`Shader <class_Shader>` to the ``ColorRect``'s
 ``ShaderMaterial``. You can access the frame's texture and UV with a
-``sampler2D`` using ``hint_screen_texture`` and the built in ``SCREEN_UV``
+``sampler2D`` using ``hint_screen_texture`` and the built-in ``SCREEN_UV``
 uniforms.
 
 Copy the following code to your shader. The code below is a hex pixelization

--- a/tutorials/shaders/shader_materials.rst
+++ b/tutorials/shaders/shader_materials.rst
@@ -23,7 +23,7 @@ Examples of this are:
 -  Create custom particle code.
 -  And much more!
 
-Godot provides built in functionality to make frequent operations
+Godot provides built-in functionality to make frequent operations
 easier. Additionally, Godot's shader editor will detect errors as you
 type, so you can see your edited shaders in real-time. It is also
 possible to edit shaders using a visual, node-based graph editor.

--- a/tutorials/shaders/shader_reference/canvas_item_shader.rst
+++ b/tutorials/shaders/shader_reference/canvas_item_shader.rst
@@ -222,7 +222,7 @@ run. Use render_mode ``light_only`` if you only want to see the impact of
 lighting on an object; this can be useful when you only want the object visible
 where it is covered by light.
 
-If you define a light function it will replace the built in light function,
+If you define a light function it will replace the built-in light function,
 even if your light function is empty.
 
 Below is an example of a light shader that takes a CanvasItem's normal map into account:

--- a/tutorials/xr/ar_passthrough.rst
+++ b/tutorials/xr/ar_passthrough.rst
@@ -19,7 +19,7 @@ result is used.
 
     In Godot 4.3 we have implemented a unified approach that is explained on this help page
     so you don't need to worry about these differences, the :ref:`XRInterface <class_xrinterface>`
-    implementation is now responsible for applying the correct platform dependent method [#]_.
+    implementation is now responsible for applying the correct platform-dependent method [#]_.
 
     For headsets such as the Meta Quest and HTC Elite you will need to use the
     `OpenXR vendors plugin v3.0.0 <https://github.com/GodotVR/godot_openxr_vendors/releases>`__

--- a/tutorials/xr/openxr_settings.rst
+++ b/tutorials/xr/openxr_settings.rst
@@ -18,7 +18,7 @@ For other backends you can enable OpenXR at any time by calling ``initialize`` o
 
 This also needs to be enabled to get access to the action map editor.
 
-You can use the ``--xr-mode on`` command line switch to force this to on.
+You can use the ``--xr-mode on`` command-line switch to force this to on.
 
 Default Action Map
 ------------------


### PR DESCRIPTION
Hi. I have done some searching and replacing within the docs, adding hyphens where grammatically correct, that is, when something is used as an adjective ("open-source license") versus a noun ("Godot is open source"). Hope this is welcome!