### PR TITLE
Standardize header syntax within About section

### DIFF
--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -84,39 +84,39 @@ how the text has to be included, but here are the most common approaches (you
 only need to implement one of them, not all).
 
 Credits screen
-^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~
 
 Include the above license text somewhere in the credits screen. It can be at the
 bottom after showing the rest of the credits. Most large studios use this
 approach with open source licenses.
 
 Licenses screen
-^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~
 
 Some games have a special menu (often in the settings) to display licenses.
 This menu is typically accessed with a button called **Third-party Licenses**
 or **Open Source Licenses**.
 
 Output log
-^^^^^^^^^^
+~~~~~~~~~~
 
 Printing the license text using the :ref:`print() <class_@GlobalScope_method_print>`
 function may be enough on platforms where a global output log is readable.
 This is the case on desktop platforms, Android and HTML5 (but not iOS).
 
 Accompanying file
-^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~
 
 If the game is distributed on desktop platforms, a file containing the license
 text can be added to the software that is installed to the user PC.
 
 Printed manual
-^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~
 
 If the game includes a printed manual, the license text can be included there.
 
 Link to the license
-^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~
 
 The Godot Engine developers consider that a link to ``godotengine.org/license``
 in your game documentation or credits would be an acceptable way to satisfy

--- a/about/docs_changelog.rst
+++ b/about/docs_changelog.rst
@@ -17,32 +17,32 @@ New pages since version 4.3
 ---------------------------
 
 2D
-^^
+~~
 
 - :ref:`doc_introduction_to_2d`
 
 3D
-^^
+~~
 
 - :ref:`doc_spring_arm`
 
 Editor
-^^^^^^
+~~~~~~
 
 - :ref:`doc_using_the_xr_editor`
 
 Performance
-^^^^^^^^^^^
+~~~~~~~~~~~
 
 - :ref:`doc_pipeline_compilations`
 
 Rendering
-^^^^^^^^^
+~~~~~~~~~
 
 - :ref:`doc_renderers`
 
 Shaders
-^^^^^^^
+~~~~~~~
 
 - :ref:`doc_shader_functions`
 
@@ -50,39 +50,39 @@ New pages since version 4.2
 ---------------------------
 
 About
-^^^^^
+~~~~~
 
 - :ref:`doc_system_requirements`
 
 2D
-^^
+~~
 
 - :ref:`doc_2d_parallax`
 
 Contributing
-^^^^^^^^^^^^
+~~~~~~~~~~~~
 
 - :ref:`doc_handling_compatibility_breakages`
 - :ref:`doc_ways_to_contribute`
 
 GDExtension
-^^^^^^^^^^^
+~~~~~~~~~~~
 
 - :ref:`doc_gdextension_file`
 - :ref:`doc_gdextension_docs_system`
 
 Migrating
-^^^^^^^^^
+~~~~~~~~~
 
 - :ref:`doc_upgrading_to_godot_4.3`
 
 Rendering
-^^^^^^^^^
+~~~~~~~~~
 
 - :ref:`doc_compositor`
 
 XR
-^^
+~~
 
 - :ref:`doc_a_better_xr_start_script`
 - :ref:`doc_openxr_passthrough`
@@ -96,27 +96,27 @@ New pages since version 4.1
 ---------------------------
 
 C#
-^^
+~~
 
 - :ref:`doc_c_sharp_diagnostics`
 
 Development
-^^^^^^^^^^^
+~~~~~~~~~~~
 
 - :ref:`doc_2d_coordinate_systems`
 
 Migrating
-^^^^^^^^^
+~~~~~~~~~
 
 - :ref:`doc_upgrading_to_godot_4.2`
 
 I/O
-^^^
+~~~
 
 - :ref:`doc_runtime_loading_and_saving`
 
 Platform-specific
-^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~
 
 - :ref:`doc_android_library`
 
@@ -124,18 +124,18 @@ New pages since version 4.0
 ---------------------------
 
 Development
