### PR TITLE
Fix the "Example lobby implementation" section of the High-level multiplayer tutorial

### DIFF
--- a/tutorials/networking/high_level_multiplayer.rst
+++ b/tutorials/networking/high_level_multiplayer.rst
@@ -415,6 +415,7 @@ have loaded the game scene.
 
     func remove_multiplayer_peer():
         multiplayer.multiplayer_peer = null
+        players.clear()
 
 
     # When the server decides to start the game from a UI scene,
@@ -550,6 +551,7 @@ have loaded the game scene.
         private void RemoveMultiplayerPeer()
         {
             Multiplayer.MultiplayerPeer = null;
+            _players.Clear();
         }
 
         // When the server decides to start the game from a UI scene,


### PR DESCRIPTION
Closes #10367 

### What I Did

- Corrected both the GDScript and C# code examples in the "Example lobby implementation" section of the [Networking/High-level multiplayer](https://docs.godotengine.org/en/stable/tutorials/networking/high_level_multiplayer.html#example-lobby-implementation) tutorial.