### PR TITLE
Fix a typo in class_audiostreamsynchronized.rst

### DIFF
--- a/classes/class_audiostreamsynchronized.rst
+++ b/classes/class_audiostreamsynchronized.rst
@@ -19,7 +19,7 @@ Stream that can be fitted with sub-streams, which will be played in-sync.
 Description
 -----------
 
-This is a stream that can be fitted with sub-streams, which will be played in-sync. The streams being at exactly the same time when play is pressed, and will end when the last of them ends. If one of the sub-streams loops, then playback will continue.
+This is a stream that can be fitted with sub-streams, which will be played in-sync. The streams begin at exactly the same time when play is pressed, and will end when the last of them ends. If one of the sub-streams loops, then playback will continue.
 
 .. rst-class:: classref-reftable-group
 


### PR DESCRIPTION
Fix a typo ("being" -> "begin")

Context:

>The streams begin at exactly the same time when play is pressed