### PR TITLE
Note that `render_mode wireframe` doesn't work in Compatibility

### DIFF
--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -43,7 +43,7 @@ For visual examples of these render modes, see :ref:`Standard Material 3D and OR
 +-------------------------------+------------------------------------------------------------------------------------------------------+
 | **unshaded**                  | Result is just albedo. No lighting/shading happens in material.                                      |
 +-------------------------------+------------------------------------------------------------------------------------------------------+
-| **wireframe**                 | Geometry draws using lines.                                                                          |
+| **wireframe**                 | Geometry draws using lines. Not supported in the Compatibility renderer.                             |
 +-------------------------------+------------------------------------------------------------------------------------------------------+
 | **diffuse_burley**            | Burley (Disney PBS) for diffuse (default).                                                           |
 +-------------------------------+------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/98532, https://github.com/godotengine/godot/issues/98532#issuecomment-2448127668.