### PR TITLE
Update note about Parallax2D being experimental

### DIFF
--- a/tutorials/2d/2d_parallax.rst
+++ b/tutorials/2d/2d_parallax.rst
@@ -10,13 +10,11 @@ Parallax is an effect used to simulate depth by having textures move at differen
 provides the :ref:`Parallax2D<class_parallax2d>` node to achieve this effect. It can still be easy to get tripped
 up though, so this page provides in-depth descriptions of some properties and how to fix some common mistakes.
 
-.. UPDATE: Experimental. When Parallax2D is no longer experimental, remove this
-.. note and remove this comment.
-
 .. note::
-    This page only covers how to use :ref:`Parallax2D<class_parallax2d>`. This node is still experimental, so the
-    implementation might change in future versions of Godot. However, it is still recommended to use over the
-    :ref:`ParallaxLayer<class_parallaxlayer>` and :ref:`ParallaxBackground<class_parallaxbackground>` nodes. 
+
+    This page covers how to use :ref:`Parallax2D<class_parallax2d>`, which is
+    recommended to use over the :ref:`ParallaxLayer<class_parallaxlayer>` and
+    :ref:`ParallaxBackground<class_parallaxbackground>` nodes.
 
 Scroll scale
 ------------


### PR DESCRIPTION
Followup to https://github.com/godotengine/godot/pull/101983, which removes the "experimental" label from the Parallax2D node.