### PR TITLE
Document bitmask C# API difference

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_differences.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_differences.rst
@@ -805,7 +805,7 @@ GDScript              C#
 
 Bitmasks
 -------
-Some methods, such as :ref:`ResourceFormatSaver _Save <class-resourceformatsaver-private-method-save>`
+Some methods, such as :ref:`ResourceFormatSaver._Save <class-resourceformatsaver-private-method-save>`,
 use a bitmask with multiple bit flags. While C# will convert a signed ``int`` to an
 unsigned ``uint`` when passing values into these methods, you must use a ``uint``
 when overriding these methods in your own code. Using an ``int`` can result in

--- a/tutorials/scripting/c_sharp/c_sharp_differences.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_differences.rst
@@ -803,6 +803,14 @@ GDScript              C#
 ``hex64(int)``        ``Color(ulong)``
 ====================  ==============================================================
 
+Bitmasks
+-------
+Some methods, such as :ref:`ResourceFormatSaver _Save <class-resourceformatsaver-private-method-save>`
+use a bitmask with multiple bit flags. While C# will convert a signed ``int`` to an
+unsigned ``uint`` when passing values into these methods, you must use a ``uint``
+when overriding these methods in your own code. Using an ``int`` can result in
+confusing "no suitable method found to override" error messages.
+
 Array
 -----
 


### PR DESCRIPTION
I spent a good couple hours today beating my head against an inscrutable C# compile error tonight that ended up being because of some methods that use bitmasks as an argument wanting a `uint` in C# instead of an `int` in the type signature, something that doesn't appear on GDScript-focused documentation as a difference between signed and unsigned ints doesn't exist in GDScript. Due to C# type coercion in most cases this is niche enough that not many people will run into it, but I want to prevent other people running into this wall as well, so I've put a quick note of bitmasks using `uint` for method overrides in the C# API differences doc.