### PR TITLE
Remove reference to 3.1 as a minimum version

### DIFF
--- a/tutorials/best_practices/scenes_versus_scripts.rst
+++ b/tutorials/best_practices/scenes_versus_scripts.rst
@@ -118,8 +118,6 @@ There are two systems for registering types:
    - Engine developers must add support for languages manually (both name exposure and
      runtime accessibility).
 
-   - Godot 3.1+ only.
-
    - The Editor scans project folders and registers any exposed names for all
      scripting languages. Each scripting language must implement its own
      support for exposing this information.


### PR DESCRIPTION
No longer relevant in Godot 4.x.