### PR TITLE
Fix instruction for RISC-V (the previous instruction didn't work)

### DIFF
--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -423,7 +423,7 @@ You also need to add ``$RISCV_TOOLCHAIN_PATH/bin`` to your user's PATH environme
 
 ::
 
-	export PATH="$RISCV_TOOLCHAIN_PATH/bin:$PATH"
+	PATH="$RISCV_TOOLCHAIN_PATH/bin:$PATH"
 
 .. warning:: Since riscv-gnu-toolchain uses its own Clang located
 			 in the ``bin`` folder, this command may block you from
@@ -442,6 +442,13 @@ Go to the root of the source code, and execute the following build command:
     scons arch=rv64 use_llvm=yes linker=mold lto=none target=editor \
         ccflags="--sysroot=$RISCV_TOOLCHAIN_PATH/sysroot --gcc-toolchain=$RISCV_TOOLCHAIN_PATH -target riscv64-unknown-linux-gnu" \
         linkflags="--sysroot=$RISCV_TOOLCHAIN_PATH/sysroot --gcc-toolchain=$RISCV_TOOLCHAIN_PATH -target riscv64-unknown-linux-gnu"
+
+.. note::
+
+    RISC-V GCC has `bugs with its atomic operations <https://github.com/riscv-collab/riscv-gcc/issues/15>`__
+    which prevent it from compiling Godot correctly. That's why Clang is used instead. Make sure that
+    it *can* compile to RISC-V. You can verify by executing this command ``clang -print-targets``,
+    make sure you see ``riscv64`` on the list of targets.
 
 The command is similar in nature, but with some key changes. ``ccflags`` and
 ``linkflags`` append additional flags to the build. ``--sysroot`` points to

--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -419,26 +419,13 @@ variable like this:
 This way, we won't have to manually set the directory location
 each time we want to reference it.
 
-You also need to add ``$RISCV_TOOLCHAIN_PATH/bin`` to your user's PATH environment variable.
-
-::
-
-	PATH="$RISCV_TOOLCHAIN_PATH/bin:$PATH"
-
-.. warning:: Since riscv-gnu-toolchain uses its own Clang located
-			 in the ``bin`` folder, this command may block you from
-			 accessing another version of Clang if one is installed.
-			 So it's recommended to run this command every time
-			 before compiling Godot for RISC-V devices instead of adding it to the
-			 ``$HOME/.bash_profile`` file.
-
-
 With all the above setup, we are now ready to build Godot.
 
 Go to the root of the source code, and execute the following build command:
 
 ::
 
+    PATH="$RISCV_TOOLCHAIN_PATH/bin:$PATH"
     scons arch=rv64 use_llvm=yes linker=mold lto=none target=editor \
         ccflags="--sysroot=$RISCV_TOOLCHAIN_PATH/sysroot --gcc-toolchain=$RISCV_TOOLCHAIN_PATH -target riscv64-unknown-linux-gnu" \
         linkflags="--sysroot=$RISCV_TOOLCHAIN_PATH/sysroot --gcc-toolchain=$RISCV_TOOLCHAIN_PATH -target riscv64-unknown-linux-gnu"
@@ -449,6 +436,15 @@ Go to the root of the source code, and execute the following build command:
     which prevent it from compiling Godot correctly. That's why Clang is used instead. Make sure that
     it *can* compile to RISC-V. You can verify by executing this command ``clang -print-targets``,
     make sure you see ``riscv64`` on the list of targets.
+
+.. warning:: The code above includes adding ``$RISCV_TOOLCHAIN_PATH/bin`` to the PATH,
+             but only for the following ``scons`` command. Since riscv-gnu-toolchain uses
+             its own Clang located in the ``bin`` folder, adding ``$RISCV_TOOLCHAIN_PATH/bin``
+             to your user's PATH environment variable may block you from accessing another
+             version of Clang if one is installed. For this reason not recommended to make
+             it permanent. You can also omit the ``PATH="$RISCV_TOOLCHAIN_PATH/bin:$PATH"`` line
+             if you want to use scons with self-installed version of Clang, but it may have
+             compatibility issues with riscv-gnu-toolchain.
 
 The command is similar in nature, but with some key changes. ``ccflags`` and
 ``linkflags`` append additional flags to the build. ``--sysroot`` points to

--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -425,7 +425,7 @@ Go to the root of the source code, and execute the following build command:
 
 ::
 
-    PATH="$RISCV_TOOLCHAIN_PATH/bin:$PATH"
+    PATH="$RISCV_TOOLCHAIN_PATH/bin:$PATH" \
     scons arch=rv64 use_llvm=yes linker=mold lto=none target=editor \
         ccflags="--sysroot=$RISCV_TOOLCHAIN_PATH/sysroot --gcc-toolchain=$RISCV_TOOLCHAIN_PATH -target riscv64-unknown-linux-gnu" \
         linkflags="--sysroot=$RISCV_TOOLCHAIN_PATH/sysroot --gcc-toolchain=$RISCV_TOOLCHAIN_PATH -target riscv64-unknown-linux-gnu"

--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -403,12 +403,6 @@ To cross-compile Godot for RISC-V devices, we need to setup the following items:
   If in doubt, `use this version <https://github.com/riscv-collab/riscv-gnu-toolchain/releases/tag/2021.12.22>`__,
   and download ``riscv64-glibc-ubuntu-18.04-nightly-2021.12.22-nightly.tar.gz``. Extract
   it somewhere and remember its path.
-- Clang. RISC-V GCC has
-  `bugs with its atomic operations <https://github.com/riscv-collab/riscv-gcc/issues/15>`__
-  which prevent it from compiling Godot correctly. Any version of Clang from 16.0.0 upwards
-  will suffice. Download it from the package manager of your distro, and make sure that
-  it *can* compile to RISC-V. You can verify by executing this command ``clang -print-targets``,
-  make sure you see ``riscv64`` on the list of targets.
 - `mold <https://github.com/rui314/mold/releases>`__. This fast linker,
   is the only one that correctly links the resulting binary. Download it, extract it,
   and make sure to add its ``bin`` folder to your PATH. Run
@@ -424,6 +418,20 @@ variable like this:
 
 This way, we won't have to manually set the directory location
 each time we want to reference it.
+
+You also need to add ``$RISCV_TOOLCHAIN_PATH/bin`` to your user's PATH environment variable.
+
+::
+
+	export PATH="$RISCV_TOOLCHAIN_PATH/bin:$PATH"
+
+.. warning:: Since riscv-gnu-toolchain uses its own Clang located
+			 in the ``bin`` folder, this command may block you from
+			 accessing another version of Clang if one is installed.
+			 So it's recommended to run this command every time
+			 before compiling Godot for RISC-V devices instead of adding it to the
+			 ``$HOME/.bash_profile`` file.
+
 
 With all the above setup, we are now ready to build Godot.
 

--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -441,8 +441,8 @@ Go to the root of the source code, and execute the following build command:
              but only for the following ``scons`` command. Since riscv-gnu-toolchain uses
              its own Clang located in the ``bin`` folder, adding ``$RISCV_TOOLCHAIN_PATH/bin``
              to your user's PATH environment variable may block you from accessing another
-             version of Clang if one is installed. For this reason not recommended to make
-             it permanent. You can also omit the ``PATH="$RISCV_TOOLCHAIN_PATH/bin:$PATH"`` line
+             version of Clang if one is installed. For this reason it's not recommended to make
+             adding the bin folder permanent. You can also omit the ``PATH="$RISCV_TOOLCHAIN_PATH/bin:$PATH"`` line
              if you want to use scons with self-installed version of Clang, but it may have
              compatibility issues with riscv-gnu-toolchain.
 


### PR DESCRIPTION
I checked this for Godot 4.3 sources on a Virtual Machine with Ubuntu 22.04.3(LTE). This pull request is the only instruction that worked for me. In all other cases I get an error.
I came to the conclusion that the user does not need to install clang at all to compile for RISC-V, since clang comes with the tool specified in the documentation. Moreover, only this toolset can be used for compilation. Check out details of my experiment:

As you can see below, I have clang installed (version 18.1.8, much better then 16-minimum mentioned in documentation). When I try to use command from actual version of "Compiling for Linux, *BSD" page, I get an error at the end of Godot compilation. ( "scons platform=linuxbsd use_llvm=yes linker=lld" works well therefore it's not problem with my clang )
![image](https://github.com/user-attachments/assets/dd4e1c25-d6d0-4e52-9f12-745799358020)

Now I gonna uninstall official clang and check the same scons command after adding $RISCV_TOOLCHAIN_PATH/bin into PATH. Let's uninstall clang and llvm via apt-get purge command. To check that clang were trully uninstalled I trying to check it's version again.
![image](https://github.com/user-attachments/assets/dea9ae79-2545-46e5-a9c1-a13c11659620)
![image](https://github.com/user-attachments/assets/fdfedd5d-7b86-42bb-b70b-8ec0a57d112f)
![image](https://github.com/user-attachments/assets/40d66ca9-7fff-4c37-97a3-f7784f7ef121)
(here I open a new terminal)
![image](https://github.com/user-attachments/assets/25339e55-332b-4dda-82b5-380d505ec080)
![image](https://github.com/user-attachments/assets/b6fb8e70-94d1-40a0-9f96-9b0ade06b67e)
As you can see, now my Linux environment use built-in clang from riscv-gnu-toolchain path and it compiles Godot without errors. But, of course, adding $RISCV_TOOLCHAIN_PATH/bin into PATH would automatically "replaces" the installed Clang with another one if you have it on your system. The same is true vice versa — if the user installs a separate Сlang, then when trying to compile for RISC-V, an inappropriate version can be selected. That's why I recommend not to make adding to PATH permanent and do it every time before RISC-V-compiling.
![image](https://github.com/user-attachments/assets/82ef9412-168b-4195-bf46-d0987b97d61a)


In actual page version said: "RISC-V GCC has bugs with its atomic operations which prevent it from compiling Godot correctly". I **can not** prove that Godot compiled in my case have no such bugs, since I don't have any RISC-V devices. This requires testing (I attached the compiled file at the end of this comment). But, as I understang, GCC and Clang are different compilers, and I don't use GCC in suggested instruction.

[godot.linuxbsd.editor.rv64.llvm](https://drive.google.com/file/d/1KqfWt9hYatyGaub9bML87hPmTj7B9KuK/view?usp=sharing)