### PR TITLE
Add custom Sphinx roles for editor UI

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -150,6 +150,8 @@
     --kbd-shadow-color: #b0b7bf;
     --kbd-text-color: #444d56;
 
+    --ui-btn-background-color: #d3d7e1;
+
     --code-example-good-color: #3fb950;
     --code-example-bad-color: #f85149;
 
@@ -279,6 +281,8 @@
         --kbd-outline-color: #3d4144;
         --kbd-shadow-color: #1e2023;
         --kbd-text-color: #e2f2ff;
+        
+        --ui-btn-background-color: #22252d;
 
         --code-example-good-color: #3fb950;
         --code-example-bad-color: #f85149;
@@ -1815,4 +1819,22 @@ p + .classref-constant {
 /* Giscus */
 #godot-giscus {
     margin-bottom: 1em;
+}
+
+/* */
+.uistyle {
+    font-weight: 700;
+}
+
+.uibutton, .uipath, .uiwindow , .uieditor, .uifield, .uilabel, .uimenu, .uipath, .normalproperty, .uigeneric, .uidock, .uitab, .uipanel {
+    font-size: 80%;
+    border-radius: 4px;
+    padding: 2.4px 6px;
+    margin: auto 2px;
+    border: 0px solid #7fbbe3;
+    background: var(--ui-btn-background-color);
+}
+
+.uiproperty, .uisection, .uiprojsection {
+
 }

--- a/conf.py
+++ b/conf.py
@@ -298,6 +298,54 @@ if is_i18n and os.path.exists("../classes/" + language):
 
     os.symlink("../classes/" + language, "classes")
 
+rst_prolog = """
+.. role:: btn
+   :class: uibutton uistyle
+
+.. role:: editor
+   :class: uieditor uistyle
+
+.. role:: field
+    :class: uifield uistyle
+
+.. role:: lbl
+    :class: uilabel uistyle
+
+.. role:: menu
+    :class: uimenu uistyle
+
+.. role:: path
+    :class: uipath uistyle
+
+.. role:: property
+    :class: normalproperty
+
+.. role:: ui
+    :class: uigeneric uistyle
+
+.. role:: uiproperty
+    :class: uiproperty uistyle
+
+.. role:: uisection
+    :class: uisection uistyle
+
+.. role:: wndw
+    :class: uiwindow uistyle
+
+.. role:: projsection
+    :class: uiprojsection uistyle
+
+.. role:: tab
+    :class: uitab uistyle
+
+.. role:: dock
+    :class: uidock uistyle
+
+.. role:: panel
+    :class: uipanel uistyle
+
+"""
+
 # Couldn't find a way to retrieve variables nor do advanced string
 # concat from reST, so had to hardcode this in the "epilog" added to
 # all pages. This is used in index.rst to display the Weblate badge.

--- a/contributing/documentation/docs_writing_guidelines.rst
+++ b/contributing/documentation/docs_writing_guidelines.rst
@@ -537,3 +537,110 @@ Follow these guidelines for when to refer to a specific Godot version:
 - If a feature was added in a 3.x major or minor version, **do not specify** when 
   the feature was added. These features are old enough that the exact version
   in which they were added is not relevant.
