### PR TITLE
TIME is affected by time_scale

### DIFF
--- a/tutorials/shaders/shader_reference/canvas_item_shader.rst
+++ b/tutorials/shaders/shader_reference/canvas_item_shader.rst
@@ -50,26 +50,27 @@ Global built-ins
 
 Global built-ins are available everywhere, including custom functions.
 
-+-------------------+-----------------------------------------------------------------------------------------+
-| Built-in          | Description                                                                             |
-+===================+=========================================================================================+
-| in float **TIME** | Global time since the engine has started, in seconds. It repeats after every ``3,600``  |
-|                   | seconds (which can  be changed with the                                                 |
-|                   | :ref:`rollover<class_ProjectSettings_property_rendering/limits/time/time_rollover_secs>`|
-|                   | setting). It's not affected by :ref:`time_scale<class_Engine_property_time_scale>` or   |
-|                   | pausing. If you need  a ``TIME`` variable that can be scaled or paused, add your own    |
-|                   | :ref:`global shader uniform<doc_shading_language_global_uniforms>` and update it each   |
-|                   | frame.                                                                                  |      
-+-------------------+-----------------------------------------------------------------------------------------+
-| in float **PI**   | A ``PI`` constant (``3.141592``).                                                       |
-|                   | A ratio of a circle's circumference to its diameter and amount of radians in half turn. |
-+-------------------+-----------------------------------------------------------------------------------------+
-| in float **TAU**  | A ``TAU`` constant (``6.283185``).                                                      |
-|                   | An equivalent of ``PI * 2`` and amount of radians in full turn.                         |
-+-------------------+-----------------------------------------------------------------------------------------+
-| in float **E**    | An ``E`` constant (``2.718281``).                                                       |
-|                   | Euler's number and a base of the natural logarithm.                                     |
-+-------------------+-----------------------------------------------------------------------------------------+
++-------------------+------------------------------------------------------------------------------------------+
+| Built-in          | Description                                                                              |
++===================+==========================================================================================+
+| in float **TIME** | Global time since the engine has started, in seconds. It repeats after every ``3,600``   |
+|                   | seconds (which can  be changed with the                                                  |
+|                   | :ref:`rollover<class_ProjectSettings_property_rendering/limits/time/time_rollover_secs>` |
+|                   | setting). It's affected by                                                               |
+|                   | :ref:`time_scale<class_Engine_property_time_scale>` but not by pausing. If you need a    |
+|                   | ``TIME`` variable that is not affected by time scale, add your own                       |
+|                   | :ref:`global shader uniform<doc_shading_language_global_uniforms>` and update it each    |
+|                   | frame.                                                                                   |
++-------------------+------------------------------------------------------------------------------------------+
+| in float **PI**   | A ``PI`` constant (``3.141592``).                                                        |
+|                   | A ratio of a circle's circumference to its diameter and amount of radians in half turn.  |
++-------------------+------------------------------------------------------------------------------------------+
+| in float **TAU**  | A ``TAU`` constant (``6.283185``).                                                       |
+|                   | An equivalent of ``PI * 2`` and amount of radians in full turn.                          |
++-------------------+------------------------------------------------------------------------------------------+
+| in float **E**    | An ``E`` constant (``2.718281``).                                                        |
+|                   | Euler's number and a base of the natural logarithm.                                      |
++-------------------+------------------------------------------------------------------------------------------+
 
 Vertex built-ins
 ^^^^^^^^^^^^^^^^

--- a/tutorials/shaders/shader_reference/fog_shader.rst
+++ b/tutorials/shaders/shader_reference/fog_shader.rst
@@ -31,26 +31,27 @@ Global built-ins
 Global built-ins are available everywhere, including in custom functions.
 
 
