### PR TITLE
Replace broken link to official discord

### DIFF
--- a/about/introduction.rst
+++ b/about/introduction.rst
@@ -37,7 +37,7 @@ is a great starting point.
 
 In case you have trouble with one of the tutorials or your project,
 you can find help on the various `Community channels <https://godotengine.org/community/>`_,
-especially the Godot `Discord <https://discord.gg/bdcfAYM4W9>`_ community and
+especially the Godot `Discord <https://discord.gg/godotengine>`_ community and
 `Forum <https://forum.godotengine.org/>`_.
 
 About Godot Engine


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-docs/issues/10192.

Uses the link to the official discord that is on https://godotengine.org/community/.