### PR TITLE
Fix Code order section saying it's the first section in GDScript style guide

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -734,7 +734,7 @@ more easily, and also makes for cleaner diffs in version control when items are 
 Code order
 ----------
 
-This first section focuses on code order. For formatting, see
+This section focuses on code order. For formatting, see
 :ref:`formatting`. For naming conventions, see :ref:`naming_conventions`.
 
 We suggest to organize GDScript code this way:


### PR DESCRIPTION
It's not the first section of the page anymore.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/156#discussioncomment-10721474.
