### PR TITLE
How to bind to external libraries with GDExtension

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_binding_to_external_libraries.rst
+++ b/tutorials/scripting/gdextension/gdextension_binding_to_external_libraries.rst
@@ -1,0 +1,4 @@
+.. _gdextension_binding_to_external_libraries:
+
+Bind to external libraries with GDExtension
+===========================================


### PR DESCRIPTION
Since https://docs.godotengine.org/en/stable/contributing/development/core_and_modules/binding_to_external_libraries.html exists for C++ modules, it could be a good idea to have a manual about how to setup external libraries with GDExtension.

I think it's important to explain the most common issues a user can encounter when trying to bind external libraries, such as compiler errors, and how to fix them.

Godot Engine is probably one of the best platforms to develop on top for beginners and intermediates that want to grow as open source contributors and developers.

I open this draft so that I can gather suggestions while I try to write this section during my current trial and error.

The worst stumbling blocks right have been linking and https://github.com/godotengine/godot-cpp/pull/1469 https://github.com/godotengine/godot-cpp/pull/1319 https://github.com/godotengine/godot-cpp/pull/957