### PR TITLE
Fix incorrect notice about XDG paths working on all platforms in Data paths

### DIFF
--- a/tutorials/io/data_paths.rst
+++ b/tutorials/io/data_paths.rst
@@ -142,8 +142,9 @@ depending on the platform. By default, these paths are:
 
 Godot complies with the `XDG Base Directory Specification
 <https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html>`__
-on all platforms. You can override environment variables following the
-specification to change the editor and project data paths.
+on Linux/*BSD. You can override the ``XDG_DATA_HOME``, ``XDG_CONFIG_HOME`` and
+``XDG_CACHE_HOME`` environment variables to change the editor and project data
+paths.
 
 .. note:: If you use `Godot packaged as a Flatpak
           <https://flathub.org/apps/details/org.godotengine.Godot>`__, the

--- a/tutorials/io/data_paths.rst
+++ b/tutorials/io/data_paths.rst
@@ -142,7 +142,7 @@ depending on the platform. By default, these paths are:
 
 Godot complies with the `XDG Base Directory Specification
 <https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html>`__
-on Linux/*BSD. You can override the ``XDG_DATA_HOME``, ``XDG_CONFIG_HOME`` and
+on Linux/\*BSD. You can override the ``XDG_DATA_HOME``, ``XDG_CONFIG_HOME`` and
 ``XDG_CACHE_HOME`` environment variables to change the editor and project data
 paths.
 


### PR DESCRIPTION
They are only effective on Linux/*BSD. (For reference, in most other apps, it's rare for XDG environment variables to have an effect on other platforms.)

- See https://github.com/godotengine/godot-docs-user-notes/discussions/106#discussioncomment-10757552.