+
+Use roles for editor UI
+-----------------------
+
+Custom roles are defined for many editor UI elements. When referring to UI actions
+that the user must do, like pressing buttons, opening menus, or opening dialogs,
+use these tags. We do this for a few reasons:
+
+- Usages are tracked separately. It's easier to search for all usages of a single
+  editor UI element when they are tagged like this.
+- Style is consistent, and can be changed per-element.
+- In the future, we may add more complex custom roles, and tagging will make
+  replacing all usages later easier.
+
+When in doubt, use one of these roles:
+
+- ``:btn:``  A button, toggle, or most other clickable UI elements. If the reader
+  is meant to click on it, and it's not a menu, use this.
+- ``:menu:``  A series of menus to click through, or a single menu to click on.
+  When listing a series of menus, separate them with ``>``.
+- ``:uiproperty:`` A property in the inspector. Note that you can also link to a
+  property, or use ``code style`` to refer to a property when used in *code* rather
+  than the inspector.
+- ``:ui`` A catch-all role for any editor UI elements. Use this if you would have
+  otherwise just used **bold style**. It can be changed later, if necessary.
+
+There are several more specific roles, too. Most of these render the same as the
+more general roles, but exist for tagging purposes:
+
+- ``:field:`` An input field in the editor; anything that you type into. Excludes
+  properties, though.
+- ``:path:``  A UI navigation path in the editor. Use ``:uisection:`` instead for
+  nested sections in the inspector. Use ``:uiproperty:`` instead for inspector
+  properties that include a section like ``Process > Mode``. Use ``:projsection:``
+  for sections in the project settings.
+- ``:wndw:``  An editor window, popup dialog, or modal. Anything that can be
+  separately dragged and has a title.
+- ``:uisection:``  A section in the inspector.
+- ``:projsection:``  A section in the project settings.
+- ``:tab:`` A tab.
+- ``:dock:`` A dock.
+- ``:panel:`` A panel.
+
+Examples
+~~~~~~~~
+
+Adding a sprite and setting some properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In the :dock:`Scene` dock, click :btn:`2D Scene` to create a new scene.
+
+Add a new :ref:`Sprite2D <class_Sprite2D>` to the scene by right-clicking on the
+root node and choosing :btn:`Add Child Node...`. In the :wndw:`Create New Node`
+window, search for "Sprite2D", select it, and then click :btn:`Create`.
+
+On the sprite, under :uisection:`Offset`, set :uiproperty:`Offset` to ``(16, 32)``
+and enable :uiproperty:`Flip H`. Set :uiproperty:`Animation > HFrames` to ``10``.
+In :uisection:`CanvasItem > Visibility`, set the :uiproperty:`Modulate` color to
+``ff0000``.
+
+.. tip:: 
+    
+    Don't forget to save your scene in :menu:`Scene > Save Scene...`. When the
+    :wndw:`Save Scene As...` window pops up, enter "my_scene.tscn" in the
+    :field:`File` field, then click :btn:`Save`.
+
+Setting project settings
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Go to :menu:`Project > Project Settings`, then select the
+:ref:`Max FPS <class_ProjectSettings_property_application/run/max_fps>`
+setting under :projsection:`Application > Run`. Don't forget to click the
+:btn:`Advanced Settings` toggle. Then, in :field:`Filter Settings`, search for
+"physics". Go to :projsection:`Physics > 3D > Solver`, and set
+:uiproperty:`Solver Iterations` to ``16``.
+
+All style roles
+~~~~~~~~~~~~~~~
+
+|styleroles|
+
+.. note::
+    
+    |styleroles|
+
+.. warning::
+
+    |styleroles|
+
+.. danger::
+
+    |styleroles|
+
+.. tip::
+
+    |styleroles|
+
+.. admonition:: Custom admonition
+
+    |styleroles|
+
+.. All the inline roles which are used in the docs. External links don't work in a substitution.
+.. |styleroles| replace:: Built-in styles: ``code``, **bold**, and *italics*.
+    Built-in roles: :kbd:`kbd`, :ref:`ref <doc_about_intro>`, :ref:`ref <class_node>`.
+    Custom roles: :btn:`btn`, :menu:`menu > menu > menu`, :uiproperty:`uiproperty`, :ui:`ui`,
+    :field:`field`, :path:`path > path > path`, :wndw:`wndw`, :uisection:`uisection`,
+    :projsection:`projsection`, :tab:`tab`, :dock:`dock`, :panel:`panel`.


### PR DESCRIPTION
This PR is a proof of concept, and is subject to change. It only implements the custom roles and a short example usage section. I have a separate branch for actual usage changes, with several hundred already changed. Decisions of which roles to add are being driven by actual usage.

### What this is

This PR adds custom Sphinx roles, like `:btn:`, `:menu:`, and `:ui:`, for various editor UI elements. It renders most of them with bold text and a light blue-gray background.

It looks like this:

