### PR TITLE
Add an introduction to the 2D index page

### DIFF
--- a/tutorials/2d/index.rst
+++ b/tutorials/2d/index.rst
@@ -1,5 +1,14 @@
 :allow_comments: False
 
+Godot includes a dedicated 2D renderer and 2D physics engine, as well as
+2D-specific features like tilemaps, particles, and animation systems. This
+section covers most 2D-specific topics in Godot.
+
+For 2D topics not covered in this section, see also :ref:`doc_2d_skeletons` and
+:ref:`doc_navigation_overview_2d`. For using physics in 2D, see
+:ref:`doc_physics_index`. There is also a step-by-step tutorial on creating a 2D
+game in :ref:`doc_your_first_2d_game`.
+
 2D
 ==
 

--- a/tutorials/physics/index.rst
+++ b/tutorials/physics/index.rst
@@ -1,5 +1,7 @@
 :allow_comments: False
 
+.. _doc_physics_index:
+
 Physics
 =======
 


### PR DESCRIPTION
Addresses https://github.com/godotengine/godot-docs/issues/4108.

A bit of a stub introduction, but serves its purpose of summarizing and providing links to related sections. 

Note that we recently added a [more colorful introduction](https://docs.godotengine.org/en/latest/tutorials/2d/introduction_to_2d.html#introduction-to-2d) to 2D in https://github.com/godotengine/godot-docs/pull/9621. It's still an open question what the ideal structure for introducing sections of the manual is. Some sections include multiple paragraphs on the index, some sections include a short intro on the index and a separate long introduction page, and most sections still only include links on the index page.
