### PR TITLE
Add comments about non-monospaced tables

### DIFF
--- a/tutorials/3d/3d_antialiasing.rst
+++ b/tutorials/3d/3d_antialiasing.rst
@@ -291,6 +291,10 @@ same time.
 Antialiasing comparison
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+.. Note that this table uses emojis, which are not monospaced in most editors.
+.. The table looks malformed but is not. When making changes, check the nearby
+.. lines for guidance.
+
 +--------------------------+--------------------------+--------------------------+--------------------------+--------------------------+--------------------------+--------------------------+
 | Feature                  | MSAA                     | TAA                      | FSR2                     | FXAA                     | SSAA                     | SSRL                     |
 +==========================+==========================+==========================+==========================+==========================+==========================+==========================+

--- a/tutorials/rendering/renderers.rst
+++ b/tutorials/rendering/renderers.rst
@@ -121,6 +121,10 @@ Hardware with RenderingDevice support is hardware which can run Vulkan, Direct3D
 Overall comparison
 ~~~~~~~~~~~~~~~~~~
 
+.. Note that these tables use emojis, which are not monospaced in most editors.
+.. The tables look malformed but are not. When making changes, check the nearby
+.. lines for guidance.
+
 +---------------------+--------------------------+--------------------------+--------------------------+
 | Feature             | Compatibility            | Mobile                   | Forward+                 |
 +=====================+==========================+==========================+==========================+


### PR DESCRIPTION
This came up a couple times in reviews of the original PRs for these tables, and in a followup PR. Hopefully this saves some frustration in future maintenance.

The upgrading to 4.1, 4.2, 4.3 pages also use emojis in a table, but those are subject to much less future maintenance so I think its fine to omit this note in those pages.