### PR TITLE
Note limitation of shader world coordinates with large world coordinates

### DIFF
--- a/tutorials/physics/large_world_coordinates.rst
+++ b/tutorials/physics/large_world_coordinates.rst
@@ -229,6 +229,23 @@ some limitations when it comes to 3D rendering precision:
 - :ref:`Triplanar mapping <doc_standard_material_3d_triplanar_mapping>` doesn't
   benefit from increased precision. Materials using triplanar mapping will exhibit
   visible jittering when far away from the world origin.
+- In double-precision builds, world space coordinates in a shader ``fragment()``
+  function can't be reconstructed from view space, for example:
+
+  .. code-block:: glsl
+
+    vec3 world = (INV_VIEW_MATRIX * vec4(VERTEX, 1.0)).xyz;
+    
+  Instead, calculate the world space coordinates in the ``vertex()`` function and
+  pass them using a :ref:`varying<doc_shading_language_varyings>`, for example:
+
+  .. code-block:: glsl
+  
+    varying vec3 world;
+    void vertex() {
+        world = (MODEL_MATRIX * vec4(VERTEX, 1.0)).xyz;
+    }
+
 
 2D rendering currently doesn't benefit from increased precision when large world
 coordinates are enabled. This can cause visible model snapping to occur when

--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -662,6 +662,7 @@ function calls is not allowed, such as from ``int`` to ``float`` (``1`` to ``1.0
         vec3 green = get_color(1.0);
     }
 
+.. _doc_shading_language_varyings:
 
 Varyings
 --------


### PR DESCRIPTION
This came from helping a user use world space coordinates in a `fragment()` shader while using a double precision build. The easy solution of `vec3 world = (INV_VIEW_MATRIX * vec4(VERTEX, 1.0)).xyz;` didn't work, but passing a varying did. It's a niche problem and a niche solution, but I think that's okay on this page.

After confirming that user's problem was fixed by passing a varying, I also tested it myself on a build of https://github.com/roalyr/godot-for-3d-open-worlds, which is a double-precision build and also has some other changes which I don't think affect this. I couldn't find any official double precision builds.