### PR TITLE
Update list of debugging settings

### DIFF
--- a/tutorials/scripting/debug/overview_of_debugging_tools.rst
+++ b/tutorials/scripting/debug/overview_of_debugging_tools.rst
@@ -232,8 +232,8 @@ broke on.
 Debug project settings
 ----------------------
 
-In the project settings, there is a **Debug** category with three subcategories
-which control different things.
+In the project settings, there is a **Debug** category with subcategories which
+control different things. Enable **Advanced Settings** to change these settings.
 
 Settings
 ++++++++
@@ -242,11 +242,28 @@ These are some general settings such as printing the current FPS
 to the **Output** panel, the maximum amount of functions when profiling
 and others.
 
+File Logging
+++++++++++++
+
+These settings allow you to log console output and error messages to files.
+
 GDScript
 ++++++++
 
 These settings allow you to toggle specific GDScript warnings, such as for
+unused variables. You can also turn off warnings completely. See 
+:ref:`doc_gdscript_warning_system` for more information.
+
+Shader Language
++++++++++++++++
+
+These settings allow you to toggle specific shader warnings, such as for
 unused variables. You can also turn off warnings completely.
+
+Canvas Items
+++++++++++++
+
+These settings are for canvas item redraw debugging.
 
 Shapes
 ++++++


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-docs/issues/10226.

I do think listing the project settings subcategories here is a bit of an antipattern. But the right improvement is a larger change, either expanding the [Project Settings](https://docs.godotengine.org/en/stable/tutorials/editor/project_settings.html) manual page with a full list of settings categories, or adding some in-engine category descriptions that can then be copied into the class reference and online class reference.