### PR TITLE
Update GDScript syntax highlighter

### DIFF
--- a/_extensions/gdscript.py
+++ b/_extensions/gdscript.py
@@ -80,7 +80,9 @@ class GDScriptLexer(RegexLexer):
             (r"[]{}:(),;[]", Punctuation),
             (r"(\\)(\n)", Whitespace),
             (r"\\", Text),
-            (r"(in|and|or|not)\b", Operator.Word),
+            # modules/gdscript/gdscript.cpp - GDScriptLanguage::get_reserved_words()
+            # Operators.
+            (r"(and|as|in|is|not|or)\b", Operator.Word),
             (
                 r"!=|==|<<|>>|&&|\+=|-=|\*=|/=|%=|&=|\|=|\|\||[-~+/*%=<>&^.!|$]",
                 Operator,
@@ -138,26 +140,28 @@ class GDScriptLexer(RegexLexer):
             (
                 words(
                     (
-                        "and",
-                        "await",
-                        "in",
-                        "get",
-                        "set",
-                        "not",
-                        "or",
-                        "as",
-                        "breakpoint",
+                        # modules/gdscript/gdscript.cpp - GDScriptLanguage::get_reserved_words()
+                        # Declarations.
                         "class",
                         "class_name",
-                        "extends",
-                        "is",
-                        "func",
-                        "signal",
                         "const",
                         "enum",
+                        "extends",
+                        "func",
+                        "namespace", # Reserved for potential future use.
+                        "signal",
                         "static",
+                        "trait", # Reserved for potential future use.
                         "var",
+                        # Other keywords.
+                        "await",
+                        "breakpoint",
+                        "self",
                         "super",
+                        "yield", # Reserved for potential future use.
+                        # Not really keywords, but used in property syntax.
+                        "set",
+                        "get",
                     ),
                     suffix=r"\b",
                 ),
@@ -168,12 +172,14 @@ class GDScriptLexer(RegexLexer):
             (
                 words(
                     (
+                        # modules/gdscript/gdscript.cpp - GDScriptLanguage::get_reserved_words()
+                        # Control flow.
                         "break",
                         "continue",
                         "elif",
                         "else",
-                        "if",
                         "for",
+                        "if",
                         "match",
                         "pass",
                         "return",
@@ -196,9 +202,13 @@ class GDScriptLexer(RegexLexer):
                         "absf",
                         "absi",
                         "acos",
+                        "acosh",
+                        "angle_difference",
                         "asin",
+                        "asinh",
                         "atan",
                         "atan2",
+                        "atanh",
                         "bezier_derivative",
                         "bezier_interpolate",
                         "bytes_to_var",
@@ -234,6 +244,7 @@ class GDScriptLexer(RegexLexer):
                         "is_instance_id_valid",
                         "is_instance_valid",
                         "is_nan",
+                        "is_same",
                         "is_zero_approx",
                         "lerp",
                         "lerp_angle",
@@ -271,6 +282,7 @@ class GDScriptLexer(RegexLexer):
                         "remap",
                         "rid_allocate_id",
                         "rid_from_int64",
+                        "rotate_toward",
                         "round",
                         "roundf",
                         "roundi",
@@ -290,6 +302,8 @@ class GDScriptLexer(RegexLexer):
                         "str_to_var",
                         "tan",
                         "tanh",
+                        "type_convert",
+                        "type_string",
                         "typeof",
                         "var_to_bytes",
                         "var_to_bytes_with_objects",
@@ -307,13 +321,13 @@ class GDScriptLexer(RegexLexer):
                         "dict_to_inst",
                         "get_stack",
                         "inst_to_dict",
+                        "is_instance_of",
                         "len",
                         "load",
                         "preload",
                         "print_debug",
                         "print_stack",
                         "range",
-                        "str",
                         "type_exists",
                     ),
                     prefix=r"(?<!\.)",
@@ -321,16 +335,18 @@ class GDScriptLexer(RegexLexer):
                 ),
                 Name.Builtin,
             ),
-            (r"((?<!\.)(self|super|false|true)|(PI|TAU|NAN|INF)" r")\b", Name.Builtin.Pseudo),
+            # modules/gdscript/gdscript.cpp - GDScriptLanguage::get_reserved_words()
+            # Special values. Constants.
+            (r"((?<!\.)(false|null|true)|(INF|NAN|PI|TAU))\b", Name.Builtin.Pseudo),
             (
                 words(
                     (
+                        # core/variant/variant.cpp - Variant::get_type_name()
+                        # `Nil` is excluded because it is not allowed in GDScript.
                         "bool",
                         "int",
                         "float",
                         "String",
-                        "StringName",
-                        "NodePath",
                         "Vector2",
                         "Vector2i",
                         "Rect2",
@@ -338,16 +354,21 @@ class GDScriptLexer(RegexLexer):
                         "Transform2D",
                         "Vector3",
                         "Vector3i",
-                        "AABB",
-                        "Plane",
-                        "Quaternion",
                         "Vector4",
                         "Vector4i",
+                        "Plane",
+                        "AABB",
+                        "Quaternion",
                         "Basis",
                         "Transform3D",
+                        "Projection",
                         "Color",
                         "RID",
                         "Object",
+                        "Callable",
+                        "Signal",
+                        "StringName",
+                        "NodePath",
                         "Dictionary",
                         "Array",
                         "PackedByteArray",
@@ -358,9 +379,10 @@ class GDScriptLexer(RegexLexer):
                         "PackedStringArray",
                         "PackedVector2Array",
                         "PackedVector3Array",
-                        "PackedVector4Array",
                         "PackedColorArray",
-                        "null",
+                        "PackedVector4Array",
+                        # The following are also considered types in GDScript.
+                        "Variant",
                         "void",
                     ),
                     prefix=r"(?<!\.)",
@@ -373,9 +395,11 @@ class GDScriptLexer(RegexLexer):
             (
                 words(
                     (
+                        # modules/gdscript/doc_classes/@GDScript.xml
                         "@export",
                         "@export_category",
                         "@export_color_no_alpha",
+                        "@export_custom",
                         "@export_dir",
                         "@export_enum",
                         "@export_exp_easing",
@@ -387,6 +411,7 @@ class GDScriptLexer(RegexLexer):
                         "@export_flags_3d_navigation",
                         "@export_flags_3d_physics",
                         "@export_flags_3d_render",
+                        "@export_flags_avoidance",
                         "@export_global_dir",
                         "@export_global_file",
                         "@export_group",
@@ -394,10 +419,13 @@ class GDScriptLexer(RegexLexer):
                         "@export_node_path",
                         "@export_placeholder",
                         "@export_range",
+                        "@export_storage",
                         "@export_subgroup",
+                        "@export_tool_button",
                         "@icon",
                         "@onready",
                         "@rpc",
+                        "@static_unload",
                         "@tool",
                         "@warning_ignore",
                     ),


### PR DESCRIPTION
* Closes #10179.

Source code:

* [`GDScriptLanguage::get_reserved_words()`](https://github.com/godotengine/godot/blob/ef8d981267702de38ffc24136f9d823d31781c60/modules/gdscript/gdscript.cpp#L2752)
* [`modules/gdscript/doc_classes/@GDScript.xml`](https://github.com/godotengine/godot/blob/master/modules/gdscript/doc_classes/%40GDScript.xml)
* [`Variant::get_type_name()`](https://github.com/godotengine/godot/blob/ef8d981267702de38ffc24136f9d823d31781c60/core/variant/variant.cpp#L45)
* [`doc/classes/@GlobalScope.xml`](https://github.com/godotengine/godot/blob/master/doc/classes/%40GlobalScope.xml)