### PR TITLE
Fix comment syntax in chroma key example shader

### DIFF
--- a/tutorials/animation/playing_videos.rst
+++ b/tutorials/animation/playing_videos.rst
@@ -272,28 +272,28 @@ To implement the chroma key effect, follow these steps:
 
    shader_type canvas_item;
 
-   # Uniform variables for chroma key effect
+   // Uniform variables for chroma key effect
    uniform vec3 chroma_key_color : source_color = vec3(0.0, 1.0, 0.0);
    uniform float pickup_range : hint_range(0.0, 1.0) = 0.1;
    uniform float fade_amount : hint_range(0.0, 1.0) = 0.1;
 
    void fragment() {
-       # Get the color from the texture at the given UV coordinates
+       // Get the color from the texture at the given UV coordinates
        vec4 color = texture(TEXTURE, UV);
 
-       # Calculate the distance between the current color and the chroma key color
+       // Calculate the distance between the current color and the chroma key color
        float distance = length(color.rgb - chroma_key_color);
 
-       # If the distance is within the pickup range, discard the pixel
-       # the lesser the distance more likely the colors are
+       // If the distance is within the pickup range, discard the pixel
+       // the lesser the distance more likely the colors are
        if (distance <= pickup_range) {
            discard;
        }
 
-       # Calculate the fade factor based on the pickup range and fade amount
+       // Calculate the fade factor based on the pickup range and fade amount
        float fade_factor = smoothstep(pickup_range, pickup_range + fade_amount, distance);
 
-       # Set the output color with the original RGB values and the calculated fade factor
+       // Set the output color with the original RGB values and the calculated fade factor
        COLOR = vec4(color.rgb, fade_factor);
    }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-docs/issues/9934.

Simple comment syntax replacement. Verified that the shader compiles in 4.3. Did not verify the correctness of the code or the comments.