### PR TITLE
Add note to use varyings to access builtins in shader pages

### DIFF
--- a/tutorials/shaders/shader_reference/canvas_item_shader.rst
+++ b/tutorials/shaders/shader_reference/canvas_item_shader.rst
@@ -45,6 +45,10 @@ Values marked as ``in`` are read-only. Values marked as ``out`` can optionally b
 not necessarily contain sensible values. Values marked as ``inout`` provide a sensible default
 value, and can optionally be written to. Samplers cannot be written to so they are not marked.
 
+Not all built-ins are available in all processing functions. To access a vertex
+built-in from the ``fragment()`` function, you can use a :ref:`varying <doc_shading_language_varyings>`.
+The same applies for accessing fragment built-ins from the ``light()`` function.
+
 Global built-ins
 ----------------
 

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -97,6 +97,10 @@ Values marked as ``in`` are read-only. Values marked as ``out`` can optionally b
 not necessarily contain sensible values. Values marked as ``inout`` provide a sensible default
 value, and can optionally be written to. Samplers cannot be written to so they are not marked.
 
+Not all built-ins are available in all processing functions. To access a vertex
+built-in from the ``fragment()`` function, you can use a :ref:`varying <doc_shading_language_varyings>`.
+The same applies for accessing fragment built-ins from the ``light()`` function.
+
 Global built-ins
 ----------------
 


### PR DESCRIPTION
Addresses https://github.com/godotengine/godot-docs/issues/10604.

In theory, the fact that shader builtins are different depending on the function is obvious and already noted in [Shading language](https://docs.godotengine.org/en/latest/tutorials/shaders/shader_reference/shading_language.html#built-in-variables). In practice, it's easy to miss that stub section and go straight to the Spatial or CanvasItem pages instead. So I think duplicating this note in two pages is appropriate.