### PR TITLE
Fix ambiguity in angle_difference function

### DIFF
--- a/classes/class_@globalscope.rst
+++ b/classes/class_@globalscope.rst
@@ -5320,7 +5320,7 @@ Returns the hyperbolic arc (also called inverse) cosine of ``x``, returning a va
 
 :ref:`float<class_float>` **angle_difference**\ (\ from\: :ref:`float<class_float>`, to\: :ref:`float<class_float>`\ ) :ref:`🔗<class_@GlobalScope_method_angle_difference>`
 
-Returns the difference between the two angles, in the range of ``[-PI, +PI]``. When ``from`` and ``to`` are opposite, returns ``-PI`` if ``from`` is smaller than ``to``, or ``PI`` otherwise.
+Returns the difference between the two radians, in the range of ``[-PI, +PI]``. When ``from`` and ``to`` are opposite, returns ``-PI`` if ``from`` is smaller than ``to``, or ``PI`` otherwise.
 
 .. rst-class:: classref-item-separator
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

The current wording does not make it clear that the unit received by the function is in radians (or -PI to PI).
To make it more clear to the end user that the function should get a signed radian instead of angles, this has been explicitly added.