### PR TITLE
Link to project settings when mentioning them

### DIFF
--- a/tutorials/2d/2d_antialiasing.rst
+++ b/tutorials/2d/2d_antialiasing.rst
@@ -80,8 +80,8 @@ affect** the following kinds of aliasing in any way:
 - Aliasing in font rendering.
 
 MSAA can be enabled in the Project Settings by changing the value of the
-**Rendering > Anti Aliasing > Quality > MSAA 2D** setting. It's important to change
-the value of the **MSAA 2D** setting and not **MSAA 3D**, as these are entirely
+:ref:`Rendering > Anti Aliasing > Quality > MSAA 2D<class_ProjectSettings_property_rendering/anti_aliasing/quality/msaa_2d>`
+setting. It's important to change the value of the **MSAA 2D** setting and not **MSAA 3D**, as these are entirely
 separate settings.
 
 Comparison between no antialiasing (left) and various MSAA levels (right). The

--- a/tutorials/2d/2d_parallax.rst
+++ b/tutorials/2d/2d_parallax.rst
@@ -78,8 +78,11 @@ do?
 Make the viewport smaller
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The simplest answer is to make the viewport the same size or smaller than your textures. Click on
-``Project -> Project Settings -> Window`` and change the viewport height and width to match your background.
+The simplest answer is to make the viewport the same size or smaller than your textures. 
+In **Project Settings > Display > Window**, change the
+:ref:`Viewport Width<class_ProjectSettings_property_display/window/size/viewport_width>`
+and :ref:`Viewport Height<class_ProjectSettings_property_display/window/size/viewport_height>`
+settings to match your background.
 
 .. image:: img/2d_parallax_size_viewport.webp
 

--- a/tutorials/2d/custom_drawing_in_2d.rst
+++ b/tutorials/2d/custom_drawing_in_2d.rst
@@ -254,9 +254,9 @@ You will have to code a function to perform this and draw it yourself.
 
     The following instructions use a fixed set of coordinates that could be too small
     for high resolution screens (larger than 1080p). If that is your case, and the
