### PR TITLE
Add `CLIP_SPACE_FAR` built-in description to spatial shaders

### DIFF
--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -96,25 +96,32 @@ Global built-ins
 
 Global built-ins are available everywhere, including custom functions.
 
-+-------------------+-----------------------------------------------------------------------------------------+
-| Built-in          | Description                                                                             |
-+===================+=========================================================================================+
-| in float **TIME** | Global time since the engine has started, in seconds. It repeats after every ``3,600``  |
-|                   | seconds (which can  be changed with the                                                 |
-|                   | :ref:`rollover<class_ProjectSettings_property_rendering/limits/time/time_rollover_secs>`|
-|                   | setting). It's not affected by :ref:`time_scale<class_Engine_property_time_scale>` or   |
-|                   | pausing. If you need  a ``TIME`` variable that can be scaled or paused, add your own    |
-|                   | :ref:`global shader uniform<doc_shading_language_global_uniforms>` and update it each   |
-|                   | frame.                                                                                  | 
-+-------------------+-----------------------------------------------------------------------------------------+
-| in float **PI**   | A ``PI`` constant (``3.141592``).                                                       |
-|                   | A ratio of a circle's circumference to its diameter and amount of radians in half turn. |
-+-------------------+-----------------------------------------------------------------------------------------+
-| in float **TAU**  | A ``TAU`` constant (``6.283185``).                                                      |
-|                   | An equivalent of ``PI * 2`` and amount of radians in full turn.                         |
-+-------------------+-----------------------------------------------------------------------------------------+
-| in float **E**    | An ``E`` constant (``2.718281``). Euler's number and a base of the natural logarithm.   |
-+-------------------+-----------------------------------------------------------------------------------------+
++-----------------------------+------------------------------------------------------------------------------------------+
+| Built-in                    | Description                                                                              |
++=============================+==========================================================================================+
+| in float **TIME**           | Global time since the engine has started, in seconds. It repeats after every ``3,600``   |
+|                             | seconds (which can  be changed with the                                                  |
+|                             | :ref:`rollover<class_ProjectSettings_property_rendering/limits/time/time_rollover_secs>` |
+|                             | setting). It's not affected by :ref:`time_scale<class_Engine_property_time_scale>` or    |
+|                             | pausing. If you need  a ``TIME`` variable that can be scaled or paused, add your own     |
+|                             | :ref:`global shader uniform<doc_shading_language_global_uniforms>` and update it each    |
+|                             | frame.                                                                                   | 
++-----------------------------+------------------------------------------------------------------------------------------+
+| in float **PI**             | A ``PI`` constant (``3.141592``).                                                        |
+|                             | A ratio of a circle's circumference to its diameter and amount of radians in half turn.  |
++-----------------------------+------------------------------------------------------------------------------------------+
+| in float **TAU**            | A ``TAU`` constant (``6.283185``).                                                       |
+|                             | An equivalent of ``PI * 2`` and amount of radians in full turn.                          |
++-----------------------------+------------------------------------------------------------------------------------------+
+| in float **E**              | An ``E`` constant (``2.718281``). Euler's number and a base of the natural logarithm.    |
++-----------------------------+------------------------------------------------------------------------------------------+
+| in bool **OUTPUT_IS_SRGB**  | ``true`` when output is in sRGB color space (this is ``true`` in the Compatibility       |
+|                             | renderer, ``false`` in Forward+ and Forward Mobile).                                     |
++----------------------------------------+-------------------------------------------------------------------------------+
+| in float **CLIP_SPACE_FAR** | Clip space far ``z`` value.                                                              |
+|                             | In the Forward+ or Mobile renderers, it's ``0.0``.                                       |
+|                             | In the Compatibility renderer, it's ``-1.0``.                                            |
++-----------------------------+------------------------------------------------------------------------------------------+
 
 Vertex built-ins
 ^^^^^^^^^^^^^^^^
@@ -180,10 +187,6 @@ shader, this value can be used as desired.
 | in vec3 **CAMERA_DIRECTION_WORLD**     | Camera direction, in world space.                      |
 +----------------------------------------+--------------------------------------------------------+
 | in uint **CAMERA_VISIBLE_LAYERS**      | Cull layers of the camera rendering the current pass.  |
-+----------------------------------------+--------------------------------------------------------+
-| in bool **OUTPUT_IS_SRGB**             | ``true`` when output is in sRGB color space            |
-|                                        | (this is ``true`` in the Compatibility renderer,       |
-|                                        | ``false`` in Forward+ and Forward Mobile).             |
 +----------------------------------------+--------------------------------------------------------+
 | in int **INSTANCE_ID**                 | Instance ID for instancing.                            |
 +----------------------------------------+--------------------------------------------------------+
@@ -284,9 +287,6 @@ these properties, and if you don't write to them, Godot will optimize away the c
 | in vec4 **COLOR**                      | COLOR that comes from the ``vertex()`` function.                                                 |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
 | in vec2 **POINT_COORD**                | Point coordinate for drawing points with ``POINT_SIZE``.                                         |
-+----------------------------------------+--------------------------------------------------------------------------------------------------+
-| in bool **OUTPUT_IS_SRGB**             | ``true`` when output is in sRGB color space (this is ``true`` in the Compatibility renderer,     |
-|                                        | ``false`` in Forward+ and Forward Mobile).                                                       |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
 | in mat4 **MODEL_MATRIX**               | Model/local space to world space transform.                                                      |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
@@ -483,10 +483,6 @@ If you want the lights to add together, add the light contribution to ``DIFFUSE_
 | in float **METALLIC**             | Metallic.                                                              |
 +-----------------------------------+------------------------------------------------------------------------+
 | in float **ROUGHNESS**            | Roughness.                                                             |
-+-----------------------------------+------------------------------------------------------------------------+
-| in bool **OUTPUT_IS_SRGB**        | ``true`` when output is in sRGB color space.                           |
-|                                   | This is ``true`` in the Compatibility renderer,                        |
-|                                   | ``false`` in Forward+ and Forward Mobile.                              |
 +-----------------------------------+------------------------------------------------------------------------+
 | out vec3 **DIFFUSE_LIGHT**        | Diffuse light result.                                                  |
 +-----------------------------------+------------------------------------------------------------------------+


### PR DESCRIPTION
To reflect changes from https://github.com/godotengine/godot/pull/95057
