### PR TITLE
Briefly document Vector<> variations

### DIFF
--- a/contributing/development/core_and_modules/core_types.rst
+++ b/contributing/development/core_and_modules/core_types.rst
@@ -104,7 +104,7 @@ memnew/memdelete also use a little C++ magic and notify Objects right
 after they are created, and right before they are deleted.
 
 For dynamic memory, use one of Godot's sequence types such as ``Vector<>``
-or ``LocalVector<>``. ``Vector<>`` behaves much like an STL ``Vector<>``,
+or ``LocalVector<>``. ``Vector<>`` behaves much like an STL ``std::vector<>``,
 but is simpler and uses Copy-On-Write (CoW) semantics. CoW copies of
 ``Vector<>`` can safely access the same data from different threads, but
 several threads cannot access the same ``Vector<>`` instance safely.

--- a/contributing/development/core_and_modules/core_types.rst
+++ b/contributing/development/core_and_modules/core_types.rst
@@ -103,18 +103,25 @@ which are equivalent to new, delete, new[] and delete[].
 memnew/memdelete also use a little C++ magic and notify Objects right
 after they are created, and right before they are deleted.
 
-For dynamic memory, use Godot's ``Vector<>`` or one of its variations.
-Godot's ``Vector<>`` behaves much like an STL ``Vector<>``, but is simpler,
-thread safe, and uses Copy-On-Write semantics.
-It can be safely passed via public API.
+For dynamic memory, use one of Godot's sequence types such as ``Vector<>``
+or ``LocalVector<>``. ``Vector<>`` behaves much like an STL ``Vector<>``,
+but is simpler and uses Copy-On-Write (CoW) semantics. CoW copies of
+``Vector<>`` can safely access the same data from different threads, but
+several threads cannot access the same ``Vector<>`` instance safely.
+It can be safely passed via public API if it has a ``Packed`` alias.
 
-The ``Packed*Array`` :ref:`types <doc_gdscript_packed_arrays>` are aliases for
-specific ``Vector<*>`` types (e.g., ``PackedByteArray``, ``PackedInt32Array``)
-that are accessible via GDScript. Prefer using the ``Packed*Array`` aliases
-when available.
+The ``Packed*Array`` :ref:`types <doc_gdscript_packed_arrays>` are aliases
+for specific ``Vector<*>`` types (e.g., ``PackedByteArray``,
+``PackedInt32Array``) that are accessible via GDScript. Outside of core,
+prefer using the ``Packed*Array`` aliases for functions exposed to scripts,
+and ``Vector<>`` for other occasions.
 
-``LocalVector<>`` is a non-COW version, with less overhead. It is intended for
-internal use where the benefits of COW are not needed.
+``LocalVector<>`` is much more like ``std::vector`` than ``Vector<>``.
+It is non-CoW, with less overhead. It is intended for internal use where
+the benefits of CoW are not needed. Note that neither ``LocalVector<>``
+nor ``Vector<>`` are drop-in replacements for each other. They are two
+unrelated types with similar interfaces, both using a buffer as their
+storage strategy.
 
 References:
 ~~~~~~~~~~~

--- a/contributing/development/core_and_modules/core_types.rst
+++ b/contributing/development/core_and_modules/core_types.rst
@@ -103,7 +103,18 @@ which are equivalent to new, delete, new[] and delete[].
 memnew/memdelete also use a little C++ magic and notify Objects right
 after they are created, and right before they are deleted.
 
-For dynamic memory, use Vector<>.
+For dynamic memory, use Godot's ``Vector<>`` or one of its variations.
+Godot's ``Vector<>`` behaves much like an STL ``Vector<>``, but is simpler,
+thread safe, and uses Copy-On-Write semantics.
+It can be safely passed via public API.
+
+The ``Packed*Array`` :ref:`types <doc_gdscript_packed_arrays>` are aliases for
+specific ``Vector<*>`` types (e.g., ``PackedByteArray``, ``PackedInt32Array``)
+that are accessible via GDScript. Prefer using the ``Packed*Array`` aliases
+when available.
+
+``LocalVector<>`` is a non-COW version, with less overhead. It is intended for
+internal use where the benefits of COW are not needed.
 
 References:
 ~~~~~~~~~~~

--- a/contributing/development/core_and_modules/core_types.rst
+++ b/contributing/development/core_and_modules/core_types.rst
@@ -123,6 +123,11 @@ nor ``Vector<>`` are drop-in replacements for each other. They are two
 unrelated types with similar interfaces, both using a buffer as their
 storage strategy.
 
+``List<>`` is another Godot sequence type, using a doubly-linked list as
+its storage strategy. Prefer ``Vector<>`` (or ``LocalVector<>``) over
+``List<>`` unless you're sure you need it, as cache locality and memory
+fragmentation tend to be more important with small collections.
+
 References:
 ~~~~~~~~~~~
 

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -890,6 +890,8 @@ native or user class, or enum. Nested array types (like ``Array[Array[int]]``) a
     The only exception was made for the ``Array`` (``Array[Variant]``) type, for user convenience
     and compatibility with old code. However, operations on untyped arrays are considered unsafe.
 
+.. _doc_gdscript_packed_arrays:
+
 Packed arrays
 ^^^^^^^^^^^^^
 


### PR DESCRIPTION
This continues #10329.

`Packed*Array` aliases seem universally preferred where available, so a link to the list of types seems appropriate.

`LocalVector` is used sparingly, so mentioning the intent and rough tradeoff involved seems right for an overview.

_Bugsquad edit: closes https://github.com/godotengine/godot-docs/issues/6259._

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