-^^^^^^^^^^^
+~~~~~~~~~~~
 
 - :ref:`doc_internal_rendering_architecture`
 - :ref:`doc_using_sanitizers`
 
 Migrating
-^^^^^^^^^
+~~~~~~~~~
 
 - :ref:`doc_upgrading_to_godot_4.1`
 
 Physics
-^^^^^^^
+~~~~~~~
 
 - :ref:`doc_troubleshooting_physics_issues`
 
@@ -143,12 +143,12 @@ New pages since version 3.6
 ---------------------------
 
 2D
-^^
+~~
 
 - :ref:`doc_2d_antialiasing`
 
 3D
-^^
+~~
 
 - :ref:`doc_3d_antialiasing`
 - :ref:`doc_faking_global_illumination`
@@ -163,32 +163,32 @@ New pages since version 3.6
 - :ref:`doc_physical_light_and_camera_units`
 
 Animation
-^^^^^^^^^
+~~~~~~~~~
 
 - :ref:`doc_creating_movies`
 
 Assets pipeline
-^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~
 
 - :ref:`doc_retargeting_3d_skeletons`
 
 Development
-^^^^^^^^^^^
+~~~~~~~~~~~
 
 - :ref:`doc_custom_platform_ports`
 
 Migrating
-^^^^^^^^^
+~~~~~~~~~
 
 - :ref:`doc_upgrading_to_godot_4`
 
 Physics
-^^^^^^^
+~~~~~~~
 
 - :ref:`doc_large_world_coordinates`
 
 Scripting
-^^^^^^^^^
+~~~~~~~~~
 
 - :ref:`doc_custom_performance_monitors`
 - :ref:`doc_c_sharp_collections`
@@ -196,17 +196,17 @@ Scripting
 - :ref:`doc_c_sharp_variant`
 
 Shaders
-^^^^^^^
+~~~~~~~
 
 - :ref:`doc_compute_shaders`
 
 Workflow
-^^^^^^^^
+~~~~~~~~
 
 - :ref:`doc_pr_review_guidelines`
 
 XR
-^^
+~~
 
 - :ref:`doc_introducing_xr_tools`
 - :ref:`doc_xr_action_map`
@@ -221,17 +221,17 @@ New pages since version 3.4
 ---------------------------
 
 3D
-^^
+~~
 
 - :ref:`doc_3d_text`
 
 Animation
-^^^^^^^^^
+~~~~~~~~~
 
 - :ref:`doc_playing_videos`
 
 Editor
-^^^^^^
+~~~~~~
 
 - :ref:`doc_managing_editor_features`
 
@@ -239,12 +239,12 @@ New pages since version 3.3
 ---------------------------
 
 C++
-^^^
+~~~
 
 - :ref:`doc_cpp_usage_guidelines`
 
 GDScript
-^^^^^^^^
+~~~~~~~~
 
 - :ref:`doc_gdscript_documentation_comments`
 
@@ -252,31 +252,31 @@ New pages since version 3.2
 ---------------------------
 
 3D
-^^
+~~
 
 - :ref:`doc_3d_rendering_limitations`
 
 About
-^^^^^
+~~~~~
 
 - :ref:`doc_troubleshooting`
 - :ref:`doc_list_of_features`
 - :ref:`doc_release_policy`
 
 Best practices
-^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~
 
 - :ref:`doc_version_control_systems`
 
 Community
-^^^^^^^^^
+~~~~~~~~~
 
 - :ref:`doc_best_practices_for_engine_contributors`
 - :ref:`doc_bisecting_regressions`
 - :ref:`doc_editor_and_docs_localization`
 
 Development
-^^^^^^^^^^^
+~~~~~~~~~~~
 
 - :ref:`doc_introduction_to_editor_development`
 - :ref:`doc_editor_style_guide`
@@ -286,46 +286,46 @@ Development
 - Configuring an IDE: :ref:`doc_configuring_an_ide_code_blocks`
 
 Editor
