### PR TITLE
CI: Remove EOF fixer from pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
-      - id: end-of-file-fixer
       - id: fix-byte-order-marker
       - id: mixed-line-ending
         args: ['--fix=lf']


### PR DESCRIPTION
As this isn't enforced on the files used from the main engine repository, this currently seems more trouble than its worth.

Notably, we got a build failure from https://github.com/godotengine/godot-docs/pull/10309 due to the generated index for the classes:
```bash
diff --git a/classes/index.rst b/classes/index.rst
index 5eb1dd9..74d350c 100644
--- a/classes/index.rst
+++ b/classes/index.rst
@@ -1088,4 +1088,3 @@ Variant types
     class_vector3i
     class_vector4
     class_vector4i
-
Error: Process completed with exit code 1.
```
We could re-add this in the future if we change this, however I'm not really convinced removing newlines from the end of files is useful.