### PR TITLE
GH: Offline builds need to install imagemagick on Ubuntu 24.04+

### DIFF
--- a/.github/workflows/build_offline_docs.yml
+++ b/.github/workflows/build_offline_docs.yml
@@ -45,7 +45,7 @@ jobs:
           echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
           echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
           sudo apt update
-          sudo apt install parallel libwebp7
+          sudo apt install parallel libwebp7 imagemagick
 
       - name: Save virtualenv cache
         uses: actions/cache/save@v4


### PR DESCRIPTION
On Ubuntu 24.04 Imagemagick is no longer pre-installed, so `convert` isn't found by default, which we use when building the ePub.