### PR TITLE
add flex layout for left nav container

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1368,13 +1368,12 @@ p + .classref-constant {
 }
 
 .wy-side-nav-search {
+    flex-grow: 0;
+    flex-shrink: 0;
+    flex-basis: max-content;
     background-color: var(--navbar-background-color);
     color: var(--navbar-level-1-color);
     margin-right: 8px;
-}
-
-.wy-side-nav-search.fixed {
-    position: fixed;
 }
 
 @media only screen and (min-width: 769px) {
@@ -1692,6 +1691,8 @@ p + .classref-constant {
 @media only screen and (min-width: 769px) {
     .wy-side-scroll {
         overflow: hidden;
+        display: flex;
+        flex-direction: column;
     }
 
     .wy-nav-side .wy-side-scroll .ethical-rtd {
@@ -1702,7 +1703,7 @@ p + .classref-constant {
 .wy-menu.wy-menu-vertical {
     overflow-y: auto;
     overflow-x: hidden;
-    max-height: calc(100% - 348px);
+    flex: 1;
     padding-bottom: 24px;
 }
 @media screen and (max-width: 768px) {

--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -54,22 +54,11 @@ const registerOnScrollEvent = (function(){
         if (currentScroll >= scrollTopPixels) {
           // After the page is scrolled below the threshold, we fix everything in place.
           $search.css('margin-top', `-${scrollTopPixels}px`);
-          $menu.css('margin-top', `${menuTopMargin}px`);
-          $menu.css('max-height', `calc(100% - ${menuHeightOffset_fixed}px)`);
         }
         else {
           // Between the top of the page and the threshold we calculate intermediate values
           // to guarantee a smooth transition.
           $search.css('margin-top', `-${currentScroll}px`);
-          $menu.css('margin-top', `${menuTopMargin + (scrollTopPixels - currentScroll)}px`);
-
-          if (currentScroll > 0) {
-            const scrolledPercent = (scrollTopPixels - currentScroll) / scrollTopPixels;
-            const offsetValue = menuHeightOffset_fixed + menuHeightOffset_diff * scrolledPercent;
-            $menu.css('max-height', `calc(100% - ${offsetValue}px)`);
-          } else {
-            $menu.css('max-height', `calc(100% - ${menuHeightOffset_default}px)`);
-          }
         }
       };
 
@@ -98,7 +87,6 @@ const registerOnScrollEvent = (function(){
         }
       };
 
-      $search.addClass('fixed');
       $ethical.addClass('fixed');
 
       // Adjust the inner height of navigation so that the banner can be overlaid there later.
@@ -126,12 +114,9 @@ const registerOnScrollEvent = (function(){
       $window.unbind('scroll');
       $menu.unbind('scroll');
 
-      $search.removeClass('fixed');
       $ethical.removeClass('fixed');
 
       $search.css('margin-top', `0px`);
-      $menu.css('margin-top', `0px`);
-      $menu.css('max-height', 'initial');
       $menuPadding.css('height', `0px`);
       $ethical.css('margin-top', '0px');
       $ethical.css('display', 'block');


### PR DESCRIPTION
fixes #10352 

this PR makes the left nav a flex container. by doing that, it also removes the manual calculation that happens in custom.js using fixed margin numbers. that manual calculation makes parts of the left nav non-scrollable in e.g. "stable" mode of the docs. with this PR, any changes to the top portion of the left nav's height will not matter as the bottom part will flex on the available height automatically.