### PR TITLE
Fix improper format in Code Block in `gdscript_basics.rst`

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -572,8 +572,8 @@ directly *above* a documentable item (such as a member variable), or at the top
 of a file. Dedicated formatting options are also available. See
 :ref:`doc_gdscript_documentation_comments` for details.
 
-
 ::
+
     ## This comment will appear in the script documentation.
     var value
 


### PR DESCRIPTION
This PR closes #10460.

The code block wasn't rendering because it was missing its first blank line. I also deleted an extra stray line before it for consistency.
