### PR TITLE
Remove link to hxgodot

### DIFF
--- a/tutorials/scripting/gdextension/what_is_gdextension.rst
+++ b/tutorials/scripting/gdextension/what_is_gdextension.rst
@@ -97,7 +97,6 @@ The bindings below are developed and maintained by the community:
 
 - `D <https://github.com/godot-dlang/godot-dlang>`__
 - `Go <https://github.com/grow-graphics/gd>`__
-- `Haxe <https://hxgodot.github.io/>`__
 - `Rust <https://github.com/godot-rust/gdext>`__
 - `Swift <https://github.com/migueldeicaza/SwiftGodot>`__
 


### PR DESCRIPTION
The [page linked in the documentation](https://hxgodot.github.io/) returns a 404
I've removed the link, as [hxgodot has been archived since October 12th](https://github.com/HxGodot/hxgodot)

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
