### PR TITLE
Fix incorrect C# code examples in the "Making main screen plugins" tutorial

### DIFF
--- a/tutorials/plugins/editor/making_main_screen_plugins.rst
+++ b/tutorials/plugins/editor/making_main_screen_plugins.rst
@@ -92,7 +92,7 @@ Add five extra methods such that the script looks like this:
 
         public override Texture2D _GetPluginIcon()
         {
-            return EditorInterface.GetEditorTheme().GetIcon("Node", "EditorIcons");
+            return EditorInterface.Singleton.GetEditorTheme().GetIcon("Node", "EditorIcons");
         }
     }
     #endif
@@ -210,7 +210,7 @@ Here is the full plugin script:
         {
             MainPanelInstance = (Control)MainPanel.Instantiate();
             // Add the main panel to the editor's main viewport.
-            EditorInterface.GetEditorMainScreen().AddChild(MainPanelInstance);
+            EditorInterface.Singleton.GetEditorMainScreen().AddChild(MainPanelInstance);
             // Hide the main panel. Very much required.
             _MakeVisible(false);
         }
@@ -244,7 +244,7 @@ Here is the full plugin script:
         public override Texture2D _GetPluginIcon()
         {
             // Must return some kind of Texture for the icon.
-            return EditorInterface.GetEditorTheme().GetIcon("Node", "EditorIcons");
+            return EditorInterface.Singleton.GetEditorTheme().GetIcon("Node", "EditorIcons");
         }
     }
     #endif


### PR DESCRIPTION
The C# examples in the ["Making main screen plugins" tutorial](https://docs.godotengine.org/en/stable/tutorials/plugins/editor/making_main_screen_plugins.html) do not compile because `EditorInterface.GetEditorMainScreen()` is not a static method. The correct usage is to refer to the singleton object with `EditorInterface.Singleton.GetEditorMainScreen()`

Incorrect usage:
![image](https://github.com/user-attachments/assets/f64893ae-ad57-4184-aea7-85905864245d)
Correct usage: 
![image](https://github.com/user-attachments/assets/35720dc9-8599-4f52-9c32-78ca47d68567)


<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
