### PR TITLE
Fix "some times" typo

### DIFF
--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -248,7 +248,7 @@ angle add a setter ``set(new_speed)`` which is executed with the input from the 
 Getting notified when resources change
 --------------------------------------
 
-Some times you want your tool to use a resource. However, when you change a
+Sometimes you want your tool to use a resource. However, when you change a
 property of that resource in the editor, the ``set()`` method of your tool will
 not be called.
 


### PR DESCRIPTION
The space in "some times" is a mistake and should be removed. "Sometimes" is one word, not two (as can be seen when it is used correctly further down the page at the start of the "Running one-off scripts using EditorScript" section).
