### PR TITLE
Add a gdextension online documentation guide.

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_docs_system.rst
+++ b/tutorials/scripting/gdextension/gdextension_docs_system.rst
@@ -170,3 +170,22 @@ Currently they supported tags for the GDExtension documentation system are:
         ``#ff00ff``, see :ref:`doc_bbcode_in_richtextlabel_hex_colors`).
 
     - ``[color={code/name}]{text}[/color]``
+
+Publishing documentation online
+---------------------
+
+You may want to publish an online reference for your gdextension, akin to this website. The most important step is to built ``.rst`` files from your ``.xml`` ones:
+
+.. code-block:: none
+
+    # You'll need to have python installed for this command to work.
+    curl -sSL https://raw.githubusercontent.com/godotengine/godot/master/doc/tools/make_rst.py | python3 - -o "docs/classes" -l "en" doc_classes
+
+Your ``.rst`` files will now be available in ``docs/classes/``. From here, you can use any documentation builder to create a website from them. `godot-docs <https://hosted.weblate.org/projects/godot-engine/godot-docs>`_ uses `Sphinx <https://www.sphinx-doc.org/en/master/>`_. You can use the repository as a basis to build your own documentation system. This is where you'll have to get a bit creative, but here's a rough outline of the steps involved:
+
+#. Add `godot-docs <https://hosted.weblate.org/projects/godot-engine/godot-docs>`_ as a submodule to your ``docs/`` folder.
+#. Copy over its ``conf.py``, ``index.rst``, ``.readthedocs.yaml`` files into ``/docs/``. You may later decide to copy over more of godot-docs' files into your own project, like ``_templates/layout.html``. 
+#. Modify these files according to your project. This mostly involves adjusting paths to point to the ``godot-docs`` subfolder, as well as strings to reflect it's your project rather than godot you're building the docs for.
+#. Create an account on `readthedocs.org <http://readthedocs.org>`_. Import your project, and modify its base ``.readthedocs.yaml`` file path to ``/docs/.readthedocs.yaml``.
+
+Once you have completed all these steps, your documentation should be available at <repo-name>.readthedocs.io.


### PR DESCRIPTION
First step to address https://github.com/godotengine/godot-proposals/issues/10733.

The guide explains, in very short, how to create online documentation (much like the [godot docs](https://docs.godotengine.org/en/stable/index.html) themselves) for a gdextension.

You can see a working example here: https://numdot.readthedocs.io/ ([source](https://github.com/Ivorforce/NumDot/tree/main/docs)).

A link to my example might be helpful to recreate what I did - but I elected not to link it because I felt it may be weird to link to a third party project. Let me know what you think.