### PR TITLE
Update C# Rider install steps for now built-in plugin "Godot Support"

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -90,7 +90,7 @@ In Godot's **Editor → Editor Settings** menu:
 In Rider:
 
 - Set **MSBuild version** to **.NET Core**.
-- Install the **Godot support** plugin (Not needed for Rider 2024.2 and above).
+- If you are using a Rider version below 2024.2, install the **Godot support** plugin. This functionality is now built into Rider.
 
 Visual Studio Code
 ~~~~~~~~~~~~~~~~~~

--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -90,7 +90,7 @@ In Godot's **Editor → Editor Settings** menu:
 In Rider:
 
 - Set **MSBuild version** to **.NET Core**.
-- Install the **Godot support** plugin.
+- Install the **Godot support** plugin (Not needed for Rider 2024.2 and above).
 
 Visual Studio Code
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
As of Rider 2024.2 the plugin is bundled with the software and can't be installed which can be confusing. https://plugins.jetbrains.com/plugin/13882-godot-support

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
