### PR TITLE
Typo fix in signals.rst

### DIFF
--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -147,8 +147,8 @@ methods "_on_node_name_signal_name". Here, it'll be "_on_button_pressed".
 
 .. note::
 
-    If you are using an external editor (such as VS Code) this
-    automatic code generation might not work. In this case you need to connect
+    If you are using an external editor (such as VS Code), this
+    automatic code generation might not work. In this case, you need to connect
     the signal via code as explained in the next section.
 
 Click the Connect button to complete the signal connection and jump to the

--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -148,7 +148,7 @@ methods "_on_node_name_signal_name". Here, it'll be "_on_button_pressed".
 .. note::
 
     If you are using an external editor (such as VS Code) this
-    automatic code generation might not work. In this case you need to to connect
+    automatic code generation might not work. In this case you need to connect
     the signal via code as explained in the next section.
 
 Click the Connect button to complete the signal connection and jump to the


### PR DESCRIPTION
Just fixed a small typo that I noticed when reading "Using signals": 

> In this case you need **to to** connect the signal via code...

(Second "Note" in "Connecting a signal in the editor").