### PR TITLE
Update code example to use "is not" in Static Typing

### DIFF
--- a/tutorials/scripting/gdscript/static_typing.rst
+++ b/tutorials/scripting/gdscript/static_typing.rst
@@ -260,7 +260,7 @@ get full autocompletion on the player variable thanks to that cast.
     in some cases, it can also lead to bugs. Use the ``as`` keyword only if this
     behavior is intended. A safer alternative is to use the ``is`` keyword::
 
-        if not (body is PlayerController):
+        if body is not PlayerController:
             push_error("Bug: body is not PlayerController.")
 
         var player: PlayerController = body


### PR DESCRIPTION
Godot 4.3 added the ability to use "is not" instead of "not a is b" for improved readability. This code example should be updated to use the new feature to be more up to date with the latest version.

Also, the original line used parentheses in its conditional statement, which is explicitly against the [style guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html#avoid-unnecessary-parentheses).