### PR TITLE
Add navigation buttons before user-contributed notes on all pages.

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -52,6 +52,16 @@
 
 {% if (not meta or meta.get('allow_comments') != 'False') and godot_show_article_comments %}
 <div id="godot-giscus">
+    {%- if (theme_prev_next_buttons_location == 'bottom' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
+      <div class="rst-footer-buttons" role="navigation">
+        {%- if prev %}
+          <a href="{{ prev.link|e }}" class="btn btn-neutral float-left" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left" aria-hidden="true"></span> {{ _('Previous') }}</a>
+        {%- endif %}
+        {%- if next %}
+          <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <span class="fa fa-arrow-circle-right" aria-hidden="true"></span></a>
+        {%- endif %}
+      </div>
+    {%- endif %}
     <hr>
         <h2>User-contributed notes</h2>
     <p>


### PR DESCRIPTION
Currently the Previous and Next navigation buttons are in the footer, using default ReadTheDocs format. 

On pages with user-contributed notes, e.g., [here]( https://docs.godotengine.org/en/stable/getting_started/first_2d_game/05.the_main_game_scene.html) , the notes can take up more than 3/4 of the page, requiring you to significantly scroll down to reach those buttons.

This PR adds an extra set of buttons before the user-contributed notes for ease of navigation. On pages without these notes, there should be no change.

Fixes: #9971
Fixes: #10468 
