### PR TITLE
Fix unreachable pages in sidebar under C# Diagnostics

### DIFF
--- a/tutorials/scripting/c_sharp/diagnostics/index.rst
+++ b/tutorials/scripting/c_sharp/diagnostics/index.rst
@@ -8,8 +8,7 @@ C# diagnostics
 Godot includes analyzers that inspect your C# source code to check for invalid
 or unsupported code and let you know that something is wrong during build time.
 
-Rules
------
+.. rubric:: Rules
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Fixes some more cases of https://github.com/godotengine/godot-docs/issues/8792.

Sidebar after this change:
![msedge_BfsnPiBnXK](https://github.com/user-attachments/assets/76b75810-dc06-4d85-860c-8dc4ad9a04c5)
