### PR TITLE
Fix broken link in README to Contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ add-on.
 
 All contributors are welcome to help on the Godot documentation.
 
-To get started, head to the [Contributing section](https://docs.godotengine.org/en/latest/contributing/ways_to_contribute.html#contributing-to-the-documentation) of the online manual. There, you will find all the information you need to write and submit changes.
+To get started, head to the [Contributing section](https://docs.godotengine.org/en/latest/contributing/how_to_contribute.html) of the online manual. There, you will find all the information you need to write and submit changes.
 
 Here are some quick links to the areas you might be interested in:
 


### PR DESCRIPTION
The previous link was to ["ways to contribute"](https://docs.godotengine.org/en/latest/contributing/ways_to_contribute.html#contributing-to-the-documentation).  
I'm guessing that should be to ["how to contribute"](https://docs.godotengine.org/en/latest/contributing/how_to_contribute.html) now.  

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
