### PR TITLE
Simply remove some words

### DIFF
--- a/contributing/development/handling_compatibility_breakages.rst
+++ b/contributing/development/handling_compatibility_breakages.rst
@@ -100,7 +100,7 @@ like ``core/math/a_star_grid_2d.compat.inc`` in this case:
 
     #endif // DISABLE_DEPRECATED
 
-Unless the change in compatibility is complex, the compatibility method should simply call the modified method directly,
+Unless the change in compatibility is complex, the compatibility method should call the modified method directly,
 instead of duplicating that method. Make sure to match the default arguments for that method (in the example above this would be ``false``).
 
 This file should always be placed next to the original file, and have ``.compat.inc`` at the end instead of ``.cpp`` or ``.h``.

--- a/tutorials/assets_pipeline/import_process.rst
+++ b/tutorials/assets_pipeline/import_process.rst
@@ -47,7 +47,7 @@ be discarded. After clicking **Reimport**, the chosen parameters will only be
 used for this asset and on future reimports.
 
 Changing the import parameters of several assets at the same time is also
-possible. Simply select all of them together in the resources dock and the
+possible. Select all of them together in the FileSystem dock and the
 exposed parameters will apply to all of them when reimporting.
 
 Reimporting multiple assets

--- a/tutorials/performance/general_optimization.rst
+++ b/tutorials/performance/general_optimization.rst
@@ -226,7 +226,7 @@ algorithms and data structures are the best they can be. Data access should be
 local (to make best use of CPU cache), and it can often be better to use compact
 storage of data (again, always profile to test results). Often, you precalculate
 heavy computations ahead of time. This can be done by performing the computation
-when loading a level, by loading a file containing precalculated data or simply
+when loading a level, by loading a file containing precalculated data, or
 by storing the results of complex calculations into a script constant and
 reading its value.
 

--- a/tutorials/platform/web/javascript_bridge.rst
+++ b/tutorials/platform/web/javascript_bridge.rst
@@ -136,7 +136,7 @@ Can I use my favorite library?
 ------------------------------
 
 You most likely can. First, you have to
-include your library in the page. You can simply customize the
+include your library in the page. You can customize the
 :ref:`Head Include <doc_javascript_export_options>` during export (see below),
 or even :ref:`write your own template <doc_customizing_html5_shell>`.
 

--- a/tutorials/rendering/compositor.rst
+++ b/tutorials/rendering/compositor.rst
@@ -12,8 +12,7 @@ a :ref:`Camera3D <class_Camera3D>` and apply only to
 the Viewport using that camera.
 
 The :ref:`Compositor <class_Compositor>` resource is used to configure
-the compositor. To get started, simply create a new compositor on
-the appropriate node:
+the compositor. To get started, create a new compositor on the appropriate node:
 
 .. image:: img/new_compositor.webp
 

--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -96,8 +96,8 @@ Now that we've downloaded our prerequisites, it is time to build the C++
 bindings.
 
 The repository contains a copy of the metadata for the current Godot release,
-but if you need to build these bindings for a newer version of Godot, simply
-call the Godot executable:
+but if you need to build these bindings for a newer version of Godot, call
+the Godot executable:
 
 .. code-block:: none
 

--- a/tutorials/scripting/gdscript/gdscript_advanced.rst
+++ b/tutorials/scripting/gdscript/gdscript_advanced.rst
@@ -525,5 +525,4 @@ exists is desirable:
         if object.has_method("smash"):
             object.smash()
 
-Then, simply define that method and anything the rock touches can be
-smashed.
+Then, define that method and anything the rock touches can be smashed.

--- a/tutorials/shaders/shader_reference/shader_functions.rst
+++ b/tutorials/shaders/shader_reference/shader_functions.rst
@@ -3645,7 +3645,7 @@ Bitwise function descriptions
     The returned value will have bits [offset, offset + bits + 1] taken from [0, bits - 1] of ``insert`` and
     all other bits taken directly from the corresponding bits of base.
 
-    .. note:: If bits is zero, the result will simply be the original value of base.
+    .. note:: If bits is zero, the result will be the original value of base.
 
     .. warning::
         The result will be undefined if:

--- a/tutorials/ui/bbcode_in_richtextlabel.rst
+++ b/tutorials/ui/bbcode_in_richtextlabel.rst
@@ -1052,7 +1052,7 @@ the Inspector by adding it to the **Markup > Custom Effects** array, or in code 
     tag will be left as-is.
 
 There is only one function that you need to extend: ``_process_custom_fx(char_fx)``.
-Optionally, you can also provide a custom BBCode identifier simply by adding a member
+Optionally, you can also provide a custom BBCode identifier by adding a member
 name ``bbcode``. The code will check the ``bbcode`` property automatically or will
 use the name of the file to determine what the BBCode tag should be.
 

--- a/tutorials/ui/custom_gui_controls.rst
+++ b/tutorials/ui/custom_gui_controls.rst
@@ -131,7 +131,7 @@ when:
 
 This function is
 :ref:`Control._gui_input() <class_Control_private_method__gui_input>`.
