### PR TITLE
Fix code sample for add_autoload_singleton in plugin

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -450,12 +450,12 @@ Use the following code to register a singleton from an editor plugin:
     const AUTOLOAD_NAME = "SomeAutoload"
 
 
-    func _enter_tree():
+    func _enable_plugin():
         # The autoload can be a scene or script file.
         add_autoload_singleton(AUTOLOAD_NAME, "res://addons/my_addon/some_autoload.tscn")
 
 
-    func _exit_tree():
+    func _disable_plugin():
         remove_autoload_singleton(AUTOLOAD_NAME)
 
  .. code-tab:: csharp
@@ -469,13 +469,13 @@ Use the following code to register a singleton from an editor plugin:
         // Replace this value with a PascalCase autoload name.
         private const string AutoloadName = "SomeAutoload";
 
-        public override void _EnterTree()
+        public override void _EnablePlugin()
         {
             // The autoload can be a scene or script file.
             AddAutoloadSingleton(AutoloadName, "res://addons/MyAddon/SomeAutoload.tscn");
         }
 
-        public override void _ExitTree()
+        public override void _DisablePlugin()
         {
             RemoveAutoloadSingleton(AutoloadName);
         }


### PR DESCRIPTION
- Add documentation for issue https://github.com/godotengine/godot/issues/68285
- Add issue https://github.com/godotengine/godot-docs/issues/9571 
- Add issue https://github.com/godotengine/godot/issues/94249

Replace the `_enter_tree` and `_exit_tree` for `_enable_plugin` and `_disable_plugin` to prevent the addition and removal of the auto_load script when the editor starts and closes.

Edited: Added issue 9571 and 94249

_Bugsquad edit:_
Fixes https://github.com/godotengine/godot/issues/68285
Fixes https://github.com/godotengine/godot-docs/issues/9571
Fixes https://github.com/godotengine/godot/issues/94249