### PR TITLE
Document only direct child nodes accounting for CollisionShape2D/3D

### DIFF
--- a/tutorials/physics/collision_shapes_2d.rst
+++ b/tutorials/physics/collision_shapes_2d.rst
@@ -14,9 +14,10 @@ accuracy tradeoffs.
 
 You can define the shape of a :ref:`class_PhysicsBody2D` by adding one or more
 :ref:`CollisionShape2Ds <class_CollisionShape2D>` or
-:ref:`CollisionPolygon2Ds <class_CollisionPolygon2D>` as child nodes.
-Note that you must add a :ref:`class_Shape2D` *resource* to collision shape
-nodes in the Inspector dock.
+:ref:`CollisionPolygon2Ds <class_CollisionPolygon2D>` as *direct* child nodes.
+Indirect child nodes (i.e. children of child nodes) will be ignored and won't be
+used as collision shapes. Also, note that you must add a :ref:`class_Shape2D`
+*resource* to collision shape nodes in the Inspector dock.
 
 .. note::
 

--- a/tutorials/physics/collision_shapes_3d.rst
+++ b/tutorials/physics/collision_shapes_3d.rst
@@ -13,9 +13,10 @@ Godot provides many kinds of collision shapes, with different performance and
 accuracy tradeoffs.
 
 You can define the shape of a :ref:`class_PhysicsBody3D` by adding one or more
-:ref:`CollisionShape3Ds <class_CollisionShape3D>` as child nodes. Note that you must
-add a :ref:`class_Shape3D` *resource* to collision shape nodes in the Inspector
-dock.
+:ref:`CollisionShape3Ds <class_CollisionShape3D>` as *direct* child nodes.
+Indirect child nodes (i.e. children of child nodes) will be ignored and won't be
+used as collision shapes. Also, note that you must add a :ref:`class_Shape3D`
+*resource* to collision shape nodes in the Inspector dock.
 
 .. note::
 


### PR DESCRIPTION
Indirect children are currently ignored.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/44#discussioncomment-11673707.