### PR TITLE
Add multiple renderer support to Advanced Postprocessing

### DIFF
--- a/tutorials/shaders/advanced_postprocessing.rst
+++ b/tutorials/shaders/advanced_postprocessing.rst
@@ -108,10 +108,6 @@ from ``0.0`` to ``1.0`` in the ``z`` direction when using the Vulkan backend.
 Reconstruct the NDC using ``SCREEN_UV`` for the ``x`` and ``y`` axis, and
 the depth value for ``z``.
 
-.. note::
-
-    This tutorial assumes the use of the Vulkan renderer, which uses NDCs with a Z-range
-    of ``[0.0, 1.0]``. In contrast, OpenGL uses NDCs with a Z-range of ``[-1.0, 1.0]``.
 
 .. code-block:: glsl
 
@@ -119,6 +115,28 @@ the depth value for ``z``.
     float depth = texture(depth_texture, SCREEN_UV).x;
     vec3 ndc = vec3(SCREEN_UV * 2.0 - 1.0, depth);
   }
+
+.. note::
+
+  This tutorial assumes the use of the Forward+ or Mobile renderers, which both
+  use Vulkan NDCs with a Z-range of ``[0.0, 1.0]``. In contrast, the Compatibility
+  renderer uses OpenGL NDCs with a Z-range of ``[-1.0, 1.0]``. For the Compatibility
+  renderer, replace the NDC calculation with this instead:
+  
+  .. code-block:: glsl
+
+    vec3 ndc = vec3(SCREEN_UV, depth) * 2.0 - 1.0;
+
+  You can also use the ``CURRENT_RENDERER`` and ``RENDERER_COMPATIBILITY``
+  built-in defines for a shader that will work in all renderers:
+
+  .. code-block:: glsl
+
+    #if CURRENT_RENDERER == RENDERER_COMPATIBILITY
+    vec3 ndc = vec3(SCREEN_UV, depth) * 2.0 - 1.0;
+    #else
+    vec3 ndc = vec3(SCREEN_UV * 2.0 - 1.0, depth);
+    #endif
 
 Convert NDC to view space by multiplying the NDC by ``INV_PROJECTION_MATRIX``.
 Recall that view space gives positions relative to the camera, so the ``z`` value will give us


### PR DESCRIPTION
Addresses https://github.com/godotengine/godot-docs/issues/10204.

Adds code for the Compatibility renderer to the Advanced Postprocessing page.

With https://github.com/godotengine/godot/pull/98549 merged, there is now a way to detect the renderer in shaders that has low no runtime cost. Unlike using `OUTPUT_IS_SRGB`, it also is obvious what it does. Alternately, `CLIP_SPACE_FAR` could be used in the example here, since NDC depends directly on that value. But the math to do so is non-obvious, and using a renderer define here is more obvious and instructive.