### PR TITLE
Replace mentions of Reference with RefCounted

### DIFF
--- a/contributing/development/core_and_modules/object_class.rst
+++ b/contributing/development/core_and_modules/object_class.rst
@@ -274,7 +274,7 @@ References:
 Resources
 ----------
 
-:ref:`Resource <class_resource>` inherits from Reference, so all resources
+:ref:`Resource <class_resource>` inherits from RefCounted, so all resources
 are reference counted. Resources can optionally contain a path, which
 reference a file on disk. This can be set with ``resource.set_path(path)``,
 though this is normally done by the resource loader. No two different

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1035,7 +1035,7 @@ it will raise an error.
 Valid types are:
 
 - Built-in types (Array, Vector2, int, String, etc.).
-- Engine classes (Node, Resource, Reference, etc.).
+- Engine classes (Node, Resource, RefCounted, etc.).
 - Constant names if they contain a script resource (``MyScript`` if you declared ``const MyScript = preload("res://my_script.gd")``).
 - Other classes in the same script, respecting scope (``InnerClass.NestedClass`` if you declared ``class NestedClass`` inside the ``class InnerClass`` in the same scope).
 - Script classes declared with the ``class_name`` keyword.


### PR DESCRIPTION
This is a (really) tiny correction so I've not created an issue, I hope that's OK!

This PR replaces two outdated mentions of `Reference` with `RefCounted`.
I grepped far and wide and I believe this is the last of them.