### PR TITLE
Add info about layer mask exporting to physics_introduction.rst

### DIFF
--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -180,6 +180,12 @@ would be as follows::
     # (2^(1-1)) + (2^(3-1)) + (2^(4-1)) = 1 + 4 + 8 = 13
     pow(2, 1-1) + pow(2, 3-1) + pow(2, 4-1)
 
+Export annotations can be used to export bitmasks in the editor with a user-friendly GUI::
+
+    # @export_flags_2d_physics var layers_2d_physics
+
+Additional export annotations are available for render and navigation layers, in both 2D and 3D. See :ref:`exporting_bit_flags`
+
 
 Area2D
 ------

--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -184,7 +184,7 @@ Export annotations can be used to export bitmasks in the editor with a user-frie
 
     # @export_flags_2d_physics var layers_2d_physics
 
-Additional export annotations are available for render and navigation layers, in both 2D and 3D. See :ref:`exporting_bit_flags`
+Additional export annotations are available for render and navigation layers, in both 2D and 3D. See :ref:`doc_gdscript_exports_exporting_bit_flags`.
 
 
 Area2D

--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -182,7 +182,7 @@ would be as follows::
 
 Export annotations can be used to export bitmasks in the editor with a user-friendly GUI::
 
-    # @export_flags_2d_physics var layers_2d_physics
+    @export_flags_2d_physics var layers_2d_physics
 
 Additional export annotations are available for render and navigation layers, in both 2D and 3D. See :ref:`doc_gdscript_exports_exporting_bit_flags`.
 

--- a/tutorials/scripting/gdscript/gdscript_exports.rst
+++ b/tutorials/scripting/gdscript/gdscript_exports.rst
@@ -248,6 +248,8 @@ It must be noted that even if the script is not being run while in the
 editor, the exported properties are still editable. This can be used
 in conjunction with a :ref:`script in "tool" mode <doc_gdscript_tool_mode>`.
 
+.. _doc_gdscript_exports_exporting_bit_flags:
+
 Exporting bit flags
 -------------------
 


### PR DESCRIPTION
The docs page for raycasting provides a link to the physics introduction page for how to set a collision mask on a raycast created in code. The physics introduction page does not mention export annotations for exporting a collision mask. This pull request adds a brief bit about exporting layer masks, and links to the export annotation docs page.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
