### PR TITLE
Add mention of Auto Reload Scripts on External Change option to the e…

### DIFF
--- a/tutorials/editor/external_editor.rst
+++ b/tutorials/editor/external_editor.rst
@@ -65,6 +65,10 @@ Some example **Exec Flags** for various editors include:
     For Emacs, you can call ``emacsclient`` instead of ``emacs`` if
     you use the server mode.
 
+Automatically reloading your changes
+------------------------------------
+To have Godot Editor automatically reload any changes to the scripts you make in an external text editor, enable **Editor > Editor Settings > Text Editor > Behavior > Auto Reload Scripts on External Change**
+
 Using External Editor in Debugger
 ---------------------------------
 

--- a/tutorials/editor/external_editor.rst
+++ b/tutorials/editor/external_editor.rst
@@ -67,7 +67,8 @@ Some example **Exec Flags** for various editors include:
 
 Automatically reloading your changes
 ------------------------------------
-To have Godot Editor automatically reload any changes to the scripts you make in an external text editor, enable **Editor > Editor Settings > Text Editor > Behavior > Auto Reload Scripts on External Change**
+To have the Godot Editor automatically reload any script that has been changed by an external text editor,
+enable **Editor > Editor Settings > Text Editor > Behavior > Auto Reload Scripts on External Change**.
 
 Using External Editor in Debugger
 ---------------------------------


### PR DESCRIPTION
**Auto Reload Scripts on External Change** setting is not advertised anywhere, you have to know it's there to enable it. Mentioning it in the tutorial for external editor configuration allows users to turn it on and avoid dealing with unnecessary "The following files are newer on disk" dialog.