### PR TITLE
Tweaked wording for max_slides

### DIFF
--- a/classes/class_characterbody2d.rst
+++ b/classes/class_characterbody2d.rst
@@ -298,7 +298,7 @@ If ``false``, the body will slide on floor's slopes when :ref:`velocity<class_Ch
 - |void| **set_max_slides**\ (\ value\: :ref:`int<class_int>`\ )
 - :ref:`int<class_int>` **get_max_slides**\ (\ )
 
-Maximum number of times the body can change direction before it stops when calling :ref:`move_and_slide<class_CharacterBody2D_method_move_and_slide>`.
+Maximum number of times the body can change direction before it stops when calling :ref:`move_and_slide<class_CharacterBody2D_method_move_and_slide>`. Must be > 0.
 
 .. rst-class:: classref-item-separator
 

--- a/classes/class_characterbody3d.rst
+++ b/classes/class_characterbody3d.rst
@@ -302,7 +302,7 @@ If ``false``, the body will slide on floor's slopes when :ref:`velocity<class_Ch
 - |void| **set_max_slides**\ (\ value\: :ref:`int<class_int>`\ )
 - :ref:`int<class_int>` **get_max_slides**\ (\ )
 
-Maximum number of times the body can change direction before it stops when calling :ref:`move_and_slide<class_CharacterBody3D_method_move_and_slide>`.
+Maximum number of times the body can change direction before it stops when calling :ref:`move_and_slide<class_CharacterBody3D_method_move_and_slide>`. Must be > 0.
 
 .. rst-class:: classref-item-separator
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Accept or reject, IDC, I wasted 3 hours trying to figure out why it was sliding twice instead of once. Consider this PR my therapy. Hopefully it helps others.