### PR TITLE
Fix codespell not running on some files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Linter checks
         run: |
           bash _tools/format.sh
-          codespell -I _tools/codespell-ignore.txt -x _tools/codespell-ignore-lines.txt -S tutorials/i18n/locales.rst {about,community,contributing,getting_started,tutorials}/**/*.rst
+          codespell -I _tools/codespell-ignore.txt -x _tools/codespell-ignore-lines.txt -S tutorials/i18n/locales.rst {about,community,contributing,getting_started,tutorials}/{*.rst,**/*.rst,**/**/*.rst,**/**/**/*.rst}
 
       # Use dummy builder to improve performance as we don't need the generated HTML in this workflow.
       - name: Sphinx build

--- a/contributing/development/compiling/getting_source.rst
+++ b/contributing/development/compiling/getting_source.rst
@@ -50,7 +50,7 @@ after the ``--branch`` (or just ``-b``) argument::
 
     # After cloning, optionally go to a specific commit.
     # This can be used to access the source code at a specific point in time,
-    # e.g. for development snapshots, betas and releaes candidates.
+    # e.g. for development snapshots, betas and release candidates.
     cd godot
     git checkout f4af8201bac157b9d47e336203d3e8a8ef729de2
 


### PR DESCRIPTION
Codespell was not running on some files.

The current command should check multiple directory levels, but it does not:
```
codespell -I _tools/codespell-ignore.txt -x _tools/codespell-ignore-lines.txt -S tutorials/i18n/locales.rst {about,community,contributing,getting_started,tutorials}/**/*.rst
```
 It was only checking `.rst` files that were one directory below the top-level directories (`about`, `community`, `contributing`, etc). It was not checking direct children of the top-level directories, nor was it checking children that were more deeply nested within subdirectories. This means that the entire `about` section was not being checked at all, since all the pages there are direct children of top-level folders.

This updated command is a crude way to check multiple levels. There should be a better way to do this, but for some reason that way is *not* just using a single `/**/`.
```
codespell -I _tools/codespell-ignore.txt -x _tools/codespell-ignore-lines.txt -S tutorials/i18n/locales.rst {about,community,contributing,getting_started,tutorials}/{*.rst,**/*.rst,**/**/*.rst,**/**/**/*.rst}
```

One uncaught typo was found with the updated command.

If you want to test out this updated codespell command, or a better alternate, try putting a typo like "1nd" in one file in each folder nesting level, then run the command (either locally or in CI).