### PR TITLE
Add GitHub Action to automatically create cherrypick PRs

### DIFF
--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -1,0 +1,70 @@
+name: Create Cherrypick PR
+
+on:
+  pull_request:
+      types:
+        - closed
+      branches:
+        # TODO extract this to an env variable?
+        - 'master'
+
+env:
+  # TODO add a way to handle multiple potential cherrypick targets.
+  TARGET_BRANCH: '4.3'
+  USERNAME: 'Godot Organization'
+  EMAIL: 'noreply@godotengine.org'
+
+jobs:
+  Create-cherrypick-PR:
+    # Only attempt to cherrypick PRs with a single commit. 
+    # PRs with multiple commits are merged with "Squash and merge" and are structured differently.
+    # The cherrypick label is hardcoded because contains() doesn't seem to be able to use an environment variable as a second argument.
+    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.commits == 1 && contains( github.event.pull_request.labels.*.name, 'cherrypick:4.3' ) }}
+    runs-on: ubuntu-latest
+    env:
+      # In the typical case of a PR with a single commit, merged with a merge commit,
+      # this will be the commit to cherrypick.
+      COMMIT_HASH: ${{ github.event.pull_request.head.sha }}
+      PR_NUMBER: ${{ github.event.number }}
+
+    steps:
+  
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ env.TARGET_BRANCH }}
+
+    - name: Cherrypick Commit
+      id: cherrypick_commit
+      continue-on-error: true
+      # TODO maybe only fetch some branches?
+      run: |
+        git config user.name "${{ env.USERNAME }}"
+        git config user.email "${{ env.EMAIL }}"
+        git fetch
+        git cherry-pick -m 1 ${{ env.COMMIT_HASH }}
+
+    - name: Create Pull Request
+      if: steps.cherrypick_commit.outcome == 'success'
+      uses: peter-evans/create-pull-request@v7
+      with:
+        commit-message: 'Cherrypick to ${{ env.TARGET_BRANCH }}'
+        branch: 'cherrypick-${{ env.PR_NUMBER }}-${{ env.TARGET_BRANCH }}'
+        delete-branch: true
+
+        # Configure the commit author.
+        author: '${{ env.USERNAME }} <${{ env.EMAIL }}>'
+        committer: '${{ env.USERNAME }} <${{ env.EMAIL }}>'
+
+        # Configure the pull request.
+        title: 'Cherrypick ${{ env.PR_NUMBER }} to ${{ env.TARGET_BRANCH }}'
+        body: 'Cherrypick #${{ env.PR_NUMBER }} to ${{ env.TARGET_BRANCH }}.'
+        # TODO only add the bug or enhancement label, depending on which the original PR uses.
+        labels: 'bug,enhancement'
+
+    - name: Handle failure
+      if: steps.cherrypick_commit.outcome == 'failure'
+      run: |
+        echo "Can't automatically cherrypick. Potential causes:"
+        echo "- PR has multiple commits. Did you squash and merge?"
+        echo "- Cherrypick did not apply cleanly and can't be auto-merged."

--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -5,24 +5,24 @@ on:
       types:
         - closed
       branches:
-        # TODO extract this to an env variable?
+        # TODO: Extract this to an env variable?
         - 'master'
 
 env:
-  # TODO add a way to handle multiple potential cherrypick targets.
+  # TODO: Add a way to handle multiple potential cherrypick targets.
   TARGET_BRANCH: '4.3'
   USERNAME: 'Godot Organization'
   EMAIL: 'noreply@godotengine.org'
 
 jobs:
   Create-cherrypick-PR:
-    # The cherrypick label is hardcoded because contains() doesn't seem to be able to use an environment variable as a second argument.
+    # The cherrypick label is hardcoded because `contains()` doesn't seem to be able to use an environment variable as a second argument.
     if: ${{ github.event.pull_request.merged == true && contains( github.event.pull_request.labels.*.name, 'cherrypick:4.3' ) }}
     runs-on: ubuntu-latest
     env:
       # "Ternary" hack featured in the official docs.
       # When using "Squash and merge", the commit hash is the last merge commit of the pull request merge branch.
-      # When using "Merge",  the commit hash is the last commit to the head branch of the pull request.
+      # When using "Merge", the commit hash is the last commit to the head branch of the pull request.
       # This is mildly error-prone, since in theory we could merge multiple commits without squashing.
       # We are relying on human review of the generated PRs to catch that.
       COMMIT_HASH: ${{ github.event.pull_request.commits > 1 && github.sha || github.event.pull_request.head.sha }}
