### PR TITLE
LineEdit Node "Emoji Menu Enabled" property: If ``false``, "Emoji and…

### DIFF
--- a/classes/class_lineedit.rst
+++ b/classes/class_lineedit.rst
@@ -890,7 +890,7 @@ If ``false``, existing text cannot be modified and new text cannot be added.
 - |void| **set_emoji_menu_enabled**\ (\ value\: :ref:`bool<class_bool>`\ )
 - :ref:`bool<class_bool>` **is_emoji_menu_enabled**\ (\ )
 
-If ``false``, "Emoji and Symbols" menu is enabled.
+If ``true``, "Emoji and Symbols" menu is enabled.
 
 .. rst-class:: classref-item-separator
 


### PR DESCRIPTION
… Symbols" menu is enabled. changed to: If ``true``, "Emoji and Symbols" menu is enabled.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
