### PR TITLE
Fix outdated reference to `register_class` function in GDExtension C++ example

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -295,7 +295,7 @@ The ``initialize_example_module`` and ``uninitialize_example_module`` functions 
 called respectively when Godot loads our plugin and when it unloads it. All
 we're doing here is parse through the functions in our bindings module to
 initialize them, but you might have to set up more things depending on your
-needs. We call the function ``register_class`` for each of our classes in our library.
+needs. We call the ``GDREGISTER_CLASS`` macro for each of our classes in our library.
 
 The important function is the third function called ``example_library_init``.
 We first call a function in our bindings library that creates an initialization object.


### PR DESCRIPTION
This was replaced by the `GDREGISTER_CLASS` macro in Godot 4.0.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/36#discussioncomment-10621249.
