### PR TITLE
Update the compilation instruction for linux

### DIFF
--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -16,7 +16,7 @@ Requirements
 For compiling under Linux or other Unix variants, the following is
 required:
 
-- GCC 9+ or Clang 6+.
+- GCC 13+ or Clang 6+.
 - `Python 3.8+ <https://www.python.org/downloads/>`_.
 - `SCons 4.0+ <https://scons.org/pages/download.html>`_ build system.
 - pkg-config (used to detect the development libraries listed below).
@@ -42,6 +42,19 @@ Distro-specific one-liners
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. tabs::
+    .. tab:: All distros x84_64
+
+        ::
+            mkdir -p ~/godot-toolchain/ && cd ~/godot-toolchain/
+            
+            # Download the Godot Engine's toolchain, extract it and configure it
+            wget https://github.com/godotengine/buildroot/releases/download/godot-2023.08.x-4/x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2
+            tar xvf x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2
+            cd x86_64-godot-linux-gnu_sdk-buildroot/ && ./relocate-sdk.sh
+
+            # Build Godot
+            export PATH="~/godot-toolchain/x86_64-godot-linux-gnu_sdk-buildroot/bin:${PATH}"
+            scons platform=linuxbsd
 
     .. tab:: Alpine Linux
 

--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -16,7 +16,7 @@ Requirements
 For compiling under Linux or other Unix variants, the following is
 required:
 
-- GCC 13+ or Clang 6+.
+- GCC 9+ or Clang 6+.
 - `Python 3.8+ <https://www.python.org/downloads/>`_.
 - `SCons 4.0+ <https://scons.org/pages/download.html>`_ build system.
 - pkg-config (used to detect the development libraries listed below).
@@ -42,19 +42,6 @@ Distro-specific one-liners
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. tabs::
-    .. tab:: All distros x84_64
-
-        ::
-            mkdir -p ~/godot-toolchain/ && cd ~/godot-toolchain/
-            
-            # Download the Godot Engine's toolchain, extract it and configure it
-            wget https://github.com/godotengine/buildroot/releases/download/godot-2023.08.x-4/x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2
-            tar xvf x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2
-            cd x86_64-godot-linux-gnu_sdk-buildroot/ && ./relocate-sdk.sh
-
-            # Build Godot
-            export PATH="~/godot-toolchain/x86_64-godot-linux-gnu_sdk-buildroot/bin:${PATH}"
-            scons platform=linuxbsd
 
     .. tab:: Alpine Linux
 
@@ -625,3 +612,24 @@ running ``scons -h``, then looking for options starting with ``builtin_``.
     across Linux distributions anymore. Do not use this approach for creating
     binaries you intend to distribute to others, unless you're creating a
     package for a Linux distribution.
+
+Using Godot official toolchain for production build
+---------------------------------------------------
+
+Contains the Godot buildroot to generate toolchains for building the Godot engine in
+a portable way for Linux. Using these toolchains is the best way to distribute Linux
+builds of your custom-compiled Godot game.
+
+
+::
+
+    mkdir -p ~/godot-toolchain/ && cd ~/godot-toolchain/
+            
+    # Download the Godot Engine's toolchain, extract it and configure it
+    wget https://github.com/godotengine/buildroot/releases/download/godot-2023.08.x-4/x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2
+    tar xvf x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2
+    cd x86_64-godot-linux-gnu_sdk-buildroot/ && ./relocate-sdk.sh
+
+    # Build Godot
+    export PATH="~/godot-toolchain/x86_64-godot-linux-gnu_sdk-buildroot/bin:${PATH}"
+    scons platform=linuxbsd


### PR DESCRIPTION
Since the master branch crashes using GCC 12, I think updating the requirement to GCC 13 might be a good idea (see issue: https://github.com/godotengine/godot/issues/100768 )

Also, since there's a publicly available toolchian that's easy to install, and doesn't mess up with the user's machine, I'd rather add this as an option.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
