### PR TITLE
4.3 Cherrypicks: shaders

### DIFF
--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -793,6 +793,19 @@ GDScript:
           in the shader. It must match *exactly* to the name of the uniform in
           the shader or else it will not be recognized.
 
+.. note:: There is a limit to the total size of shader uniforms that you can use
+          in a single shader. On most desktop platforms, this limit is ``65536``
+          bytes, or 4096 ``vec4`` uniforms. On mobile platforms, the limit is
+          typically ``16384`` bytes, or 1024 ``vec4`` uniforms. Vector uniforms
+          smaller than a ``vec4``, such as ``vec2`` or ``vec3``, are padded to
+          the size of a ``vec4``. Scalar uniforms such as ``int`` or ``float``
+          are not padded, and ``bool`` is padded to the size of an ``int``.
+          
+          Arrays count as the total size of their contents. If you need a uniform
+          array that is larger than this limit, consider packing the data into a
+          texture instead, since the *contents* of a texture do not count towards
+          this limit, only the size of the sampler uniform.
+
 Any GLSL type except for *void* can be a uniform. Additionally, Godot provides
 optional shader hints to make the compiler understand for what the uniform is
 used, and how the editor should allow users to modify it.

--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -383,7 +383,7 @@ accessible outside of the shader.
 
     shader_type spatial;
 
-    const float PI = 3.14159265358979323846;
+    const float GOLDEN_RATIO = 1.618033988749894;
 
 Constants of the ``float`` type must be initialized using ``.`` notation after the
 decimal part or by using the scientific notation. The optional ``f`` post-suffix is
@@ -800,7 +800,7 @@ GDScript:
           smaller than a ``vec4``, such as ``vec2`` or ``vec3``, are padded to
           the size of a ``vec4``. Scalar uniforms such as ``int`` or ``float``
           are not padded, and ``bool`` is padded to the size of an ``int``.
-          
+
           Arrays count as the total size of their contents. If you need a uniform
           array that is larger than this limit, consider packing the data into a
           texture instead, since the *contents* of a texture do not count towards


### PR DESCRIPTION
I think I did this right?

I didn't fully apply the changes to the shader built-in tables because the improvement still works without them.

Original PRs:
https://github.com/godotengine/godot-docs/pull/10153
https://github.com/godotengine/godot-docs/pull/10107
https://github.com/godotengine/godot-docs/pull/10163