### PR TITLE
Update file_access.h location

### DIFF
--- a/contributing/development/core_and_modules/custom_resource_format_loaders.rst
+++ b/contributing/development/core_and_modules/custom_resource_format_loaders.rst
@@ -263,7 +263,7 @@ calls into ``std::istream``.
 
 .. code-block:: cpp
 
-    #include "core/os/file_access.h"
+    #include "core/io/file_access.h"
 
     #include <istream>
     #include <streambuf>
@@ -298,7 +298,7 @@ References
 
 - `istream <https://cplusplus.com/reference/istream/istream/>`_
 - `streambuf <https://cplusplus.com/reference/streambuf/streambuf/?kw=streambuf>`_
-- `core/io/file_access.h <https://github.com/godotengine/godot/blob/master/core/os/file_access.h>`_
+- `core/io/file_access.h <https://github.com/godotengine/godot/blob/master/core/io/file_access.h>`_
 
 Registering the new file format
 -------------------------------


### PR DESCRIPTION
`os/file_access.h` moved to `io/file_access.h` in godotengine/godot@9e328bb5b.

Interestingly, the label in the bulleted list was updated, but the link itself was not.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
