### PR TITLE
scripting_player_input.rst: fix small inaccuracy about conditionals

### DIFF
--- a/getting_started/step_by_step/scripting_player_input.rst
+++ b/getting_started/step_by_step/scripting_player_input.rst
@@ -63,7 +63,8 @@ right, and ``-1`` means they want to turn left.
 
 To produce these values, we introduce conditions and the use of ``Input``. A
 condition starts with the ``if`` keyword in GDScript and ends with a colon. The
-condition is the expression between the keyword and the end of the line.
+condition is the expression between the keyword and the colon at the end of the
+line.
 
 To check if a key was pressed this frame, we call ``Input.is_action_pressed()``.
 The method takes a text string representing an input action and returns ``true``


### PR DESCRIPTION
In its original version, the text implies that the colon is part of the conditional, but that is not correct. This fixes that.