### PR TITLE
Remove links to YouTube devlogs

### DIFF
--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -35,12 +35,6 @@ Text tutorials
 - `Game Dev Artisan website <https://gamedevartisan.com/>`__
 - `Night Quest Games Blog <https://www.nightquestgames.com/blog-articles/>`__
 
-Devlogs
--------
-
-- `bitbrain <https://www.youtube.com/@bitbraindev>`_
-- `DevDuck (2D) <https://www.youtube.com/@devduck/videos>`_
-
 Resources
 ---------
 


### PR DESCRIPTION
I'm not sure about this, and it needs full consensus from the docs team.

In https://github.com/godotengine/godot-docs/pull/10023, we removed a curated list of YouTube tutorials. However, we left two links to YouTube devlogs:
- https://www.youtube.com/@bitbraindev/videos
- https://www.youtube.com/@devduck/videos

I suggest removing those, since it seems a bit strange to leave an exception on the page specifically for devlogs. Was there a specific reason to do so? With devlog links we still have the same problem of needing a foundation review for new additions.

Additionally, one of the *two* currently linked devlogs includes a mix of short tutorials and devlog content. If we leave devlogs on the page, it may function as a loophole to get a specific channel linked from the official docs. (To be clear I don't mean to single out a specific creator here, but it's hard when the page only links two of them.)