### PR TITLE
Remove trailing double quote from link in GLTFState documentation

### DIFF
--- a/classes/class_gltfstate.rst
+++ b/classes/class_gltfstate.rst
@@ -32,7 +32,7 @@ Tutorials
 
 - :doc:`Runtime file loading and saving <../tutorials/io/runtime_file_loading_and_saving>`
 
-- `glTF asset header schema <https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/asset.schema.json">`__
+- `glTF asset header schema <https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/asset.schema.json>`__
 
 .. rst-class:: classref-reftable-group
 


### PR DESCRIPTION
The GLTFState class documentation links to a schema file on GitHub, but the hyperlink contains a trailing double quote, leading to a 404 page instead.

This PR fixes this typo:

- old: [https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/asset.schema.json"](https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/asset.schema.json")
- fixed: [https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/asset.schema.json](https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/asset.schema.json)