### PR TITLE
Remove the new "switch-menu" in sidebartitle

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -170,6 +170,11 @@ html_theme_options = {
     "logo_only": True,
     # Collapse navigation (False makes it tree-like)
     "collapse_navigation": False,
+    # Remove version and language picker beneath the title
+    "version_selector": False,
+    "language_selector": False,
+    # Set Flyout menu to attached
+    "flyout_display": "attached",
 }
 
 html_title = supported_languages[language] % ( "(" + version + ")" )


### PR DESCRIPTION
The new Layout includes a version and language switcher above the search field.
As we have the flyout menu, or bottom switch, this are not needed.
![grafik](https://github.com/user-attachments/assets/0c6e2a7f-bab2-4e3f-9f94-ed2e9a27f079)

_Bugsquad edit: Followup to https://github.com/godotengine/godot-docs/pull/10158_