### PR TITLE
Add note about LightmapGI only baking nodes under its parent

### DIFF
--- a/tutorials/3d/global_illumination/using_lightmap_gi.rst
+++ b/tutorials/3d/global_illumination/using_lightmap_gi.rst
@@ -82,8 +82,10 @@ Setting up
 
 .. note::
 
-    The LightmapGI node only bakes nodes under its parent.
-    This is because some people may require several separate lightmaps in the same scene.
+    The LightmapGI node only bakes nodes that are on the same level as the
+    LightmapGI node (siblings), or nodes that are children of the
+    LightmapGI node. This allows you to use several LightmapGI nodes to bake
+    different parts of the scene, independently from each other.
 
 First of all, before the lightmapper can do anything, the objects to be baked need
 a UV2 layer and a texture size. A UV2 layer is a set of secondary texture coordinates

--- a/tutorials/3d/global_illumination/using_lightmap_gi.rst
+++ b/tutorials/3d/global_illumination/using_lightmap_gi.rst
@@ -80,6 +80,11 @@ Setting up
     graphics API limitations on those devices. On Android and web platforms,
     only *rendering* lightmaps that were baked on a desktop PC is supported.
 
+.. note::
+
+    The LightmapGI node only bakes nodes under its parent.
+    This is because some people may require several separate lightmaps in the same scene.
+
 First of all, before the lightmapper can do anything, the objects to be baked need
 a UV2 layer and a texture size. A UV2 layer is a set of secondary texture coordinates
 that ensures any face in the object has its own place in the UV map. Faces must


### PR DESCRIPTION
`LightmapGI`'s documentation currently doesn't mention the fact it only bakes nodes under its parent. 
This can make the user think there is something wrong with their scene setup or 3D models, as it refuses to bake when the user's models / world isn't under the same parent as the `LightmapGI`.

I personally encountered this issue because I tried adding a `LightmapGI` underneath a blank node called "Environment" under which a `WorldEnvironment` was also present, and the `LightmapGI` complained about having nothing to bake.

Made for the #9694 issue
Linked class reference PR: [godotengine/godot#99079](https://github.com/godotengine/godot/pull/99079)

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
