### PR TITLE
Add more Python-related files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,14 +3,28 @@
 .env
 
 _build/
-env/
-__pycache__
-*.pyc
 *~
 .directory
 .vs/
 .vscode/
 *.mo
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Common environment files
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# User created Python virtual environment as described in the docs
+godot-docs-venv/
 
 # Vim temp files
 *.swo
@@ -44,9 +58,6 @@ logo.h
 # Output of list-unused-images.sh tool
 tmp-unused-images
 tmp-unused-images-history
-
-# User created Python virtual environement as described in the docs
-godot-docs-venv/
 
 # Jetbrains IDE files
 /.idea/


### PR DESCRIPTION
I tend to name all my environments `venv`, but there's also a bunch of tooling assuming that. Makes the workflow more friendly because you don't see an explosion of files in git.

Based on https://www.toptal.com/developers/gitignore/api/python which is under CC0 license, took a moment to organize the file similarly

> Yo dawg, I heard you like `venv`, so we put more `venv` in your `.gitignore` so you can ignore `venv` while you `git`

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
