### PR TITLE
Remove default labels from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Report incorrect or outdated documentation
 title: ''
-labels: bug
+labels: ''
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -2,7 +2,7 @@
 name: Enhancement request
 about: Suggest new documentation or improving existing documentation
 title: ''
-labels: enhancement
+labels: ''
 assignees: ''
 ---
 


### PR DESCRIPTION
Why:
- Many reporters don't understand exactly what we consider a "bug" or an "enhancement" for the docs. If a user tries to do something, look for information in the docs, and can't find what they need, that sure *feels* like a bug, even if we consider missing information to be an enhancement.
- The line between the two *is* a bit fuzzy for the docs. A lot of the time, I see an issue that should probably be an enhancement rather than a bug, but it's not a big enough deal to change the label.
- Issues starting with a label makes it difficult to filter the list of issues for untriaged and unlabeled issues.
- Keeps consistency with the other Godot repos, where a new issue starts out totally unlabeled, and it is up to issue triagers to determine the appropriate labels.

Personally, when triaging docs issues I would much rather start from an empty list of labels than a potentially incorrect single label.

I'd like to hear what other frequent triagers think. CC @AThousandShips @skyace65