### PR TITLE
Fix indentation on mouse_and_input_coordinates.rst

### DIFF
--- a/tutorials/inputs/mouse_and_input_coordinates.rst
+++ b/tutorials/inputs/mouse_and_input_coordinates.rst
@@ -29,14 +29,14 @@ for example:
  .. code-tab:: gdscript GDScript
 
     func _input(event):
-       # Mouse in viewport coordinates.
-       if event is InputEventMouseButton:
-           print("Mouse Click/Unclick at: ", event.position)
-       elif event is InputEventMouseMotion:
-           print("Mouse Motion at: ", event.position)
+        # Mouse in viewport coordinates.
+        if event is InputEventMouseButton:
+            print("Mouse Click/Unclick at: ", event.position)
+        elif event is InputEventMouseMotion:
+            print("Mouse Motion at: ", event.position)
 
-       # Print the size of the viewport.
-       print("Viewport Resolution is: ", get_viewport().get_visible_rect().size)
+        # Print the size of the viewport.
+        print("Viewport Resolution is: ", get_viewport().get_visible_rect().size)
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
There was a space missing, causing inconsistent indentation and making the code not copy pastable.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
