### PR TITLE
Typo fix for Interpolation gif description

### DIFF
--- a/tutorials/3d/particles/properties.rst
+++ b/tutorials/3d/particles/properties.rst
@@ -98,7 +98,7 @@ property has no effect.
    :alt: Particles running at low FPS
    :align: right
 
-   Interpolation on (left) vs. off (right)
+   Interpolation off (left) vs. on (right)
 
 The ``Fixed FPS`` property limits how often the particle system is processed. This includes
 property updates as well as collision and attractors. This can improve performance a lot,


### PR DESCRIPTION
The original description was backwards. This is a small edit that fixes it.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
