### PR TITLE
Add notes on calculating normals for non-uniformly scaled meshes

### DIFF
--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -136,6 +136,8 @@ it manually with the following code:
     void vertex() {
         VERTEX = (MODELVIEW_MATRIX * vec4(VERTEX, 1.0)).xyz;
         NORMAL = normalize((MODELVIEW_MATRIX * vec4(NORMAL, 0.0)).xyz);
+        // If the mesh you apply this shader to involves non-uniform scaling, you may need to calculate the correct normals using the following method:
+        //NORMAL = normalize((transpose(inverse(MODELVIEW_MATRIX)) * vec4(NORMAL, 0.0)).xyz);
         BINORMAL = normalize((MODELVIEW_MATRIX * vec4(BINORMAL, 0.0)).xyz);
         TANGENT = normalize((MODELVIEW_MATRIX * vec4(TANGENT, 0.0)).xyz);
     }


### PR DESCRIPTION
This PR adds notes on manually calculating normals in the  spatial shader for non-uniformly scaled meshes

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
