### PR TITLE
Add color constants reference to BBCode in RichTextLabel

### DIFF
--- a/tutorials/ui/bbcode_in_richtextlabel.rst
+++ b/tutorials/ui/bbcode_in_richtextlabel.rst
@@ -812,10 +812,16 @@ Font options
 Named colors
 ~~~~~~~~~~~~
 
-For tags that allow specifying a color by name you can use names of the constants from
+For tags that allow specifying a color by name, you can use names of the constants from
 the built-in :ref:`class_Color` class. Named classes can be specified in a number of
 styles using different casings: ``DARK_RED``, ``DarkRed``, and ``darkred`` will give
 the same exact result.
+
+See this image for a list of color constants:
+
+.. image:: /img/color_constants.png
+
+`View at full size <https://raw.githubusercontent.com/godotengine/godot-docs/master/img/color_constants.png>`__
 
 .. _doc_bbcode_in_richtextlabel_hex_colors:
 


### PR DESCRIPTION
This reference is already present in the Color class reference, but this embeds it directly in the page to save users a click.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/141#discussioncomment-10743241.