### PR TITLE
Clarify the impact of "Normal Map (RG Channels)" on texture imports.

### DIFF
--- a/tutorials/assets_pipeline/importing_images.rst
+++ b/tutorials/assets_pipeline/importing_images.rst
@@ -348,8 +348,10 @@ does not use the blue channel.
 A third option **Normal Map (RG Channels)** is *only* available in layered
 textures (:ref:`class_Cubemap`, :ref:`class_CubemapArray`, :ref:`class_Texture2DArray`
 and :ref:`class_Texture3D`). This forces all layers from the texture to be imported
-with the RG color format to reduce memory usage, with only the red and green
-channels preserved. This only has an effect on textures with the **VRAM Compressed**
+with the RG color format, with only the red and green
+channels preserved. :abbr:`RGTC (Red-Green Texture Compression)` compression is able to
+preserve its detail much better, while using the same amount of memory as a standard
+RGBA VRAM-compressed texture This only has an effect on textures with the **VRAM Compressed**
 or **Basis Universal** compression modes.
 
 .. _doc_importing_images_mipmaps:

--- a/tutorials/assets_pipeline/importing_images.rst
+++ b/tutorials/assets_pipeline/importing_images.rst
@@ -351,7 +351,7 @@ and :ref:`class_Texture3D`). This forces all layers from the texture to be impor
 with the RG color format, with only the red and green
 channels preserved. :abbr:`RGTC (Red-Green Texture Compression)` compression is able to
 preserve its detail much better, while using the same amount of memory as a standard
-RGBA VRAM-compressed texture This only has an effect on textures with the **VRAM Compressed**
+RGBA VRAM-compressed texture. This only has an effect on textures with the **VRAM Compressed**
 or **Basis Universal** compression modes.
 
 .. _doc_importing_images_mipmaps:


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Updating the docs to specify that the RG texture compression does not reduce memory usage, it improves quality. [Per Clay John](https://github.com/godotengine/godot/issues/101610#issuecomment-2593974739), this is a documentation issue not a code issue.

Fixes godot-engine/godot#101610