### PR TITLE
Add CSS styles for fake header rubrics

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1816,3 +1816,21 @@ p + .classref-constant {
 #godot-giscus {
     margin-bottom: 1em;
 }
+
+/* To ensure all pages are reachable from the sidebar, we use the rubric 
+   directive to create fake headers instead of real semantic headers in some
+   index pages. These classes emulate the existing real header styles.*/
+
+/* class-fake-h1 is not needed, since that would be a page title. */
+.class-fake-h2 {
+    font-size: 150%;
+    font-family: var(--header-font-family);
+}
+
+.class-fake-h3 {
+    font-size: 125%;
+    font-family: var(--header-font-family);
+}
+
+/* class-fake-h4 and smaller are not needed, since the index pages only have two
+   levels of header nesting. */

--- a/contributing/development/compiling/index.rst
+++ b/contributing/development/compiling/index.rst
@@ -19,6 +19,7 @@ The articles below should help you navigate configuration options available, as 
 prerequisites required to compile Godot exactly the way you need.
 
 .. rubric:: Basics of building Godot
+   :class: class-fake-h2
 
 Let's start with basics, and learn how to get Godot's source code, and then which options
 to use to compile it regardless of your target platform.
@@ -31,6 +32,7 @@ to use to compile it regardless of your target platform.
    introduction_to_the_buildsystem
 
 .. rubric:: Building for target platforms
+   :class: class-fake-h2
 
 Below you can find instructions for compiling the engine for your specific target platform.
 Note that Godot supports cross-compilation, which means you can compile it for a target platform
@@ -50,6 +52,7 @@ will try their best to cover all possible situations.
    compiling_for_web
 
 .. rubric:: Other compilation targets and options
+   :class: class-fake-h2
 
 Some additional universal compilation options require further setup. Namely, while Godot
 does have C#/.NET support as a part of its main codebase, it does not get compiled by

--- a/contributing/development/core_and_modules/index.rst
+++ b/contributing/development/core_and_modules/index.rst
@@ -7,6 +7,7 @@ The following pages are meant to introduce the global organization of Godot Engi
 source code, and give useful tips for extending and fixing the engine on the C++ side.
 
 .. rubric:: Getting started with Godot's source code
+   :class: class-fake-h2
 
 This section covers the basics that you will encounter in (almost) every source file.
 
@@ -25,6 +26,7 @@ This section covers the basics that you will encounter in (almost) every source 
    scripting_development
 
 .. rubric:: Extending Godot by modifying its source code
+   :class: class-fake-h2
 
 This section covers what you can do by modifying Godot's C++ source code.
 

--- a/tutorials/scripting/index.rst
+++ b/tutorials/scripting/index.rst
@@ -11,6 +11,7 @@ sections. For instance, to learn about inputs, we recommend you to read
 :ref:`Inputs <toc-learn-features-inputs>`.
 
 .. rubric:: Programming languages
+   :class: class-fake-h2
 
 The sections below each focus on a given programming language.
 


### PR DESCRIPTION
Followup to https://github.com/godotengine/godot-docs/pull/9989.

The sphinx [rubric directive](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-rubric) is used in place of real semantic headers in some index pages. This change adds CSS styles that mimic the current real `h2` and `h3` styles, and applies those to the fake header rubrics.

Only `fake-h2` is used in this PR, but `fake-h3` will be needed for the changes in https://github.com/godotengine/godot-docs/pull/10110.

I followed this [stackoverflow answer](https://stackoverflow.com/a/23549957) to implement this.

Current `h2` and `h3` styles are pulled from https://github.com/readthedocs/sphinx_rtd_theme/blob/7b894f5e7a5053dd35de406bc779020c229f20a9/sphinx_rtd_theme/static/css/theme.css and from: https://github.com/godotengine/godot-docs/blob/9a44730c9297b058b0186dd99a9f3579c1a1e132/_static/css/custom.css#L304-L314

### Comparison of [Building from Source](https://docs.godotengine.org/en/latest/contributing/development/compiling/)

**Master (after https://github.com/godotengine/godot-docs/pull/9989). Note the tiny rubric headers:**
![firefox_rTpHBXShbg](https://github.com/user-attachments/assets/0c514642-07d6-4a3f-9036-b407b8f69bad)
**This PR. Note that headers match the existing `h2` style:**
![firefox_x1FpucX9zv](https://github.com/user-attachments/assets/35e87e79-3677-4fb7-afc3-431a423b0fde)
**4.2 (Before https://github.com/godotengine/godot-docs/pull/9989):**
![image](https://github.com/user-attachments/assets/9f7cdd43-91a6-426d-ab4b-9d26e9076ad1)
