### PR TITLE
Tweak wording in Contributing to the class reference

### DIFF
--- a/contributing/documentation/updating_the_class_reference.rst
+++ b/contributing/documentation/updating_the_class_reference.rst
@@ -11,11 +11,12 @@ methods, properties, and global objects, available for scripting. The class refe
 is available online, from the documentation sidebar, and in the Godot editor, from
 the help menu.
 
-As the engine grows and features are added or modified, some parts of the class reference
-become obsolete and new descriptions and examples need to be added. While developers are
-encouraged to document all of their work in the class reference when submitting a pull request,
-we can't expect everyone to be able to write high quality documentation, so there is
-always work for contributors like you to polish existing and create missing reference material.
+As the engine grows and features are added or modified, some parts of the class
+reference become obsolete and new descriptions and examples need to be added.
+While developers are required to document their work in the class reference when
+submitting a pull request, we can't expect every programmer to be a good
+technical writer. There is always work for contributors like you to polish
+existing and create missing reference material.
 
 The source of the class reference
 ---------------------------------


### PR DESCRIPTION
Factual change: contributors are now *required* to write class reference documentation for changes.
Subjective change: referring to contributions as "low quality" is needlessly hostile. Though I'm not sure if saying "you're not a good technical writer" is *that* much better. It's at least less direct.
Also wrapped to 80 characters.