### PR TITLE
Update "Exporting for the Web" to include 4.3 features

### DIFF
--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -17,13 +17,39 @@ in the user's browser.
 .. attention::
 
     Projects written in C# using Godot 4 currently cannot be exported to the
-    web. To use C# on web platforms, use Godot 3 instead.
+    web. See `this blog post <https://godotengine.org/article/platform-state-in-csharp-for-godot-4-2/#web>`__
+    for more information.
+
+    To use C# on web platforms, use Godot 3 instead.
 
 .. tip::
 
     Use the browser-integrated developer console, usually opened
-    with :kbd:`F12` (:kbd:`Cmd + Option + I` on macOS), to view
+    with :kbd:`F12` or :kbd:`Ctrl + Shift + I` (:kbd:`Cmd + Option + I` on macOS), to view
     **debug information** like JavaScript, engine, and WebGL errors.
+
+    If the shortcut doesn't work, it's because Godot actually captures the input.
+    You can still open the developer console by accessing the browser's menu.
+
+.. note::
+
+    Due to security concerns with ``SharedArrayBuffer`` due to various exploits,
+    the use of multiple threads for the Web platform has multiple drawbacks,
+    including requiring specific server-side headers and complete cross-origin isolation
+    (meaning no ads, nor third-party integrations on the website hosting your game).
+
+    Since Godot 4.3, Godot supports exporting your game on a single thread, which
+    solves this issue. While it has some drawbacks on its own (it cannot use threads, and is
+    not as performant as the multi-threaded export), it doesn't require as much overhead to install.
+    It is also more compatible overall with stores like `itch.io <https://itch.io/>` or Web publishers like
+    `Poki <https://poki.com/>`__ or `CrazyGames <https://crazygames.com/>`__. The single-threaded export
+    works very well on macOS and iOS too, where it always had compatibility issues with multiple threads
+    exports.
+
+    For these reasons, it is the preferred and now default way to export your games on the Web.
+
+    For more information, see `this blog post about single-threaded Web export
+    <https://godotengine.org/article/progress-report-web-export-in-4-3/#single-threaded-web-export>`__.
 
 .. seealso::
 
@@ -232,6 +258,17 @@ player to click, tap or press a key/button to enable audio, for instance when di
 .. warning:: Access to microphone requires a
              :ref:`secure context <doc_javascript_secure_contexts>`.
 
+.. warning::
+
+        Since Godot 4.3, by default Web exports will use samples instead of streams
+        to play audio.
+
+        This is due to the way browsers prefer to play audio and the lack of processing power
+        available when exporting Web games with the **Use Threads** export option off.
+
+        Please note that audio effects aren't yet implemented for samples.
+
+
 Networking
 ~~~~~~~~~~
 
@@ -275,13 +312,6 @@ to remap them based on model/vendor/OS due to privacy considerations.
 
 .. warning:: Requires a :ref:`secure context <doc_javascript_secure_contexts>`.
 
-Boot splash is not displayed
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The default HTML page does not display the boot splash while loading. However,
-the image is exported as a PNG file, so :ref:`custom HTML pages <doc_customizing_html5_shell>`
-can display it.
-
 .. _doc_exporting_for_web_serving_the_files:
 
 Serving the files
@@ -293,8 +323,8 @@ used, see :ref:`doc_customizing_html5_shell`.
 
 .. warning::
 
-    If either :ref:`thread support or extension support <doc_exporting_for_web_thread_extension_support>`
-    are enabled, the exported project will require
+    Only when exporting with **Use Threads**, to ensure low audio latency and the
+    ability to use :ref:`class_Thread` in web exports, Godot 4 web exports use
     `SharedArrayBuffer <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer>`__.
     This requires a :ref:`secure context <doc_javascript_secure_contexts>`,
     while also requiring the following CORS headers to be set when serving the files:
@@ -325,9 +355,7 @@ The other exported files are served as they are, next to the ``.html`` file,
 names unchanged. The ``.wasm`` file is a binary WebAssembly module implementing
 the engine. The ``.pck`` file is the Godot main pack containing your game. The
 ``.js`` file contains start-up code and is used by the ``.html`` file to access
-the engine. The ``.png`` file contains the boot splash image. It is not used in
-the default HTML page, but is included for
-:ref:`custom HTML pages <doc_customizing_html5_shell>`.
+the engine. The ``.png`` file contains the boot splash image.
 
 The ``.pck`` file is binary, usually delivered with the MIME-type
 :mimetype:`application/octet-stream`. The ``.wasm`` file is delivered as


### PR DESCRIPTION
The [Exporting for the Web](https://docs.godotengine.org/en/stable/tutorials/export/exporting_for_web.html) page is horribly outdated, especially with the 4.3 changes. 

Sorry for that, I completely forgot to update it when I created the new features.

Features:
- changes the warning about `SharedArrayBuffer` into a note, as this was pretty much "fixed" with the single-threaded exports.
- removes the warning about macOS and iOS incompatibility.
- removes mentions of the splash screen not displaying (https://github.com/godotengine/godot/pull/91128 was merged for 4.3)
- edit a warning about exporting the game and installation issues (mentions now that applies only for threaded exports)

Bugsquad edit: closes  #9983