### PR TITLE
Fix `Switch` node boolean conversion description in Visual shaders

### DIFF
--- a/tutorials/shaders/visual_shaders.rst
+++ b/tutorials/shaders/visual_shaders.rst
@@ -224,7 +224,7 @@ Switch node
 ~~~~~~~~~~~
 
 The ``Switch`` node returns a vector if the boolean condition is ``true`` or
-``false``. ``Boolean`` was introduced above. If you convert a vector to a true
-boolean, all components of the vector should be above zero.
+``false``. ``Boolean`` was introduced above. If you want to convert a vector
+to a true boolean, all components of the vector should be non-zero.
 
 .. image:: img/vs_switch.webp


### PR DESCRIPTION
I believe a "true boolean vector" is a vector which evaluates to true. This occurs if any element of the vector is non-zero

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
