### PR TITLE
Enforce style guidelines with custom codespell dictionary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Linter checks
         run: |
           bash _tools/format.sh
-          codespell -I _tools/codespell-ignore.txt -x _tools/codespell-ignore-lines.txt -S tutorials/i18n/locales.rst {about,community,contributing,getting_started,tutorials}/{*.rst,**/*.rst,**/**/*.rst,**/**/**/*.rst}
+
+          codespell -D- -D _tools/codespell-dict.txt -I _tools/codespell-ignore.txt -x _tools/codespell-ignore-lines.txt -S tutorials/i18n/locales.rst {about,community,contributing,getting_started,tutorials}/{*.rst,**/*.rst,**/**/*.rst,**/**/**/*.rst}
 
       # Use dummy builder to improve performance as we don't need the generated HTML in this workflow.
       - name: Sphinx build

--- a/_tools/codespell-dict.txt
+++ b/_tools/codespell-dict.txt
@@ -1,0 +1,1 @@
+anti-aliasing->antialiasing

--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -369,7 +369,7 @@ See :ref:`doc_renderers` for a detailed comparison of the rendering methods.
 - ETC2 (not supported on macOS).
 - S3TC (not supported on mobile/Web platforms).
 
-**Anti-aliasing:**
+**Antialiasing:**
 
 - Temporal :ref:`antialiasing <doc_3d_antialiasing>` (TAA).
 - AMD FidelityFX Super Resolution 2.2 :ref:`antialiasing <doc_3d_antialiasing>` (FSR2),

--- a/tutorials/2d/custom_drawing_in_2d.rst
+++ b/tutorials/2d/custom_drawing_in_2d.rst
@@ -487,7 +487,7 @@ You should get the following output:
 Unlike ``draw_polygon()``, polylines can only have a single unique color
 for all its points (the second argument). This method has 2 additional
 arguments: the width of the line (which is as small as possible by default)
-and enabling or disabling the anti-aliasing (it is disabled by default).
+and enabling or disabling the antialiasing (it is disabled by default).
 
 The order of the ``_draw`` calls is important- like with the Node positions on
 the tree hierarchy, the different shapes will be drawn from top to bottom,

--- a/tutorials/troubleshooting.rst
+++ b/tutorials/troubleshooting.rst
@@ -177,7 +177,7 @@ OpenGL applications by your graphics driver.
 - **AMD (Windows):** Open the start menu and choose **AMD Software**. Click the
   settings "cog" icon in the top-right corner. Go to the **Graphics** tab,
   scroll to the bottom and click **Advanced** to unfold its settings. Disable
-  **Morphological Anti-Aliasing**.
+  **Morphological Antialiasing**.
 
 Third-party vendor-independent utilities such as vkBasalt may also force
 sharpening or FXAA on all Vulkan applications. You may want to check their


### PR DESCRIPTION
Adds a custom dictionary to codespell. Both the default codespell dictionary and our custom dictionary are checked, using multiple copies of the `-D` argument.

Currently, this dictionary only contains "anti-aliasing -> antialiasing". Later, we can add other style guidelines that we want to enforce, like perhaps "run-time -> runtime". https://github.com/godotengine/godot-docs/issues/10218 tracks potential words to add.

Note that codespell is limited here. We can't check for phrases with spaces or for specific capitalizations. We also can't check for phrases which we don't want to enforce a style for 99%+ of the time, since each exception needs to be listed in an ignore file. So the number of entries in the custom dictionary will likely remain low.

---
Addresses https://github.com/godotengine/godot-docs/issues/10218, but does not close.
This PR is a pure superset of https://github.com/godotengine/godot-docs/pull/10220. It uses the same fix for codespell not checking some files. It also includes the one typo found by the other PR, so that the CI passes. However, I made two separate PRs because we probably want to merge the simple bug fix before this feature change.