### PR TITLE
Compiling for Linux/BSD: Add openKylin

### DIFF
--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -196,6 +196,28 @@ Distro-specific one-liners
               scons \
               llvm
 
+    .. tab:: openKylin
+
+        ::
+
+            sudo apt update
+            sudo apt install -y \
+              python3-pip \
+              build-essential \
+              pkg-config \
+              libx11-dev \
+              libxcursor-dev \
+              libxinerama-dev \
+              libgl1-mesa-dev \
+              libglu1-mesa-dev \
+              libasound2-dev \
+              libpulse-dev \
+              libudev-dev \
+              libxi-dev \
+              libxrandr-dev \
+              libwayland-dev
+            sudo pip install scons
+
     .. tab:: openSUSE
 
         ::


### PR DESCRIPTION
Salvages https://github.com/godotengine/godot-docs/pull/9858, fixing the alphabetic sorting.