### PR TITLE
Add 3->4 upgrading information about NDC, light(), and reverse-z

### DIFF
--- a/tutorials/migrating/upgrading_to_godot_4.rst
+++ b/tutorials/migrating/upgrading_to_godot_4.rst
@@ -509,13 +509,14 @@ environment effect and its visual knobs remain within the Environment resource.
 Updating shaders
 ^^^^^^^^^^^^^^^^
 
-There have been some changes to shaders that aren't covered by the upgrade tool.
+There have been some changes to shaders that aren't covered by the upgrade tool. 
+You will need to make some manual changes, especially if your shader is advanced.
 
 The ``.shader`` file extension is no longer supported, which means you must
 rename ``.shader`` files to ``.gdshader`` and update references accordingly in
 scene/resource files using an external text editor.
 
-Some notable renames you will need to perform in shaders are:
+Some notable changes you will need to perform in shaders are:
 
 - Texture filter and repeat modes are now set on individual uniforms, rather
   than the texture files themselves.
@@ -524,6 +525,15 @@ Some notable renames you will need to perform in shaders are:
 - :ref:`Built in matrix variables were renamed. <doc_spatial_shader>`
 - Particles shaders no longer use the ``vertex()`` processor function. Instead
   they use ``start()`` and ``process()``.
+- In Forward+ and Mobile, normalized device coordinates now have a Z-range of [0,1]
+  instead of [-1,1]. When reconstructing NDC from ``SCREEN_UV`` and depth, use 
+  ``vec3 ndc = vec3(SCREEN_UV * 2.0 - 1.0, depth);`` instead of 
+  ``vec3 ndc = vec3(SCREEN_UV, depth) * 2.0 - 1.0;``. Compatibility is unchanged.
+- The lighting model changed. If your shader has a custom ``light()`` function,
+  you may need to make changes to get the same visual result.
+- In 4.3 and up, the reverse Z depth buffer technique is now implemented, which 
+  may break advanced shaders. See 
+  `Introducing Reverse Z (AKA I'm sorry for breaking your shader) <https://godotengine.org/article/introducing-reverse-z/>`__.
 
 See :ref:`doc_shading_language` for more information.
 


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot/issues/96704 by changing the docs.

- Adds information about normalized device coordinates changing from 3.x/Compatibility to Forward+/Mobile.
- Adds a note that shaders with custom lighting will need changes.
- Links to reverse-z changes. As more and more 4.x versions are released, reverse-z will become the default, and most users finding this page will need to apply reverse-z changes if their shader needs it. We should not expect users to visit each minor version conversion page in sequence in order to find this information.

---

Summary of the original issue: a simplified version of the shader in https://github.com/paddy-exe/Godot-RealTimeCaustics was converted automatically from 3 to 4, then all the manual fixes mentioned [here](https://docs.godotengine.org/en/stable/tutorials/migrating/upgrading_to_godot_4.html#updating-shaders) were applied. But the shader still has no visible output.
Two additional changes had to be made so the shader works in 4.3 Forward+:
- Convert the NDC reconstruction from ` vec3 ndc = vec3(SCREEN_UV, depth) * 2.0 - 1.0;` to ` vec3 ndc = vec3(SCREEN_UV* 2.0 - 1.0, depth);`. 
- Change ALBEDO = vec3(0.0); to ALBEDO = vec3(1.0);. The shader is doing additive lighting using the `light()` function, and requires a change to ALBEDO to look similar to 3.x.

These kinds of changes cannot be supported by an automatic conversion tool, and they can't even be exhaustively listed. We can list common cases, and clarify the warning that advanced shaders will need more manual work.
