### PR TITLE
Note that shader function descriptions are modified from OpenGL docs

### DIFF
--- a/tutorials/shaders/shader_reference/shader_functions.rst
+++ b/tutorials/shaders/shader_reference/shader_functions.rst
@@ -66,6 +66,14 @@ GLSL ES 3.0 specification.
         vector multiplied by matrix, and matrix multiplied by matrix. These do not operate component-wise,
         but rather perform the correct linear algebraic multiply.
 
+These function descriptions are adapted and modified from
+`official OpenGL documentation <https://registry.khronos.org/OpenGL-Refpages/gl4/>`__
+originally published by Khronos Group under the
+`Open Publication License <https://opencontent.org/openpub>`__.
+Each function description links to the corresponding official OpenGL
+documentation. Modification history for this page can be found on
+`GitHub <https://github.com/godotengine/godot-docs/blob/master/tutorials/shaders/shader_reference/shader_functions.rst>`__.
+
 .. rst-class:: classref-section-separator
 
 ----


### PR DESCRIPTION
Hopefully the note is relatively self-explanatory; if not it needs to be reworded.

Function descriptions on this page are largely adapted from [official OpenGL docs](https://registry.khronos.org/OpenGL-Refpages/gl4/), for example [abs()](https://registry.khronos.org/OpenGL-Refpages/gl4/html/abs.xhtml), sometimes with little or no modifications. As such, we need to conform to the terms of the [Open Publication License](https://opencontent.org/openpub). The most relevant section is:
```
All modified versions of documents covered by this license, including translations, anthologies, compilations and partial documents, must meet the following requirements:
1. The modified version must be labeled as such.
2. The person making the modifications must be identified and the modifications dated.
3. Acknowledgement of the original author and publisher if applicable must be retained according to normal academic citation practices.
4. The location of the original unmodified document must be identified.
5. The original author’s (or authors’) name(s) may not be used to assert or imply endorsement of the resulting document without the original author’s (or authors’) permission.
```
I believe the notice added in this PR fulfills the requirements here. The GitHub source for this page should be linked as it identifies the authors and dates of modifications.