### PR TITLE
Clarify FlowContainer get_line_count explanation

### DIFF
--- a/classes/class_flowcontainer.rst
+++ b/classes/class_flowcontainer.rst
@@ -247,7 +247,7 @@ Method Descriptions
 
 :ref:`int<class_int>` **get_line_count**\ (\ ) |const| :ref:`🔗<class_FlowContainer_method_get_line_count>`
 
-Returns the current line count.
+Returns the number of wrapped lines. (Not the number of items in a line.)
 
 .. rst-class:: classref-section-separator
 


### PR DESCRIPTION
Make it more obvious that it's not giving you the number of items in  a line and avoid restating the name of the function as  documentation.

