### PR TITLE
Add hint that navmesh geometry nodes can be parsed by groupname

### DIFF
--- a/tutorials/navigation/navigation_using_navigationmeshes.rst
+++ b/tutorials/navigation/navigation_using_navigationmeshes.rst
@@ -49,6 +49,10 @@ node, the individual parsing, baking, and region update steps are all combined i
 
 The nodes are available in 2D and 3D as :ref:`NavigationRegion2D<class_NavigationRegion2D>` and :ref:`NavigationRegion3D<class_NavigationRegion3D>` respectively.
 
+.. tip::
+
+    The navigation mesh ``source_geometry_mode`` can be switched to parse specific node group names so nodes that should be baked can be placed anywhere in the scene.
+
 .. tabs::
 
    .. tab:: Baking with a NavigationRegion2D


### PR DESCRIPTION
Adds hint that navmesh geometry nodes can be parsed by groupname.

This is just missed way too often by new users that struggle around how they can get their nodes below the NavigationRegion node while it is as simple as just switching the parse settings on the NavigationPolygon/NavigationMesh resource.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
