### PR TITLE
Add Web export file name section

### DIFF
--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -37,6 +37,19 @@ in the user's browser.
     general, especially when using the GLES2 rendering backend (which only
     requires WebGL 1.0).
 
+Export file name
+----------------
+
+We do suggest users to export their Web projects with ``index.html`` as the file name.
+``index.html`` is usually the default file loaded by web servers when accessing the
+parent directory, usually hiding the name of that file.
+
+.. attention::
+
+    The Godot 4 Web export expects some files to be named the same name as the one set in the
+    initial export. Some issues could occur if some exported files are renamed, including the
+    main HTML file.
+
 WebGL version
 -------------
 
@@ -141,7 +154,7 @@ player to click, tap or press a key/button to enable audio, for instance when di
 .. seealso:: Google offers additional information about their `Web Audio autoplay
              policies <https://sites.google.com/a/chromium.org/dev/audio-video/autoplay>`__.
 
-             Apple's Safari team also posted additional information about their `Auto-Play Policy Changes for macOS 
+             Apple's Safari team also posted additional information about their `Auto-Play Policy Changes for macOS
              <https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/>`__.
 
 .. warning:: Access to microphone requires a


### PR DESCRIPTION
Add a file name section to the Web export article. It's there especially for the "attention" part.

<img width="837" alt="Capture d’écran, le 2024-10-25 à 13 16 19" src="https://github.com/user-attachments/assets/61a2ce9a-968a-4e91-a3b6-d0b30210eeda">

This PR was promised to be made here:  https://github.com/godotengine/godot/issues/97580#issuecomment-2438345603