### PR TITLE
Cherrypick #10242 (Add info about layer mask exporting to physics_introduction) to master

### DIFF
--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -180,6 +180,12 @@ would be as follows::
     # (2^(1-1)) + (2^(3-1)) + (2^(4-1)) = 1 + 4 + 8 = 13
     pow(2, 1-1) + pow(2, 3-1) + pow(2, 4-1)
 
+Export annotations can be used to export bitmasks in the editor with a user-friendly GUI::
+
+    @export_flags_2d_physics var layers_2d_physics
+
+Additional export annotations are available for render and navigation layers, in both 2D and 3D. See :ref:`doc_gdscript_exports_exporting_bit_flags`.
+
 
 Area2D
 ------

--- a/tutorials/scripting/gdscript/gdscript_exports.rst
+++ b/tutorials/scripting/gdscript/gdscript_exports.rst
@@ -298,6 +298,8 @@ It must be noted that even if the script is not being run while in the
 editor, the exported properties are still editable. This can be used
 in conjunction with a :ref:`script in "tool" mode <doc_gdscript_tool_mode>`.
 
+.. _doc_gdscript_exports_exporting_bit_flags:
+
 Exporting bit flags
 -------------------
 


### PR DESCRIPTION
Cherry-pick of https://github.com/godotengine/godot-docs/pull/10242 to `master`.