### PR TITLE
Link to Getting Started Input tutorial from Input examples page

### DIFF
--- a/getting_started/first_3d_game/02.player_input.rst
+++ b/getting_started/first_3d_game/02.player_input.rst
@@ -84,6 +84,8 @@ Save the scene as ``player.tscn``
 With the nodes ready, we can almost get coding. But first, we need to define
 some input actions.
 
+.. _doc_first_3d_game_input_actions:
+
 Creating input actions
 ----------------------
 

--- a/tutorials/inputs/inputevent.rst
+++ b/tutorials/inputs/inputevent.rst
@@ -194,10 +194,12 @@ There are several specialized types of InputEvent, described in the table below:
 |                                                                   | as feedback. (more on this below)       |
 +-------------------------------------------------------------------+-----------------------------------------+
 
-Actions
--------
+.. _doc_input_actions:
 
-Actions are a grouping of zero or more InputEvents into a commonly
+Input actions
+-------------
+
+Input actions are a grouping of zero or more InputEvents into a commonly
 understood title (for example, the default "ui_left" action grouping both joypad-left input and a keyboard's left arrow key). They are not required to represent an
 InputEvent but are useful because they abstract various inputs when
 programming the game logic.
@@ -238,6 +240,11 @@ The Input singleton has a method for this:
     ev.Pressed = true;
     // Feedback.
     Input.ParseInputEvent(ev);
+
+
+.. seealso::
+   See :ref:`doc_first_3d_game_input_actions` for a tutorial on adding input
+   actions in the project settings.
 
 InputMap
 --------

--- a/tutorials/inputs/inputevent.rst
+++ b/tutorials/inputs/inputevent.rst
@@ -194,8 +194,6 @@ There are several specialized types of InputEvent, described in the table below:
 |                                                                   | as feedback. (more on this below)       |
 +-------------------------------------------------------------------+-----------------------------------------+
 
-.. _doc_input_actions:
-
 Input actions
 -------------
 

--- a/tutorials/inputs/inputevent.rst
+++ b/tutorials/inputs/inputevent.rst
@@ -243,6 +243,7 @@ The Input singleton has a method for this:
 
 
 .. seealso::
+
    See :ref:`doc_first_3d_game_input_actions` for a tutorial on adding input
    actions in the project settings.
 


### PR DESCRIPTION
See https://github.com/godotengine/godot-docs/issues/10199 for reasoning. The Input manual section does not have a visual tutorial on using the Project Settings Input Map, but the Getting Started tutorials do. As a stopgap measure, the input examples page should link to one of those tutorials, and the 3D one is more in-depth.

I think that a larger change than this (described in https://github.com/godotengine/godot-docs/issues/10199) is needed eventually, but this is an improvement in the meantime.