### PR TITLE
CI: Skip class reference sync and offline docs on forks

### DIFF
--- a/.github/workflows/build_offline_docs.yml
+++ b/.github/workflows/build_offline_docs.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   build:
+    # Don't run scheduled runs on forks unless the CI_OFFLINE_DOCS_CRON variable is set to 'true'.
+    # Manual runs can still be triggered as normal.
+    if: ${{ github.repository_owner == 'godotengine' || github.event_name != 'schedule' || vars.CI_OFFLINE_DOCS_CRON == 'true' }}
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.github/workflows/sync_class_ref.yml
+++ b/.github/workflows/sync_class_ref.yml
@@ -15,6 +15,9 @@ concurrency:
 
 jobs:
   build:
+    # Don't run scheduled runs on forks unless the CI_SYNC_CLASS_REF_CRON variable is set to 'true'.
+    # Manual runs can still be triggered as normal.
+    if: ${{ github.repository_owner == 'godotengine' || github.event_name != 'schedule' || vars.CI_SYNC_CLASS_REF_CRON == 'true' }}
     name: Update class reference files based on the engine revision
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Currently, we automatically run scheduled Github actions to sync the class reference for `master` and to build offline documentation for `master`,  `stable` and `3.6`.

However, this also happens on all forks by default if they have actions enabled, which generates unnecessary notification spam and wastes computing resources needlessly; the large majority of forks are docs contributors unlikely to have any interest in either of these.

With this, scheduled runs are skipped by default on forks. They can be re-enabled by setting repository variables. Manual runs can be triggered as normal and remain unaffected.