-^^^^^^
+~~~~~~
 
 - :ref:`doc_default_key_mapping`
 - :ref:`doc_using_the_web_editor`
 
 Export
-^^^^^^
+~~~~~~
 
 - :ref:`doc_exporting_for_dedicated_servers`
 
 Input
-^^^^^
+~~~~~
 
 - :ref:`doc_controllers_gamepads_joysticks`
 
 Math
-^^^^
+~~~~
 
 - :ref:`doc_random_number_generation`
 
 Platform-specific
-^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~
 
 - :ref:`doc_plugins_for_ios`
 - :ref:`doc_ios_plugin`
 - :ref:`doc_html5_shell_classref`
 
 Physics
-^^^^^^^
+~~~~~~~
 
 - :ref:`doc_collision_shapes_2d`
 - :ref:`doc_collision_shapes_3d`
 
 Shaders
-^^^^^^^
+~~~~~~~
 
 - :ref:`doc_shaders_style_guide`
 
 Scripting
-^^^^^^^^^
+~~~~~~~~~
 
 - :ref:`doc_debugger_panel`
 - :ref:`doc_creating_script_templates`
@@ -334,7 +334,7 @@ Scripting
 - :ref:`doc_gdscript_warning_system` (split from :ref:`doc_gdscript_static_typing`)
 
 User Interface (UI)
-^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~
 
 - :ref:`doc_control_node_gallery`
 
@@ -342,39 +342,39 @@ New pages since version 3.1
 ---------------------------
 
 Project workflow
-^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~
 
 - :ref:`doc_android_gradle_build`
 
 2D
-^^
+~~
 
 - :ref:`doc_2d_sprite_animation`
 
 Audio
-^^^^^
+~~~~~
 
 - :ref:`doc_recording_with_microphone`
 - :ref:`doc_sync_with_audio`
 
 Math
-^^^^
+~~~~
 
 - :ref:`doc_beziers_and_curves`
 - :ref:`doc_interpolation`
 
 Inputs
-^^^^^^
+~~~~~~
 
 - :ref:`doc_input_examples`
 
 Internationalization
-^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~
 
 - :ref:`doc_localization_using_gettext`
 
 Shading
-^^^^^^^
+~~~~~~~
 
 - Your First Shader Series:
     - :ref:`doc_introduction_to_shaders`
@@ -384,24 +384,24 @@ Shading
 - :ref:`doc_visual_shaders`
 
 Networking
-^^^^^^^^^^
+~~~~~~~~~~
 
 - :ref:`doc_webrtc`
 
 Plugins
-^^^^^^^
+~~~~~~~
 
 - :ref:`doc_android_plugin`
 - :ref:`doc_inspector_plugins`
 - :ref:`doc_visual_shader_plugins`
 
 Multi-threading
-^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~
 
 - :ref:`doc_using_multiple_threads`
 
 Creating content
-^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~
 
 Procedural geometry series:
   - :ref:`Procedural geometry <toc-procedural_geometry>`
@@ -411,13 +411,13 @@ Procedural geometry series:
   - :ref:`doc_immediatemesh`
 
 Optimization
-^^^^^^^^^^^^
+~~~~~~~~~~~~
 
 - :ref:`doc_using_multimesh`
 - :ref:`doc_using_servers`
 
 Legal
-^^^^^
+~~~~~
 
 - :ref:`doc_complying_with_licenses`
 
@@ -425,18 +425,18 @@ New pages since version 3.0
 ---------------------------
 
 Step by step
-^^^^^^^^^^^^
+~~~~~~~~~~~~
 
 - :ref:`doc_signals`
 - Exporting
 
 Scripting
-^^^^^^^^^
+~~~~~~~~~
 
 - :ref:`doc_gdscript_static_typing`
 
 Project workflow
-^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~
 
 Best Practices:
 
@@ -452,43 +452,43 @@ Best Practices:
 - :ref:`doc_logic_preferences`
 
 2D
