### PR TITLE
[4.3] Change Edit on GitHub link to point to master

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -184,7 +184,7 @@ html_context = {
     "display_github": not is_i18n,  # Integrate GitHub
     "github_user": "godotengine",  # Username
     "github_repo": "godot-docs",  # Repo name
-    "github_version": "4.3",  # Version
+    "github_version": "master",  # Version
     "conf_py_path": "/",  # Path in the checkout to the docs root
     "godot_docs_title": supported_languages[language],
     "godot_docs_basepath": "https://docs.godotengine.org/",


### PR DESCRIPTION
This has been discussed a few times in RC. The choice here is between having the link point to 4.3, and receiving 4.3 PRs which as a general rule we do not accept, or having the link point to master, and a slight chance that a page is renamed/moved and 404s.

From my cursory knowledge of RTD, I think this changing this field won't have any side effects, it only affects the construction of the URL. ~~But I'm not 100% sure and I couldn't find out for sure in the RTD source.~~ It was in the RTD Sphinx theme, not the RTD main repo. This seems to be the only usage of this config value, so it seems like there will be no side effects:
https://github.com/readthedocs/sphinx_rtd_theme/blob/8d4d394dad2d55cf9a4db880effac6aa5c7b12e6/sphinx_rtd_theme/breadcrumbs.html#L39

(And, when we branch the docs to a stable minor version in the future, we should leave this field as `master` rather than the new minor version.)