### PR TITLE
[Draft] Add glossary of common terms

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -101,6 +101,7 @@ the ``GodotEngine.epub`` file in an e-book reader application.
    tutorials/troubleshooting
    tutorials/editor/index
    tutorials/migrating/index
+   tutorials/glossary
 
    tutorials/2d/index
    tutorials/3d/index

--- a/tutorials/3d/3d_antialiasing.rst
+++ b/tutorials/3d/3d_antialiasing.rst
@@ -38,6 +38,8 @@ detailed below.
     You can compare antialiasing algorithms in action using the
     `3D Antialiasing demo project <https://github.com/godotengine/godot-demo-projects/tree/master/3d/antialiasing>`__.
 
+.. _doc_3d_antialiasing_msaa:
+
 Multisample antialiasing (MSAA)
 -------------------------------
 
@@ -176,6 +178,8 @@ value of the **Rendering > Anti Aliasing > Quality > Screen Space AA** setting t
 Comparison between no antialiasing (left) and FXAA (right):
 
 .. image:: img/antialiasing_fxaa.webp
+
+.. _doc_3d_antialiasing_ssaa:
 
 Supersample antialiasing (SSAA)
 -------------------------------

--- a/tutorials/3d/environment_and_post_processing.rst
+++ b/tutorials/3d/environment_and_post_processing.rst
@@ -410,6 +410,8 @@ geometry. Transparent materials won't be reflected, as they don't write to the d
 This also applies to shaders that use ``hint_screen_texture`` or ``hint_depth_texture``
 uniforms.
 
+.. _doc_environment_and_post_processing_ssao:
+
 Screen-Space Ambient Occlusion (SSAO)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tutorials/glossary.rst
+++ b/tutorials/glossary.rst
@@ -1,0 +1,97 @@
+.. _doc_glossary:
+
+Glossary
+========
+
+This page contains definitions for common terms that you will see throughout the
+manual. It includes many Godot-specific terms, as well as some common game 
+evelopment and graphics terms that may be unfamiliar to you.
+
+.. glossary::
+
+    Antialiasing
+        A rendering technique to make edges appear smoother. Godot supports several antialiasing techniques. See :ref:`doc_3d_antialiasing`.
+
+    Compatibility renderer
+        A fast, simple renderer for desktop and mobile that uses OpenGL. See :ref:`doc_renderers`.
+
+    CPU
+        Central processing unit. Executes code mostly in sequence, one instruction at a time. Godot uses the CPU for all processing except for rendering graphics. 
+
+    Direct3D 12
+        A modern, low-level graphics API, developed by Microsoft. 
+
+    DOF
+        Depth of field.
+
+    Forward+ renderer
+        An advanced renderer for desktop that uses modern graphics drivers. See :ref:`doc_renderers`.
+
+    FXAA
+        Fast approximate antialiasing. See :ref:`doc_3d_antialiasing_fxaa`.
+
+    GDExtension
+        A Godot-specific technology that lets the engine interact with native shared libraries at run-time. See :ref:`doc_what_is_gdextension`
+
+    GDScript
+        A high-level, object-oriented, imperative, and gradually typed programming language built for Godot. See :ref:`doc_gdscript`.
+
+    GPU
+        Graphics Processor Unit. Executes code mostly in parallel, and very fast. Godot uses the GPU for rendering graphics.
+
+    HDR
+        High dynamic range. See :ref:`doc_high_dynamic_range`.
+
+    Linear color space
+        The color space used internally by the Forward+ and Mobile renderers. See :ref:`doc_high_dynamic_range`.
+
+    Metal
+        A modern, low-level graphics API developed by Apple.
+
+    Mobile renderer
+       A renderer for mobile and desktop that uses modern graphics drivers. See :ref:`doc_renderers`.
+
+    MSAA
+        Multisample antialiasing. See :ref:`doc_3d_antialiasing_msaa`.
+
+    OpenGL
+        A cross-platform graphics API. Used by Godot for the Compatibility renderer.
+
+    Renderer
+        The rendering engine used to draw graphics. Godot has multiple renderers, with different features. See :ref:`doc_renderers`.
+
+    Rendering method
+        Another term for renderer.
+
+    Rendering driver
+        The rendering driver tells the GPU what to do, by communicating with a graphics API such as OpenGL or Vulkan.
+
+    Shader
+        A program that runs on the GPU, used to draw graphics. See :ref:`doc_introduction_to_shaders`.
+
+    SDFGI
+        Signed distance field global illumination. A kind of global illumation. See :ref:`doc_using_sdfgi`.
+
+    SDR
+        Standard dynamic range. See :ref:`doc_high_dynamic_range`.
+
+    sRGB color space
+        Standard RGB (red, green, blue). See :ref:`doc_high_dynamic_range`.
+
+    SSAA
+        Supersample antialiasing. See :ref:`doc_3d_antialiasing_ssaa`.
+
+    SSAO
+        Screen-space ambient occlusion. See :ref:`doc_environment_and_post_processing_ssao`.
+
+    SSIL
+        Screen-space indirect lighting. A kind of global illumination. See :ref`doc_environment_and_post_processing_ssil`.
+
+    Viewport
+        A view into the screen, used to render nodes. See :ref:`doc_viewports`.
+
+    VisualShader
+        A shader created using a graph-based visual editor. See :ref:`doc_visual_shaders`.
+
+    Vulkan
+        A modern, low-level, cross-platform graphics API. 


### PR DESCRIPTION
Adds a glossary of common terms to the online manual.

Uses the sphinx [glossary](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#glossary) directive.

On its own, this is perhaps a solution in search of a problem. But it's also relatively low-risk and low-cost to add, since it links to other pages, but no other pages depend on it.

With the addition of links *to* the glossary, this could be a much more useful improvement. We can link to these terms with the [term role](https://www.sphinx-doc.org/en/master/usage/referencing.html#role-term). Alternately, we can also integrate [hoverxref](https://sphinx-hoverxref.readthedocs.io/en/latest/) to add tooltips for common terms like acronyms, which link into the glossary.

See also previous discussion in https://github.com/godotengine/godot-docs/issues/1650#issuecomment-1870252031.

**Kinds of terms that will be included in the glossary:**
**Very common nodes or godot concepts:** control, node, viewport, signal, resource
**Godot-specific terms:** renderer, rendering driver, server (in the Godot sense)
**Godot proper nouns:** GDScript, GDExtension, Forward+ renderer, Mobile renderer, Compatibility renderer, RenderingDevice
**Other proper nouns:** Vulkan, Metal, Direct3D 12
**Acronyms, including common gamedev/graphics terms:** CPU, GPU, DOF, FXAA, MSAA, SSAA, SSAO, SSIL, SDFGI, HDR, SDR, sRGB

The current definitions are roughly representative of the final page in terms of length. Each term should be briefly defined, with 1-3 sentences, and link to a relevant portion of the documentation. However, the current *list* of terms is not yet complete.

I'm leaving this as a draft to discuss whether this is something worth including at all, and if so, whether there would need to be major changes to implementation.

The page renders like this with the current theme:
![msedge_R4lc0e487K](https://github.com/user-attachments/assets/1fc7b83e-fdfb-4ec8-a247-8f397000a83b)

