### PR TITLE
Update fedora embree package

### DIFF
--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -576,7 +576,7 @@ listed in the :ref:`doc_compiling_for_linuxbsd_oneliners`:
         ::
 
             sudo dnf install -y \
-              embree3-devel \
+              embree-devel \
               enet-devel \
               glslang-devel \
               graphite2-devel \


### PR DESCRIPTION
Fix embree package name to install for Fedora. You need embree 4 to compile Godot from source while using system libraries. Embree4 appears to be packaged as `embree-devel`. https://packages.fedoraproject.org/pkgs/embree/embree-devel/

If the previously suggested version of embree is installed, the following compile error occurs:
```
In file included from modules/raycast/lightmap_raycaster_embree.cpp:33:
modules/raycast/lightmap_raycaster_embree.h:40:10: fatal error: embree4/rtcore.h: No such file or directory
   40 | #include <embree4/rtcore.h>
      |          ^~~~~~~~~~~~~~~~~~
compilation terminated.
```