### PR TITLE
remove inexistent find_custom and rfind_custom functions from Array section

### DIFF
--- a/classes/class_array.rst
+++ b/classes/class_array.rst
@@ -131,8 +131,6 @@ Methods
    +-------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | :ref:`int<class_int>`               | :ref:`find<class_Array_method_find>`\ (\ what\: :ref:`Variant<class_Variant>`, from\: :ref:`int<class_int>` = 0\ ) |const|                                                                              |
    +-------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-   | :ref:`int<class_int>`               | :ref:`find_custom<class_Array_method_find_custom>`\ (\ method\: :ref:`Callable<class_Callable>`, from\: :ref:`int<class_int>` = 0\ ) |const|                                                            |
-   +-------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | :ref:`Variant<class_Variant>`       | :ref:`front<class_Array_method_front>`\ (\ ) |const|                                                                                                                                                    |
    +-------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | :ref:`int<class_int>`               | :ref:`get_typed_builtin<class_Array_method_get_typed_builtin>`\ (\ ) |const|                                                                                                                            |
@@ -184,8 +182,6 @@ Methods
    | |void|                              | :ref:`reverse<class_Array_method_reverse>`\ (\ )                                                                                                                                                        |
    +-------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | :ref:`int<class_int>`               | :ref:`rfind<class_Array_method_rfind>`\ (\ what\: :ref:`Variant<class_Variant>`, from\: :ref:`int<class_int>` = -1\ ) |const|                                                                           |
-   +-------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-   | :ref:`int<class_int>`               | :ref:`rfind_custom<class_Array_method_rfind_custom>`\ (\ method\: :ref:`Callable<class_Callable>`, from\: :ref:`int<class_int>` = -1\ ) |const|                                                         |
    +-------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
    | |void|                              | :ref:`shuffle<class_Array_method_shuffle>`\ (\ )                                                                                                                                                        |
    +-------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -759,35 +755,6 @@ Returns the index of the **first** occurrence of ``what`` in this array, or ``-1
 
 ----
 
-.. _class_Array_method_find_custom:
-
-.. rst-class:: classref-method
-
-:ref:`int<class_int>` **find_custom**\ (\ method\: :ref:`Callable<class_Callable>`, from\: :ref:`int<class_int>` = 0\ ) |const| :ref:`🔗<class_Array_method_find_custom>`
-
-Returns the index of the **first** element in the array that causes ``method`` to return ``true``, or ``-1`` if there are none. The search's start can be specified with ``from``, continuing to the end of the array.
-
-\ ``method`` is a callable that takes an element of the array, and returns a :ref:`bool<class_bool>`.
-
-\ **Note:** If you just want to know whether the array contains *anything* that satisfies ``method``, use :ref:`any<class_Array_method_any>`.
-
-
-.. tabs::
-
- .. code-tab:: gdscript
-
-    func is_even(number):
-        return number % 2 == 0
-    
-    func _ready():
-        print([1, 3, 4, 7].find_custom(is_even.bind())) # prints 2
-
-
-
-.. rst-class:: classref-item-separator
-
-----
-
 .. _class_Array_method_front:
 
 .. rst-class:: classref-method
@@ -1236,18 +1203,6 @@ Reverses the order of all elements in the array.
 :ref:`int<class_int>` **rfind**\ (\ what\: :ref:`Variant<class_Variant>`, from\: :ref:`int<class_int>` = -1\ ) |const| :ref:`🔗<class_Array_method_rfind>`
 
 Returns the index of the **last** occurrence of ``what`` in this array, or ``-1`` if there are none. The search's start can be specified with ``from``, continuing to the beginning of the array. This method is the reverse of :ref:`find<class_Array_method_find>`.
-
-.. rst-class:: classref-item-separator
-
-----
-
-.. _class_Array_method_rfind_custom:
-
-.. rst-class:: classref-method
-
-:ref:`int<class_int>` **rfind_custom**\ (\ method\: :ref:`Callable<class_Callable>`, from\: :ref:`int<class_int>` = -1\ ) |const| :ref:`🔗<class_Array_method_rfind_custom>`
-
-Returns the index of the **last** element of the array that causes ``method`` to return ``true``, or ``-1`` if there are none. The search's start can be specified with ``from``, continuing to the beginning of the array. This method is the reverse of :ref:`find_custom<class_Array_method_find_custom>`.
 
 .. rst-class:: classref-item-separator
 


### PR DESCRIPTION
changelog:
- removed `find_custom` method from the Array section
- removed `rfind_custom` method from the Array section

for cleanup reasons, Array class does not have those methods as of 4.4.dev2


why is this in the docs? aside from community requests, there is not even a hint of this feature