### PR TITLE
Update functions names in example code to match 4.x nomenclature

### DIFF
--- a/tutorials/ui/gui_skinning.rst
+++ b/tutorials/ui/gui_skinning.rst
@@ -131,12 +131,12 @@ is applied to them. Those methods accept the theme type as one of the arguments.
  .. code-tab:: gdscript
 
    var accent_color = get_theme_color("accent_color", "MyType")
-   label.add_color_override("font_color", accent_color)
+   label.add_theme_color_override("font_color", accent_color)
 
  .. code-tab:: csharp
 
    Color accentColor = GetThemeColor("accent_color", "MyType");
-   label.AddColorOverride("font_color", accentColor);
+   label.AddThemeColorOverride("font_color", accentColor);
 
 To give more customization opportunities types can also be linked together as
 type variations. This is another use-case for custom theme types. For example,


### PR DESCRIPTION
Changed the function to override theme font color from "add_color_override" to "add_theme_color_override", as the previous version is not recognized by my 4.3 Godot Editor. 

Judging by the documentation archives, it seems that "add_color_override" was the version used in Godot 3.

From Control's 4.3 documentation, it seems C# functions have also been updated to include Theme in their name. It would make sense, so I updated it too, but I'm not 100% sure it actually works this way.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
