### PR TITLE
Add missing word, "is"

### DIFF
--- a/tutorials/math/interpolation.rst
+++ b/tutorials/math/interpolation.rst
@@ -138,4 +138,4 @@ Here is how it looks:
 
 .. image:: img/interpolation_follow.gif
 
-This useful for smoothing camera movement, allies following you (ensuring they stay within a certain range), and many other common game patterns.
+This is useful for smoothing camera movement, allies following you (ensuring they stay within a certain range), and many other common game patterns.


### PR DESCRIPTION
The phrase, "This useful for smoothing camera movement..." appears to be missing a word. It should be, "This is useful for smoothing camera movement..." instead.