### PR TITLE
Offline docs: actions/checkout@v4 migration

### DIFF
--- a/.github/workflows/build_offline_docs.yml
+++ b/.github/workflows/build_offline_docs.yml
@@ -36,6 +36,8 @@ jobs:
           # Keep the current build and the previous build (in case a scheduled build failed).
           # This makes it more likely to have at least one successful build available at all times.
           retention-days: 15
+          if-no-files-found: error
+          overwrite: true
 
       - name: Sphinx - Build ePub
         run: |
@@ -58,3 +60,5 @@ jobs:
           # Keep the current build and the previous build (in case a scheduled build failed).
           # This makes it more likely to have at least one successful build available at all times.
           retention-days: 15
+          if-no-files-found: error
+          overwrite: true


### PR DESCRIPTION
As of the `v4` of the `actions/checkout` Github action, artifacts can't be overwritten by default anymore, so we need to enable that manually.

`if-no-files-found: error` makes sure we error if the file we want (and expect) to upload isn't found. By default, only a warning is generated.

See: https://github.com/actions/upload-artifact?tab=readme-ov-file#usage

This should be cherry-picked to all branches https://github.com/godotengine/godot-docs/pull/8627 has been cherry-picked to (all branches where the Github action was updated to `v4`).