### PR TITLE
Add Instructions to disable swipe-to-dismiss on WearOS

### DIFF
--- a/tutorials/export/android_gradle_build.rst
+++ b/tutorials/export/android_gradle_build.rst
@@ -57,3 +57,20 @@ configuration is needed.
 
     For example, ``_example/image.png`` will **not** be included as an asset,
     but ``_image.png`` will.
+
+Disable Swipe-to-Dismiss on Wear OS
+-----------------------------------
+
+To disable swipe-to-dismiss functionality on Wear OS devices, follow these steps:
+
+1. Open the file ``res://android/build/res/values/themes.xml`` in your file editor.
+2. Add or update the ``android:windowSwipeToDismiss`` attribute to ``false`` in the `GodotAppMainTheme` style.
+
+Example:
+
+.. code-block:: xml
+
+    <style name="GodotAppMainTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar">
+        <item name="android:windowDrawsSystemBarBackgrounds">false</item>
+        <item name="android:windowSwipeToDismiss">false</item>
+    </style>


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11357

Implementing the requested feature is not feasible for the Legacy export and can only be achieved for Gradle build exports. As a result, the most practical approach is to handle this manually. This PR adds documentation with clear instructions on how to achieve this manually for Gradle builds.

> [!NOTE]
> The **Gradle build export** section seemed like the most appropriate place to incorporate this instruction. However, if you believe there’s a better location for it, please let me know! 