@@ -38,7 +38,7 @@ jobs:
     - name: Cherrypick Commit
       id: cherrypick_commit
       continue-on-error: true
-      # TODO maybe only fetch some branches?
+      # TODO: Maybe only fetch some branches?
       run: |
         git config user.name "${{ env.USERNAME }}"
         git config user.email "${{ env.EMAIL }}"
@@ -60,7 +60,7 @@ jobs:
         # Configure the pull request.
         title: 'Cherrypick ${{ env.PR_NUMBER }} to ${{ env.TARGET_BRANCH }}'
         body: 'Cherrypick #${{ env.PR_NUMBER }} to ${{ env.TARGET_BRANCH }}.'
-        # TODO only add the bug or enhancement label, depending on which the original PR uses.
+        # TODO: Only add the bug or enhancement label, depending on which the original PR uses.
         labels: 'bug,enhancement'
 
     - name: Handle failure

--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -16,15 +16,16 @@ env:
 
 jobs:
   Create-cherrypick-PR:
-    # Only attempt to cherrypick PRs with a single commit. 
-    # PRs with multiple commits are merged with "Squash and merge" and are structured differently.
     # The cherrypick label is hardcoded because contains() doesn't seem to be able to use an environment variable as a second argument.
-    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.commits == 1 && contains( github.event.pull_request.labels.*.name, 'cherrypick:4.3' ) }}
+    if: ${{ github.event.pull_request.merged == true && contains( github.event.pull_request.labels.*.name, 'cherrypick:4.3' ) }}
     runs-on: ubuntu-latest
     env:
-      # In the typical case of a PR with a single commit, merged with a merge commit,
-      # this will be the commit to cherrypick.
-      COMMIT_HASH: ${{ github.event.pull_request.head.sha }}
+      # "Ternary" hack featured in the official docs.
+      # When using "Squash and merge", the commit hash is the last merge commit of the pull request merge branch.
+      # When using "Merge",  the commit hash is the last commit to the head branch of the pull request.
+      # This is mildly error-prone, since in theory we could merge multiple commits without squashing.
+      # We are relying on human review of the generated PRs to catch that.
+      COMMIT_HASH: ${{ github.event.pull_request.commits > 1 && github.sha || github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.number }}
 
     steps:


### PR DESCRIPTION
Uses peter-evans/create-pull-request and actions/checkout, both of which are already dependencies.

When merging a PR with a cherrypick label, attempt to cherrypick a single commit into a new branch, then create a PR.

Handles squash and merge, by checking the number of commits in the PR, and choosing the commit to cherrypick accordingly.

Fails if the cherrypick does not apply cleanly.

Does not attempt to merge the new PR.
Does not attempt to update stable.

---

This will likely need to wait until we stop using `stable`, since each auto-cherrypicked PR would need a separate PR to update stable. We can definitely automate that with another action, and I think we can even make the second action trigger on merge of any of these automatic cherrypick PRs... but that seems very messy. If we wait until stable is no longer used, then these automatic cherrypick PRs can simply be merged after giving them a human review, and then will trigger a rebuild of the docs.

**To test this** I recommend making a new `fake-master` or similar branch in your fork, create a `5.3` branch and a `cherrypick:5.3` label, and then change the relevant strings in the workflow file to refer to those branches instead. At least, that's how I tested.

**Potential future improvements:**
- [x] Handle squash and merge PRs. The API doesn't explicitly expose a way to test how a PR was merged. But we can check the number of commits in the PR, and handle the two cases differently. This *is* prone to error if for example we squash and merge a PR with a single commit, or merge commit a PR with several commits. But I think that in those cases the cherrypick will not apply cleanly, and still fail. And there should be a human review for these auto-cherrypicks anyway.

Optional:
- Handle cherrypicking to multiple past branches. I ran into some limitations of the GHA syntax and couldn't figure out how to use an env variable within a `contains()`. So I couldn't figure this out in the initial implementation. There should be some way, though.
- Remove the cherrypick label automatically when the cherrypick is merged?
- Comment automatically when the cherrypick is merged?
- Comment in the PR if the cherrypick does *not* apply cleanly?