### PR TITLE
Github Action / Offline Docs Workflow: Don't cancel other offline builds if one fails

### DIFF
--- a/.github/workflows/build_offline_docs.yml
+++ b/.github/workflows/build_offline_docs.yml
@@ -13,6 +13,8 @@ jobs:
     if: ${{ github.repository_owner == 'godotengine' || github.event_name != 'schedule' || vars.CI_OFFLINE_DOCS_CRON == 'true' }}
     runs-on: ubuntu-22.04
     strategy:
+      max-parallel: 1
+      fail-fast: false
       matrix:
         branch:
           - master


### PR DESCRIPTION
The default of a Github action `matrix` is to cancel all running jobs in it if one fails (see [here](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast)).

This means that currently, with the 3.6 branch failing, we also don't get new stable/4.3 builds. This PR changes that, and also makes sure we only ever have one runner running offline docs builds at a time to not cause congestion.

Relevant to https://github.com/godotengine/godot-docs/issues/10581.