### PR TITLE
[Proof of Concept] Use :guilabel: Sphinx role for editor UI, with custom CSS

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1816,3 +1816,15 @@ p + .classref-constant {
 #godot-giscus {
     margin-bottom: 1em;
 }
+
+/* Display :guilabel: and :menuselection: tags as simple bold. */
+.rst-content .guilabel,
+.rst-content .menuselection {
+    border: 0px;
+    background: none;
+    font-size: 100%;
+    font-weight: 700;
+    border-radius: 0;
+    padding: 0;
+    margin: 0;
+}

--- a/tutorials/editor/project_manager.rst
+++ b/tutorials/editor/project_manager.rst
@@ -8,7 +8,7 @@ you create, remove, import, or play game projects:
 
 .. image:: img/editor_ui_intro_project_manager_01.webp
 
-To change the editors language click on the **Settings** Button in the top right
+To change the editors language click on the :guilabel:`Settings` Button in the top right
 corner:
 
 .. image:: img/editor_ui_intro_project_manager_02.webp
@@ -32,14 +32,14 @@ Creating and importing projects
 
 To create a new project:
 
-1. Click the **Create** button on the top-left of the window.
-2. Give the project a name, then open the file browser using the **Browse** button,
+1. Click the :guilabel:`Create` button on the top-left of the window.
+2. Give the project a name, then open the file browser using the :guilabel:`Browse` button,
    and choose an empty folder on your computer to save the files. Alternatively,
-   you can enable **Create Folder** option to automatically create a new sub-folder
+   you can enable :guilabel:`Create Folder` option to automatically create a new sub-folder
    with the project name, following the directory naming convention set in the
    settings. An empty folder will show a green tick on the right.
 3. Select one of the rendering backends (this can also be changed later).
-4. Click the **Create & Edit** button to create the project folder and open it in the editor.
+4. Click the :guilabel:`Create & Edit` button to create the project folder and open it in the editor.
 
 .. image:: img/editor_ui_intro_project_manager_04.webp
 
@@ -50,7 +50,7 @@ To create a new project:
 Using the file browser
 ~~~~~~~~~~~~~~~~~~~~~~
 
-From the **Create New Project** window, click the **Browse** button to open
+From the :guilabel:`Create New Project` window, click the :guilabel:`Browse` button to open
 Godot's file browser. You can pick a location or type the folder's path in the
 **Path** field, after choosing a drive.
 
@@ -65,9 +65,9 @@ are seen.
 
 The last button on the right will create a new folder.
 
-Favorited folders will be displayed on the left side under the **Favorites** section. You can sort the
+Favorited folders will be displayed on the left side under the :guilabel:`Favorites` section. You can sort the
 favorites using the up and down buttons in this section.
-Last chosen folders will be listed under the **Recent** list.
+Last chosen folders will be listed under the :guilabel:`Recent` list.
 
 .. image:: img/editor_ui_intro_project_manager_05.webp
 
@@ -79,7 +79,7 @@ list. Double click on it to open it in the editor.
 
 .. image:: img/editor_ui_intro_project_manager_06.webp
 
-You can similarly import existing projects using the **Import** button. Locate the
+You can similarly import existing projects using the :guilabel:`Import` button. Locate the
 folder that contains the project or the **project.godot** file to import and
 edit it.
 
@@ -96,15 +96,15 @@ When the folder path is correct, you'll see a green checkmark.
 Downloading demos and templates
 -------------------------------
 
-From the **Asset Library** tab you can download open source project
+From the :guilabel:`Asset Library` tab you can download open source project
 templates and demos from the :ref:`Asset Library <toc-learn-features-assetlib>` to help
 you get started faster.
 
 The first time you open this tab you'll notice that it's asking you to go online.
 For privacy reasons the project manager, and Godot editor, can't access the internet
-by default. To enable accessing the internet click the **Go Online** button. This will
+by default. To enable accessing the internet click the :guilabel:`Go Online` button. This will
 also allow project manager to notify you about updates. If you wish to turn this off
-in the future go into project manager settings and change **Network Mode** to "Offline"
+in the future go into project manager settings and change :guilabel:`Network Mode` to ``Offline``.
 
 Now that Godot is connected to the internet you can download a demo or template, to
 do this:
@@ -121,15 +121,15 @@ Managing projects with tags
 
 For users with a lot of projects on one PC it can be a lot to keep track of. To aid
 in this Godot allows you to create project tags. To add a tag to a project click on the
-project in the project manager, then click on the **Manage Tags** button
+project in the project manager, then click on the :guilabel:`Manage Tags` button
 
 .. image:: img/editor_ui_intro_project_manager_11.webp
 
-This will open up the manage project tags window. To add a tag click the plus button.
+This will open up the :guilabel:`Manage Project Tags` window. To add a tag click the plus button.
 
 .. image:: img/editor_ui_intro_project_manager_12.webp
 
-Type out the tag name, and click **OK**. Your project will now have a tag added to it.
+Type out the tag name, and click :guilabel:`OK`. Your project will now have a tag added to it.
 These tags can be used for any other project in your project manager.
 
 To show projects with a specific tag only, you can click on the tags or write ``tag:`` 


### PR DESCRIPTION
https://github.com/godotengine/godot-docs/issues/8890 inspired me to take a look at what else Sphinx offers that we are not using.

Sphinx (and RTD) supports two roles that we can use for semantic markup: [:guilabel:](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-guilabel) for any UI labels in the editor, and [:menuselection:](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-menuselection) specifically for menu interaction paths. In the docs, we currently use **bold style** for all of **Editor Window Names**, **Editor Buttons**, **Menu > Navigation > Paths**, and **Inspector Properties**, as well as for **simple emphasis**.

It would be nice to differentiate these two usages. Using an actual semantic role will make finding all instances of editor UI labels easier. These have a tendency to become out of date, as Godot updates. It will also allow us to tweak the style of editor UI labels independently from other usages of bold.

We can use these two Sphinx roles, to semantically differentiate these usages from other usages of **bold style**. By default, in the RTD Sphinx theme the `:guilabel:` role look like this:
![msedge_RZYRAwMuEr](https://github.com/user-attachments/assets/5d3a0ebf-25d6-403d-8956-11f7e26fc771)
In this PR, I've added custom CSS so it just looks like our usual **bold** style instead:
![msedge_BFoZ8hpGNp](https://github.com/user-attachments/assets/306a3008-0b90-4158-a128-ad68d16ea53d)

The `:menuselection:` role looks similar, except it automatically replaces `-->` with a single arrow `‣`. I don't think we *need* to use this one instead of manually constructing **Menu > Navigation > Paths**. We might want to keep using the common `>` symbol.

There are benefits to replacing existing usages with semantic roles, even if we continue to use simple bold style instead of the default RTD Sphinx theme.