### PR TITLE
Correct "ConnectionCheck" return type

### DIFF
--- a/tutorials/best_practices/godot_notifications.rst
+++ b/tutorials/best_practices/godot_notifications.rst
@@ -279,7 +279,7 @@ nodes that one might create at runtime.
     {
         private Node _parentCache;
 
-        public void ConnectionCheck()
+        public bool ConnectionCheck()
         {
             return _parentCache.HasUserSignal("InteractedWith");
         }


### PR DESCRIPTION
It was marked as "void" when it should be "bool".

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