-+---------------------------------+-----------------------------------------------------------------------------------------+
-| Built-in                        | Description                                                                             |
-+=================================+=========================================================================================+
-| in float **TIME**               | Global time since the engine has started, in seconds. It repeats after every ``3,600``  |
-|                                 | seconds (which can  be changed with the                                                 |
-|                                 | :ref:`rollover<class_ProjectSettings_property_rendering/limits/time/time_rollover_secs>`|
-|                                 | setting). It's not affected by :ref:`time_scale<class_Engine_property_time_scale>` or   |
-|                                 | pausing. If you need  a ``TIME`` variable that can be scaled or paused, add your own    |
-|                                 | :ref:`global shader uniform<doc_shading_language_global_uniforms>` and update it each   |
-|                                 | frame.                                                                                  | 
-+---------------------------------+-----------------------------------------------------------------------------------------+
-| in float **PI**                 | A ``PI`` constant (``3.141592``).                                                       |
-|                                 | A ratio of a circle's circumference to its diameter and amount of radians in half turn. |
-+---------------------------------+-----------------------------------------------------------------------------------------+
-| in float **TAU**                | A ``TAU`` constant (``6.283185``).                                                      |
-|                                 | An equivalent of ``PI * 2`` and amount of radians in full turn.                         |
-+---------------------------------+-----------------------------------------------------------------------------------------+
-| in float **E**                  | An ``E`` constant (``2.718281``).                                                       |
-|                                 | Euler's number and a base of the natural logarithm.                                     |
-+---------------------------------+-----------------------------------------------------------------------------------------+
++-----------------------------------+------------------------------------------------------------------------------------------+
+| Built-in                          | Description                                                                              |
++===================================+==========================================================================================+
+| in float **TIME**                 | Global time since the engine has started, in seconds. It repeats after every ``3,600``   |
+|                                   | seconds (which can  be changed with the                                                  |
+|                                   | :ref:`rollover<class_ProjectSettings_property_rendering/limits/time/time_rollover_secs>` |
+|                                   | setting). It's affected by                                                               |
+|                                   | :ref:`time_scale<class_Engine_property_time_scale>` but not by pausing. If you need a    |
+|                                   | ``TIME`` variable that is not affected by time scale, add your own                       |
+|                                   | :ref:`global shader uniform<doc_shading_language_global_uniforms>` and update it each    |
+|                                   | frame.                                                                                   |
++-----------------------------------+------------------------------------------------------------------------------------------+
+| in float **PI**                   | A ``PI`` constant (``3.141592``).                                                        |
+|                                   | A ratio of a circle's circumference to its diameter and amount of radians in half turn.  |
++-----------------------------------+------------------------------------------------------------------------------------------+
+| in float **TAU**                  | A ``TAU`` constant (``6.283185``).                                                       |
+|                                   | An equivalent of ``PI * 2`` and amount of radians in full turn.                          |
++-----------------------------------+------------------------------------------------------------------------------------------+
+| in float **E**                    | An ``E`` constant (``2.718281``).                                                        |
+|                                   | Euler's number and a base of the natural logarithm.                                      |
++-----------------------------------+------------------------------------------------------------------------------------------+
 
 Fog built-ins
 ^^^^^^^^^^^^^

--- a/tutorials/shaders/shader_reference/particle_shader.rst
+++ b/tutorials/shaders/shader_reference/particle_shader.rst
@@ -54,25 +54,26 @@ Global built-ins
 
 Global built-ins are available everywhere, including custom functions.
 
