### PR TITLE
Add a command snippet to build only modified documentation

### DIFF
--- a/contributing/documentation/building_the_manual.rst
+++ b/contributing/documentation/building_the_manual.rst
@@ -176,7 +176,7 @@ You can specify a list of files to build, which can greatly speed up compilation
     make html FILELIST='classes/class_node.rst classes/class_resource.rst'
 
 The list of files can also be provided by the ``git`` command.
-This way you can automatically get names of all files that were changed since
+This way you can automatically get the names of all files that have changed since
 the last commit (``sed`` is used to put them on the same line).
 
 .. code:: sh

--- a/contributing/documentation/building_the_manual.rst
+++ b/contributing/documentation/building_the_manual.rst
@@ -162,8 +162,33 @@ RAM for Sphinx alone.
 Specifying a list of files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. warning::
+
+    This section will not work on Windows, since the repository is using
+    a simplified ``make.bat`` script instead of the real GNU Make program.
+    If you would like to get a Linux terminal on your system, consider using
+    `Windows Subsystem for Linux (WSL) <https://learn.microsoft.com/en-us/windows/wsl/>`__.
+
 You can specify a list of files to build, which can greatly speed up compilation:
 
 .. code:: sh
 
     make html FILELIST='classes/class_node.rst classes/class_resource.rst'
+
+The list of files can also be provided by the ``git`` command.
+This way you can automatically get names of all files that were changed since
+the last commit (``sed`` is used to put them on the same line).
+
+.. code:: sh
+
+    make html FILELIST="$(git diff HEAD --name-only | sed -z 's/\n/ /g')"
+
+You can replace ``HEAD`` with ``master`` to return all files changed from the
+``master`` branch:
+
+.. code:: sh
+
+    make html FILELIST="$(git diff master --name-only | sed -z 's/\n/ /g')"
+
+If any images were modified, the output will contain some warnings about them,
+but the build will proceed correctly.


### PR DESCRIPTION
I imagine the main reason to use `FILELIST` is to only rebuild the files that are being worked on.

I don't usually work in ~~PowerShell~~ Windows but if you require a ~~PS~~ Windows version to accept the contribution, I can try to make it work.

There are some more nice ways to use it like `git diff --staged` or `git diff master` but I thought it would be too much here. But let me know if you'd actually like it included, I imagine it could help reviewers.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
