### PR TITLE
Rename shading language to GDShader

### DIFF
--- a/contributing/development/core_and_modules/internal_rendering_architecture.rst
+++ b/contributing/development/core_and_modules/internal_rendering_architecture.rst
@@ -307,9 +307,8 @@ recompile the editor or export template binary.
 
 Some material features such as height mapping, refraction and proximity fade are
 not part of core shaders, and are performed in the default BaseMaterial3D using
-the Godot shader language instead (not GLSL). This is done by procedurally
-generating the required shader code depending on the features enabled in the
-material.
+GDShader instead (not GLSL). This is done by procedurally generating the required
+shader code depending on the features enabled in the material.
 
 By convention, shader files with ``_inc`` in their name are included in other
 GLSL files for better code reuse. Standard GLSL preprocessing is used to achieve

--- a/contributing/workflow/bug_triage_guidelines.rst
+++ b/contributing/workflow/bug_triage_guidelines.rst
@@ -130,7 +130,7 @@ describe an issue or pull request.
 -  *Plugin*: relates to problems encountered while writing plugins.
 -  *Porting*: relates to some specific platforms or exporting projects.
 -  *Rendering*: relates to the 2D and 3D rendering engines.
--  *Shaders*: relates to the Godot shader language or visual shaders.
+-  *Shaders*: relates to GDShader or visual shaders.
 -  *Tests*: relates to unit tests.
 -  *Thirdparty*: relates to third-party libraries used in Godot.
 -  *XR*: relates to Augmented Reality or Virtual Reality.

--- a/tutorials/shaders/compute_shaders.rst
+++ b/tutorials/shaders/compute_shaders.rst
@@ -25,9 +25,9 @@ Now let's get started by creating a short compute shader.
 
 First, in the **external** text editor of your choice, create a new file called
 ``compute_example.glsl`` in your project folder. When you write compute shaders
-in Godot, you write them in GLSL directly. The Godot shader language is based on
-GLSL. If you are familiar with normal shaders in Godot, the syntax below will
-look somewhat familiar.
+in Godot, you write them in GLSL directly. Godot's shading language, GDShader, 
+is based on GLSL. If you are familiar with normal shaders in Godot, the syntax 
+below will look somewhat familiar.
 
 .. note::
 

--- a/tutorials/shaders/converting_glsl_to_godot_shaders.rst
+++ b/tutorials/shaders/converting_glsl_to_godot_shaders.rst
@@ -1,21 +1,20 @@
 .. _doc_converting_glsl_to_godot_shaders:
 
-Converting GLSL to Godot shaders
-================================
+Converting GLSL to GDShader
+===========================
 
-This document explains the differences between Godot's shading language and GLSL
-and gives practical advice on how to migrate shaders from other sources, such as
-Shadertoy and The Book of Shaders, into Godot shaders.
+This document explains the differences between GLSL and Godot's shading language, GDShader.
+It also gives practical advice on how to migrate shaders from other sources, such as
+Shadertoy and The Book of Shaders, into GDShader.
 
-For detailed information on Godot's shading language, please refer to the
+For detailed information on GDShader, please refer to the
 :ref:`Shading Language <doc_shading_language>` reference.
 
 GLSL
 ----
 
-Godot uses a shading language based on GLSL with the addition of a few
-quality-of-life features. Accordingly, most features available in GLSL are
-available in Godot's shading language.
+GDShader is based on GLSL with the addition of a few quality-of-life features. 
+Accordingly, most features available in GLSL are available in GDShader.
 
 Shader programs
 ^^^^^^^^^^^^^^^
@@ -74,7 +73,7 @@ rename ``main`` to ``fragment``.
 Macros
 ^^^^^^
 
-The :ref:`Godot shader preprocessor<doc_shader_preprocessor>` supports the following macros:
+The :ref:`GDShader preprocessor<doc_shader_preprocessor>` supports the following macros:
 
 * ``#define`` / ``#undef``
 * ``#if``, ``#elif``, ``#else``, ``#endif``, ``defined()``, ``#ifdef``, ``#ifndef``
@@ -108,7 +107,7 @@ uniforms, so they are not editable from the main program.
 Coordinates
 ^^^^^^^^^^^
 
-``gl_FragCoord`` in GLSL and ``FRAGCOORD`` in the Godot shading language use the
+``gl_FragCoord`` in GLSL and ``FRAGCOORD`` in the GDShader use the
 same coordinate system. If using UV in Godot, the y-coordinate will be flipped
 upside down.
 

--- a/tutorials/shaders/introduction_to_shaders.rst
+++ b/tutorials/shaders/introduction_to_shaders.rst
@@ -4,8 +4,8 @@ Introduction to shaders
 =======================
 
 This page explains what shaders are and will give you an overview of how they
-work in Godot. For a detailed reference of the engine's shading language, see
-:ref:`doc_shading_language`.
+work in Godot. For a detailed reference of the engine's shading language, GDShader,
+see :ref:`doc_shading_language`.
 
 Shaders are a special kind of program that runs on Graphics Processing Units
 (GPUs). They were initially used to shade 3D scenes but can nowadays do much
@@ -46,7 +46,7 @@ look like this.
 Shaders in Godot
 ----------------
 
