### PR TITLE
Update Sphinx and requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/_static/css/algolia.css
+++ b/_static/css/algolia.css
@@ -1,6 +1,0 @@
-.wy-nav-side { overflow: visible; }
-.wy-side-scroll { overflow-x: inherit; }
-
-.algolia-autocomplete {
-    display: block !important;
-}

--- a/conf.py
+++ b/conf.py
@@ -9,7 +9,7 @@ import os
 
 # -- General configuration ------------------------------------------------
 
-needs_sphinx = "1.3"
+needs_sphinx = "8.1"
 
 # Sphinx extension module names and templates location
 sys.path.append(os.path.abspath("_extensions"))
@@ -63,6 +63,9 @@ if not on_rtd:
 
 # Specify the site name for the Open Graph extension.
 ogp_site_name = "Godot Engine documentation"
+ogp_social_cards = {
+    "enable": False
+}
 
 if not os.getenv("SPHINX_NO_GDSCRIPT"):
     extensions.append("gdscript")
@@ -158,7 +161,6 @@ highlight_language = "gdscript"
 # -- Options for HTML output ----------------------------------------------
 
 html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 if on_rtd:
     using_rtd_theme = True
 
@@ -168,8 +170,6 @@ html_theme_options = {
     "logo_only": True,
     # Collapse navigation (False makes it tree-like)
     "collapse_navigation": False,
-    # Hide the documentation version name/number under the logo
-    "display_version": False,
 }
 
 html_title = supported_languages[language] % ( "(" + version + ")" )
@@ -211,16 +211,14 @@ html_extra_path = ["robots.txt"]
 # These paths are either relative to html_static_path
 # or fully qualified paths (e.g. https://...)
 html_css_files = [
-    'css/algolia.css',
-    'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css',
-    "css/custom.css?10", # Increment the number at the end when the file changes to bust the cache.
+    "css/custom.css",
 ]
 
 if not on_rtd:
     html_css_files.append("css/dev.css")
 
 html_js_files = [
-    "js/custom.js?7", # Increment the number at the end when the file changes to bust the cache.
+    "js/custom.js",
 ]
 
 # Output file base name for HTML help builder

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,29 +3,22 @@
 # https://github.com/readthedocs/readthedocs.org/blob/master/requirements/docs.txt
 
 # Base dependencies
-pygments==2.15.1
+pygments==2.18.0
 
 # Sphinx base and RTD theme.
-sphinx==4.4.0
-sphinx_rtd_theme==1.1.1
+sphinx==8.1.3
+sphinx_rtd_theme==3.0.1
 
 # Sphinx extensions.
 
 # Code tabs extension to display codeblocks in different languages as tabs.
-sphinx-tabs==3.4.0
+sphinx-tabs==3.4.7
 # Adds a 'copy' button to the right of codeblocks.
-sphinx-copybutton==0.5.1
+sphinx-copybutton==0.5.2
 # Custom 404 error page (more useful than the default).
-sphinx-notfound-page==0.8.3
+sphinx-notfound-page==1.0.4
 # Adds Open Graph tags in the HTML `<head>` tag.
-sphinxext-opengraph==0.7.5
-
-# These get pulled in by Sphinx, we need to pin these as higher versions require Sphinx 5.0+.
-sphinxcontrib-applehelp==1.0.4
-sphinxcontrib-htmlhelp==2.0.1
-sphinxcontrib-qthelp==1.0.3
-sphinxcontrib-serializinghtml==1.1.5
-sphinxcontrib-devhelp==1.0.2
+sphinxext-opengraph==0.9.1
 
 # `.. video::` directive support to embed videos in documentation pages.
-sphinxcontrib-video==0.2.1rc0
+sphinxcontrib-video==0.2.1


### PR DESCRIPTION
supersede #7443

- Update CI OS version for sphinx 8.x support (I guess phyton version?)
- disable social cards, because of warnings
- remove `html_theme_path` and `display_version` as this are outdated options
- remove search css, as this shouldn't be required anymore
- remove cache busters, as this is now integrated
- remove pinned dependencies
- update dependencies

- `class_scripteditor.rst: document is referenced in multiple toctrees: ['classes/index', 'classes/index'], selecting: classes/index <- classes/class_scripteditor` is an information and can't be suppressed, like a warning. (as far as I know)