### PR TITLE
Rephrase dictionary description in Advanced GDScript

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_advanced.rst
+++ b/tutorials/scripting/gdscript/gdscript_advanced.rst
@@ -230,11 +230,9 @@ Or unordered sets:
 Dictionaries
 ------------
 
-Dictionaries are a powerful tool in dynamically typed languages.
-Most programmers that come from statically typed languages (such as C++
-or C#) ignore their existence and make their life unnecessarily more
-difficult. This datatype is generally not present in such languages (or
-only in limited form).
+Dictionaries are a powerful tool in dynamically typed languages. In
+GDScript, untyped dictionaries can be used for many cases where a statically
+typed language would tend to use another data structure.
 
 Dictionaries can map any value to any other value with complete
 disregard for the datatype used as either key or value. Contrary to


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot-docs/issues/8435. Avoids the incorrect claim that Dictionaries don't exist in C++/C#, and avoids unnecessary hostility and any mention of specific other languages at all.

I don't really know if this is the ideal way to rephrase this. This whole section kind of needs a rewrite anyway, since it partially duplicates [GDScript Reference / Dictionary](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_basics.html#dictionary), and also needs to at least mention typed dictionaries.