### PR TITLE
CI updates (master branch)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,7 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      # ReadTheDocs is staying on v1.
+      # We need to decide on when we upgrade Sphinx manually,
+      # as historically, this has been proven to often imply larger changes
+      # (RTD compat, upgrading extensions, other dependencies, our content, etc.).
       - dependency-name: "sphinx"

--- a/.github/workflows/build_offline_docs.yml
+++ b/.github/workflows/build_offline_docs.yml
@@ -18,6 +18,8 @@ jobs:
           - master
           - stable
           - 3.6
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_offline_docs.yml
+++ b/.github/workflows/build_offline_docs.yml
@@ -11,7 +11,7 @@ jobs:
     # Don't run scheduled runs on forks unless the CI_OFFLINE_DOCS_CRON variable is set to 'true'.
     # Manual runs can still be triggered as normal.
     if: ${{ github.repository_owner == 'godotengine' || github.event_name != 'schedule' || vars.CI_OFFLINE_DOCS_CRON == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         branch:

--- a/.github/workflows/build_offline_docs.yml
+++ b/.github/workflows/build_offline_docs.yml
@@ -32,7 +32,7 @@ jobs:
           sudo apt install parallel libwebp7
 
       - name: Sphinx - Build HTML
-        run: make SPHINXOPTS='--color' html
+        run: make SPHINXOPTS='--color -j 4' html
 
       - uses: actions/upload-artifact@v4
         with:
@@ -54,7 +54,7 @@ jobs:
           sed -i 's/"godot_is_latest": True/"godot_is_latest": False/' conf.py
           sed -i 's/"godot_show_article_status": True/"godot_show_article_status": False/' conf.py
 
-          make SPHINXOPTS='--color' epub
+          make SPHINXOPTS='--color -j 4' epub
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_offline_docs.yml
+++ b/.github/workflows/build_offline_docs.yml
@@ -12,6 +12,7 @@ jobs:
     # Manual runs can still be triggered as normal.
     if: ${{ github.repository_owner == 'godotengine' || github.event_name != 'schedule' || vars.CI_OFFLINE_DOCS_CRON == 'true' }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 180
     strategy:
       matrix:
         branch:

--- a/.github/workflows/build_offline_docs.yml
+++ b/.github/workflows/build_offline_docs.yml
@@ -25,11 +25,32 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
+      - name: Get Python version
+        id: pythonv
+        run: |
+          echo "PYTHON_VERSION=$(python --version)" >> $GITHUB_OUTPUT
+
+      - name: Restore cached virtualenv
+        uses: actions/cache/restore@v4
+        with:
+          key: venv-${{ runner.os }}-${{ steps.pythonv.outputs.PYTHON_VERSION }}-${{ hashFiles('requirements.txt') }}
+          path: .venv
+
       - name: Install dependencies
         run: |
-          sudo pip3 install -r requirements.txt
+          python -m venv .venv
+          source .venv/bin/activate
+          python -m pip install -r requirements.txt
+          echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
+          echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
           sudo apt update
           sudo apt install parallel libwebp7
+
+      - name: Save virtualenv cache
+        uses: actions/cache/save@v4
+        with:
+          key: venv-${{ runner.os }}-${{ steps.pythonv.outputs.PYTHON_VERSION }}-${{ hashFiles('requirements.txt') }}
+          path: .venv
 
       - name: Sphinx - Build HTML
         run: make SPHINXOPTS='--color -j 4' html

--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -18,7 +18,7 @@ jobs:
   Create-cherrypick-PR:
     # The cherrypick label is hardcoded because `contains()` doesn't seem to be able to use an environment variable as a second argument.
     if: ${{ github.event.pull_request.merged == true && contains( github.event.pull_request.labels.*.name, 'cherrypick:4.3' ) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       # "Ternary" hack featured in the official docs.
       # When using "Squash and merge", the commit hash is the last merge commit of the pull request merge branch.
@@ -29,7 +29,7 @@ jobs:
       PR_NUMBER: ${{ github.event.number }}
 
     steps:
-  
+
     - name: Checkout
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -28,8 +28,11 @@ jobs:
       COMMIT_HASH: ${{ github.event.pull_request.commits > 1 && github.sha || github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.number }}
 
-    steps:
+    permissions:
+      contents: write
+      pull-requests: write
 
+    steps:
     - name: Checkout
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -19,6 +19,7 @@ jobs:
     # The cherrypick label is hardcoded because `contains()` doesn't seem to be able to use an environment variable as a second argument.
     if: ${{ github.event.pull_request.merged == true && contains( github.event.pull_request.labels.*.name, 'cherrypick:4.3' ) }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     env:
       # "Ternary" hack featured in the official docs.
       # When using "Squash and merge", the commit hash is the last merge commit of the pull request merge branch.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
 
       # Use dummy builder to improve performance as we don't need the generated HTML in this workflow.
       - name: Sphinx build
-        run: make SPHINXOPTS='--color -W' dummy
+        run: make SPHINXOPTS='--color -j 4 -W' dummy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,33 @@ jobs:
       - name: Style checks via pre-commit
         uses: pre-commit/action@v3.0.1
 
+      - name: Get Python version
+        id: pythonv
+        run: |
+          echo "PYTHON_VERSION=$(python --version)" >> $GITHUB_OUTPUT
+
+      - name: Restore cached virtualenv
+        uses: actions/cache/restore@v4
+        with:
+          key: venv-${{ runner.os }}-${{ steps.pythonv.outputs.PYTHON_VERSION }}-${{ hashFiles('requirements.txt') }}
+          path: .venv
+
       - name: Install dependencies
-        run: sudo pip3 install -r requirements.txt
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          python -m pip install -r requirements.txt
+          echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
+          echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
+
+      - name: Save virtualenv cache
+        uses: actions/cache/save@v4
+        with:
+          key: venv-${{ runner.os }}-${{ steps.pythonv.outputs.PYTHON_VERSION }}-${{ hashFiles('requirements.txt') }}
+          path: .venv
 
       # Use dummy builder to improve performance as we don't need the generated HTML in this workflow.
       - name: Sphinx build
-        run: make SPHINXOPTS='--color -j 4 -W' dummy
+        run: |
+          source .venv/bin/activate
+          make SPHINXOPTS='--color -j 4 -W' dummy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sync_class_ref.yml
+++ b/.github/workflows/sync_class_ref.yml
@@ -3,9 +3,10 @@ name: Sync Class Reference
 on:
   workflow_dispatch:
   # Scheduled updates only run on the default/master branch.
+  # Other branches need to be run manually (usually after a new release for that branch).
   schedule:
-    # Run it at night (European time) every Saturday.
-    # The offset is there to try and avoid the high load times.
+    # Run it at (European) night time every Saturday.
+    # The offset is there to try and avoid high load times.
     - cron: '15 3 * * 6'
 
 # Make sure jobs cannot overlap.

--- a/.github/workflows/sync_class_ref.yml
+++ b/.github/workflows/sync_class_ref.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       engine_rev: 'master'
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout the documentation repository

--- a/.github/workflows/sync_class_ref.yml
+++ b/.github/workflows/sync_class_ref.yml
@@ -19,7 +19,7 @@ jobs:
     # Manual runs can still be triggered as normal.
     if: ${{ github.repository_owner == 'godotengine' || github.event_name != 'schedule' || vars.CI_SYNC_CLASS_REF_CRON == 'true' }}
     name: Update class reference files based on the engine revision
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       engine_rev: 'master'
 

--- a/.github/workflows/sync_class_ref.yml
+++ b/.github/workflows/sync_class_ref.yml
@@ -21,6 +21,7 @@ jobs:
     if: ${{ github.repository_owner == 'godotengine' || github.event_name != 'schedule' || vars.CI_SYNC_CLASS_REF_CRON == 'true' }}
     name: Update class reference files based on the engine revision
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     env:
       engine_rev: 'master'
     permissions:

--- a/.github/workflows/sync_class_ref.yml
+++ b/.github/workflows/sync_class_ref.yml
@@ -11,7 +11,7 @@ on:
 
 # Make sure jobs cannot overlap.
 concurrency:
-  group: classref-sync-ci-master
+  group: classref-sync-ci-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/conf.py
+++ b/conf.py
@@ -140,7 +140,7 @@ if not language in supported_languages.keys():
 is_i18n = tags.has("i18n")  # noqa: F821
 print("Build language: {}, i18n tag: {}".format(language, is_i18n))
 
-exclude_patterns = ["_build"]
+exclude_patterns = [".*", "**/.*", "_build", "_tools"]
 
 # fmt: off
 # These imports should *not* be moved to the start of the file,


### PR DESCRIPTION
Happy 2025! Time for some ~~spring~~ cleaning in the new year:
- Update from Ubuntu `22.04` to `24.04` (and replace all use of `ubuntu-latest` with `24.04` for consistency)
    - Update workflows to use Python `venv`s, as newer Ubuntu (and Debian) versions don't want us trashing global packages with Python packages (see [here](https://www.omgubuntu.co.uk/2023/04/pip-install-error-externally-managed-environment-fix))
      - Using virtualenvs also means we now need to exclude directories starting with `.` from Sphinx builds, to support `.venv` (this would have been a good idea anyway, for `.git`, `.vscode` and so on)
- Fix permission issues (by adding write permissions to repo contents and/or PRs where those are now needed, see [here](https://graphite.dev/guides/github-actions-permissions), originally added around 2021, now mandatory), this should hopefully fix the issues with https://github.com/godotengine/godot-docs/pull/10361)
-  (Hopefully) improve CI build times by utilizing up to 4 CPUs (which according to [docs](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners) seems now save to assume for Github action runners)
- Change all references to `github.ref` to `github.ref_name`, which should be equivalent to the old behaviour (see [here](https://github.blog/changelog/2023-09-13-github-actions-updates-to-github_ref-and-github-ref/))
- Set timeouts (by default, Github waits 6 hours before killing a hung job, whereas all our stuff should be killed with fire way earlier, most take a few minutes a most, with building the offline docs being the longest at 1-2 hours, not 6)
- Update some comments that have grown old by now