### PR TITLE
Remove note in Submitting to Asset Library

### DIFF
--- a/community/asset_library/submitting_to_assetlib.rst
+++ b/community/asset_library/submitting_to_assetlib.rst
@@ -211,12 +211,6 @@ You can check all assets currently pending a review `here <https://godotengine.o
 The approval process is manual and may take up to a few days for your asset to be accepted (or rejected), so please
 be patient!
 
-.. note::
-
-    You may have some luck accelerating the approval process by messaging the
-    moderators and AssetLib reviewers on the `Godot Contributors Chat <https://chat.godotengine.org/>`_,
-    or the official Discord server.
-
 You will be informed when your asset is reviewed. If it was rejected,
 you will be told why that may have been, and you will be able to submit it again
 with the appropriate changes.


### PR DESCRIPTION
Removes a note which encourages users to message AssetLib reviewers for faster approval.

**Previously, removed only the mention of discord from the note. Previous description:**
The discord should not be used for development purposes, and this note makes an assumption that AssetLib reviewers are present in the official discord, which may no longer be true. This note was originally 7 years ago, when "official discord server" referred to what is now the Godot Cafe discord.

Arguably the note should be removed entirely, or replaced with something like:
```
If you have any questions about the asset review process, you can ask in the Godot Contributors chat.
```
Including a note in the official submission process to bother the reviewers seems possibly incorrect.