-Godot provides a shading language based on the popular OpenGL Shading Language
+Godot provides a shading language called GDShader based on the popular OpenGL Shading Language
 (GLSL) but simplified. The engine handles some of the lower-level initialization
 work for you, making it easier to write complex shaders.
 

--- a/tutorials/shaders/shader_reference/shader_preprocessor.rst
+++ b/tutorials/shaders/shader_reference/shader_preprocessor.rst
@@ -195,7 +195,7 @@ Be careful, as ``defined()`` must only wrap a single identifier within parenthes
 
 **#if preprocessor versus if statement: Performance caveats**
 
-The :ref:`shading language <doc_shading_language>` supports run-time ``if`` statements:
+:ref:`GDShader<doc_shading_language>` supports run-time ``if`` statements:
 
 .. code-block:: glsl
 

--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -6,7 +6,7 @@ Shading language
 Introduction
 ------------
 
-Godot uses a shading language similar to GLSL ES 3.0. Most datatypes and
+Godot uses a shading language called GDShader. It's similar to GLSL ES 3.0. Most datatypes and
 functions are supported, and the few remaining ones will likely be added over
 time.
 

--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -6,13 +6,13 @@ Shading language
 Introduction
 ------------
 
-Godot uses a shading language called GDShader. It's similar to GLSL ES 3.0. Most datatypes and
-functions are supported, and the few remaining ones will likely be added over
+Godot uses a shading language called GDShader, based on GLSL ES 3.0 with some differences.
+Most datatypes and functions are supported, and the few remaining ones will likely be added over
 time.
 
 If you are already familiar with GLSL, the :ref:`Godot Shader Migration
 Guide<doc_converting_glsl_to_godot_shaders>` is a resource that will help you
-transition from regular GLSL to Godot's shading language.
+transition from regular GLSL to GDShader.
 
 Data types
 ----------
@@ -89,7 +89,7 @@ Most GLSL ES 3.0 datatypes are supported:
 Comments
 ~~~~~~~~
 
-The shading language supports the same comment syntax as used in C# and C++:
+GDShader supports the same comment syntax as used in C# and C++:
 
 .. code-block:: glsl
 
@@ -501,7 +501,7 @@ is the list of them in precedence order:
 Flow control
 ------------
 
-Godot Shading language supports the most common types of flow control:
+GDShader supports the most common types of flow control:
 
 .. code-block:: glsl
 
@@ -601,7 +601,7 @@ render compared to not rendering any object in the first place.
 Functions
 ---------
 
-It is possible to define functions in a Godot shader. They use the following
+It is possible to define functions in GDShader. They use the following
 syntax:
 
 .. code-block:: glsl
@@ -639,7 +639,7 @@ Example below:
 
 .. note::
 
-    Unlike GLSL, Godot's shader language does **not** support function
+    Unlike GLSL, GDShader does **not** support function
     overloading. This means that a function cannot be defined several times with
     different argument types or numbers of arguments. As a workaround, use
     different names for functions that accept a different number of arguments or

--- a/tutorials/shaders/shaders_style_guide.rst
+++ b/tutorials/shaders/shaders_style_guide.rst
@@ -8,9 +8,8 @@ encourage writing clean, readable code and promote consistency across projects,
 discussions, and tutorials. Hopefully, this will also support the development of
 auto-formatting tools.
 
-Since the Godot shader language is close to C-style languages and GLSL, this
-guide is inspired by Godot's own GLSL formatting. You can view examples of
-GLSL files in Godot's source code
+Since GDShader is close to C-style languages and GLSL, this guide is inspired 
+by Godot's own GLSL formatting. You can view examples of GLSL files in Godot's source code
 `here <https://github.com/godotengine/godot/blob/master/drivers/gles3/shaders/>`__.
 
 Style guides aren't meant as hard rulebooks. At times, you may not be able to

--- a/tutorials/shaders/visual_shaders.rst
+++ b/tutorials/shaders/visual_shaders.rst
@@ -159,7 +159,7 @@ exhaustive and might be expanded with more nodes and examples.
 Expression node
 +++++++++++++++
 
-The ``Expression`` node allows you to write Godot Shading Language (GLSL-like)
+The ``Expression`` node allows you to write GDShader (GLSL-like)
 expressions inside your visual shaders. The node has buttons to add any amount
 of required input and output ports and can be resized. You can also set up the
 name and type of each port. The expression you have entered will apply


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/4350.
Closes https://github.com/godotengine/godot-proposals/issues/10784.

Companion PR to https://github.com/godotengine/godot/pull/97298.

The places that definitely need to be changed are [Shading Language/Introduction](https://docs.godotengine.org/en/stable/tutorials/shaders/shader_reference/shading_language.html#introduction), the [Shader class reference](https://docs.godotengine.org/en/stable/classes/class_shader.html), and the [GLSL Migration Guide](https://docs.godotengine.org/en/stable/tutorials/shaders/converting_glsl_to_godot_shaders.html#doc-converting-glsl-to-godot-shaders). In places like compute shaders where godot *does* use GLSL, we should make the distinction that "GLSL is used, not GDShader"

Unlike the class ref, for the manual we don't need to replace every reference to the shading language with "GDShader" immediately, to avoid breaking translations.

_Bugsquad edit: Waiting on main repo PR https://github.com/godotengine/godot/pull/97298_
