### PR TITLE
Update Editor Icons page to reflect usage of `svgo`

### DIFF
--- a/contributing/development/code_style_guidelines.rst
+++ b/contributing/development/code_style_guidelines.rst
@@ -61,6 +61,8 @@ You need to use **clang-format 17** to be compatible with Godot's format. Later 
 be suitable, but previous versions may not support all used options, or format
 some things differently, leading to style issues in pull requests.
 
+.. _doc_pre_commit_hook:
+
 Pre-commit hook
 ^^^^^^^^^^^^^^^
 

--- a/contributing/development/code_style_guidelines.rst
+++ b/contributing/development/code_style_guidelines.rst
@@ -61,7 +61,7 @@ You need to use **clang-format 17** to be compatible with Godot's format. Later 
 be suitable, but previous versions may not support all used options, or format
 some things differently, leading to style issues in pull requests.
 
-.. _doc_pre_commit_hook:
+.. _doc_code_style_guidelines_pre_commit_hook:
 
 Pre-commit hook
 ^^^^^^^^^^^^^^^

--- a/contributing/development/editor/creating_icons.rst
+++ b/contributing/development/editor/creating_icons.rst
@@ -48,7 +48,7 @@ Icon optimization
 
 Because the editor renders SVGs once at load time, they need to be small
 in size so they can be efficiently parsed. When the
-:ref:`pre-commit hook <doc_pre_commit_hook>` runs, it automatically optimizes
+:ref:`pre-commit hook <doc_code_style_guidelines_pre_commit_hook>` runs, it automatically optimizes
 the SVG using `svgo <https://github.com/svg/svgo>`_.
 
 .. note::

--- a/contributing/development/editor/creating_icons.rst
+++ b/contributing/development/editor/creating_icons.rst
@@ -47,24 +47,9 @@ Icon optimization
 ~~~~~~~~~~~~~~~~~
 
 Because the editor renders SVGs once at load time, they need to be small
-in size so they can be efficiently parsed. Editor icons must be first
-optimized before being added to the engine, to do so:
-
-1. Install `svgcleaner <https://github.com/RazrFalcon/svgcleaner>`__
-   by downloading a binary from its
-   `Releases tab <https://github.com/RazrFalcon/svgcleaner/releases/latest>`__
-   and placing it into a location in your ``PATH`` environment variable.
-
-2. Run the command below, replacing ``svg_source.svg`` with the path to your
-   SVG file (which can be a relative or absolute path):
-
-   .. code-block:: bash
-
-       svgcleaner --multipass svg_source.svg svg_optimized.svg
-
-The ``--multipass`` switch improves compression, so make sure to include it.
-The optimized icon will be saved to ``svg_optimized.svg``. You can also change
-the destination parameter to any relative or absolute path you'd like.
+in size so they can be efficiently parsed. When the
+:ref:`pre-commit hook <doc_pre_commit_hook>` runs, it automatically optimizes
+the SVG using `svgo <https://github.com/svg/svgo>`_.
 
 .. note::
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-docs/issues/9769.

After https://github.com/godotengine/godot/pull/92766, icons can now be optimized automatically by the pre-commit hook.