### PR TITLE
Clarify when `FRAGCOORD.z` is used as depth output

### DIFF
--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -272,8 +272,9 @@ these properties, and if you don't write to them, Godot will optimize away the c
 +========================================+==================================================================================================+
 | in vec2 **VIEWPORT_SIZE**              | Size of viewport (in pixels).                                                                    |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
-| in vec4 **FRAGCOORD**                  | Coordinate of pixel center in screen space. ``xy`` specifies position in window, ``z``           |
-|                                        | specifies fragment depth if ``DEPTH`` is not used. Origin is lower-left.                         |
+| in vec4 **FRAGCOORD**                  | Coordinate of pixel center in screen space. ``xy`` specifies position in window. Origin is lower |
+|                                        | left. ``z`` specifies fragment depth. It is also used as the output value for the fragment depth |
+|                                        | unless ``DEPTH`` is written to.                                                                  |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
 | in bool **FRONT_FACING**               | ``true`` if current face is front facing.                                                        |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/69184