### PR TITLE
Added notes on bit depth for ints and floats

### DIFF
--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -32,7 +32,7 @@ Most GLSL ES 3.0 datatypes are supported:
 +----------------------+---------------------------------------------------------------------------------+
 | **bvec4**            | Four-component vector of booleans.                                              |
 +----------------------+---------------------------------------------------------------------------------+
-| **int**              | Signed scalar integer.                                                          |
+| **int**              | 32 bit signed scalar integer.                                                          |
 +----------------------+---------------------------------------------------------------------------------+
 | **ivec2**            | Two-component vector of signed integers.                                        |
 +----------------------+---------------------------------------------------------------------------------+
@@ -48,7 +48,7 @@ Most GLSL ES 3.0 datatypes are supported:
 +----------------------+---------------------------------------------------------------------------------+
 | **uvec4**            | Four-component vector of unsigned integers.                                     |
 +----------------------+---------------------------------------------------------------------------------+
-| **float**            | Floating-point scalar.                                                          |
+| **float**            | 32 bit floating-point scalar.                                                          |
 +----------------------+---------------------------------------------------------------------------------+
 | **vec2**             | Two-component vector of floating-point values.                                  |
 +----------------------+---------------------------------------------------------------------------------+
@@ -227,7 +227,7 @@ variables, arguments and varyings:
 
     lowp vec4 a = vec4(0.0, 1.0, 2.0, 3.0); // low precision, usually 8 bits per component mapped to 0-1
     mediump vec4 a = vec4(0.0, 1.0, 2.0, 3.0); // medium precision, usually 16 bits or half float
-    highp vec4 a = vec4(0.0, 1.0, 2.0, 3.0); // high precision, uses full float or integer range (default)
+    highp vec4 a = vec4(0.0, 1.0, 2.0, 3.0); // high precision, uses full float or integer range (32 bit default)
 
 
 Using lower precision for some operations can speed up the math involved (at the
@@ -937,6 +937,9 @@ table of the corresponding types:
 .. note:: Be careful when setting shader uniforms from GDScript, no error will
           be thrown if the type does not match. Your shader will just exhibit
           undefined behavior.
+
+.. warning::
+    As with the last note, no error will be thrown if the typing does not match while setting a shader uniform, this unintuitively includes setting a (GDscript) 64 bit int/float into a Godot shader language int/float (32 bit). This may lead to unintentional consequences in cases where high precision is required.
 
 Uniforms can also be assigned default values:
 


### PR DESCRIPTION
Added a small note about the bit depth of integers and floats in Godot's shading language as it is not explicitly stated anywhere.

The bit depth of integer and floats in GDscript and Godot's shading language are different, which can cause problems with lost precision in calculations when integers are set from GDscript as floats/ints in GDscript are 64 bits instead of 32 bits (the standard in GLSL ES 3.0).

While Added a small note about the bit depth of integers and floats in Godot's shading language as it is not explicitly stated anywhere.

The bit depth of integer and floats in GDscript and Godot's shading language are different, which can cause problems with lost precision in calculations when integers are set from GDscript as floats/ints in GDscript are 64 bits instead of 32 bits (the standard in GLSL ES 3.0).

While most are unlikely to run into problems due to this difference in bit depth, it can cause mathematical errors in edge cases. As stated by previous contributors, no error will be thrown if types do not match while setting a shader uniform. This includes GDscript floats being set as Godot shader floats (which may not be intuitive).


Examples of problems this may cause:
When setting two floats with time.get_unix_time_from_system()  in GDscript (which returns a 64 bit float) a few seconds apart, when compared in the shader they will be equal to each other, and when subtracted from one another they will equal 0.0 due to the 32 bit depth of floats in the shader language.

This is not intuitive to debug without documentation as when using the get function in GDscript, they will still subtract correctly so that the second float will be greater than the first float in GDscript, even if they won’t subtract correctly within the shader.most are unlikely to run into problems due to this difference in bit depth, it can cause mathematical errors in edge cases. As stated by previous contributors, no error will be thrown if types do not match while setting a shader uniform. This includes GDscript floats being set as Godot shader floats (which may not be intuitive).

Additionally some functions mention 32 bit floating point numbers (look at packHalf2x16 for example) however I could not find anywhere that states that the default bit depth of int / floats was 32 bit and not 64 bit like in GDscript.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
