### PR TITLE
Update random_number_generation.rst

### DIFF
--- a/tutorials/math/random_number_generation.rst
+++ b/tutorials/math/random_number_generation.rst
@@ -179,7 +179,7 @@ and ``to``, and returns a random integer between ``from`` and ``to``:
  .. code-tab:: csharp
 
     // Prints a random integer between -10 and 10.
-    GD.Print(GD.RandiRange(-10, 10));
+    GD.Print(GD.RandRange(-10, 10));
 
 Get a random array element
 --------------------------


### PR DESCRIPTION
Fixed a typo in the C# version of randi_range().
It was noted RandiRange instead of RandRange.
Correction based on :
https://docs.godotengine.org/en/stable/classes/class_%40globalscope.html#class-globalscope-method-randi-range
