### PR TITLE
Document `var x = await signal` returns signal arguments.

### DIFF
--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -543,6 +543,13 @@ To emit values along with the signal, add them as extra arguments to the
         EmitSignal(SignalName.HealthChanged, oldHealth, _health);
     }
 
+Awaiting signals
+-------
+
+The ``await`` keyword can be used to wait until a signal is emitted. If the signal emits one argument it will be returned by ``await``. If the signal emits multiple arguments ``await`` will return an :ref:`Array<class_Array>` containing the arguments in order.
+
+See :ref:`Awaiting signals or coroutines<doc_gdscript_awaiting_signals_or_coroutines>`.
+
 Summary
 -------
 

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -2471,6 +2471,7 @@ Our ``BattleLog`` node receives each element in the binds array as an extra argu
         var damage = old_value - new_value
         label.text += character_name + " took " + str(damage) + " damage."
 
+.. _doc_gdscript_awaiting_signals_or_coroutines:
 
 Awaiting signals or coroutines
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2490,11 +2491,11 @@ For example, to stop execution until the user presses a button, you can do somet
 
 If the signal emits a **single** argument, ``await`` returns a value with the same type as the argument::
 
-    signal user_accepted(accepted_analytics: bool)
+    signal user_accepted(accepted_analytics)
 
     func wait_confirmation():
         print("Prompting user")
-        var analytics: bool = await user_accepted
+        var analytics = await user_accepted
         print("User confirmed")
         if analytics:
             print("User accepted analytics")
@@ -2502,11 +2503,11 @@ If the signal emits a **single** argument, ``await`` returns a value with the sa
 
 However, if the signal emits **multiple** arguments, ``await`` returns an ``Array[Variant]`` containing the signal arguments in order::
 
-    signal user_accepted(accepted_analytics: bool, accepted_crash_report_upload: bool)
+    signal user_accepted(accepted_analytics, accepted_crash_report_upload)
 
     func wait_confirmation():
         print("Prompting user")
-        var result: Array[Variant] = await user_accepted
+        var result = await user_accepted
         print("User confirmed")
         if result[0]:
             print("User accepted analytics")

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -2488,7 +2488,33 @@ For example, to stop execution until the user presses a button, you can do somet
         print("User confirmed")
         return true
 
-In this case, the ``wait_confirmation`` becomes a coroutine, which means that the caller also needs to await it::
+If the signal emits a **single** argument, ``await`` returns a value with the same type as the argument::
+
+    signal user_accepted(accepted_analytics: bool)
+
+    func wait_confirmation():
+        print("Prompting user")
+        var analytics: bool = await user_accepted
+        print("User confirmed")
+        if analytics:
+            print("User accepted analytics")
+        return true
+
+However, if the signal emits **multiple** arguments, ``await`` returns an ``Array[Variant]`` containing the signal arguments in order::
+
+    signal user_accepted(accepted_analytics: bool, accepted_crash_report_upload: bool)
+
+    func wait_confirmation():
+        print("Prompting user")
+        var result: Array[Variant] = await user_accepted
+        print("User confirmed")
+        if result[0]:
+            print("User accepted analytics")
+        if result[1]:
+            print("User accepted crash report upload")
+        return true
+
+When you use ``await`` inside ``wait_confirmation``, the function becomes a coroutine, which means that the caller also needs to await it::
 
     func request_confirmation():
         print("Will ask the user")

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -2501,7 +2501,7 @@ If the signal emits a **single** argument, ``await`` returns a value with the sa
             print("User accepted analytics")
         return true
 
-However, if the signal emits **multiple** arguments, ``await`` returns an ``Array[Variant]`` containing the signal arguments in order::
+However, if the signal emits **multiple** arguments, ``await`` returns an :ref:`Array<class_Array>` containing the signal arguments in order::
 
     signal user_accepted(accepted_analytics, accepted_crash_report_upload)
 


### PR DESCRIPTION
The `await` keyword being able to return signal arguments is not documented anywhere. There is also a special behavior, where if the signal returns more than one argument the `await` keyword returns an `Array` with the arguments in order.
 - Documented the behavior in the "GDScript Reference" page, under pre-existing section "Awaiting signals or coroutines", and added some tested usage examples.
 - Mentioned the behavior and added a reference in the "Using Signals" page, under a new section "Awaiting signals", near the end.

This PR addresses the following issue: https://github.com/godotengine/godot-docs/issues/8393