### PR TITLE
Correctly name enum type

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_exports.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_exports.rst
@@ -363,7 +363,7 @@ combine multiple flags using logical OR (``|``) are also possible.
 .. code-block:: csharp
 
     [Flags]
-    public enum MyEnum
+    public enum SpellElements
     {
         Fire = 1 << 1,
         Water = 1 << 2,


### PR DESCRIPTION
Previously the example defined a "MyEnum" enum, but used a "SpellElements" type export. I've changed so it now defines a "SpellElements" enum.