### PR TITLE
Add a note about GDScript format strings in C++

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_format_string.rst
+++ b/tutorials/scripting/gdscript/gdscript_format_string.rst
@@ -286,5 +286,5 @@ Combining both the ``String.format`` method and the ``%`` operator could be usef
 | ``"Hi, {0} v{version}".format({0:"Godette", "version":"%0.2f" % 3.114})`` | Hi, Godette v3.11 |
 +---------------------------------------------------------------------------+-------------------+
 
-In Godot's C++ code, GDScript format strings can accessed using the
+In Godot's C++ code, GDScript format strings can be accessed using the
 ``vformat`` helper function in the :ref:`Variant<class_Variant>` header.

--- a/tutorials/scripting/gdscript/gdscript_format_string.rst
+++ b/tutorials/scripting/gdscript/gdscript_format_string.rst
@@ -285,3 +285,6 @@ Combining both the ``String.format`` method and the ``%`` operator could be usef
 +---------------------------------------------------------------------------+-------------------+
 | ``"Hi, {0} v{version}".format({0:"Godette", "version":"%0.2f" % 3.114})`` | Hi, Godette v3.11 |
 +---------------------------------------------------------------------------+-------------------+
+
+In Godot's C++ code, GDScript format strings can accessed using the
+``vformat`` helper function in the :ref:`Variant<class_Variant>` header.


### PR DESCRIPTION
I placed this at the bottom of the page because that section already contained advanced use cases, and was already talking about functions because it mentioned the `String.format` function.

This text is true for both in-engine code and GDExtension, because `vformat` is available in both.