### PR TITLE
Fix video alignment after dependency update

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1844,3 +1844,11 @@ p + .classref-constant {
 #godot-giscus {
     margin-bottom: 1em;
 }
+
+/** Center videos embedded using the sphinxcontrib-video plugin.
+ * That plugin makes assumptions about `align-center` and `align-left` that our
+ * theme does not follow, so we set the `align-default` class instead to avoid
+ * collisions and have full control of how videos are aligned. */
+.align-default {
+    text-align: center
+}

--- a/contributing/documentation/docs_image_guidelines.rst
+++ b/contributing/documentation/docs_image_guidelines.rst
@@ -242,6 +242,7 @@ videos should be included with the following code snippet::
        :autoplay:
        :loop:
        :muted:
+       :align: default
 
 Where ``documentation_video.webp`` would be changed to the name of the video you
 created. Name your videos in a way that makes their meaning clear, possibly with

--- a/tutorials/2d/2d_parallax.rst
+++ b/tutorials/2d/2d_parallax.rst
@@ -45,6 +45,7 @@ The video below displays how these values affect scrolling while in-game:
    :autoplay:
    :loop:
    :muted:
+   :align: default
 
 Infinite repeat
 ---------------

--- a/tutorials/3d/csg_tools.rst
+++ b/tutorials/3d/csg_tools.rst
@@ -27,6 +27,7 @@ Interior environments can be created by using inverted primitives.
    :autoplay:
    :loop:
    :muted:
+   :align: default
 
 .. seealso::
 

--- a/tutorials/3d/spring_arm.rst
+++ b/tutorials/3d/spring_arm.rst
@@ -121,3 +121,4 @@ Run the game and notice that mouse movement now rotates the camera around the ch
    :autoplay:
    :loop:
    :muted:
+   :align: default


### PR DESCRIPTION
In https://github.com/godotengine/godot-docs/pull/10462 we updated our dependency on [sphinxcontrib-video](https://github.com/sphinx-contrib/video), which added the ability to specify alignment for videos in https://github.com/sphinx-contrib/video/pull/40. However, that changed the existing alignment behavior.

In the 4.3 (current stable) branch of the docs, before we bumped the dependency, videos were left-aligned:
![firefox_FENvnNFgY0](https://github.com/user-attachments/assets/fa6d0523-94c0-442b-9e96-fc8a4488f255)
In the current latest branch, after we updated the dependency, videos are now default left-aligned, but when placed immediately before a section header, appear next to the header rather than above it:
![firefox_gNWoq656FW](https://github.com/user-attachments/assets/bf65ad0e-b12f-4644-ba44-e0d180bbae0d)

I believe this is due to some assumptions made by the video plugin. When you set `:align: left` (see [here](https://sphinxcontrib-video.readthedocs.io/en/latest/quickstart.html#options)), div containing the video has the `align-left` class, and similarly for `:align: center` becoming `align-center`, etc.

The theme used by the docs for the plugin does:
```css
.align-left {
  text-align: left;
}
```
While our theme does:
```css
.rst-content .align-left {
  float: left;
  margin: 0 24px 24px 0;
}
```
Similarly, ~~our theme does not actually center when using `align-center`~~ our theme's centering using `align-center` does not work on the 100% width div used by the video plugin.

Our Sphinx theme is mostly not our own, but is based on the [Sphinx RTD theme](https://github.com/readthedocs/sphinx_rtd_theme). We could probably align our version of `align-center` and `align-left` with the assumptions made by the plugin, but that may have side effects. **We should perhaps investigate this later.**

**Rejected solution:**
Use `:align: center`. Since this doesn't use `float`, it doesn't cause a wrapping problem, and it matches the behavior of our 4.3 docs. But it is also still aligned left, while semantically it says "centered".

**Proposed solution:**
Use the `align-default`, along with some custom CSS to either left- or center-align, depending on what we think looks better. Currently this PR center-aligns. As best I can tell, this is unused in the Sphinx RTD theme so we can freely set CSS for it without worrying about side effects. 

I think it's still worth investigating later if we can use either `align-left` or `align-center` instead, but that would likely involve some CSS changes anyway to override what the default Sphinx RTD theme is doing. So it doesn't really save any technical complexity.

Here's what the options look like, with a video placed immediately before a section header. Only the first option uses custom CSS; it is what is implemented in this PR.
![msedge_xwe4eLSsAn](https://github.com/user-attachments/assets/7870c9b4-cd61-45b9-9ec0-427214bb18e1)

(BTW, thanks @markdibarry for catching this while we're still in beta!)