### PR TITLE
Change from blender directory to blender exec

### DIFF
--- a/tutorials/assets_pipeline/importing_3d_scenes/available_formats.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/available_formats.rst
@@ -122,7 +122,7 @@ editor (if opening a project that already contains ``.blend`` files). If you
 keep Blender installed at its default location, Godot should be able to detect
 its path automatically. If this isn't the case, configure the path to the
 Blender executable in the Editor Settings
-(**Filesystem > Import > Blender > Blender 3 Path**).
+(**Filesystem > Import > Blender > Blender Path**).
 
 If you keep ``.blend`` files within your project folder but don't want them to
 be imported by Godot, disable **Filesystem > Import > Blender > Enabled** in the

--- a/tutorials/assets_pipeline/importing_3d_scenes/available_formats.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/available_formats.rst
@@ -121,7 +121,7 @@ To use ``.blend`` import, you must install Blender before opening the Godot
 editor (if opening a project that already contains ``.blend`` files). If you
 keep Blender installed at its default location, Godot should be able to detect
 its path automatically. If this isn't the case, configure the path to the
-directory containing the Blender executable in the Editor Settings
+Blender executable in the Editor Settings
 (**Filesystem > Import > Blender > Blender 3 Path**).
 
 If you keep ``.blend`` files within your project folder but don't want them to


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
The editor is currently expecting the path to the executable rather than the directory where it is located.

Engine doc change: https://github.com/godotengine/godot/pull/102044