-^^
+~~
 
 - :ref:`doc_2d_lights_and_shadows`
 - :ref:`doc_2d_meshes`
 
 3D
-^^
+~~
 
 - :ref:`doc_csg_tools`
 - :ref:`doc_animating_thousands_of_fish`
 - :ref:`doc_controlling_thousands_of_fish`
 
 Physics
-^^^^^^^
+~~~~~~~
 
 - :ref:`doc_ragdoll_system`
 - :ref:`doc_soft_body`
 
 Animation
-^^^^^^^^^
+~~~~~~~~~
 
 - :ref:`doc_2d_skeletons`
 - :ref:`doc_animation_tree`
 
 GUI
-^^^
+~~~
 
 - :ref:`doc_gui_containers`
 
 Viewports
-^^^^^^^^^
+~~~~~~~~~
 
 - :ref:`doc_viewport_as_texture`
 - :ref:`doc_custom_postprocessing`
 
 Shading
-^^^^^^^
+~~~~~~~
 
 - :ref:`doc_converting_glsl_to_godot_shaders`
 - :ref:`doc_advanced_postprocessing`
@@ -502,40 +502,40 @@ Shading Reference:
 - :ref:`doc_particle_shader`
 
 Plugins
-^^^^^^^
+~~~~~~~
 
 - :ref:`doc_making_main_screen_plugins`
 - :ref:`doc_3d_gizmo_plugins`
 
 Platform-specific
-^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~
 
 - :ref:`doc_customizing_html5_shell`
 
 Multi-threading
-^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~
 
 - :ref:`doc_thread_safe_apis`
 
 Creating content
-^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~
 
 - :ref:`doc_making_trees`
 
 Miscellaneous
-^^^^^^^^^^^^^
+~~~~~~~~~~~~~
 
 - :ref:`doc_jitter_stutter`
 - :ref:`doc_running_code_in_the_editor`
 - :ref:`doc_change_scenes_manually`
 
 Compiling
-^^^^^^^^^
+~~~~~~~~~
 
 - :ref:`doc_optimizing_for_size`
 - :ref:`doc_compiling_with_script_encryption_key`
 
 Engine development
-^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~
 
 - :ref:`doc_binding_to_external_libraries`

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -256,7 +256,7 @@ This will automatically perform the required steps for desktop integration.
 Alternatively, you can manually perform the steps that an installer would do for you:
 
 Windows
-^^^^^^^
+~~~~~~~
 
 - Move the Godot executable to a stable location (i.e. outside of your Downloads folder),
   so you don't accidentally move it and break the shortcut in the future.
@@ -267,14 +267,14 @@ Windows
   **Pin to Task Bar**.
 
 macOS
-^^^^^
+~~~~~
 
 Drag the extracted Godot application to ``/Applications/Godot.app``, then drag it
 to the Dock if desired. Spotlight will be able to find Godot as long as it's in
 ``/Applications`` or ``~/Applications``.
 
 Linux
-^^^^^
+~~~~~
 
 - Move the Godot binary to a stable location (i.e. outside of your Downloads folder),
   so you don't accidentally move it and break the shortcut in the future.

--- a/about/system_requirements.rst
+++ b/about/system_requirements.rst
@@ -16,7 +16,7 @@ These are the **minimum** specifications required to run the Godot editor and wo
 on a simple 2D or 3D project:
 
 Desktop or laptop PC - Minimum
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. When adjusting specifications, make sure to only mention hardware that can run the required OS version.
 .. For example, the x86 CPU requirement for macOS is set after the MacBook Air 11" (late 2010 model),
@@ -72,7 +72,7 @@ Desktop or laptop PC - Minimum
     rendering method when running Godot on a Windows version older than 10.
 
 Mobile device (smartphone/tablet) - Minimum
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 +----------------------+-----------------------------------------------------------------------------------------+
 | **CPU**              | - **Android:** SoC with any 32-bit or 64-bit ARM or x86 CPU                             |
