### PR TITLE
Use more idiomatic English in How to Contribute

### DIFF
--- a/contributing/how_to_contribute.rst
+++ b/contributing/how_to_contribute.rst
@@ -34,7 +34,7 @@ Fundraising
 - **Publish Godot Games.**
   You heard right, simply publishing a game #MadeWithGodot can positively impact the well-being of this project.
   Your personal success elevates the engine to a viable alternative for other developers, growing the community further.
-  Additionally, it opens the doors for us to approach industry contacts about possible cooperations.
+  Additionally, it opens the door for us to approach industry contacts about possible collaborations.
 
 
 Technical contributions


### PR DESCRIPTION
Pretty marginal change, take it or leave it.
Plural "cooperations" is not really idiomatic English (at least where I am from!). Plural "collaborations" can be used in a similar way.
"Opens the door" is typically more common than "opens the doors", but I don't think the latter form is *wrong*. We're already changing the string, though, so might as well change this too.