### PR TITLE
Fix wrong editor setting in Overview of Debugging Tools

### DIFF
--- a/tutorials/scripting/debug/overview_of_debugging_tools.rst
+++ b/tutorials/scripting/debug/overview_of_debugging_tools.rst
@@ -223,7 +223,7 @@ The **Break** button causes a break in the script like a breakpoint would.
 a function if possible. Otherwise, it does the same thing as **Step Over**.
 
 The **Debug with External Editor** option lets you debug your game with an external editor.
-This option is also accessible in **Editor Settings > Debugger**.
+You can set a shortcut for it in **Editor Settings > Shortcuts > Debugger**.
 
 When the debugger breaks on a breakpoint, a green triangle arrow is visible in
 the script editor's gutter. This arrow indicates the line of code the debugger


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-docs/issues/10292.

The paragraph referred to an *editor setting* "Debug with External Editor" that was missing, but there is an *editor shortcut* with the same name.