-+-------------------+-----------------------------------------------------------------------------------------+
-| Built-in          | Description                                                                             |
-+===================+=========================================================================================+
-| in float **TIME** | Global time since the engine has started, in seconds. It repeats after every ``3,600``  |
-|                   | seconds (which can  be changed with the                                                 |
-|                   | :ref:`rollover<class_ProjectSettings_property_rendering/limits/time/time_rollover_secs>`|
-|                   | setting). It's not affected by :ref:`time_scale<class_Engine_property_time_scale>` or   |
-|                   | pausing. If you need  a ``TIME`` variable that can be scaled or paused, add your own    |
-|                   | :ref:`global shader uniform<doc_shading_language_global_uniforms>` and update it each   |
-|                   | frame.                                                                                  | 
-+-------------------+-----------------------------------------------------------------------------------------+
-| in float **PI**   | A ``PI`` constant (``3.141592``).                                                       |
-|                   | A ratio of a circle's circumference to its diameter and amount of radians in half turn. |
-+-------------------+-----------------------------------------------------------------------------------------+
-| in float **TAU**  | A ``TAU`` constant (``6.283185``).                                                      |
-|                   | An equivalent of ``PI * 2`` and amount of radians in full turn.                         |
-+-------------------+-----------------------------------------------------------------------------------------+
-| in float **E**    | An ``E`` constant (``2.718281``). Euler's number and a base of the natural logarithm.   |
-+-------------------+-----------------------------------------------------------------------------------------+
++-------------------+------------------------------------------------------------------------------------------+
+| Built-in          | Description                                                                              |
++===================+==========================================================================================+
+| in float **TIME** | Global time since the engine has started, in seconds. It repeats after every ``3,600``   |
+|                   | seconds (which can  be changed with the                                                  |
+|                   | :ref:`rollover<class_ProjectSettings_property_rendering/limits/time/time_rollover_secs>` |
+|                   | setting). It's affected by                                                               |
+|                   | :ref:`time_scale<class_Engine_property_time_scale>` but not by pausing. If you need a    |
+|                   | ``TIME`` variable that is not affected by time scale, add your own                       |
+|                   | :ref:`global shader uniform<doc_shading_language_global_uniforms>` and update it each    |
+|                   | frame.                                                                                   |
++-------------------+------------------------------------------------------------------------------------------+
+| in float **PI**   | A ``PI`` constant (``3.141592``).                                                        |
+|                   | A ratio of a circle's circumference to its diameter and amount of radians in half turn.  |
++-------------------+------------------------------------------------------------------------------------------+
+| in float **TAU**  | A ``TAU`` constant (``6.283185``).                                                       |
+|                   | An equivalent of ``PI * 2`` and amount of radians in full turn.                          |
++-------------------+------------------------------------------------------------------------------------------+
+| in float **E**    | An ``E`` constant (``2.718281``). Euler's number and a base of the natural logarithm.    |
++-------------------+------------------------------------------------------------------------------------------+
 
 Start and Process built-ins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tutorials/shaders/shader_reference/sky_shader.rst
+++ b/tutorials/shaders/shader_reference/sky_shader.rst
@@ -157,10 +157,10 @@ There are 4 ``LIGHTX`` lights, accessed as ``LIGHT0``, ``LIGHT1``, ``LIGHT2``, a
 | in float **TIME**               | Global time since the engine has started, in seconds. It repeats after every ``3,600``                                   |
 |                                 | seconds (which can  be changed with the                                                                                  |
 |                                 | :ref:`rollover<class_ProjectSettings_property_rendering/limits/time/time_rollover_secs>`                                 |
-|                                 | setting). It's not affected by :ref:`time_scale<class_Engine_property_time_scale>` or                                    |
-|                                 | pausing. If you need  a ``TIME`` variable that can be scaled or paused, add your own                                     |
+|                                 | setting). It's affected by :ref:`time_scale<class_Engine_property_time_scale>` but not by pausing. If you need a         |
+|                                 | ``TIME`` variable that is not affected by time scale, add your own                                                       |
 |                                 | :ref:`global shader uniform<doc_shading_language_global_uniforms>` and update it each                                    |
-|                                 | frame.                                                                                                                   |                          
+|                                 | frame.                                                                                                                   |
 +---------------------------------+--------------------------------------------------------------------------------------------------------------------------+
 | in vec3 **POSITION**            | Camera position, in world space.                                                                                         |
 +---------------------------------+--------------------------------------------------------------------------------------------------------------------------+

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -98,32 +98,32 @@ Global built-ins
 
 Global built-ins are available everywhere, including custom functions.
 
