### PR TITLE
Remove link to Reddit list of tutorials

### DIFF
--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -3,7 +3,10 @@
 Tutorials and resources
 =======================
 
-This is a list of third-party tutorials and resources created by the Godot community. For resources, remember that there is the official `Godot Asset Library <https://godotengine.org/asset-library/asset>`_ full of official and community resources too! Also, have a look at this `huge list over at Reddit <https://www.reddit.com/r/godot/comments/an0iq5/godot_tutorials_list_of_video_and_written/>`_.
+This is a list of third-party tutorials and resources created by the Godot
+community. For resources, remember that there is the official
+`Godot Asset Library <https://godotengine.org/asset-library/asset>`_ full of
+official and community resources too!
 
 Think there is something missing here? Feel free to submit a `Pull Request <https://github.com/godotengine/godot-docs/blob/master/community/tutorials.rst>`_ as always.
 


### PR DESCRIPTION
I'm not sure about this one. But the PR is straightforward, so I made it and we can discuss whether it's a good idea.

The [linked Reddit post](https://www.reddit.com/r/godot/comments/an0iq5/godot_tutorials_list_of_video_and_written/) is 6 years old, from the 3.x days. While most of the tutorials would still work in Godot 4 with some modifications, I'm not sure if the official docs (for 4.x) should link to a list of mainly 3.x tutorials.

With a cursory search for a similar post for 4.x, the closest I found was https://www.reddit.com/r/godot/comments/1gd9f1n/ultimate_tutorial_list/, which isn't as comprehensive. If the docs did not already contain the old link, I wouldn't go out of my way to add a link to this new post. (I also would not go out of my way to add the existing link, if it wasn't already in the docs.)

There is a a trend of removing as many external links from the docs as possible, between this, the removal of video tutorial links, and the moving the list of official community channels to the website. I'm not sure if that's a good thing or not. It does help to downscope and reduce maintenance, but it also maybe is whittling away the usefulness of the docs.