### PR TITLE
Add a gdextension online documentation guide.

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_docs_system.rst
+++ b/tutorials/scripting/gdextension/gdextension_docs_system.rst
@@ -172,3 +172,23 @@ Currently they supported tags for the GDExtension documentation system are:
         ``#ff00ff``, see :ref:`doc_bbcode_in_richtextlabel_hex_colors`).
 
     - ``[color={code/name}]{text}[/color]``
+
+
+Publishing documentation online
+-------------------------------
+
+You may want to publish an online reference for your gdextension, akin to this website. The most important step is to build ``.rst`` files from your ``.xml`` ones:
+
+.. code-block:: none
+
+    # You'll need to have python installed for this command to work.
+    curl -sSL https://raw.githubusercontent.com/godotengine/godot/master/doc/tools/make_rst.py | python3 - -o "docs/classes" -l "en" doc_classes
+
+Your ``.rst`` files will now be available in ``docs/classes/``. From here, you can use any documentation builder to create a website from them. `godot-docs <https://hosted.weblate.org/projects/godot-engine/godot-docs>`_ uses `Sphinx <https://www.sphinx-doc.org/en/master/>`_. You can use the repository as a basis to build your own documentation system. This is where you'll have to get a bit creative, but here's a rough outline of the steps involved:
+
+1. Add `godot-docs <https://hosted.weblate.org/projects/godot-engine/godot-docs>`_ as a submodule to your ``docs/`` folder.
+2. Copy over its ``conf.py``, ``index.rst``, ``.readthedocs.yaml`` files into ``/docs/``. You may later decide to copy over more of godot-docs' files into your own project, like ``_templates/layout.html``.
+3. Modify these files according to your project. This mostly involves adjusting paths to point to the ``godot-docs`` subfolder, as well as strings to reflect it's your project rather than godot you're building the docs for.
+4. Create an account on `readthedocs.org <http://readthedocs.org>`_. Import your project, and modify its base ``.readthedocs.yaml`` file path to ``/docs/.readthedocs.yaml``.
+
+Once you have completed all these steps, your documentation should be available at <repo-name>.readthedocs.io.

--- a/tutorials/scripting/gdextension/gdextension_docs_system.rst
+++ b/tutorials/scripting/gdextension/gdextension_docs_system.rst
@@ -192,9 +192,9 @@ The most important step is to build reStructuredText (``.rst``) files from your 
 Your ``.rst`` files will now be available in ``docs/classes/``. From here, you can use
 any documentation builder that supports reStructuredText syntax to create a website from them.
 
-`godot-docs <https://hosted.weblate.org/projects/godot-engine/godot-docs>`_ uses `Sphinx <https://www.sphinx-doc.org/en/master/>`_. You can use the repository as a basis to build your own documentation system. The following guide describes the basic steps, but they are not exhaustive: You will need a bit of personal insight to make it work.
+`godot-docs <https://github.com/godotengine/godot-docs>`_ uses `Sphinx <https://www.sphinx-doc.org/en/master/>`_. You can use the repository as a basis to build your own documentation system. The following guide describes the basic steps, but they are not exhaustive: You will need a bit of personal insight to make it work.
 
-1. Add `godot-docs <https://hosted.weblate.org/projects/godot-engine/godot-docs>`_ as a submodule to your ``docs/`` folder.
+1. Add `godot-docs <https://github.com/godotengine/godot-docs>`_ as a submodule to your ``docs/`` folder.
 2. Copy over its ``conf.py``, ``index.rst``, ``.readthedocs.yaml`` files into ``/docs/``. You may later decide to copy over and edit more of godot-docs' files, like ``_templates/layout.html``.
 3. Modify these files according to your project. This mostly involves adjusting paths to point to the ``godot-docs`` subfolder, as well as strings to reflect it's your project rather than Godot you're building the docs for.
 4. Create an account on `readthedocs.org <http://readthedocs.org>`_. Import your project, and modify its base ``.readthedocs.yaml`` file path to ``/docs/.readthedocs.yaml``.

--- a/tutorials/scripting/gdextension/gdextension_docs_system.rst
+++ b/tutorials/scripting/gdextension/gdextension_docs_system.rst
@@ -177,18 +177,23 @@ Currently they supported tags for the GDExtension documentation system are:
 Publishing documentation online
 -------------------------------
 
