### PR TITLE
Add `WARNING:` to list of admonitions

### DIFF
--- a/contributing/development/code_style_guidelines.rst
+++ b/contributing/development/code_style_guidelines.rst
@@ -344,7 +344,7 @@ Godot's codebase.
   always end them with a period.
 - Reference variable/function names and values using backticks.
 - Wrap comments to ~100 characters.
-- You can use ``TODO:``, ``FIXME:``, ``NOTE:``, or ``HACK:`` as admonitions
+- You can use ``TODO:``, ``FIXME:``, ``NOTE:``, ``WARNING:``, or ``HACK:`` as admonitions
   when needed.
 
 **Example:**


### PR DESCRIPTION
- Related godotengine/godot#96923

Inspired by [this thread](https://github.com/godotengine/godot/pull/96797#discussion_r1756979768) discussing a potential unification of "warning" syntax in comments. This PR aims to address that idea by integrating `WARNING:` as a new codestyle admonition.