### PR TITLE
Fix Introduction to 2D scale hot key

### DIFF
--- a/tutorials/2d/introduction_to_2d.rst
+++ b/tutorials/2d/introduction_to_2d.rst
@@ -71,7 +71,7 @@ from left to right:
   :ref:`doc_introduction_to_2d_the_viewport` for more details.
 - **Rotate Mode** (:kbd:`E`): Enables rotation mode for the selected nodes. See 
   :ref:`doc_introduction_to_2d_the_viewport` for more details.
-- **Scale Mode** (:kbd:`R`): Enables scaling and displays scaling gizmos in both 
+- **Scale Mode** (:kbd:`S`): Enables scaling and displays scaling gizmos in both 
   axes for the selected node(s). See :ref:`doc_introduction_to_2d_the_viewport` for more details.
 - **Show list of selectable nodes at position clicked**: As the description suggests, 
   this provides a list of selectable nodes at the clicked position as a context menu, if 
@@ -91,7 +91,7 @@ from left to right:
   x and y coordinates. Dragging from a position to another one measures the distance in pixels.
   If you drag diagonally, it will draw a triangle and show the separate distances in terms 
   of x, y, and total distance to the target, including the angles to the axes in degrees.
-  The :kbd:`R` key also activates the ruler. If snapping is enabled, it also displays the 
+  The :kbd:`R` key activates the ruler. If snapping is enabled, it also displays the 
   measurements in terms of grid count:
 
 .. figure:: img/2d_ruler_with_snap.webp


### PR DESCRIPTION
Change description of the scale tool to correctly suggest the 'S' hot key instead of the 'R' hot key. This issue is likely a carry over of the 'R' hot key being used for scale in the 3D workspace.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
