### PR TITLE
Add Shader functions page to documentation changelog

### DIFF
--- a/about/docs_changelog.rst
+++ b/about/docs_changelog.rst
@@ -36,6 +36,11 @@ Rendering
 
 - :ref:`doc_renderers`
 
+Shaders
+^^^^^^^
+
+- :ref:`doc_shader_functions`
+
 New pages since version 4.2
 ---------------------------
 


### PR DESCRIPTION
https://github.com/godotengine/godot-docs/pull/9338 adds a new page. This PR adds that page to the documentation changelog.