### PR TITLE
Fix builtin_types link in tutorial gdscript_basics page

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -572,8 +572,6 @@ considered a comment.
     The list of highlighted keywords and their colors can be changed in the **Text
     Editor > Theme > Comment Markers** section of the Editor Settings.
 
-.. _doc_gdscript_builtin_types:
-
 Code regions
 ~~~~~~~~~~~~
 
@@ -662,6 +660,8 @@ A line can be continued multiple times like this:
     4 + \
     10 + \
     4
+
+.. _doc_gdscript_builtin_types:
 
 Built-in types
 --------------


### PR DESCRIPTION
It's linked to a wrong position.
- Check this link: [https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_basics.html#doc-gdscript-builtin-types](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_basics.html#doc-gdscript-builtin-types)

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
