### PR TITLE
Rename Renderers page to List of renderers

### DIFF
--- a/tutorials/rendering/index.rst
+++ b/tutorials/rendering/index.rst
@@ -12,8 +12,8 @@ Rendering
    :maxdepth: 1
    :name: toc-learn-features-rendering
 
+   renderers
    viewports
    multiple_resolutions
    jitter_stutter
    compositor
-   renderers

--- a/tutorials/rendering/renderers.rst
+++ b/tutorials/rendering/renderers.rst
@@ -1,7 +1,7 @@
 .. _doc_renderers:
 
-Renderers
-=========
+List of renderers
+=================
 
 .. seealso::
 
@@ -112,7 +112,7 @@ Feature comparison
 
 This is not a complete list of the features of each renderer. If a feature is
 not listed here, it is available in all renderers, though it may be much faster
-on some renderers. For a list of *all* features in Godot, see :ref:`doc_list_of_features`. 
+on some renderers. For a list of *all* features in Godot, see :ref:`doc_list_of_features`.
 
 Hardware with RenderingDevice support is hardware which can run Vulkan, Direct3D
 12, or Metal.


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-docs/pull/10114.

___

- Put it first in the list of pages in the Rendering section, as it makes more sense to be read first.
