### PR TITLE
Remove unnecessary note from doc page

### DIFF
--- a/contributing/workflow/pr_workflow.rst
+++ b/contributing/workflow/pr_workflow.rst
@@ -97,9 +97,6 @@ To clone your fork from GitHub, use the following command:
 
     git clone https://github.com/USERNAME/godot
 
-.. note:: In our examples, the "$" character denotes the command line prompt
-          on typical UNIX shells. It is not part of the command and should
-          not be typed.
 
 After a little while, you should have a ``godot`` directory in your current
 working directory. Move into it using the ``cd`` command:


### PR DESCRIPTION
Removed unnecessary note, as this page got rid of "$" signs in below …

https://github.com/godotengine/godot-docs/pull/9956

before:
![image](https://github.com/user-attachments/assets/ddd5002f-37ab-4565-9e14-0dc1f683ea3d)

after:
![image](https://github.com/user-attachments/assets/20990681-8630-4414-a931-533733c5e9e6)

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