-You may want to publish an online reference for your gdextension, akin to this website. The most important step is to build ``.rst`` files from your ``.xml`` ones:
+You may want to publish an online reference for your GDExtension, akin to this website. The most important step is to build reStructuredText (``.rst``) files from your XML class reference:
 
 .. code-block:: none
 
-    # You'll need to have python installed for this command to work.
+    # You'll need to have Python installed for this command to work.
     curl -sSL https://raw.githubusercontent.com/godotengine/godot/master/doc/tools/make_rst.py | python3 - -o "docs/classes" -l "en" doc_classes
 
-Your ``.rst`` files will now be available in ``docs/classes/``. From here, you can use any documentation builder to create a website from them. `godot-docs <https://hosted.weblate.org/projects/godot-engine/godot-docs>`_ uses `Sphinx <https://www.sphinx-doc.org/en/master/>`_. You can use the repository as a basis to build your own documentation system. This is where you'll have to get a bit creative, but here's a rough outline of the steps involved:
+Your ``.rst`` files will now be available in ``docs/classes/``. From here, you can use
+any documentation builder that supports reStructuredText syntax to create a website from them.
+`godot-docs <https://hosted.weblate.org/projects/godot-engine/godot-docs>`_ uses `Sphinx <https://www.sphinx-doc.org/en/master/>`_.
+You can use the repository as a basis to build your own documentation system.
+This is where you'll have to get a bit creative, but here's a rough outline
+of the steps involved:
 
 1. Add `godot-docs <https://hosted.weblate.org/projects/godot-engine/godot-docs>`_ as a submodule to your ``docs/`` folder.
 2. Copy over its ``conf.py``, ``index.rst``, ``.readthedocs.yaml`` files into ``/docs/``. You may later decide to copy over more of godot-docs' files into your own project, like ``_templates/layout.html``.
-3. Modify these files according to your project. This mostly involves adjusting paths to point to the ``godot-docs`` subfolder, as well as strings to reflect it's your project rather than godot you're building the docs for.
+3. Modify these files according to your project. This mostly involves adjusting paths to point to the ``godot-docs`` subfolder, as well as strings to reflect it's your project rather than Godot you're building the docs for.
 4. Create an account on `readthedocs.org <http://readthedocs.org>`_. Import your project, and modify its base ``.readthedocs.yaml`` file path to ``/docs/.readthedocs.yaml``.
 
-Once you have completed all these steps, your documentation should be available at <repo-name>.readthedocs.io.
+Once you have completed all these steps, your documentation should be available at ``<repo-name>.readthedocs.io``.

--- a/tutorials/scripting/gdextension/gdextension_docs_system.rst
+++ b/tutorials/scripting/gdextension/gdextension_docs_system.rst
@@ -178,8 +178,7 @@ Publishing documentation online
 -------------------------------
 
 You may want to publish an online reference for your GDExtension, akin to this website.
-The most important step is to build reStructuredText (``.rst``) files from your XML
-class reference:
+The most important step is to build reStructuredText (``.rst``) files from your XML class reference:
 
 .. code-block:: none
 

--- a/tutorials/scripting/gdextension/gdextension_docs_system.rst
+++ b/tutorials/scripting/gdextension/gdextension_docs_system.rst
@@ -180,24 +180,22 @@ Publishing documentation online
 You may want to publish an online reference for your GDExtension, similar to this website.
 The most important step is to build reStructuredText (``.rst``) files from your XML class reference:
 
-.. code-block:: none
+.. code-block:: bash
 
-    # The following script needs a dummy version.py.
+    # The upcoming script needs a dummy version.py, so download it first:
     curl -sSLO https://raw.githubusercontent.com/godotengine/godot/refs/heads/master/version.py
 
-    # Edit version.py with new valzes before proceeding.
-    # You'll need to have Python installed for this command to work.
+    # Edit version.py according to your project before proceeding.
+    # Then, run the rst generator. You'll need to have Python installed for this command to work.
     curl -sSL https://raw.githubusercontent.com/godotengine/godot/master/doc/tools/make_rst.py | python3 - -o "docs/classes" -l "en" doc_classes
 
 Your ``.rst`` files will now be available in ``docs/classes/``. From here, you can use
 any documentation builder that supports reStructuredText syntax to create a website from them.
