### PR TITLE
Remove references to 3.x minor versions

### DIFF
--- a/tutorials/animation/2d_skeletons.rst
+++ b/tutorials/animation/2d_skeletons.rst
@@ -13,8 +13,7 @@ and most 3D modeling applications support it. For 2D, as this function is not
 used as often, it's difficult to find mainstream software aimed for this.
 
 One option is to create animations in third-party software such as Spine or
-Dragonbones. From Godot 3.1 onwards, though, this functionality is supported
-built-in.
+Dragonbones. This functionality is also supported built-in.
 
 Why would you want to do skeletal animations directly in Godot? The answer is
 that there are many advantages to it:

--- a/tutorials/animation/animation_tree.rst
+++ b/tutorials/animation/animation_tree.rst
@@ -12,9 +12,6 @@ function calling, audio and sub-animation tracks, is pretty much unique.
 
 However, the support for blending those animations via ``AnimationPlayer`` is relatively limited, as only a fixed cross-fade transition time can be set.
 
-:ref:`AnimationTree <class_AnimationTree>` is a new node introduced in Godot 3.1 to deal with advanced transitions.
-It supersedes the ancient ``AnimationTreePlayer``, while adding a huge amount of features and flexibility.
-
 Creating an AnimationTree
 -------------------------
 

--- a/tutorials/audio/sync_with_audio.rst
+++ b/tutorials/audio/sync_with_audio.rst
@@ -23,7 +23,9 @@ The most common way to reduce latency is to shrink the audio buffers (again, by 
 
 This is a common tradeoff, so Godot ships with sensible defaults that should not need to be altered.
 
-The problem, in the end, is not this slight delay but synchronizing graphics and audio for games that require it. Beginning with Godot 3.2, some helpers were added to obtain more precise playback timing.
+The problem, in the end, is not this slight delay but synchronizing graphics and
+audio for games that require it. Some helpers are available to obtain more 
+precise playback timing.
 
 Using the system clock to sync
 ------------------------------

--- a/tutorials/editor/using_the_web_editor.rst
+++ b/tutorials/editor/using_the_web_editor.rst
@@ -5,8 +5,8 @@
 Using the Web editor
 ====================
 
-Since Godot 3.3, there is a `Web editor <https://editor.godotengine.org/>`__
-you can use to work on new or existing projects.
+There is a `Web editor <https://editor.godotengine.org/>`__ you can use to work
+on new or existing projects.
 
 .. note::
 

--- a/tutorials/inputs/controllers_gamepads_joysticks.rst
+++ b/tutorials/inputs/controllers_gamepads_joysticks.rst
@@ -136,10 +136,6 @@ use ``Input.is_action_pressed()``:
     held, ``Input.is_action_just_pressed()`` will only return ``true`` for one
     frame after the button has been pressed.
 
-In Godot versions before 3.4, such as 3.3, ``Input.get_vector()`` and
-``Input.get_axis()`` aren't available. Only ``Input.get_action_strength()``
-and ``Input.is_action_pressed()`` are available in Godot 3.3.
-
 Vibration
 ---------
 

--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -917,7 +917,7 @@ in that order.
 Static typing
 -------------
 
-Since Godot 3.1, GDScript supports :ref:`optional static typing<doc_gdscript_static_typing>`.
+GDScript supports :ref:`optional static typing<doc_gdscript_static_typing>`.
 
 Declared types
 ~~~~~~~~~~~~~~

--- a/tutorials/scripting/gdscript/static_typing.rst
+++ b/tutorials/scripting/gdscript/static_typing.rst
@@ -384,9 +384,9 @@ Warning system
     Detailed documentation about the GDScript warning system has been moved to
     :ref:`doc_gdscript_warning_system`.
 
-From version 3.1, Godot gives you warnings about your code as you write it:
-the engine identifies sections of your code that may lead to issues at runtime,
-but lets you decide whether or not you want to leave the code as it is.
+Godot gives you warnings about your code as you write it. The engine identifies
+sections of your code that may lead to issues at runtime, but lets you decide
+whether or not you want to leave the code as it is.
 
 We have a number of warnings aimed specifically at users of typed GDScript.
 By default, these warnings are disabled, you can enable them in Project Settings


### PR DESCRIPTION
Removes notes about features being introduced in 3.x minor versions. In 4.x, these details are no longer relevant. If the feature has been supported since before 4.0, it does not matter which minor version it was introduced in.

Note that there are some changes to pages which have an `:article_outdated: True` tag. I'm not sure if it's poor form to make minor changes to outdated articles without actually reviewing them?

A few references to 3.x minor version differences/feature introductions are still in the docs, in cases where I wasn't sure removing the reference was correct.