### PR TITLE
Add hyphens to some adjective phrases

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -653,7 +653,7 @@ XR support (AR and VR)
 
    - Including support for popular desktop headsets like the Valve Index, WMR headsets, and Quest over Link.
 
-- Support for :ref:`Android based headsets <doc_deploying_to_android>` using OpenXR through a plugin.
+- Support for :ref:`Android-based headsets <doc_deploying_to_android>` using OpenXR through a plugin.
 
   - Including support for popular stand alone headsets like the Meta Quest 1/2/3 and Pro, Pico 4, Magic Leap 2, and Lynx R1.
 

--- a/contributing/development/best_practices_for_engine_contributors.rst
+++ b/contributing/development/best_practices_for_engine_contributors.rst
@@ -219,7 +219,7 @@ is always the advised one.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Not every problem has a simple solution and, many times, the right choice is to
-use a third party library to solve the problem.
+use a third-party library to solve the problem.
 
 As Godot requires to be shipped in a large amount of platforms, we can't
 link libraries dynamically. Instead, we bundle them in our source tree.

--- a/contributing/development/configuring_an_ide/code_blocks.rst
+++ b/contributing/development/configuring_an_ide/code_blocks.rst
@@ -3,7 +3,7 @@
 Code::Blocks
 ============
 
-`Code::Blocks <https://codeblocks.org/>`_ is a free, open source, cross platform IDE.
+`Code::Blocks <https://codeblocks.org/>`_ is a free, open-source, cross-platform IDE.
 
 Creating a new project
 ----------------------

--- a/contributing/development/configuring_an_ide/visual_studio_code.rst
+++ b/contributing/development/configuring_an_ide/visual_studio_code.rst
@@ -70,7 +70,7 @@ To run and debug the project you need to create a new configuration in the ``lau
 .. figure:: img/vscode_1_create_launch.json.png
    :align: center
 
-- Select **C++ (GDB/LLDB)**. There may be another platform specific option here. If selected,
+- Select **C++ (GDB/LLDB)**. There may be another platform-specific option here. If selected,
   adjust the configuration example provided accordingly.
 - Within the ``launch.json`` file find the ``"configurations"`` array and add a new section to it:
 

--- a/contributing/development/core_and_modules/2d_coordinate_systems.rst
+++ b/contributing/development/core_and_modules/2d_coordinate_systems.rst
@@ -104,7 +104,7 @@ effects of each of them.
     *Viewport's* :ref:`canvas transform <class_Viewport_property_canvas_transform>` and the
     *CanvasLayer's* :ref:`follow viewport scale <class_CanvasLayer_property_follow_viewport_scale>`
     and can be used, if :ref:`enabled <class_CanvasLayer_property_follow_viewport_enabled>`, to
-    achieve a pseudo 3D effect. It affects the same child nodes as the *CanvasLayer transform*.
+    achieve a pseudo-3D effect. It affects the same child nodes as the *CanvasLayer transform*.
 
 - **Viewport canvas transform**
     The :ref:`canvas transform <class_Viewport_property_canvas_transform>` affects all

--- a/tutorials/export/exporting_projects.rst
+++ b/tutorials/export/exporting_projects.rst
@@ -141,7 +141,7 @@ select every scene or resource you want to export.
     ``.git`` from being included in the exported PCK file.
 
 Below the list of resources are two filters that can be setup. The first allows
-non resource files such as ``.txt``, ``.json`` and ``.csv`` to be exported with
+non-resource files such as ``.txt``, ``.json`` and ``.csv`` to be exported with
 the project. The second filter can be used to exclude every file of a certain
 type without manually deselecting every one. For example, ``.png`` files.
 

--- a/tutorials/performance/vertex_animation/animating_thousands_of_fish.rst
+++ b/tutorials/performance/vertex_animation/animating_thousands_of_fish.rst
@@ -11,7 +11,7 @@ static mesh instancing.
 
 In Godot, this can be accomplished with a custom :ref:`Shader <class_Shader>` and
 a :ref:`MultiMeshInstance3D <class_MultiMeshInstance3D>`. Using the following technique you
-can render thousands of animated objects, even on low end hardware.
+can render thousands of animated objects, even on low-end hardware.
 
 We will start by animating one fish. Then, we will see how to extend that animation to
 thousands of fish.

--- a/tutorials/platform/consoles.rst
+++ b/tutorials/platform/consoles.rst
@@ -8,7 +8,7 @@ Console porting process
 
 In order to develop for consoles in Godot, you need access to the console SDK and
 export templates for it. These export templates need to be developed either by
-yourself or someone hired to do it, or provided by a third party company.
+yourself or someone hired to do it, or provided by a third-party company.
 
 Currently, the only console Godot officially supports is Steam Deck (through the
 official Linux export templates).

--- a/tutorials/xr/ar_passthrough.rst
+++ b/tutorials/xr/ar_passthrough.rst
@@ -19,7 +19,7 @@ result is used.
 
     In Godot 4.3 we have implemented a unified approach that is explained on this help page
     so you don't need to worry about these differences, the :ref:`XRInterface <class_xrinterface>`
-    implementation is now responsible for applying the correct platform dependent method [#]_.
+    implementation is now responsible for applying the correct platform-dependent method [#]_.
 
     For headsets such as the Meta Quest and HTC Elite you will need to use the
     `OpenXR vendors plugin v3.0.0 <https://github.com/GodotVR/godot_openxr_vendors/releases>`__
@@ -91,7 +91,7 @@ by the XR runtime.
 .. image:: img/openxr_default_blend_mode.webp
 
 For passthrough devices OpenXR requires additional settings to be configured.
-These settings are platform dependent and provided through the OpenXR vendors plugin.
+These settings are platform-dependent and provided through the OpenXR vendors plugin.
 
 For example, these are the settings required on Meta Quest:
 


### PR DESCRIPTION
Supersedes https://github.com/godotengine/godot-docs/pull/9882.

Changes some instances of adjective phrases to be more grammatically correct and more consistent with the rest of the docs.

The changes in https://github.com/godotengine/godot-docs/pull/9882 fell into three categories:
- "Open source" and "command line", which are currently not planned to be changed
- "Low level" which I will make a separate PR for (https://github.com/godotengine/godot-docs/pull/10285)
- Various one-off changes which are included in this PR. I tried to find most of them but I might have missed one or two.