@@ -109,7 +109,7 @@ These are the **recommended** specifications to get a smooth experience with the
 Godot editor on a simple 2D or 3D project:
 
 Desktop or laptop PC - Recommended
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 +----------------------+---------------------------------------------------------------------------------------------+
 | **CPU**              | - **Windows:** x86_64 CPU with SSE4.2 instructions, with 4 physical cores or more, ARMv8 CPU|
@@ -147,7 +147,7 @@ Desktop or laptop PC - Recommended
 +----------------------+---------------------------------------------------------------------------------------------+
 
 Mobile device (smartphone/tablet) - Recommended
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 +----------------------+-----------------------------------------------------------------------------------------+
 | **CPU**              | - **Android:** SoC with 64-bit ARM or x86 CPU, with 3 "performance" cores or more       |
@@ -200,7 +200,7 @@ These are the **minimum** specifications required to run a simple 2D or 3D
 project exported with Godot:
 
 Desktop or laptop PC - Minimum
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. When adjusting specifications, make sure to only mention hardware that can run the required OS version.
 .. For example, the x86 CPU requirement for macOS is set after the MacBook Air 11" (late 2010 model),
@@ -254,7 +254,7 @@ Desktop or laptop PC - Minimum
     rendering method when running Godot on a Windows version older than 10.
 
 Mobile device (smartphone/tablet) - Minimum
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 +----------------------+-----------------------------------------------------------------------------------------+
 | **CPU**              | - **Android:** SoC with any 32-bit or 64-bit ARM or x86 CPU                             |
@@ -292,7 +292,7 @@ These are the **recommended** specifications to get a smooth experience with a
 simple 2D or 3D project exported with Godot:
 
 Desktop or laptop PC - Recommended
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 +----------------------+---------------------------------------------------------------------------------------------+
 | **CPU**              | - **Windows:** x86_64 CPU with SSE4.2 instructions, with 4 physical cores or more, ARMv8 CPU|
@@ -330,7 +330,7 @@ Desktop or laptop PC - Recommended
 +----------------------+---------------------------------------------------------------------------------------------+
 
 Mobile device (smartphone/tablet) - Recommended
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 +----------------------+-----------------------------------------------------------------------------------------+
 | **CPU**              | - **Android:** SoC with 64-bit ARM or x86 CPU, with 3 "performance" cores or more       |


### PR DESCRIPTION
This is a proof of concept, before making changes to the whole online documentation.

This standardizes our RST header syntax as follows:
```
Page title
==========
Renders as h1. Every page has this.

Header
------
Renders as h2. Usually appears in sidebar. Many pages only need one level of nested headers.

Sub-header
~~~~~~~~~~
Renders as h3. Appears in sidebar in some pages, depending on how deeply nested the *page* is.

Sub-sub-header
^^^^^^^^^^^^^^
Renders as h4. Usually won't appear in the sidebar.

Sub-sub-sub-header
""""""""""""""""""
Renders as h5. If you got this far something went wrong. I'm not actually sure if we have any 5-layer header nesting in the docs.
```

Feel free to bikeshed the syntax order here, if you care. `=, -, ~` is fairly common, but so is `=, -, ^`. `"""` is rarely used, but it does follow `^^^` when it is used. `+++` is occasionally used.

Edit: after going through a lot more pages, `=, -, ^` is common on pages with only 3 heading levels, but on pages with four heading levels, `=, -, ~, ^` is standard, and `=, -, ^, ~` or any variant is almost never used. So I think my original guideline is still correct.

Note that RST assigns headers based on the order they appear, *within a particular page*. So this PR will not change the header level of any existing pages. It only standardizes our syntax. This also means that this PR is not a one-to-one replacement of particular characters with other particular characters. It depends on the existing page!

Approval of this PR indicates the header syntax that I will standardize the rest of the docs with, in https://github.com/godotengine/godot-docs/pull/10370.