### PR TITLE
I18N: Remove canonical/hreflang tags, let RTD handle SEO/locale negotiation

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -13,16 +13,6 @@
 
 {% block linktags -%}
   <meta name="theme-color" content="#3d8fcc" />
-  {% if godot_inject_language_links -%}
-  {% for alternate_lang in godot_docs_supported_languages -%}
-  {# Convert to ISO 639-1 format, e.g. zh_CN -> zh-cn -#}
-  {% set alternate_lang_href = alternate_lang.lower().replace("_", "-") -%}
-  <link rel="alternate" hreflang="{{ alternate_lang_href }}" href="{{ godot_docs_basepath }}{{ alternate_lang }}/{{ godot_canonical_version }}/{{ pagename }}{{ godot_docs_suffix }}" />
-  {% endfor -%}
-  <link rel="alternate" hreflang="x-default" href="{{ godot_docs_basepath }}{{ godot_default_lang }}/{{ godot_canonical_version }}/{{ pagename }}{{ godot_docs_suffix }}" />
-
-  <link rel="canonical" href="{{ godot_docs_basepath }}{{ lang_attr }}/{{ godot_canonical_version }}/{{ pagename }}{{ godot_docs_suffix }}" />
-  {% endif -%}
   {{ super() }}
 {% endblock -%}
 

--- a/conf.py
+++ b/conf.py
@@ -181,13 +181,9 @@ html_context = {
     "github_repo": "godot-docs",  # Repo name
     "github_version": "master",  # Version
     "conf_py_path": "/",  # Path in the checkout to the docs root
-    "godot_inject_language_links": True,
-    "godot_docs_supported_languages": list(supported_languages.keys()),
     "godot_docs_title": supported_languages[language],
     "godot_docs_basepath": "https://docs.godotengine.org/",
     "godot_docs_suffix": ".html",
-    "godot_default_lang": "en",
-    "godot_canonical_version": "stable",
     # Distinguish local development website from production website.
     # This prevents people from looking for changes on the production website after making local changes :)
     "godot_title_prefix": "" if on_rtd else "(DEV) ",


### PR DESCRIPTION
This was originally added as a stopgap (by me) and turned out to be less than satisfactory. In the mean time, RTD now generates sitemaps to handle this (compare https://docs.godotengine.org/sitemap.xml), and Google actually considers our generated links here broken due to no proper backlinks if you check via their Webmaster tooling.

Removing this should hopefully mean Google uses the Sitemap and the `<html lang="">` tag to find links between alternate language versions, and prefer to show users the pages meant for their configured preferences for language/locale.

If that turns out not enough, we need to revisit this, but fix the implementation to provide proper backlinks for all languages.