### PR TITLE
Add warning about uninitialized variables in shaders

### DIFF
--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -86,6 +86,14 @@ Most GLSL ES 3.0 datatypes are supported:
 |                      | Only supported in Forward+ and Mobile, not Compatibility.                       |
 +----------------------+---------------------------------------------------------------------------------+
 
+.. warning::
+
+    Local variables are not initialized to a default value such as ``0.0``. If
+    you use a variable without assigning it first, it will contain whatever
+    value was already present at that memory location, and unpredictable visual
+    glitches will appear. However, uniforms and varyings are initialized to a
+    default value.
+
 Comments
 ~~~~~~~~
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/98223.

Adds a warning note to shading_language.rst. GDShader does not initialize local variables to 0, and an uninitialized local variable can contain an arbitrary value.

There is no section specifically about variables in this page, so I added the note to the [Data Types](https://docs.godotengine.org/en/stable/tutorials/shaders/shader_reference/shading_language.html#data-types) section.

I briefly tested both varyings and uniforms, and both appear to be consistently zero-initialized if not set manually.