### PR TITLE
Improve display of rubric fake headers with `:heading-level:` option

### DIFF
--- a/contributing/development/compiling/index.rst
+++ b/contributing/development/compiling/index.rst
@@ -19,6 +19,7 @@ The articles below should help you navigate configuration options available, as 
 prerequisites required to compile Godot exactly the way you need.
 
 .. rubric:: Basics of building Godot
+   :heading-level: 2
 
 Let's start with basics, and learn how to get Godot's source code, and then which options
 to use to compile it regardless of your target platform.
@@ -31,6 +32,7 @@ to use to compile it regardless of your target platform.
    introduction_to_the_buildsystem
 
 .. rubric:: Building for target platforms
+   :heading-level: 2
 
 Below you can find instructions for compiling the engine for your specific target platform.
 Note that Godot supports cross-compilation, which means you can compile it for a target platform
@@ -50,6 +52,7 @@ will try their best to cover all possible situations.
    compiling_for_web
 
 .. rubric:: Other compilation targets and options
+   :heading-level: 2
 
 Some additional universal compilation options require further setup. Namely, while Godot
 does have C#/.NET support as a part of its main codebase, it does not get compiled by

--- a/contributing/development/core_and_modules/index.rst
+++ b/contributing/development/core_and_modules/index.rst
@@ -7,6 +7,7 @@ The following pages are meant to introduce the global organization of Godot Engi
 source code, and give useful tips for extending and fixing the engine on the C++ side.
 
 .. rubric:: Getting started with Godot's source code
+   :heading-level: 2
 
 This section covers the basics that you will encounter in (almost) every source file.
 
@@ -25,6 +26,7 @@ This section covers the basics that you will encounter in (almost) every source 
    scripting_development
 
 .. rubric:: Extending Godot by modifying its source code
+   :heading-level: 2
 
 This section covers what you can do by modifying Godot's C++ source code.
 

--- a/tutorials/3d/particles/index.rst
+++ b/tutorials/3d/particles/index.rst
@@ -9,6 +9,7 @@ This section of the tutorial covers (3D) GPU-accelerated particle systems. Most 
 discussed here apply to CPU particles as well.
 
 .. rubric:: Introduction
+   :heading-level: 2
 
 You can use particle systems to simulate complex physical effects like fire, sparks,
 smoke, magical effects, and many more. They are very well suited for creating dynamic and organic
@@ -22,6 +23,7 @@ parameters and behaviors.
 Every particle system you create in Godot consists of two main parts: particles and emitters.
 
 .. rubric:: Particles
+   :heading-level: 3
 
 A particle is the visible part of a particle system. It's what you see on the screen when a particle
 system is active: The tiny specks of dust, the flames of a fire, the glowing orbs of a magical
@@ -31,6 +33,7 @@ color over the course of its lifetime. When you think of a fire, you can think o
 embers flying away from it as individual particles.
 
 .. rubric:: Emitters
+   :heading-level: 3
 
 An emitter is what's creating the particles. Emitters are usually not visible, but they can have
 a shape. That shape controls where and how particles are spawned, for example whether they should fill
@@ -38,6 +41,7 @@ a room like dust or shoot away from a single point like a fountain. Going back t
 an emitter would be the heat at the center of the fire that creates the embers and the flames.
 
 .. rubric:: Node overview
+   :heading-level: 3
 
 .. figure:: img/particle_nodes.webp
    :alt: A list of nodes related to 3D particles
@@ -72,6 +76,7 @@ objects in it and uses that for large-scale particle collisions.
 
 
 .. rubric:: Basic usage
+   :heading-level: 2
 
 .. toctree::
    :maxdepth: 1
@@ -82,6 +87,7 @@ objects in it and uses that for large-scale particle collisions.
    process_material_properties
 
 .. rubric:: Advanced topics
+   :heading-level: 2
 
 .. toctree::
    :maxdepth: 1

--- a/tutorials/scripting/c_sharp/diagnostics/index.rst
+++ b/tutorials/scripting/c_sharp/diagnostics/index.rst
@@ -9,6 +9,7 @@ Godot includes analyzers that inspect your C# source code to check for invalid
 or unsupported code and let you know that something is wrong during build time.
 
 .. rubric:: Rules
+   :heading-level: 2
 
 .. toctree::
    :maxdepth: 1

--- a/tutorials/scripting/index.rst
+++ b/tutorials/scripting/index.rst
@@ -11,6 +11,7 @@ sections. For instance, to learn about inputs, we recommend you to read
 :ref:`Inputs <toc-learn-features-inputs>`.
 
 .. rubric:: Programming languages
+   :heading-level: 2
 
 The sections below each focus on a given programming language.
 


### PR DESCRIPTION
Supercedes https://github.com/godotengine/godot-docs/pull/10111.
Depends on https://github.com/godotengine/godot-docs/pull/10158. The minimum Sphinx version for the [:heading-level:](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-option-rubric-heading-level) option is 7.4.1. (The CI will fail until it is updated to Sphinx 8)

In https://github.com/godotengine/godot-docs/pull/9989 and followup PRs, real semantic headers were replaced by fake headers using the `.. rubric::` directive. This PR allows those fake headers to look like real headers, using the same `h2` and `h3` styles.