### PR TITLE
Document automatic ICO generation in Changing application icon for Windows

### DIFF
--- a/tutorials/export/changing_application_icon_for_windows.rst
+++ b/tutorials/export/changing_application_icon_for_windows.rst
@@ -7,10 +7,25 @@ By default, the exported project's icon will be the Godot icon.
 You will most likely want to change that for your project. There are two types
 of icons that can be changed on Windows: the file icon and the taskbar icon.
 
-Creating an ICO file
---------------------
+Creating a custom ICO file
+--------------------------
 
-Windows does not use formats such as png or jpg for application icons. Instead,
+.. note::
+
+    Since Godot 4.1, Godot can create an ICO file for you based on the icon file
+    defined in the Windows export preset. This icon file can be in PNG, WebP or
+    SVG format. If no icon is defined in the Windows export preset, the
+    :ref:`application/config/icon <class_ProjectSettings_property_application/config/icon>`
+    project setting is used automatically instead.
+
+    This means you no longer need to follow the steps in this section to
+    manually create an ICO file, unless you wish to have control over the icon
+    design depending on its displayed size. Note that even if Godot creates the
+    ICO file for you, you still need to
+    :ref:`set up rcedit <doc_changing_application_icon_for_windows_changing_the_file_icon>`
+    so that the file icon actually changes.
+
+Windows does not use formats such as PNG or JPEG for application icons. Instead,
 it uses a Windows-only format called ICO. You can create your application icon
 in any program but you will have to convert it to an ICO file using a program such
 as GIMP.
@@ -59,6 +74,8 @@ This setting only changes the icon for your exported game on Windows.
 To set the icon for macOS, use ``Macos Native Icon``. And for any other platform,
 use the ``Icon`` setting.
 
+.. _doc_changing_application_icon_for_windows_changing_the_file_icon:
+
 Changing the file icon
 ----------------------
 
@@ -66,13 +83,6 @@ In Godot 3.5 and later, you can change the file icon without
 external tools using `godoticon <https://github.com/pkowal1982/godoticon>`__.
 Changing the file icon this way should work for executables containing
 an embedded PCK.
-
-.. warning::
-
-    There are `known issues <https://github.com/godotengine/godot/issues/33466>`__
-    when changing the application icon in executables that embed a PCK file.
-    It's recommended to avoid using rcedit for now if you choose to enable the
-    **Embed Pck** option for your Windows export preset in the Export dialog.
 
 The file icon is the icon of the executable that you click on to start
 the project.
@@ -94,8 +104,8 @@ Navigate to and select the rcedit executable.
     Linux and macOS users will also need to install
     `WINE <https://www.winehq.org/>`_ to use rcedit.
 
-    On macOS 10.15 (Catalina) or later, make sure to use a 64-bit version of
-    both WINE and rcedit since 32-bit applications aren't supported anymore.
+    On macOS, make sure to use a 64-bit version of both WINE and rcedit since
+    32-bit applications aren't supported anymore.
 
 .. image:: img/icon_rcedit.webp
 


### PR DESCRIPTION
- Remove outdated notice about known issue.
- Remove mention of macOS Catalina (and replace it with just macOS), as it's now the lowest supported version to run Godot on (with the Compatibility rendering method only).

___

- This closes https://github.com/godotengine/godot-docs/issues/10518.