### PR TITLE
Document profiler autostart functionality

### DIFF
--- a/tutorials/scripting/debug/debugger_panel.rst
+++ b/tutorials/scripting/debug/debugger_panel.rst
@@ -88,6 +88,12 @@ tab within the Debugger bottom panel, then click **Start**:
 
    Visual Profiler tab after clicking **Start**, waiting for a few seconds, then clicking **Stop**
 
+.. tip::
+
+    You can also check **Autostart**, which will make the visual profiler automatically
+    start when the project is run the next time. Note that the **Autostart**
+    checkbox's state is not preserved across editor sessions.
+
 You will see categories and results appearing as the profiler is running. Graph
 lines also appear, with the left side being a CPU framegraph and the right side
 being a GPU framegraph.

--- a/tutorials/scripting/debug/the_profiler.rst
+++ b/tutorials/scripting/debug/the_profiler.rst
@@ -27,7 +27,10 @@ performance-intensive. It has to continually measure everything happening in the
 game and report back to the debugger, so it's off by default.
 
 To begin profiling, run your game then focus back on the editor. Click on the
-**Start** button in the top-left corner of the **Profiler** tab.
+**Start** button in the top-left corner of the **Profiler** tab. You can also
+check **Autostart**, which will make the profiler automatically start when the
+project is run the next time. Note that the **Autostart** checkbox's state is not
+preserved across editor sessions.
 
 .. note::
 


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-docs/pull/9907.
- See https://github.com/godotengine/godot/pull/96759.

Not cherry-pickable for `4.3`, as this feature is only present in 4.4.