-`godot-docs <https://hosted.weblate.org/projects/godot-engine/godot-docs>`_ uses `Sphinx <https://www.sphinx-doc.org/en/master/>`_.
-You can use the repository as a basis to build your own documentation system.
-This is where you'll have to get a bit creative, but here's a rough outline
-of the steps involved:
+
+`godot-docs <https://hosted.weblate.org/projects/godot-engine/godot-docs>`_ uses `Sphinx <https://www.sphinx-doc.org/en/master/>`_. You can use the repository as a basis to build your own documentation system. The following guide describes the basic steps, but they are not exhaustive: You will need a bit of personal insight to make it work.
 
 1. Add `godot-docs <https://hosted.weblate.org/projects/godot-engine/godot-docs>`_ as a submodule to your ``docs/`` folder.
-2. Copy over its ``conf.py``, ``index.rst``, ``.readthedocs.yaml`` files into ``/docs/``. You may later decide to copy over more of godot-docs' files into your own project, like ``_templates/layout.html``.
+2. Copy over its ``conf.py``, ``index.rst``, ``.readthedocs.yaml`` files into ``/docs/``. You may later decide to copy over and edit more of godot-docs' files, like ``_templates/layout.html``.
 3. Modify these files according to your project. This mostly involves adjusting paths to point to the ``godot-docs`` subfolder, as well as strings to reflect it's your project rather than Godot you're building the docs for.
 4. Create an account on `readthedocs.org <http://readthedocs.org>`_. Import your project, and modify its base ``.readthedocs.yaml`` file path to ``/docs/.readthedocs.yaml``.
 

--- a/tutorials/scripting/gdextension/gdextension_docs_system.rst
+++ b/tutorials/scripting/gdextension/gdextension_docs_system.rst
@@ -177,7 +177,7 @@ Currently they supported tags for the GDExtension documentation system are:
 Publishing documentation online
 -------------------------------
 
-You may want to publish an online reference for your GDExtension, akin to this website.
+You may want to publish an online reference for your GDExtension, similar to this website.
 The most important step is to build reStructuredText (``.rst``) files from your XML class reference:
 
 .. code-block:: none

--- a/tutorials/scripting/gdextension/gdextension_docs_system.rst
+++ b/tutorials/scripting/gdextension/gdextension_docs_system.rst
@@ -182,7 +182,7 @@ The most important step is to build reStructuredText (``.rst``) files from your 
 
 .. code-block:: bash
 
-    # The upcoming script needs a dummy version.py, so download it first:
+    # You need a version.py file, so download it first.
     curl -sSLO https://raw.githubusercontent.com/godotengine/godot/refs/heads/master/version.py
 
     # Edit version.py according to your project before proceeding.

--- a/tutorials/scripting/gdextension/gdextension_docs_system.rst
+++ b/tutorials/scripting/gdextension/gdextension_docs_system.rst
@@ -182,6 +182,10 @@ The most important step is to build reStructuredText (``.rst``) files from your 
 
 .. code-block:: none
 
+    # The following script needs a dummy version.py.
+    curl -sSLO https://raw.githubusercontent.com/godotengine/godot/refs/heads/master/version.py
+
+    # Edit version.py with new valzes before proceeding.
     # You'll need to have Python installed for this command to work.
     curl -sSL https://raw.githubusercontent.com/godotengine/godot/master/doc/tools/make_rst.py | python3 - -o "docs/classes" -l "en" doc_classes
 

--- a/tutorials/scripting/gdextension/gdextension_docs_system.rst
+++ b/tutorials/scripting/gdextension/gdextension_docs_system.rst
@@ -177,7 +177,9 @@ Currently they supported tags for the GDExtension documentation system are:
 Publishing documentation online
 -------------------------------
 
-You may want to publish an online reference for your GDExtension, akin to this website. The most important step is to build reStructuredText (``.rst``) files from your XML class reference:
+You may want to publish an online reference for your GDExtension, akin to this website.
+The most important step is to build reStructuredText (``.rst``) files from your XML
+class reference:
 
 .. code-block:: none
 


### PR DESCRIPTION
First step to address https://github.com/godotengine/godot-proposals/issues/10733.

The guide explains, in very short, how to create online documentation (much like the [godot docs](https://docs.godotengine.org/en/stable/index.html) themselves) for a gdextension.

You can see a working example here: https://numdot.readthedocs.io/ ([source](https://github.com/Ivorforce/NumDot/tree/main/docs)).

A link to my example might be helpful to recreate what I did - but I elected not to link it because I felt it may be weird to link to a third party project. Let me know what you think.