### PR TITLE
Only show warning box if page is outdated

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -34,9 +34,8 @@
     </div>
     {% endif %}
 
-    {% if godot_show_article_status and not godot_is_latest %}
-    <div class="admonition tip article-status">
-      {% if meta and meta.get('article_outdated') == 'True' %}
+    {% if godot_show_article_status and not godot_is_latest and meta and meta.get('article_outdated') == 'True' %}
+    <div class="admonition attention article-status">
       <p class="first admonition-title">Work in progress</p>
       <p>
         The content of this page was not yet updated for Godot
@@ -44,13 +43,6 @@
         and may be <strong>outdated</strong>. If you know how to improve this page or you can confirm
         that it's up to date, feel free to <a href="https://github.com/godotengine/godot-docs">open a pull request</a>.
       </p>
-      {% else %}
-      <p class="first admonition-title">Up to date</p>
-      <p>
-        This page is <strong>up to date</strong> for Godot <code class="docutils literal notranslate">{{ godot_version }}</code>.
-        If you still find outdated information, please <a href="https://github.com/godotengine/godot-docs">open an issue</a>.
-      </p>
-      {% endif %}
     </div>
     {% endif %}
   </div>


### PR DESCRIPTION
Additionally, changes the color of the warning box from green (tip colored) to orange (warning colored), which closes https://github.com/godotengine/godot-docs/issues/7196.

Looks like this:

![msedge_tDtOjgdb0F](https://github.com/user-attachments/assets/f1cdd186-50c9-40bc-bfd2-86e3ee6b3b90)

We no longer display this admonition declaring the page up to date:
![msedge_NXFLJtqigi](https://github.com/user-attachments/assets/2d034b95-849c-4c38-87f9-a926a26288a9)

There are 46 of these outdated pages remaining.

(Originally, this PR only color-coded the boxes as the linked issue asks for.)