-    drawing is too small consider increasing your window scale in
-    ``Menu > Project > Project settings > display/window/stretch/scale`` to adjust
-    the project to a higher resolution (a 2 or 4 scale tends to work well).
+    drawing is too small consider increasing your window scale in the project setting
+    :ref:`Display > Window > Stretch > Scale<class_ProjectSettings_property_display/window/stretch/scale>`
+    to adjust the project to a higher resolution (a 2 or 4 scale tends to work well).
 
 Drawing a custom polygon shape
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tutorials/3d/3d_antialiasing.rst
+++ b/tutorials/3d/3d_antialiasing.rst
@@ -70,8 +70,8 @@ To make specular aliasing less noticeable, use the `Screen-space roughness limit
 which is enabled by default.
 
 MSAA can be enabled in the Project Settings by changing the value of the
-**Rendering > Anti Aliasing > Quality > MSAA 3D** setting. It's important to change
-the value of the **MSAA 3D** setting and not **MSAA 2D**, as these are entirely
+:ref:`Rendering > Anti Aliasing > Quality > MSAA 3D<class_ProjectSettings_property_rendering/anti_aliasing/quality/msaa_3d>`
+setting. It's important to change the value of the **MSAA 3D** setting and not **MSAA 2D**, as these are entirely
 separate settings.
 
 Comparison between no antialiasing (left) and various MSAA levels (right).
@@ -108,8 +108,9 @@ downside of TAA is that it can exhibit *ghosting* artifacts behind moving
 objects. Rendering at a higher framerate will allow TAA to converge faster,
 therefore making those ghosting artifacts less visible.
 
-Temporal antialiasing can be enabled in the Project Settings by changing the
-value of the **Rendering > Anti Aliasing > Quality > Use TAA** setting.
+Temporal antialiasing can be enabled in the Project Settings by changing the value of the
+:ref:`Rendering > Anti Aliasing > Quality > TAA<class_ProjectSettings_property_rendering/anti_aliasing/quality/use_taa>`
+setting.
 
 Comparison between no antialiasing (left) and TAA (right):
 
@@ -172,9 +173,9 @@ as an in-game option may still be worthwhile for players with low-end GPUs.
 FXAA introduces a moderate amount of blur when enabled (more than TAA when
 still, but less than TAA when the camera is moving).
 
-FXAA can be enabled in the Project Settings by changing the
-value of the **Rendering > Anti Aliasing > Quality > Screen Space AA** setting to
-**FXAA**.
+FXAA can be enabled in the Project Settings by changing the value of the
+:ref:`Rendering > Anti Aliasing > Quality > Screen Space AA<class_ProjectSettings_property_rendering/anti_aliasing/quality/screen_space_aa>`
+setting to ``FXAA``.
 
 Comparison between no antialiasing (left) and FXAA (right):
 
@@ -194,9 +195,11 @@ The downside of SSAA is its *extremely* high cost. This cost generally makes
 SSAA difficult to use for game purposes, but you may still find supersampling
 useful for :ref:`offline rendering <doc_creating_movies>`.
 
-Supersample antialiasing is performed by increasing the **Rendering > Scaling 3D
-> Scale** advanced project setting above ``1.0`` while ensuring
-**Rendering > Scaling 3D > Mode** is set to **Bilinear** (the default).
+Supersample antialiasing is performed by increasing the
+:ref:`Rendering > Scaling 3D > Scale<class_ProjectSettings_property_rendering/scaling_3d/scale>`
+advanced project setting above ``1.0`` while ensuring
+:ref:`Rendering > Scaling 3D > Mode<class_ProjectSettings_property_rendering/scaling_3d/mode>`
+is set to ``Bilinear`` (the default).
 Since the scale factor is defined per-axis, a scale factor of ``1.5`` will result
 in 2.25× SSAA while a scale factor of ``2.0`` will result in 4× SSAA. Since Godot
 uses the hardware's own bilinear filtering to perform the downsampling, the result

--- a/tutorials/3d/3d_rendering_limitations.rst
+++ b/tutorials/3d/3d_rendering_limitations.rst
@@ -46,8 +46,9 @@ rendering, where banding may be visible when using smooth gradient textures.
 
 There are two main ways to alleviate banding:
 
-- If using the Forward+ or Forward Mobile rendering methods, enable **Use
-  Debanding** in the advanced Project Settings. This applies a fullscreen debanding
+- If using the Forward+ or Forward Mobile rendering methods, enable 
+  :ref:`Use Debanding<class_ProjectSettings_property_rendering/anti_aliasing/quality/use_debanding>`
+  in **Project Settings > Rendering > Anti Aliasing**. This applies a fullscreen debanding
   shader as a post-processing effect and is very cheap.
 - Alternatively, bake some noise into your textures. This is mainly effective in
   2D, e.g. for vignetting effects. In 3D, you can also use a `custom debanding

--- a/tutorials/3d/environment_and_post_processing.rst
+++ b/tutorials/3d/environment_and_post_processing.rst
@@ -653,7 +653,8 @@ There are 2 ways to use glow in 2D:
   rendering output.
 
   - To enable HDR in 2D, open the Project Settings, enable
-    **Rendering > Viewport > HDR 2D** then restart the editor.
+    :ref:`Rendering > Viewport > HDR 2D<class_ProjectSettings_property_rendering/viewport/hdr_2d>`
+    then restart the editor.
 
 - If you want to maximize performance, you can leave HDR disabled for 2D
   rendering. However, you will have less control on which objects glow.
@@ -676,10 +677,10 @@ There are 2 ways to use glow in 2D:
 .. warning::
 
     The 2D renderer renders in linear color space if the
-    **Rendering > Viewport > HDR 2D** project setting is enabled, so
-    ``source_color`` must also be used for uniform samplers that are
-    used as color input in ``canvas_item`` shaders. If this is not done,
-    the texture will appear washed out.
+    :ref:`Rendering > Viewport > HDR 2D<class_ProjectSettings_property_rendering/viewport/hdr_2d>`
+    project setting is enabled, so the ``source_color`` hint must also be used
+    for uniform samplers that are used as color input in ``canvas_item`` shaders.
+    If this is not done, the texture will appear washed out.
 
     If 2D HDR is disabled, ``source_color`` will keep working correctly in
     ``canvas_item`` shaders, so it's recommend to use it when relevant either