-+-----------------------------+------------------------------------------------------------------------------------------+
-| Built-in                    | Description                                                                              |
-+=============================+==========================================================================================+
-| in float **TIME**           | Global time since the engine has started, in seconds. It repeats after every ``3,600``   |
-|                             | seconds (which can  be changed with the                                                  |
-|                             | :ref:`rollover<class_ProjectSettings_property_rendering/limits/time/time_rollover_secs>` |
-|                             | setting). It's not affected by :ref:`time_scale<class_Engine_property_time_scale>` or    |
-|                             | pausing. If you need  a ``TIME`` variable that can be scaled or paused, add your own     |
-|                             | :ref:`global shader uniform<doc_shading_language_global_uniforms>` and update it each    |
-|                             | frame.                                                                                   | 
-+-----------------------------+------------------------------------------------------------------------------------------+
-| in float **PI**             | A ``PI`` constant (``3.141592``).                                                        |
-|                             | A ratio of a circle's circumference to its diameter and amount of radians in half turn.  |
-+-----------------------------+------------------------------------------------------------------------------------------+
-| in float **TAU**            | A ``TAU`` constant (``6.283185``).                                                       |
-|                             | An equivalent of ``PI * 2`` and amount of radians in full turn.                          |
-+-----------------------------+------------------------------------------------------------------------------------------+
-| in float **E**              | An ``E`` constant (``2.718281``). Euler's number and a base of the natural logarithm.    |
-+-----------------------------+------------------------------------------------------------------------------------------+
-| in bool **OUTPUT_IS_SRGB**  | ``true`` when output is in sRGB color space (this is ``true`` in the Compatibility       |
-|                             | renderer, ``false`` in Forward+ and Mobile).                                             |
-+-----------------------------+------------------------------------------------------------------------------------------+
-| in float **CLIP_SPACE_FAR** | Clip space far ``z`` value.                                                              |
-|                             | In the Forward+ or Mobile renderers, it's ``0.0``.                                       |
-|                             | In the Compatibility renderer, it's ``-1.0``.                                            |
-+-----------------------------+------------------------------------------------------------------------------------------+
++-----------------------------+-----------------------------------------------------------------------------------------------------+
+| Built-in                    | Description                                                                                         |
++=============================+=====================================================================================================+
+| in float **TIME**           | Global time since the engine has started, in seconds. It repeats after every ``3,600``              |
+|                             | seconds (which can  be changed with the                                                             |
+|                             | :ref:`rollover<class_ProjectSettings_property_rendering/limits/time/time_rollover_secs>`            |
+|                             | setting). It's affected by :ref:`time_scale<class_Engine_property_time_scale>` but not by pausing.  |
+|                             | If you need a ``TIME`` variable that is not affected by time scale, add your own                    |
+|                             | :ref:`global shader uniform<doc_shading_language_global_uniforms>` and update it each               |
+|                             | frame.                                                                                              |
++-----------------------------+-----------------------------------------------------------------------------------------------------+
+| in float **PI**             | A ``PI`` constant (``3.141592``).                                                                   |
+|                             | A ratio of a circle's circumference to its diameter and amount of radians in half turn.             |
++-----------------------------+-----------------------------------------------------------------------------------------------------+
+| in float **TAU**            | A ``TAU`` constant (``6.283185``).                                                                  |
+|                             | An equivalent of ``PI * 2`` and amount of radians in full turn.                                     |
++-----------------------------+-----------------------------------------------------------------------------------------------------+
+| in float **E**              | An ``E`` constant (``2.718281``). Euler's number and a base of the natural logarithm.               |
++-----------------------------+-----------------------------------------------------------------------------------------------------+
+| in bool **OUTPUT_IS_SRGB**  | ``true`` when output is in sRGB color space (this is ``true`` in the Compatibility                  |
+|                             | renderer, ``false`` in Forward+ and Mobile).                                                        |
++-----------------------------+-----------------------------------------------------------------------------------------------------+
+| in float **CLIP_SPACE_FAR** | Clip space far ``z`` value.                                                                         |
+|                             | In the Forward+ or Mobile renderers, it's ``0.0``.                                                  |
+|                             | In the Compatibility renderer, it's ``-1.0``.                                                       |
++-----------------------------+-----------------------------------------------------------------------------------------------------+
 
 Vertex built-ins
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Update docs to say that TIME is affected by time_scale.