### PR TITLE
Fix layout issue in `godot_notifications.rst`

### DIFF
--- a/tutorials/best_practices/godot_notifications.rst
+++ b/tutorials/best_practices/godot_notifications.rst
@@ -224,7 +224,7 @@ values will set up according to the following sequence:
 1. **Initial value assignment:** the property is assigned its initialization value,
    or its default value if one is not specified. If a setter exists, it is not used.
 
-2. **``_init()`` assignment:** the property's value is replaced by any assignments
+2. ``_init()`` **assignment:** the property's value is replaced by any assignments
    made in ``_init()``, triggering the setter.
 
 3. **Exported value assignment:** an exported property's value is again replaced by


### PR DESCRIPTION
*Follow up to https://github.com/godotengine/godot-docs/pull/10445, which had the wrong base branch.*

There is a layout issue in `godot_notifications.rst`, due to inline code marker not working properly within bold text.

Before (at `docs.godotengine.org` and `github.com/godotengine/godot-docs` respectively):
<img width="198" alt="image" src="https://github.com/user-attachments/assets/9f97eeeb-4008-4d0c-bfc8-fa71155b5b85" />
<img width="209" alt="image" src="https://github.com/user-attachments/assets/a68422b0-469e-45da-bcd2-eb8b4134fde6" />

After (at `github.com/godotengine/godot-docs`):
<img width="192" alt="image" src="https://github.com/user-attachments/assets/d08df6ed-05b3-4cc3-978f-163412139217" />
