### PR TITLE
Remove performance comparison from C# Basics

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -357,12 +357,6 @@ You can read more about this error on the `C# language reference <https://learn.
 Performance of C# in Godot
 --------------------------
 
-According to some preliminary `benchmarks <https://github.com/cart/godot3-bunnymark>`_,
-the performance of C# in Godot — while generally in the same order of magnitude
-— is roughly **~4×** that of GDScript in some naive cases. C++ is still
-a little faster; the specifics are going to vary according to your use case.
-GDScript is likely fast enough for most general scripting workloads.
-
 Most properties of Godot C# objects that are based on ``GodotObject``
 (e.g. any ``Node`` like ``Control`` or ``Node3D`` like ``Camera3D``) require native (interop) calls as they talk to
 Godot's C++ core.


### PR DESCRIPTION
Supersedes https://github.com/godotengine/godot-docs/pull/7538.

In that original PR, there was reasonable consensus to at least remove the claim that C# is 4x faster than GDScript.

I still think a larger comparison of the performance of C#, GDScript, and C++ is warranted, and it should be somewhere other than the C# section of the docs. Those changes are for another PR.