### PR TITLE
Clarify that the Better Collada addon is unmaintained in 4.x

### DIFF
--- a/tutorials/assets_pipeline/importing_3d_scenes/available_formats.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/available_formats.rst
@@ -156,7 +156,9 @@ the built-in Collada support may still work for simple scenes without animation.
 
 For complex scenes or scenes that contain animations, Godot provides a
 `Blender plugin <https://github.com/godotengine/collada-exporter>`_
-that will correctly export COLLADA scenes for use in Godot.
+that will correctly export COLLADA scenes for use in Godot. This plugin is
+not maintained or supported in Godot 4.x, but may still work depending on your
+Godot and Blender versions.
 
 Importing OBJ files in Godot
 ----------------------------


### PR DESCRIPTION
Relevant to https://github.com/godotengine/godot-proposals/issues/2130 (and https://github.com/godotengine/collada-exporter/pull/133)

See also https://github.com/godotengine/godot-docs/pull/10064.

Since the Better Collada addon does not have several pages of docs, only this single line, we can alternately just mention that it is unmaintained in Godot 4.x.