### PR TITLE
Remove individual youtube channel links from tutorials page

### DIFF
--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -14,31 +14,13 @@ The Godot video tutorials by `GDQuest <https://www.youtube.com/channel/UCxboW7x0
 
 GDQuest's *Learn GDScript From Zero* is a free and open source interactive tutorial for absolute beginners to learn to program with Godot's GDScript language. It is available as a `desktop application <https://gdquest.itch.io/learn-godot-gdscript>`_  or `in the browser <https://gdquest.github.io/learn-gdscript>`_.
 
-Some tutorials mentioned below provide more advanced tutorials, e.g. on 3D or shaders.
+Some tutorials mentioned below cover more advanced subjects, e.g. on 3D or shaders.
 
 Video tutorials
 ---------------
 
-- `Bastiaan Olij <https://www.youtube.com/BastiaanOlij>`_ (3D, AR and VR, GDScript)
-- `BornCG <https://www.youtube.com/playlist?list=PLda3VoSoc_TTp8Ng3C57spnNkOw3Hm_35>`_ (2D and 3D, GDScript)
-- `Clear Code <https://www.youtube.com/watch?v=nAh_Kx5Zh5Q>`_ (2D, GDScript, Programming Basics)
-- `FencerDevLog <https://www.youtube.com/@FencerDevLog>`_ (2D, 3D, GDScript, Shaders)
-- `FinePointCGI <https://www.youtube.com/channel/UCSojAWUnEUTUcdA9iJ6bryQ>`_ (2D, 3D, GDScript and C#)
-- `GDQuest <https://www.youtube.com/channel/UCxboW7x0jZqFdvMdCFKTMsQ/playlists>`_ (2D and 3D, GDScript and C#)
-- `Game Dev Artisan <https://www.youtube.com/@GameDevArtisan>`_ (2D, GDScript)
-- `Game Development Center <https://www.youtube.com/c/GameDevelopmentCenter>`_ (2D, networked multiplayer, GDScript)
-- `Game Endeavor <https://www.youtube.com/channel/UCLweX1UtQjRjj7rs_0XQ2Eg/videos>`_ (2D, GDScript)
-- `Gwizz <https://www.youtube.com/@Gwizz1027>`_ (2D, GDScript)
-- `Godotneers <https://www.youtube.com/@godotneers>`_ (2D, Shaders, GDScript)
-- `HeartBeast <https://www.youtube.com/@uheartbeast>`_ (2D, GDScript)
-- `Malcolm Nixon <https://youtube.com/@MalcolmAnixon>`_ (AR and VR, GDScript)
-- `Muddy Wolf <https://www.youtube.com/@MuddyWolf>`_ (2D, 3D and VR, GDSCript)
-- `KidsCanCode <https://www.youtube.com/channel/UCNaPQ5uLX5iIEHUCLmfAgKg/playlists>`__ (2D and 3D, GDScript)
-- `Maker Tech <https://www.youtube.com/@MakerTech/>`_ (2D, GDScript)
-- `Pigdev <https://www.youtube.com/@pigdev>`_ (2D, GDScript)
-- `Queble <https://www.youtube.com/@queblegamedevelopment4143>`_ (2D, GDScript)
-- `Quiver <https://quiver.dev/>`_ (2D, GDScript)
-- `Snopek Games <https://www.youtube.com/@SnopekGames>`_ (3D, networked multiplayer, AR and VR, GDScript)
+For video tutorials we recommend looking on `YouTube <https://www.youtube.com/>`_. There's many great
+channels covering a wide array of subjects.
 
 Text tutorials
 --------------


### PR DESCRIPTION
Does what the title says.

Currently on the community tutorial page we link to individual youtube channels that provide Godot tutorials. I believe we should stop doing things this way for several reasons.

One, the foundation has to review any PR that adds a channel to this page. I'm not against that but the foundation doesn't seem to be actually reviewing anything. The oldest open video PR is from April this year which is almost 5 months old. I'm not saying this to criticize the foundation for not doing this, merely pointing out that the process has created a backlog. I also think their time is better spent elsewhere for this next reason.

Two, going to our tutorials page is less efficient than just going to YouTube and searching for videos. On the tutorials page we only break down creators into broad categories, "2D" covers a wide array of topics. If someone was trying to find a creator going over, for example, tilemaps, it's not easy to find out who is doing that without going through every channel. And in comparison if someone goes straight to YouTube they just have to search for "Godot TileMapLayer" tutorial to immediately find several relevant results.

There's currently only one video tutorial on the page that links somewhere other than YouTube that I've also removed. It just feels odd to keep that linked when there's no other sites we also link to. Though I'm not against re-adding it to this PR.

I welcome all discussion on if these channel links should be removed or not.

Lastly, I've also edited the sentence before the video section to sound better.