-Simply override it in your control. No processing needs to be set.
+To use it, override it in your control. No processing needs to be set.
 
 .. tabs::
  .. code-tab:: gdscript GDScript

--- a/tutorials/xr/introducing_xr_tools.rst
+++ b/tutorials/xr/introducing_xr_tools.rst
@@ -26,7 +26,8 @@ Installing XR Tools
 
 Continuing on from our project we started in :ref:`doc_setting_up_xr` we want to add in the Godot XR Tools library.
 This can be downloaded from the `Godot XR Tools releases page <https://github.com/GodotVR/godot-xr-tools/releases>`_.
-Simply find the latest pre-release for Godot 4 and then under assets download the ``godot-xr-tools.zip`` file.
+Find the latest release for Godot 4, and under **Assets**, download the
+``godot-xr-tools.zip`` file.
 
 Once downloaded unzip the file.
 You will notice the files are held within a ``godot-xr-tools`` subfolder.

--- a/tutorials/xr/openxr_composition_layers.rst
+++ b/tutorials/xr/openxr_composition_layers.rst
@@ -72,7 +72,7 @@ Adding a composition layer
 --------------------------
 
 The second step is adding our composition layer.
-We simply add the correct composition layer node as a child node of
+We can add the correct composition layer node as a child node of
 our :ref:`XROrigin3D <class_xrorigin3d>` node.
 This is very important as the XR runtime positions everything in relation to our origin.
 
@@ -263,7 +263,7 @@ Next we remember our state for next frame.
 
     ...
 
-Finally, if we aren't intersecting, we simply clear our state.
+Finally, if we aren't intersecting, we clear our state.
 
 .. code:: gdscript
 

--- a/tutorials/xr/openxr_hand_tracking.rst
+++ b/tutorials/xr/openxr_hand_tracking.rst
@@ -185,7 +185,7 @@ You can access this information through code:
     else:
         print("No hand tracker registered")
 
-This example simply logs the state for the left hand.
+This example logs the state for the left hand.
 
 If in this example no hand tracker is returned by ``get_tracker``,
 this means the hand tracking API is not supported on the XR runtime at all.

--- a/tutorials/xr/setting_up_xr.rst
+++ b/tutorials/xr/setting_up_xr.rst
@@ -31,7 +31,11 @@ There are other XR related nodes and there is much more to say about these three
 Prerequisites for XR in Godot 4
 -------------------------------
 
-While in Godot 3 most things worked out of the box, Godot 4 needs a little more setup. This is mainly due to the more advanced nature of the Vulkan renderer. There are many rendering features in Vulkan the XR system uses that aren't enabled by default. They are very easy to turn on, simply open up your project settings and tick the XR shaders tickbox in the XR section:
+While in Godot 3 most things worked out of the box, Godot 4 needs a little more
+setup. This is mainly due to the more advanced nature of the Vulkan renderer.
+There are many rendering features in Vulkan the XR system uses that aren't
+enabled by default. To turn them on, open up your project settings and tick
+:ref:`XR > Shaders > Enabled <class_ProjectSettings_property_xr/shaders/enabled>`:
 
 .. image:: img/xr_shaders.png
 

--- a/tutorials/xr/xr_action_map.rst
+++ b/tutorials/xr/xr_action_map.rst
@@ -52,7 +52,7 @@ Godot will automatically create a default action map if no action map file is fo
   It prevents having to design a proper action map for their game/application first.
 
 For this walkthrough we're going to start with a blank action map.
-You can simply delete the "Godot action set" entry at the top by pressing the trash can icon.
+You can delete the "Godot action set" entry at the top by pressing the trash can icon.
 This will clear out all actions.
 You might also want to remove the controllers that you do not wish to setup, more on this later.
 
@@ -257,7 +257,7 @@ Profiles
 --------
 
 In OpenXR controller bindings are captured in so-called "Interaction Profiles".
-We've simply shortened it to "Profiles" because it takes up less space.
+We've shortened it to "Profiles" because it takes up less space.
 
 This generic name is chosen because controllers don't cover the entire system.
 Currently there are also profiles for trackers, remotes and tracked pens.


### PR DESCRIPTION
Do we still believe in banning [these words](https://docs.godotengine.org/en/stable/contributing/documentation/docs_writing_guidelines.html#ban-these-8-words)? If so, these are the usages of "simply" that I could find that are unambiguously in the spirit of the rule. They are cases where "simply" is an empty adverb, or where it trivializes the difficulty of learning something new. This includes most cases where the reader is instructed to "simply do something" with an imperative verb.

I left unchanged many examples of "simply" where it is a valid comparison against a more complex approach, or where it really *is* simple to do something in Godot, and this is worth remarking upon. I also left unchanged instances in outdated tutorials where I'm pretty sure the whole page needs to be rewritten.

To justify the changes, I made additional improvements to changed lines where I could find them. (But translations break at the paragraph level, so maybe I should do a second pass on the changed *paragraphs* instead?)