### PR TITLE
Bump minimum SCons/Python for builds

### DIFF
--- a/contributing/development/compiling/compiling_for_android.rst
+++ b/contributing/development/compiling/compiling_for_android.rst
@@ -26,8 +26,8 @@ Requirements
 
 For compiling under Windows, Linux or macOS, the following is required:
 
-- `Python 3.6+ <https://www.python.org/downloads/>`_.
-- `SCons 3.1.2+ <https://scons.org/pages/download.html>`_ build system.
+- `Python 3.8+ <https://www.python.org/downloads/>`_.
+- `SCons 4.0+ <https://scons.org/pages/download.html>`_ build system.
 - `Android SDK <https://developer.android.com/studio/#command-tools>`_
   (command-line tools are sufficient).
 
@@ -228,7 +228,7 @@ root directory with the following arguments:
 
 - You can add the ``debug_symbols=yes`` parameter to include the debug symbols in the generated build.
 
-- You can skip certain architectures depending on your target device to speed up compilation. 
+- You can skip certain architectures depending on your target device to speed up compilation.
 
 Remember to add ``generate_apk=yes`` to the *last* architecture you're building, so that binaries are generated after the build.
 

--- a/contributing/development/compiling/compiling_for_ios.rst
+++ b/contributing/development/compiling/compiling_for_ios.rst
@@ -13,8 +13,8 @@ Compiling for iOS
 Requirements
 ------------
 
-- `Python 3.6+ <https://www.python.org/downloads/macos/>`_.
-- `SCons 3.1.2+ <https://scons.org/pages/download.html>`_ build system.
+- `Python 3.8+ <https://www.python.org/downloads/macos/>`_.
+- `SCons 4.0+ <https://scons.org/pages/download.html>`_ build system.
 - `Xcode <https://apps.apple.com/us/app/xcode/id497799835>`_.
     - Launch Xcode once and install iOS support. If you have already launched
       Xcode and need to install iOS support, go to *Xcode -> Settings... -> Platforms*.

--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -17,8 +17,8 @@ For compiling under Linux or other Unix variants, the following is
 required:
 
 - GCC 9+ or Clang 6+.
-- `Python 3.6+ <https://www.python.org/downloads/>`_.
-- `SCons 3.1.2+ <https://scons.org/pages/download.html>`_ build system.
+- `Python 3.8+ <https://www.python.org/downloads/>`_.
+- `SCons 4.0+ <https://scons.org/pages/download.html>`_ build system.
 - pkg-config (used to detect the development libraries listed below).
 - Development libraries:
 

--- a/contributing/development/compiling/compiling_for_macos.rst
+++ b/contributing/development/compiling/compiling_for_macos.rst
@@ -15,8 +15,8 @@ Requirements
 
 For compiling under macOS, the following is required:
 
-- `Python 3.6+ <https://www.python.org/downloads/macos/>`_.
-- `SCons 3.1.2+ <https://scons.org/pages/download.html>`_ build system.
+- `Python 3.8+ <https://www.python.org/downloads/macos/>`_.
+- `SCons 4.0+ <https://scons.org/pages/download.html>`_ build system.
 - `Xcode <https://apps.apple.com/us/app/xcode/id497799835>`_
   (or the more lightweight Command Line Tools for Xcode).
 - `Vulkan SDK <https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.dmg>`_

--- a/contributing/development/compiling/compiling_for_web.rst
+++ b/contributing/development/compiling/compiling_for_web.rst
@@ -16,8 +16,8 @@ Requirements
 To compile export templates for the Web, the following is required:
 
 - `Emscripten 3.1.62+ <https://emscripten.org>`__.
-- `Python 3.6+ <https://www.python.org/>`__.
-- `SCons 3.1.2+ <https://scons.org/pages/download.html>`__ build system.
+- `Python 3.8+ <https://www.python.org/>`__.
+- `SCons 4.0+ <https://scons.org/pages/download.html>`__ build system.
 
 .. seealso:: To get the Godot source code for compiling, see
              :ref:`doc_getting_source`.

--- a/contributing/development/compiling/compiling_for_windows.rst
+++ b/contributing/development/compiling/compiling_for_windows.rst
@@ -30,10 +30,10 @@ For compiling under Windows, the following is required:
       Supports ``x86_64`` and ``x86_32`` only.
     - `MinGW-LLVM <https://github.com/mstorsjo/llvm-mingw/releases>`_ with clang can be used as
       an alternative to Visual Studio and MinGW-w64.
-      Supports ``x86_64``, ``x86_32``, and ``arm64``.      
-- `Python 3.6+ <https://www.python.org/downloads/windows/>`_. 
+      Supports ``x86_64``, ``x86_32``, and ``arm64``.
+- `Python 3.8+ <https://www.python.org/downloads/windows/>`_.
   **Make sure to enable the option to add Python to the** ``PATH`` **in the installer.**
-- `SCons 3.1.2+ <https://scons.org/pages/download.html>`_ build system. Using the
+- `SCons 4.0+ <https://scons.org/pages/download.html>`_ build system. Using the
   latest release is recommended, especially for proper support of recent Visual
   Studio releases.
 


### PR DESCRIPTION
Updates the build minimum version requirements for SCons/Python to 4.0 & 3.8 respectively, reflecting their new lower bounds introduced by godotengine/godot#99134