### PR TITLE
Fix duplicate "glyph_spacing" in bbcode docs

### DIFF
--- a/tutorials/ui/bbcode_in_richtextlabel.rst
+++ b/tutorials/ui/bbcode_in_richtextlabel.rst
@@ -715,7 +715,7 @@ Font options
 
   Extra spacing for each glyph.
 
-- **glyph_spacing**, **sp**
+- **space_spacing**, **sp**
 
   +-----------+--------------------------------------------+
   | `Values`  | Number in pixels.                          |


### PR DESCRIPTION
The correct name for the space spacing option is space_spacing.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
