### PR TITLE
Removed outdated information about Mono SDK beeing necessary

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -106,11 +106,6 @@ In Visual Studio Code:
 
 - Install the `C# <https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp>`__ extension.
 
-.. note::
-
-    If you are using Linux you need to install the `Mono SDK <https://www.mono-project.com/download/stable/#download-lin>`__
-    for the C# tools plugin to work.
-
 To configure a project for debugging, you need a ``tasks.json`` and ``launch.json`` file in
 the ``.vscode`` folder with the necessary configuration.
 


### PR DESCRIPTION
Mono SDK isn't necessary any more for Godot .NET to work properly on Linux. All functionality that was needed from Mono back then is now provided by .NET proper.

I fear Mono SDK might even cause some conflict with up-to-date .NET.
