### PR TITLE
Document Light3D shadow caster mask property

### DIFF
--- a/tutorials/3d/lights_and_shadows.rst
+++ b/tutorials/3d/lights_and_shadows.rst
@@ -125,6 +125,8 @@ There is a list of generic shadow parameters, each also has a specific function:
   moving objects. The downside of increasing shadow blur is that it will make
   the grainy pattern used for filtering more noticeable.
   See also :ref:`doc_lights_and_shadows_shadow_filter_mode`.
+- **Caster Mask:** Shadows are only cast by objects in these layers. Note that
+  this mask does not affect which objects shadows are cast *onto*.
 
 .. image:: img/lights_and_shadows_blur.webp
 


### PR DESCRIPTION
Documentation for https://github.com/godotengine/godot/pull/85338.

Note that this page does duplicate information that is in the class reference, so I opted to write a longer description than the very short description from the class reference.
