### PR TITLE
Link to foveation settings from VRS page

### DIFF
--- a/tutorials/3d/variable_rate_shading.rst
+++ b/tutorials/3d/variable_rate_shading.rst
@@ -87,6 +87,8 @@ Using variable rate shading in Godot
     shading. VRS can be used in both pancake (non-XR) and XR display modes.
 
     The Compatibility renderer does **not** support variable rate shading.
+    For XR, you can use :ref:`foveation level <doc_openxr_settings_foveation_level>`
+    as an alternative.
 
 In the advanced Project Settings, the **Rendering > VRS** section offers settings
 to control variable rate shading on the root viewport:

--- a/tutorials/xr/openxr_settings.rst
+++ b/tutorials/xr/openxr_settings.rst
@@ -163,6 +163,8 @@ If a mode is selected that is not supported by the headset, the first available 
   From Godot 4.3 onwards selecting the alpha blend mode will also perform these extra steps.
   This does require the latest vendor plugin to be installed.
 
+.. _doc_openxr_settings_foveation_level:
+
 Foveation Level
 ---------------
 


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot-docs/issues/10320 by linking to the XR foveation settings from the VRS page. If we decide not to merge this, the linked issue should be closed as not planned.

I don't use XR personally, so I pieced this together from the existing docs and the linked issues and PRs.