--- a/tutorials/3d/global_illumination/reflection_probes.rst
+++ b/tutorials/3d/global_illumination/reflection_probes.rst
@@ -187,9 +187,9 @@ reflection probe rendering. As many reflection probes as desired can be added (a
 performance allows). However, there's still a default limit of 512 *clustered
 elements* that can be present in the current camera view. A clustered element is
 an omni light, a spot light, a :ref:`decal <doc_using_decals>` or a
-:ref:`reflection probe <doc_reflection_probes>`. This limit can be increased by
-adjusting the **Rendering > Limits > Cluster Builder > Max Clustered Elements**
-advanced project setting.
+:ref:`reflection probe <doc_reflection_probes>`. This limit can be increased by adjusting
+:ref:`Max Clustered Elements<class_ProjectSettings_property_rendering/limits/cluster_builder/max_clustered_elements>`
+in **Project Settings > Rendering > Limits > Cluster Builder**.
 
 When using the Forward Mobile backend, only 8 reflection probes can be applied on each
 individual Mesh *resource*. If there are more reflection probes affecting a single mesh,

--- a/tutorials/3d/lights_and_shadows.rst
+++ b/tutorials/3d/lights_and_shadows.rst
@@ -61,9 +61,9 @@ real-time lighting. As many lights as desired can be added (as long as
 performance allows). However, there's still a default limit of 512 *clustered
 elements* that can be present in the current camera view. A clustered element is
 an omni light, a spot light, a :ref:`decal <doc_using_decals>` or a
-:ref:`reflection probe <doc_reflection_probes>`. This limit can be increased by
-adjusting the **Rendering > Limits > Cluster Builder > Max Clustered Elements**
-advanced project setting.
+:ref:`reflection probe <doc_reflection_probes>`. This limit can be increased by adjusting
+:ref:`Max Clustered Elements<class_ProjectSettings_property_rendering/limits/cluster_builder/max_clustered_elements>`
+in **Project Settings > Rendering > Limits > Cluster Builder**.
 
 When using the Forward Mobile renderer, there is a limitation of 8 OmniLights +
 8 SpotLights per mesh resource. There is also a limit of 256 OmniLights + 256
@@ -72,10 +72,12 @@ currently cannot be changed.
 
 When using the Compatibility renderer, up to 8 OmniLights + 8 SpotLights can be
 rendered per mesh resource. This limit can be increased in the advanced Project
-Settings by adjusting **Rendering > Limits > OpenGL > Max Renderable Lights**
-and/or **Rendering > Limits > OpenGL > Max Lights Per Object** at the cost of
-performance and longer shader compilation times. The limit can also be decreased
-to reduce shader compilation times and improve performance slightly.
+Settings by adjusting
+:ref:`Max Renderable Elements<class_ProjectSettings_property_rendering/limits/opengl/max_renderable_elements>`
+and/or :ref:`Max Lights per Object<class_ProjectSettings_property_rendering/limits/opengl/max_lights_per_object>`
+in **Rendering > Limits > OpenGL**, at the cost of performance and longer shader
+compilation times. The limit can also be decreased to reduce shader compilation
+times and improve performance slightly.
 
 With all rendering methods, up to 8 DirectionalLights can be visible at a time.
 However, each additional DirectionalLight with shadows enabled will reduce the

--- a/tutorials/3d/using_decals.rst
+++ b/tutorials/3d/using_decals.rst
@@ -234,8 +234,9 @@ away from the camera (and may have little to no impact on the final scene
 rendering). Using node groups, you can also prevent non-essential decorative
 decals from spawning based on user configuration.
 
-The way decals are rendered also has an impact on performance. The **Rendering >
-Textures > Decals > Filter** advanced project setting lets you control how decal
+The way decals are rendered also has an impact on performance. The
+:ref:`Rendering > Textures > Decals > Filter<class_ProjectSettings_property_rendering/textures/decals/filter>`
+advanced project setting lets you control how decal
 textures should be filtered. **Nearest/Linear** does not use mipmaps. However,
 decals will look grainy at a distance. **Nearest/Linear Mipmaps** will look
 smoother at a distance, but decals will look blurry when viewed from oblique
@@ -262,9 +263,9 @@ decal rendering. As many decals as desired can be added (as long as
 performance allows). However, there's still a default limit of 512 *clustered
 elements* that can be present in the current camera view. A clustered element is
 an omni light, a spot light, a :ref:`decal <doc_using_decals>` or a
