### PR TITLE
Clarify why the planemesh looks odd

### DIFF
--- a/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
@@ -289,9 +289,9 @@ First, we will add an :ref:`OmniLight3D<class_OmniLight3D>` to the scene.
 .. image:: img/light.png
 
 You can see the light affecting the terrain, but it looks odd. The problem is
-the light is affecting the terrain as if it were a flat plane. This is because
-the light shader uses the normals from the :ref:`Mesh <class_mesh>` to calculate
-light.
+the light is affecting the terrain as if it were made of a perfectly flat
+material without irregularities. This is because the light shader uses the
+normals from the :ref:`Mesh <class_mesh>` to calculate light.
 
 The normals are stored in the Mesh, but we are changing the shape of the Mesh in
 the shader, so the normals are no longer correct. To fix this, we can


### PR DESCRIPTION
It confused me for a decent amount of time why it said the lighting looked flat, I believe this will clarify it as the mesh isn't a flat plane as currently written. It isn't mentioned anywhere either that this randomness is to make the material seem more grainy.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
