### PR TITLE
Update documentation changelog for new Output Panel page

### DIFF
--- a/about/docs_changelog.rst
+++ b/about/docs_changelog.rst
@@ -26,6 +26,11 @@ New pages since version 4.3
 
 - :ref:`doc_spring_arm`
 
+Debug
+^^^^^
+
+- :ref:`doc_output_panel`
+
 Editor
 ^^^^^^
 


### PR DESCRIPTION
Update the documentation changelog for https://github.com/godotengine/godot-docs/pull/10333.