### PR TITLE
Fix docstring written as comment

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -744,7 +744,7 @@ We suggest to organize GDScript code this way:
     01. @tool
     02. class_name
     03. extends
-    04. # docstring
+    04. ## docstring
 
     05. signals
     06. enums


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-docs/issues/10115.