### PR TITLE
Use "built-in" and "built into", avoid "builtin", "built in", and "built-in to"

### DIFF
--- a/contributing/development/compiling/introduction_to_the_buildsystem.rst
+++ b/contributing/development/compiling/introduction_to_the_buildsystem.rst
@@ -328,7 +328,7 @@ source to initialize any SCons build options passed via the command line:
     use_llvm = "yes"
     extra_suffix = "game_title"
 
-You can also disable some of the builtin modules before compiling, saving some
+You can also disable some of the built-in modules before compiling, saving some
 time it takes to build the engine. See :ref:`doc_optimizing_for_size` page for more details.
 
 .. seealso::

--- a/contributing/documentation/docs_image_guidelines.rst
+++ b/contributing/documentation/docs_image_guidelines.rst
@@ -63,7 +63,7 @@ make an image look clean. Below is an example of good cropping.
 .. image:: img/cropped_image.webp
 
 For cropping Krita is the recommended program. While some screenshot programs do
-have cropping built in it's not always easy to get something precise. And while
+have cropping built-in it's not always easy to get something precise. And while
 Krita is designed as a painting program the cropping tool gives you pixel precision
 by default. Of course, feel free to use a different program you are familiar with.
 

--- a/tutorials/2d/using_tilemaps.rst
+++ b/tutorials/2d/using_tilemaps.rst
@@ -25,7 +25,7 @@ Specifying the TileSet in the TileMapLayer
 ------------------------------------------
 
 If you've followed the previous page on :ref:`doc_using_tilesets`, you should
-have a TileSet resource that is built-in to the TileMapLayer node. This is good for
+have a TileSet resource that is built into the TileMapLayer node. This is good for
 prototyping, but in a real world project, you will generally have multiple
 levels reusing the same tileset.
 

--- a/tutorials/editor/managing_editor_features.rst
+++ b/tutorials/editor/managing_editor_features.rst
@@ -11,7 +11,7 @@ Introduction
 In certain situations, it may be desirable to limit what features can be used
 in the Godot editor. For example, a UI designer on a team who doesn't need to
 see 3D features, or an educator slowly introducing features to students. Godot
-has a built in system called "feature profiles" to do this.
+has a built-in system called "feature profiles" to do this.
 
 With feature profiles, major features and nodes can be hidden from the editor.
 This only hides parts of the interface and does not actually remove support for

--- a/tutorials/platform/ios/plugins_for_ios.rst
+++ b/tutorials/platform/ios/plugins_for_ios.rst
@@ -490,7 +490,7 @@ On success:
 ``show_game_center``
 ~~~~~~~~~~~~~~~~~~~~
 
-Displays the built in Game Center overlay showing leaderboards,
+Displays the built-in Game Center overlay showing leaderboards,
 achievements, and challenges.
 
 Parameters

--- a/tutorials/shaders/compute_shaders.rst
+++ b/tutorials/shaders/compute_shaders.rst
@@ -143,7 +143,7 @@ careful not to read from an index larger than the size of the buffer.
 
 Finally, we write the ``main`` function which is where all the logic happens. We
 access a position in the storage buffer using the ``gl_GlobalInvocationID``
-built in variables. ``gl_GlobalInvocationID`` gives you the global unique ID for
+built-in variables. ``gl_GlobalInvocationID`` gives you the global unique ID for
 the current invocation.
 
 To continue, write the code above into your newly created ``compute_example.glsl``

--- a/tutorials/shaders/custom_postprocessing.rst
+++ b/tutorials/shaders/custom_postprocessing.rst
@@ -50,7 +50,7 @@ For this demo, we will use this :ref:`Sprite <class_Sprite2D>` of a sheep.
 
 Assign a new :ref:`Shader <class_Shader>` to the ``ColorRect``'s
 ``ShaderMaterial``. You can access the frame's texture and UV with a
-``sampler2D`` using ``hint_screen_texture`` and the built in ``SCREEN_UV``
+``sampler2D`` using ``hint_screen_texture`` and the built-in ``SCREEN_UV``
 uniforms.
 
 Copy the following code to your shader. The code below is a hex pixelization

--- a/tutorials/shaders/shader_materials.rst
+++ b/tutorials/shaders/shader_materials.rst
@@ -23,7 +23,7 @@ Examples of this are:
 -  Create custom particle code.
 -  And much more!
 
-Godot provides built in functionality to make frequent operations
+Godot provides built-in functionality to make frequent operations
 easier. Additionally, Godot's shader editor will detect errors as you
 type, so you can see your edited shaders in real-time. It is also
 possible to edit shaders using a visual, node-based graph editor.

--- a/tutorials/shaders/shader_reference/canvas_item_shader.rst
+++ b/tutorials/shaders/shader_reference/canvas_item_shader.rst
@@ -271,7 +271,7 @@ run. Use the ``light_only`` render mode if you only want to see the impact of
 lighting on an object; this can be useful when you only want the object visible
 where it is covered by light.
 
-If you define a ``light()`` function it will replace the built in light function,
+If you define a ``light()`` function it will replace the built-in light function,
 even if your light function is empty.
 
 Below is an example of a light shader that takes a CanvasItem's normal map into account:


### PR DESCRIPTION
Addresses https://github.com/godotengine/godot-docs/issues/10218.

This one can't be checked with codespell because "builtin" and "built in" still occur in plenty of valid places.