### PR TITLE
Add subsection for TileMap layer reordering

### DIFF
--- a/tutorials/2d/using_tilemaps.rst
+++ b/tutorials/2d/using_tilemaps.rst
@@ -90,6 +90,9 @@ Navigation
 .. warning::
     2D navigation meshes can not be "layered" or stacked on top of each other like visuals or physic shapes. Attempting to stack navigation meshes on the same navigation map will result in merge and logical errors that break the pathfinding.
 
+Reordering layers
+^^^^^^^^^^^^^^^^^
+
 You can reorder layers by drag-and-dropping their node in the Scene tab. You can
 also switch between which TileMapLayer node you're working on by using the buttons
 in the top right corner of the TileMap editor.


### PR DESCRIPTION
Adds subsection for TileMap layer reordering.

Currently this is appended and mashes with the navigation section. Reordering TileMapLayers is entirely unrelated so it should have its own subsection to have a clear separation of the topics.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
