### PR TITLE
Update broken link to RTD docs in comment

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -179,7 +179,7 @@ html_theme_options = {
 
 html_title = supported_languages[language] % ( "(" + version + ")" )
 
-# VCS options: https://docs.readthedocs.io/en/latest/vcs.html#github
+# Edit on GitHub options: https://docs.readthedocs.io/en/latest/guides/edit-source-links-sphinx.html
 html_context = {
     "display_github": not is_i18n,  # Integrate GitHub
     "github_user": "godotengine",  # Username


### PR DESCRIPTION
Since RTD doesn't seem to keep old versions of their docs around, I had to guess what the correct link was.

Broken link: https://docs.readthedocs.io/en/latest/vcs.html#github

Best guess at new link: https://docs.readthedocs.io/en/latest/guides/edit-source-links-sphinx.html