### PR TITLE
Fix mold instruction for old systems

### DIFF
--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -508,6 +508,12 @@ repositories, so you will have to install its binaries manually.
 
     PATH="$HOME/.local/share/mold/bin:$PATH"
 
+If your GCC version < 12.1 and you want to use ``mold`` with it, you also need to create a link ``/usr/lib/mold/ld`` to the ``mold`` file inside the ``mold/bin`` folder:
+
+::
+
+	ln $HOME/.local/share/mold/bin/mold /usr/lib/mold/ld
+
 - Open a new terminal (or run ``source "$HOME/.bash_profile"``),
   then use the following SCons command when compiling Godot::
 


### PR DESCRIPTION
I found that for old GCC mold linker works kinda differently. You can check it inside godot-4.3-stable/platform/linuxbsd/detect.py in Godot sources.

![image](https://github.com/user-attachments/assets/a9bde322-f4d9-4f7c-aae2-1c469ade07af)

I don't know why, but it starts to search a certain link in certain paths: "/usr/libexec", "/usr/local/libexec", "/usr/lib" and "/usr/local/lib", otherwise it gives an error.

I think this could be fixed in the code, but since I'm not very knowledgeable and this feature is already there, I preferred to mention it in the documentation. To be sure, users even don't need to add mold/bin folder into PATH, if they are using GCC. But it's necessary for other compilers: for exemple clang gave me an error "invalid linker name in argument '-fuse-ld=mold'", when I deleted mold/bin from PATH. So this requirement I left in documentation page without unnecessary details.

UPD: Forgot to say that I used Godot 4.3 sources.