### PR TITLE
Fix unreachable pages under 3D Particles by using fake headers

### DIFF
--- a/tutorials/3d/particles/index.rst
+++ b/tutorials/3d/particles/index.rst
@@ -8,8 +8,7 @@ Particle systems (3D)
 This section of the tutorial covers (3D) GPU-accelerated particle systems. Most of the things
 discussed here apply to CPU particles as well.
 
-Introduction
-------------
+.. rubric:: Introduction
 
 You can use particle systems to simulate complex physical effects like fire, sparks,
 smoke, magical effects, and many more. They are very well suited for creating dynamic and organic
@@ -22,8 +21,7 @@ parameters and behaviors.
 
 Every particle system you create in Godot consists of two main parts: particles and emitters.
 
-Particles
-~~~~~~~~~
+.. rubric:: Particles
 
 A particle is the visible part of a particle system. It's what you see on the screen when a particle
 system is active: The tiny specks of dust, the flames of a fire, the glowing orbs of a magical
@@ -32,16 +30,14 @@ single system. You can randomize a particle's size, its speed and movement direc
 color over the course of its lifetime. When you think of a fire, you can think of all the little
 embers flying away from it as individual particles.
 
-Emitters
-~~~~~~~~
+.. rubric:: Emitters
 
 An emitter is what's creating the particles. Emitters are usually not visible, but they can have
 a shape. That shape controls where and how particles are spawned, for example whether they should fill
 a room like dust or shoot away from a single point like a fountain. Going back to the fire example,
 an emitter would be the heat at the center of the fire that creates the embers and the flames.
 
-Node overview
-~~~~~~~~~~~~~
+.. rubric:: Node overview
 
 .. figure:: img/particle_nodes.webp
    :alt: A list of nodes related to 3D particles
@@ -75,8 +71,7 @@ colliders by hand. If you want particles to collide with large outdoor scenes, y
 objects in it and uses that for large-scale particle collisions.
 
 
-Basic usage
------------
+.. rubric:: Basic usage
 
 .. toctree::
    :maxdepth: 1
@@ -86,8 +81,7 @@ Basic usage
    properties
    process_material_properties
 
-Advanced topics
----------------
+.. rubric:: Advanced topics
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-docs/issues/8792.

Applies a similar fix as https://github.com/godotengine/godot-docs/pull/9989. Converts all headers in `tutorials\3d\particles\index.rst` to fake rubric headers. Note that in this case we can't have any real subheaders on the page at all, due to the order of the sections. If the page was structured like the following, the `toctree` would be counted as a subsection of `Introduction` and the pages would not appear in the sidebar.

```
Introduction
-------------

Some paragraphs of text.

.. rubric:: Basic usage

.. toctree::
   :maxdepth: 1
   :name: toc-particles-basic

   creating_a_3d_particle_system
```

| Master | This PR |
| - | - |
| ![firefox_BsvF5Tk4HA](https://github.com/user-attachments/assets/a15c81d6-d5b2-4bac-a3e2-bddfe67d87ff) | ![firefox_uSnItb6WOW](https://github.com/user-attachments/assets/592536c5-7134-458a-b8ce-581850723b8f) |
