### PR TITLE
Add warning about tool scripts needing editor restart

### DIFF
--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -151,6 +151,9 @@ and open a script, and change it to this:
 Save the script and return to the editor. You should now see your object rotate.
 If you run the game, it will also rotate.
 
+.. danger::
+    You may need to restart the editor. This is a known bug found in all Godot 4 versions.
+
 .. image:: img/rotating_in_editor.gif
 
 .. note::

--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -151,7 +151,7 @@ and open a script, and change it to this:
 Save the script and return to the editor. You should now see your object rotate.
 If you run the game, it will also rotate.
 
-.. danger::
+.. warning::
     You may need to restart the editor. This is a known bug found in all Godot 4 versions.
 
 .. image:: img/rotating_in_editor.gif

--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -152,7 +152,8 @@ Save the script and return to the editor. You should now see your object rotate.
 If you run the game, it will also rotate.
 
 .. warning::
-    You may need to restart the editor. This is a known bug found in all Godot 4 versions.
+    You may need to restart the editor. This is a known bug found in all Godot 4 versions:
+    `GH-66381 <https://github.com/godotengine/godot/issues/66381>`_.
 
 .. image:: img/rotating_in_editor.gif
 


### PR DESCRIPTION
See also the related [Godot Issue](https://github.com/godotengine/godot/issues/66381#issuecomment-1512641724)

Should probably be backported.

_Docs team edit: Fixes https://github.com/godotengine/godot-docs/issues/7184_