### PR TITLE
Remove "degrees" redundancy

### DIFF
--- a/tutorials/math/vectors_advanced.rst
+++ b/tutorials/math/vectors_advanced.rst
@@ -172,7 +172,7 @@ For two points in space, there are actually two planes that pass through
 them, sharing the same space but with normal pointing to the opposite
 directions. To compute the normal from the two points, the direction
 vector must be obtained first, and then it needs to be rotated 90°
-degrees to either side:
+to either side:
 
 .. tabs::
  .. code-tab:: gdscript GDScript


### PR DESCRIPTION
The phrase, "90° degrees", is a redundancy as the "°" symbol already means "degrees". It should just be ,"90°".