### PR TITLE
Fix "or_greater"/"or_less" code example

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_exports.rst
+++ b/tutorials/scripting/gdscript/gdscript_exports.rst
@@ -164,7 +164,7 @@ The limits can be only for the slider if you add the hints "or_greater" and/or "
 
 ::
 
-    @export_range(0, 100, 1, "or_greater", "or_less")
+    @export_range(0, 100, 0.1, "or_greater", "or_less") var l
 
 .. TODO: Document other hint strings usable with export_range.
 


### PR DESCRIPTION
The code example demonstrating the usage of the "or_greater" and "or_less" hints for the export_range annotation does not declare a variable after the annotation, which is inconsistent with the previous three code examples in the section. It should be declared as "var l" to follow the established pattern.

Also, giving the export_range a step of 1 does not create a slider for the property in the editor, like the text suggests, but it instead creates a spin box. The step should be changed to a float so the property can appear as a slider, as can be seen below.

![export_range](https://github.com/user-attachments/assets/933997a5-a2d4-4078-ac8b-22f505b580b2)
