### PR TITLE
Remove references to PoolVector

### DIFF
--- a/contributing/development/core_and_modules/core_types.rst
+++ b/contributing/development/core_and_modules/core_types.rst
@@ -103,36 +103,12 @@ which are equivalent to new, delete, new[] and delete[].
 memnew/memdelete also use a little C++ magic and notify Objects right
 after they are created, and right before they are deleted.
 
-For dynamic memory, the PoolVector<> template is provided. PoolVector is a
-standard vector class, and is very similar to vector in the C++ standard library.
-To create a PoolVector buffer, use this:
-
-.. code-block:: cpp
-
-    PoolVector<int> data;
-
-PoolVector can be accessed using the [] operator and a few helpers exist for this:
-
-.. code-block:: cpp
-
-    PoolVector<int>::Read r = data.read()
-    int someint = r[4]
-
-.. code-block:: cpp
-
-    PoolVector<int>::Write w = data.write()
-    w[4] = 22;
-
-These operations allow fast read/write from PoolVectors and keep it
-locked until they go out of scope. However, PoolVectors should be used
-for small, dynamic memory operations, as read() and write() are too slow for a
-large amount of accesses.
+For dynamic memory, use Vector<>.
 
 References:
 ~~~~~~~~~~~
 
 -  `core/os/memory.h <https://github.com/godotengine/godot/blob/master/core/os/memory.h>`__
--  `core/pool_vector.h <https://github.com/godotengine/godot/blob/master/core/pool_vector.cpp>`__
 
 Containers
 ----------

--- a/tutorials/navigation/navigation_using_navigationlayers.rst
+++ b/tutorials/navigation/navigation_using_navigationlayers.rst
@@ -37,7 +37,7 @@ In scripts the following helper functions can be used to work with the ``navigat
         var path_query_navigation_layers: int = 0
         path_query_navigation_layers = enable_bitmask_inx(path_query_navigation_layers, 2)
         # get a path that only considers 2-nd layer regions
-        var path: PoolVector2Array = NavigationServer2D.map_get_path(
+        var path: PackedVector2Array = NavigationServer2D.map_get_path(
             map,
             start_position,
             target_position,
@@ -120,7 +120,7 @@ In scripts the following helper functions can be used to work with the ``navigat
         var path_query_navigation_layers: int = 0
         path_query_navigation_layers = enable_bitmask_inx(path_query_navigation_layers, 2)
         # get a path that only considers 2-nd layer regions
-        var path: PoolVector3Array = NavigationServer3D.map_get_path(
+        var path: PackedVector3Array = NavigationServer3D.map_get_path(
             map,
             start_position,
             target_position,


### PR DESCRIPTION
PoolVector has not existed since 2020. It was removed in godotengine/godot@3205a92a.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

_Bugsquad edit: closes https://github.com/godotengine/godot-docs/issues/10146, possibly also https://github.com/godotengine/godot-docs/issues/3192 and https://github.com/godotengine/godot-docs/issues/6259_