### PR TITLE
Fix outdated reference to `godot.tools.html` in Compiling for the Web

### DIFF
--- a/contributing/development/compiling/compiling_for_web.rst
+++ b/contributing/development/compiling/compiling_for_web.rst
@@ -121,7 +121,7 @@ server requirements.
         python platform/web/serve.py
 
     This will serve the contents of the ``bin/`` folder and open the default web
-    browser automatically. In the page that opens, access ``godot.tools.html``
+    browser automatically. In the page that opens, access ``godot.editor.html``
     and you should be able to test the web editor this way.
 
     Note that for production use cases, this Python-based web server should not


### PR DESCRIPTION
It's `godot.editor.html` since Godot 4.0.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/148#discussioncomment-11409006.