-:ref:`reflection probe <doc_reflection_probes>`. This limit can be increased by
-adjusting the **Rendering > Limits > Cluster Builder > Max Clustered Elements**
-advanced project setting.
+:ref:`reflection probe <doc_reflection_probes>`. This limit can be increased by adjusting
+:ref:`Max Clustered Elements<class_ProjectSettings_property_rendering/limits/cluster_builder/max_clustered_elements>`
+in **Project Settings > Rendering > Limits > Cluster Builder**.
 
 When using the Forward Mobile backend, only 8 decals can be applied on each
 individual Mesh *resource*. If there are more decals affecting a single mesh,

--- a/tutorials/audio/recording_with_microphone.rst
+++ b/tutorials/audio/recording_with_microphone.rst
@@ -12,7 +12,7 @@ A simple demo is included in the official demo projects and will be used as
 support for this tutorial:
 `<https://github.com/godotengine/godot-demo-projects/tree/master/audio/mic_record>`_.
 
-You will need to enable audio input in the project settings ``Project Settings -> Audio -> Driver -> Enable Input``, or you'll just get empty audio files.
+You will need to enable audio input in the :ref:`Audio > Driver > Enable Input<class_ProjectSettings_property_audio/driver/enable_input>` project setting, or you'll just get empty audio files.
 
 The structure of the demo
 -------------------------

--- a/tutorials/performance/thread_safe_apis.rst
+++ b/tutorials/performance/thread_safe_apis.rst
@@ -71,7 +71,9 @@ Rendering
 ---------
 
 Instancing nodes that render anything in 2D or 3D (such as Sprite) is *not* thread-safe by default.
-To make rendering thread-safe, set the **Rendering > Driver > Thread Model** project setting to **Multi-Threaded**.
+To make rendering thread-safe, set the
+:ref:`Rendering > Driver > Thread Model<class_ProjectSettings_property_rendering/driver/threads/thread_model>`
+project setting to **Multi-Threaded**.
 
 Note that the Multi-Threaded thread model has several known bugs, so it may not be usable
 in all scenarios.

--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -132,7 +132,7 @@ These properties can be configured via code, or by editing them in the Inspector
 
 Keeping track of what you're using each layer for can be difficult, so you
 may find it useful to assign names to the layers you're using. Names can
-be assigned in Project Settings -> Layer Names.
+be assigned in **Project Settings > Layer Names**.
 
 .. image:: img/physics_layer_names.png
 
@@ -229,7 +229,7 @@ You can modify a rigid body's behavior via properties such as "Mass",
 "Friction", or "Bounce", which can be set in the Inspector.
 
 The body's behavior is also affected by the world's properties, as set in
-`Project Settings -> Physics`, or by entering an :ref:`Area2D <class_Area2D>`
+**Project Settings > Physics**, or by entering an :ref:`Area2D <class_Area2D>`
 that is overriding the global physics properties.
 
 When a rigid body is at rest and hasn't moved for a while, it goes to sleep.

--- a/tutorials/physics/troubleshooting_physics_issues.rst
+++ b/tutorials/physics/troubleshooting_physics_issues.rst
@@ -27,7 +27,8 @@ other solutions you can try:
   speed. The faster the object moves, the larger the collision shape should
   extend outside of the object to ensure it can collide with thin walls more
   reliably.
