### PR TITLE
Fix unreachable pages in sidebar by using fake headers in index pages

### DIFF
--- a/contributing/development/compiling/index.rst
+++ b/contributing/development/compiling/index.rst
@@ -18,8 +18,7 @@ stripped of extra modules, or an executable targeting engine development.
 The articles below should help you navigate configuration options available, as well as
 prerequisites required to compile Godot exactly the way you need.
 
-Basics of building Godot
-------------------------
+.. rubric:: Basics of building Godot
 
 Let's start with basics, and learn how to get Godot's source code, and then which options
 to use to compile it regardless of your target platform.
@@ -31,8 +30,7 @@ to use to compile it regardless of your target platform.
    getting_source
    introduction_to_the_buildsystem
 
-Building for target platforms
------------------------------
+.. rubric:: Building for target platforms
 
 Below you can find instructions for compiling the engine for your specific target platform.
 Note that Godot supports cross-compilation, which means you can compile it for a target platform
@@ -51,8 +49,7 @@ will try their best to cover all possible situations.
    cross-compiling_for_ios_on_linux
    compiling_for_web
 
-Other compilation targets and options
--------------------------------------
+.. rubric:: Other compilation targets and options
 
 Some additional universal compilation options require further setup. Namely, while Godot
 does have C#/.NET support as a part of its main codebase, it does not get compiled by

--- a/contributing/development/core_and_modules/index.rst
+++ b/contributing/development/core_and_modules/index.rst
@@ -6,8 +6,7 @@ Engine core and modules
 The following pages are meant to introduce the global organization of Godot Engine's
 source code, and give useful tips for extending and fixing the engine on the C++ side.
 
-Getting started with Godot's source code
-----------------------------------------
+.. rubric:: Getting started with Godot's source code
 
 This section covers the basics that you will encounter in (almost) every source file.
 
@@ -25,8 +24,7 @@ This section covers the basics that you will encounter in (almost) every source 
    2d_coordinate_systems
    scripting_development
 
-Extending Godot by modifying its source code
---------------------------------------------
+.. rubric:: Extending Godot by modifying its source code
 
 This section covers what you can do by modifying Godot's C++ source code.
 

--- a/tutorials/scripting/index.rst
+++ b/tutorials/scripting/index.rst
@@ -10,8 +10,7 @@ Here, you will find information that is not already covered in more specific
 sections. For instance, to learn about inputs, we recommend you to read
 :ref:`Inputs <toc-learn-features-inputs>`.
 
-Programming languages
----------------------
+.. rubric:: Programming languages
 
 The sections below each focus on a given programming language.
 


### PR DESCRIPTION
Fixes some cases of https://github.com/godotengine/godot-docs/issues/8792
May mitigate or fix https://github.com/godotengine/godot-docs/issues/8567
May mitigate or fix https://github.com/godotengine/godot-docs/issues/8566
Fixes https://github.com/godotengine/godot-docs/issues/9133

Ensures that most pages are reachable through the sidebar, by replacing real semantic headers with fake headers on index pages. As a side effect, this also means that some pages now have navigable section headers again.

---

There are many pages which do not show up in the sidebar (listed in https://github.com/godotengine/godot-docs/issues/8792). It's especially bad on the scripting pages, which are used often by end users. The contributing pages are a bit less of a problem, because they are referenced less often and only by contributors.

Any header will show up in the navigation sidebar. Currently, there is a maximum depth of 5 in the navigation sidebar. Currently, there are several index pages which serve as empty "table of contents" pages, but which use headers.

The solution I arrived at is to replace the semantic headers in these pages with a fake header, using the `.. rubric::` syntax. I used [this hack](https://stackoverflow.com/a/23544142). I am not a sphinx, RTD, or reStructuredText expert. I hacked this together because using the docs has become actively annoying. If there's a less hacky way to solve this, I'd love to hear it.

If using `rubric` is the right solution, I think the current rubric styling looks *okay*, but it's also possible to [make custom styles to match the header styles.](https://stackoverflow.com/a/23549957)

**Visual summary of changes:**
| Page | Master | This PR |
|-|-|-|
| GDScript exported properties | ![gdscript exported master](https://github.com/user-attachments/assets/0c699a9e-0b7d-4648-9884-09115880f5dc) | ![firefox_XVs3eaDzdk](https://github.com/user-attachments/assets/533c58c9-9f9c-4f68-921f-7caa5164775c) |
| C# Signals | ![c# signals master](https://github.com/user-attachments/assets/7dfa6cbd-5b39-4a61-be13-26a0d0e5b9a7) | ![firefox_k2JFaZhM4B](https://github.com/user-attachments/assets/30c6fb74-97f7-4688-83db-b8f91a77b0a8) |
| Building from Source | ![firefox_MM6ydYbh10](https://github.com/user-attachments/assets/ca16fc83-d8e9-48c8-84a9-d602a5ac4490) | ![building source pr](https://github.com/user-attachments/assets/efa1c525-f8d8-4151-9063-c359b899d78f) |
| Engine core and modules | ![firefox_ROdbWjTOT5](https://github.com/user-attachments/assets/fe38757c-22d8-4a3f-b6c0-1babada28c13) | ![engine core pr](https://github.com/user-attachments/assets/d230cb8e-937e-4264-88a6-01673a8620c0) |

I don't know the technical reason for the current nesting limit of 5. *Even if* that limit was increased, we would not be free to use as many headers as we wanted - this problem of deep nesting would show up again sooner or later. Note that even with this PR, some pages get to have section headers in the sidebar, and some only have a title.