### PR TITLE
Remove instructions on setting up Pyston for faster development

### DIFF
--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -272,7 +272,7 @@ Start a terminal, go to the root dir of the engine source code and type:
 
 .. tip::
     If you are compiling Godot to make changes or contribute to the engine,
-    you may want to use the SCons options ``dev_build=yes`` or ``dev_mode=yes``. 
+    you may want to use the SCons options ``dev_build=yes`` or ``dev_mode=yes``.
     See :ref:`doc_introduction_to_the_buildsystem_development_and_production_aliases`
     for more info.
 
@@ -601,34 +601,3 @@ running ``scons -h``, then looking for options starting with ``builtin_``.
     across Linux distributions anymore. Do not use this approach for creating
     binaries you intend to distribute to others, unless you're creating a
     package for a Linux distribution.
-
-Using Pyston for faster development
------------------------------------
-
-You can use `Pyston <https://www.pyston.org/>`__ to run SCons. Pyston is a JIT-enabled
-implementation of the Python language (which SCons is written in). It is currently
-only compatible with Linux. Pyston can speed up incremental builds significantly,
-often by a factor between 1.5× and 2×. Pyston can be combined with Clang and LLD
-to get even faster builds.
-
-- Download the `latest portable Pyston release <https://github.com/pyston/pyston/releases/latest>`__.
-- Extract the portable ``.tar.gz`` to a set location, such as ``$HOME/.local/opt/pyston/`` (create folders as needed).
-- Use ``cd`` to reach the extracted Pyston folder from a terminal,
-  then run ``./pyston -m pip install scons`` to install SCons within Pyston.
-- To make SCons via Pyston easier to run, create a symbolic link of its wrapper
-  script to a location in your ``PATH`` environment variable::
-
-    ln -s ~/.local/opt/pyston/bin/scons ~/.local/bin/pyston-scons
-
-- Instead of running ``scons <build arguments>``, run ``pyston-scons <build arguments>``
-  to compile Godot.
-
-If you can't run ``pyston-scons`` after creating the symbolic link,
-make sure ``$HOME/.local/bin/`` is part of your user's ``PATH`` environment variable.
-
-.. note::
-
-    Alternatively, you can run ``python -m pip install pyston_lite_autoload``
-    then run SCons as usual. This will automatically load a subset of Pyston's
-    optimizations in any Python program you run. However, this won't bring as
-    much of a performance improvement compared to installing "full" Pyston.

--- a/contributing/development/compiling/compiling_for_macos.rst
+++ b/contributing/development/compiling/compiling_for_macos.rst
@@ -61,7 +61,7 @@ To support both architectures in a single "Universal 2" binary, run the above tw
 
 .. tip::
     If you are compiling Godot to make changes or contribute to the engine,
-    you may want to use the SCons options ``dev_build=yes`` or ``dev_mode=yes``. 
+    you may want to use the SCons options ``dev_build=yes`` or ``dev_mode=yes``.
     See :ref:`doc_introduction_to_the_buildsystem_development_and_production_aliases`
     for more info.
 
@@ -165,22 +165,6 @@ You can then zip the ``macos_template.app`` folder to reproduce the ``macos.zip`
 template from the official Godot distribution::
 
     zip -r9 macos.zip macos_template.app
-
-Using Pyston for faster development
------------------------------------
-
-You can use `Pyston <https://www.pyston.org/>`__ to run SCons. Pyston is a
-JIT-enabled implementation of the Python language (which SCons is written in).
-Its "full" version is currently only compatible with Linux, but Pyston-lite is
-also compatible with macOS (both x86 and ARM). Pyston can speed up incremental
-builds significantly, often by a factor between 1.5× and 2×. Pyston can be
-combined with alternative linkers such as LLD or Mold to get even faster builds.
-
-To install Pyston-lite, run ``python -m pip install pyston_lite_autoload`` then
-run SCons as usual. This will automatically load a subset of Pyston's
-optimizations in any Python program you run. However, this won't bring as much
-of a performance improvement compared to installing "full" Pyston (which
-currently can't be done on macOS).
 
 Cross-compiling for macOS from Linux
 ------------------------------------


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-docs/pull/5593.

This is done for several reasons:

- Recent CPython versions such as 3.13 have mostly caught up with Pyston in terms of performance. If the trend continues, CPython may supersede Pyston's performance in the long term. This is especially the case if the experimental JIT is eventually able to run Godot's SCons setup.
- Pyston is not maintained anymore (its last release was in 2022), and the last Python version it can run is 3.8. Python 3.8 is now end-of-life. Godot's SCons setup (as well as SCons itself) will eventually require Python versions newer than 3.8.