-- Increase **Physics Ticks per Second** in the advanced Project Settings. While
+- Increase :ref:`Physics Ticks per Second<class_ProjectSettings_property_physics/common/physics_ticks_per_second>`
+  in the advanced Project Settings. While
   this has other benefits (such as more stable simulation and reduced input
   lag), this increases CPU utilization and may not be viable for mobile/web
   platforms. Multipliers of the default value of ``60`` (such as ``120``, ``180``
@@ -44,7 +45,8 @@ causes the simulation to become wobbly, making the objects unable to rest on top
 of each other without moving.
 
 Increasing the physics simulation rate can help alleviate this issue. To do so,
-increase **Physics Ticks per Second** in the advanced Project Settings. Note
+increase :ref:`Physics Ticks per Second<class_ProjectSettings_property_physics/common/physics_ticks_per_second>`
+in the advanced Project Settings. Note
 that increases CPU utilization and may not be viable for mobile/web platforms.
 Multipliers of the default value of ``60`` (such as ``120``, ``180`` or ``240``)
 should be preferred for a smooth appearance on most displays.
@@ -83,7 +85,9 @@ simulation rate (as making the shape thicker would cause a disconnect between
 the RigidBody's visual representation and its collision).
 
 In both cases, increasing the physics simulation rate can also help alleviate
-this issue. To do so, increase **Physics Ticks per Second** in the advanced
+this issue. To do so, increase
+:ref:`Physics Ticks per Second<class_ProjectSettings_property_physics/common/physics_ticks_per_second>`
+in the advanced
 Project Settings. Note that this increases CPU utilization and may not be viable
 for mobile/web platforms. Multipliers of the default value of ``60`` (such as
 ``120``, ``180`` or ``240``) should be preferred for a smooth appearance on most
@@ -115,7 +119,9 @@ vehicle (due to tunneling), but also that the simulation has little data to work
 with in general at such a high speed.
 
 Fast-moving vehicles can benefit a lot from an increased physics simulation
-rate. To do so, increase **Physics Ticks per Second** in the advanced Project
+rate. To do so, increase
+:ref:`Physics Ticks per Second<class_ProjectSettings_property_physics/common/physics_ticks_per_second>`
+in the advanced Project
 Settings. Note that this increases CPU utilization and may not be viable for
 mobile/web platforms. Multipliers of the default value of ``60`` (such as
 ``120``, ``180`` or ``240``) should be preferred for a smooth appearance on most

--- a/tutorials/platform/android/android_library.rst
+++ b/tutorials/platform/android/android_library.rst
@@ -94,7 +94,10 @@ Below we break-down the steps used to create the GLTF Viewer app.
 
 - If using ``gradle``, include the following ``aaptOptions`` configuration under the ``android > defaultConfig`` section of the app's gradle build file. Doing so allows ``gradle`` to include Godot's hidden directories when building the app binary.
 
-  - If your build system does not support including hidden directories, you can `configure the Godot project to not use hidden directories <https://docs.godotengine.org/en/stable/classes/class_projectsettings.html#class-projectsettings-property-application-config-use-hidden-project-data-directory>`_ by deselecting ``Project Settings... > Application > Config > Use Hidden Project Data Directory``.
+  - If your build system does not support including hidden directories, you can
+    configure the Godot project to not use hidden directories by deselecting 
+    :ref:`Application > Config > Use Hidden Project Data Directory<class_ProjectSettings_property_application/config/use_hidden_project_data_directory>`
+    in the Project Settings.
 
 .. code-block:: groovy
 

--- a/tutorials/scripting/creating_script_templates.rst
+++ b/tutorials/scripting/creating_script_templates.rst
@@ -43,9 +43,9 @@ Project-defined templates
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The default path to search for templates is the
-``res://script_templates/`` directory. The path can be changed by configuring
-the ``editor/script_templates_search_path`` setting in the
-:ref:`ProjectSettings <class_ProjectSettings>`, both via code and the editor.
+``res://script_templates/`` directory. The path can be changed by configuring the project setting
+:ref:`Editor > Script > Templates Search Path<class_ProjectSettings_property_editor/script/templates_search_path>`,
+both via code and the editor.
 
 If no ``script_templates`` directory is found within a project, it is simply
 ignored.

--- a/tutorials/ui/gui_skinning.rst
+++ b/tutorials/ui/gui_skinning.rst
@@ -184,8 +184,8 @@ with a custom theme. Custom themes can be applied in two ways: as a project sett
 and as a node property throughout the tree of control nodes.
 
 There are two project settings that can be adjusted to affect your entire project:
-:ref:`gui/theme/custom<class_ProjectSettings_property_gui/theme/custom>` allows you to
-set a custom project-wide theme, and :ref:`gui/theme/custom_font<class_ProjectSettings_property_gui/theme/custom_font>`
+:ref:`GUI > Theme > Custom<class_ProjectSettings_property_gui/theme/custom>` allows you to
+set a custom project-wide theme, and :ref:`GUI > Theme > Custom Font<class_ProjectSettings_property_gui/theme/custom_font>`
 does the same to the default fallback font. When a theme item is requested by a control
 node the custom project theme, if present, is checked first. Only if it doesn't have
 the item the default theme is checked.


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-docs/issues/10155.

Changes project setting mentions to link to the class reference, styling links like `Project Settings > Application > Run > Max FPS`, or in some cases splitting the setting's name and section, so that the page reads better.
