### PR TITLE
Mark Blender ESCN exporter as deprecated

### DIFF
--- a/tutorials/assets_pipeline/escn_exporter/animation.rst
+++ b/tutorials/assets_pipeline/escn_exporter/animation.rst
@@ -1,5 +1,12 @@
 Animation
 =========
+
+.. warning::
+   This chapter covers the Blender plugin
+   `Godot Blender Exporter <https://github.com/godotengine/godot-blender-exporter>`__,
+   which is deprecated in Godot 4.x. To export from Blender to Godot 4.x, use
+   one of the :ref:`available 3D formats <doc_importing_3d_scenes_available_formats>`.
+
 Animation supported:
  - transform animation of all types of objects
  - transform animation of pose bones

--- a/tutorials/assets_pipeline/escn_exporter/index.rst
+++ b/tutorials/assets_pipeline/escn_exporter/index.rst
@@ -3,8 +3,11 @@
 Blender ESCN exporter
 =====================
 
-.. note:: This chapter relates to the Blender plugin called "Godot Blender Exporter",
-          which can be downloaded here: https://github.com/godotengine/godot-blender-exporter
+.. warning::
+   This chapter covers the Blender plugin
+   `Godot Blender Exporter <https://github.com/godotengine/godot-blender-exporter>`__,
+   which is deprecated in Godot 4.x. To export from Blender to Godot 4.x, use
+   one of the :ref:`available 3D formats <doc_importing_3d_scenes_available_formats>`.
 
 This plugin can be used to export Blender scenes in a Godot-specific scene format
 called ESCN, which is similar to TSCN (text format) but will be imported as binary

--- a/tutorials/assets_pipeline/escn_exporter/lights.rst
+++ b/tutorials/assets_pipeline/escn_exporter/lights.rst
@@ -1,5 +1,12 @@
 Lights
 ======
+
+.. warning::
+    This chapter covers the Blender plugin
+    `Godot Blender Exporter <https://github.com/godotengine/godot-blender-exporter>`__,
+    which is deprecated in Godot 4.x. To export from Blender to Godot 4.x, use
+    one of the :ref:`available 3D formats <doc_importing_3d_scenes_available_formats>`.
+
 .. warning::
     By default, lamps in Blender have shadows enabled. This can cause
     performance issues in Godot.

--- a/tutorials/assets_pipeline/escn_exporter/material.rst
+++ b/tutorials/assets_pipeline/escn_exporter/material.rst
@@ -1,6 +1,12 @@
 Materials
 =========
 
+.. warning::
+  This chapter covers the Blender plugin
+  `Godot Blender Exporter <https://github.com/godotengine/godot-blender-exporter>`__,
+  which is deprecated in Godot 4.x. To export from Blender to Godot 4.x, use
+  one of the :ref:`available 3D formats <doc_importing_3d_scenes_available_formats>`.
+
 Using existing Godot materials
 ------------------------------
 

--- a/tutorials/assets_pipeline/escn_exporter/mesh.rst
+++ b/tutorials/assets_pipeline/escn_exporter/mesh.rst
@@ -1,6 +1,12 @@
 Mesh
 ====
 
+.. warning::
+   This chapter covers the Blender plugin
+   `Godot Blender Exporter <https://github.com/godotengine/godot-blender-exporter>`__,
+   which is deprecated in Godot 4.x. To export from Blender to Godot 4.x, use
+   one of the :ref:`available 3D formats <doc_importing_3d_scenes_available_formats>`.
+
 Modifiers
 ---------
 There is an exporting option :code:`Apply Modifiers` to

--- a/tutorials/assets_pipeline/escn_exporter/physics.rst
+++ b/tutorials/assets_pipeline/escn_exporter/physics.rst
@@ -1,6 +1,12 @@
 Physics properties
 ==================
 
+.. warning::
+    This chapter covers the Blender plugin
+    `Godot Blender Exporter <https://github.com/godotengine/godot-blender-exporter>`__,
+    which is deprecated in Godot 4.x. To export from Blender to Godot 4.x, use
+    one of the :ref:`available 3D formats <doc_importing_3d_scenes_available_formats>`.
+
 Exporting physics properties is done by enabling "Rigid Body" in Blender's
 physics tab:
 

--- a/tutorials/assets_pipeline/escn_exporter/skeleton.rst
+++ b/tutorials/assets_pipeline/escn_exporter/skeleton.rst
@@ -1,6 +1,12 @@
 Skeleton
 ========
 
+.. warning::
+   This chapter covers the Blender plugin
+   `Godot Blender Exporter <https://github.com/godotengine/godot-blender-exporter>`__,
+   which is deprecated in Godot 4.x. To export from Blender to Godot 4.x, use
+   one of the :ref:`available 3D formats <doc_importing_3d_scenes_available_formats>`.
+
 .. image:: img/armature.jpg
 
 Rest Bone


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-docs/issues/8196.
Alternate or complement to https://github.com/godotengine/godot-docs/pull/10064.

This PR adds a warning to each page under [Blender ESCN exporter](https://docs.godotengine.org/en/latest/tutorials/assets_pipeline/escn_exporter/index.html) that the blender plugin is depreacted in Godot 4.x. Personally, I believe even calling the plugin "deprecated" is promising too much, since it has not been maintained at all since Godot 4.0, and is producing shader errors for all tested Godot 4 versions (see https://github.com/godotengine/godot-docs/issues/8196#issuecomment-2400982178). "Deprecated" implies that the plugin functions in the current Godot version, but is not receiving updates.

Some combination of this PR and https://github.com/godotengine/godot-docs/pull/10064 (which removes these pages entirely, except for a stub redirect page) should be applied to all Godot 4.x docs versions. I see three options:
1. Apply this PR to 4.4 and cherrypick it to all 4.x docs versions (or as far back as we cherrypick).
2. Apply https://github.com/godotengine/godot-docs/pull/10064 to 4.4, and apply this PR to all previous 4.x docs versions (or as far back as we cherrypick).
3. Apply https://github.com/godotengine/godot-docs/pull/10064 to 4.4, and cherrypick it back to all previous 4.x docs versions (or as far back as we cherrypick).

Option 1 seems like the wrong choice to me. I don't think carrying these docs pages forward to future Godot 4.x versions makes sense. The plugin is unmaintained, unsupported, and does not even export at all since Blender version 4.0. The plugin does not work at all in Blender 4.2, which is the current Blender LTS version as of Godot 4.3. 

Option 2 makes sense to me, since it corrects the problem for future 4.x docs versions and keeps the existing docs pages for anyone still relying on them.

Option 3 also makes sense, and is my preferred solution. The Blender addon has in practice been unmaintained and unsupported since Godot 4.0. It should have been marked deprecated since Godot version 4.x, and perhaps not included in the Godot 4.x docs at all.



