### PR TITLE
Clarify cherry-picking workflow in Contributing to the Documentation

### DIFF
--- a/contributing/documentation/contributing_to_the_documentation.rst
+++ b/contributing/documentation/contributing_to_the_documentation.rst
@@ -49,9 +49,11 @@ contribute, you should also read:
 Contributing changes
 --------------------
 
-**Pull Requests should use the** ``master`` **branch by default.** Only make Pull
-Requests against other branches (e.g. ``2.1`` or ``3.0``) if your changes only
-apply to that specific version of Godot.
+**Pull requests should use the** ``master`` **branch by default.** Only make pull
+requests against other branches (e.g. ``3.6`` or ``4.2``) if your changes only
+apply to that specific version of Godot. After a pull request is merged into
+``master``, it will usually be cherry-picked into the current stable branch by
+documentation maintainers.
 
 Though less convenient to edit than a wiki, this Git repository is where we
 write the documentation. Having direct access to the source files in a revision


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-docs/issues/5964.

Adds a bit more information for what happens to a PR after it is merged. 

While useful, I don't think the other information shared in https://github.com/godotengine/godot-docs/issues/5964 needs to be in the docs, as it's workflow information that is likely to become out of date. I'm not *opposed* to keeping such informal knowledge in the actual docs, either, but there are other docs improvements to make first.
