### PR TITLE
Change warning boxes to danger boxes if data loss can occur

### DIFF
--- a/contributing/development/core_and_modules/custom_platform_ports.rst
+++ b/contributing/development/core_and_modules/custom_platform_ports.rst
@@ -169,7 +169,7 @@ you have two options:
 Distributing a custom platform port
 -----------------------------------
 
-.. warning::
+.. danger::
 
     Before distributing a custom platform port, make sure you're allowed to
     distribute all the code that is being linked against. Console SDKs are

--- a/contributing/workflow/bisecting_regressions.rst
+++ b/contributing/workflow/bisecting_regressions.rst
@@ -42,7 +42,7 @@ whether the issue is a regression in 4.0 or not.
 - If the issue is **not present** in 3.x, then you can try older 4.0 alphas and
   betas to determine when the regression started.
 
-.. warning::
+.. danger::
 
     Project files may be incompatible between Godot versions.
     **Make a backup of your project** before starting the bisection process.

--- a/tutorials/migrating/upgrading_to_godot_4.rst
+++ b/tutorials/migrating/upgrading_to_godot_4.rst
@@ -105,7 +105,7 @@ only ``.gdshader`` is supported in Godot 4.0.
 Running the project upgrade tool
 --------------------------------
 
-.. warning::
+.. danger::
 
     **Make a full backup of your project** before upgrading! The project upgrade
     tool will *not* perform any backups of the project that is being upgraded.

--- a/tutorials/networking/http_request_class.rst
+++ b/tutorials/networking/http_request_class.rst
@@ -149,7 +149,7 @@ For example, to set a custom user agent (the HTTP ``User-Agent`` header) you cou
         HttpRequest httpRequest = GetNode<HttpRequest>("HTTPRequest");
         httpRequest.Request("https://api.github.com/repos/godotengine/godot/releases/latest", new string[] { "User-Agent: YourCustomUserAgent" });
 
-.. warning::
+.. danger::
 
     Be aware that someone might analyse and decompile your released application and
     thus may gain access to any embedded authorization information like tokens, usernames or passwords.

--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -23,7 +23,7 @@ use cases:
 - If your player doesn't use a sprite, but draws itself using code, you can make
   that drawing code execute in the editor to see your player.
 
-.. DANGER::
+.. danger::
 
     ``@tool`` scripts run inside the editor, and let you access the scene tree
     of the currently edited scene. This is a powerful feature which also comes
@@ -503,7 +503,7 @@ currently focused on the script editor.
 
 Scripts that extend EditorScript must be ``@tool`` scripts to function.
 
-.. warning::
+.. danger::
 
     EditorScripts have no undo/redo functionality, so **make sure to save your
     scene before running one** if the script is designed to modify any data.


### PR DESCRIPTION
Promotes warning blocks to danger blocks if any loss of data can occur.

Prior to this PR, the documentation seems to use:
- "Note" for optional information, used often, 
- "Caution" only twice, 
- "Attention" only 8 times,
- "Danger" once, in the tool script page,
- and "Warning" for the vast majority of everything else. "Warning" covers a very wide range of severity, from side notes that *should* be read, potential misconceptions, conventions that are different than usual, or performance problems. It's used often enough that you might start ignoring the warning boxes.

There are a few instances where data loss or actual harm can occur, and these instances should use "Danger" instead of "Warning" to stand out. I checked all the existing "Warning" boxes, and also checked for "backup" and "version control" mentions to find anything else.

Later, I'd like to investigate maybe using the lesser-used Attention and Caution notes more often, for notes that are less severe. Both of these are still the same color as Warning, but the words have different severity. I think Attention could be used in many cases where Warning currently is.