### PR TITLE
Add note about flat shading and Grow in Standard Material page

### DIFF
--- a/tutorials/3d/standard_material_3d.rst
+++ b/tutorials/3d/standard_material_3d.rst
@@ -658,6 +658,12 @@ make it black and unshaded, reverse culling (Cull Front), and add some grow:
 
 .. image:: img/spatial_material11.png
 
+.. note::
+
+    For Grow to work as expected, the mesh must have connected faces with shared
+    vertices, or "smooth shading". If the mesh has disconnected faces with unique
+    vertices, or "flat shading", the mesh will appear to have gaps when using Grow.
+
 Transform
 ---------
 


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot/issues/70819.

I'm not 100% sure about this addition. To me this is fairly obvious, and also should be obvious from the existing example images on the page, which show a "flat shaded" box mesh which grows with gaps.

If not accepted, the original issue should be closed as not planned. 