![msedge_YpWdiI9fOd](https://github.com/user-attachments/assets/7c652ecc-40f5-43ff-8465-3a25bae39b34)

Or this:

![chrome_dmv9HGaD83](https://github.com/user-attachments/assets/4289a757-24e6-4eee-b8fa-a586923924f6)

Currently implemented are:

- ``:btn:``  A button, toggle, or most other clickable UI elements. If the reader is meant to click on it, and it's not a menu, use this.
- ``:menu:``  A series of menus to click through, or a single menu to click on. When listing a series of menus, separate them with ``>``.
- ``:uiproperty:`` A property in the inspector. Note that you can also link to a property, or use ``code style`` to refer to a property when used in *code* rather than the inspector. **It's called "uiproperty" and not "property" for a reason, since inspector properties are treated differently than properties accessed through code. "property" or "prop" should be reserved for future use for the other case.** This name is definitely too long, it will be changed.
- ``:ui`` A catch-all role for any editor UI elements. Use this if you would have otherwise just used **bold style**. It can be changed later, if necessary.
- ``:field:`` An input field in the editor; anything that you type into. Excludes properties, though.
- ``:path:``  A UI navigation path in the editor. Use ``:uisection:`` instead for nested sections in the inspector. Use ``:uiproperty:`` instead for inspector properties that include a section like ``Process > Mode``. Use ``:projsection:`` for sections in the project settings. **Probably will be merged with `menu`, but I'm keeping both around to see if there is some nuance to their usage to preserve.**
- ``:wndw:``  An editor window, popup dialog, or modal. Anything that can be separately dragged and has a title.
- ``:uisection:``  A section in the inspector. **Likely will be renamed to be shorter.**
- ``:projsection:``  A section in the project settings. **Likely will be renamed to be shorter.**
- ``:tab:`` A tab.
- ``:dock:`` A dock.
- ``:panel:`` A panel.

As you can see, some are very specific, and some are probably redundant. I'm tagging very specifically first, then I'll come back and merge them together based on *actual usage*. 

### Why

This solves two problems, style inconsistency and maintenance.

**Style inconsistency:** Style for UI elements in the editor is inconsistent. For buttons, we currently use  **bold**, *italics*, `code`, or "quotes". We've mostly standardized on **bold**, but there are a *lot* of existing usages that are inconsistent.

**Maintenance:** Using semantically meaningful roles for each separate *kind* of editor UI allows us to change the style of each one independently, without breaking translations, just by changing the CSS. It also makes searching for all instances of one kind of editor UI much easier, since the tag can be searched.

### Technical details

The custom roles are defined inline in `rst_prolog`. I experimented with more complex custom roles as a Sphinx extension, but they are not needed. All this can be accomplished in Sphinx userspace with CSS and some simple definitions:
```
.. role:: btn
   :class: uibutton uistyle
```
However, in the future we *can* change these roles to have more complex behavior, without changing the RST content files. Since all the usages will already be tagged, we can switch out the implementation of the role seamlessly.

### Downsides

- Source files are less readable.
- Source files are a bit harder to type.
- Markdown previews become less useful. Some of the new roles simply render as bold, but since they no longer use `**`, previews don't know that.
- Contributors have to know about the specific tags, rather than just using **bold** as they see fit. I think this can be mitigated by using `btn`, `menu`, and `ui` as general-purpose tags. If the tag needs to be made more specific, it can be done in review by a contributors who are more familiar. Or we can limit the overall number of tags.
- Huge translation churn for the initial set of changes.

### Q & A

#### Why not just use `:guilabel:`?

Sphinx's [guilabel](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-guilabel) and [menuselection](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-menuselection) roles are the inspiration for this PR. I tried them in https://github.com/godotengine/godot-docs/pull/10238. They look like this:

![msedge_RZYRAwMuEr](https://github.com/user-attachments/assets/2ec96d92-65d0-4ff9-8a27-77218c2625df)

For one reason, the name is too long, very annoying to type. For another, it's not granular enough in my opinion. It solves the style inconsistency problem, but does not solve the maintenance problem, since many things would be tagged together under one label.

#### Why so many specific roles?

All existing usages must be changed from **bold**, *italics*, etc to use a role. It's easier to tag them very specifically on the first pass, then replace specific roles with generic ones. We might decide to only use a few roles (I would pick `:ui:`. `:btn:`, and `:menu:`, and one for inspector properties).

#### Why `:btn:` and not `:button:`, `:wndw:` not `:window:`, etc?

I wasn't sure about this myself but after replacing a lot of usages, the extra letters do add up! I think 3-5 is the sweet spot.

#### Why not enforce a style guideline by hand?

We currently do this, and the manual is currently not consistent. Why not let the computer handle the formatting?


#### How many existing usages to change?

Just for existing **bold** usage, I found hundreds of instances to change. But after I started actually looking in files, there are lots more than this. Probably on the order of 2000+ usages to change. I think I've changed several hundred in my other branch already.
- 48 instances of `**Something** button`
- 9 instances of `**Something** window`
- 33 instances of `**Something** menu`
- 18 instances of `**Something** setting`
- 7 instances of `**Something** dropdown`
- 7 instances of `**Something** field`
- 268 instances of `**UI > Navigation > Path**`
- 95 instances of `**Inspector Property**`
- 14 instances of `click on **Something**`
- 52 instances of `click **Something**`
- 35 instances of `select **Something**`
- 24 instances of `enable **Something**`
- 46 instances of `**Something** tab`

#### Won't this cause a lot of translation churn?

Yep! That's why I want to do it once, using fairly granular tagging, and then in the future we can change style with CSS instead of editing the RST content directly.

### Future plans

At some point I'd like to take a shot at implementing a `:property:` or `:method:` role that autolinks to the class reference (and ideally is smart enough to link on the first usage in a page, then use ``code style``. See https://github.com/godotengine/godot-docs/issues/8890. This PR is a first step towards that.
