### PR TITLE
Add clarifying text for instance docs

### DIFF
--- a/getting_started/step_by_step/instancing.rst
+++ b/getting_started/step_by_step/instancing.rst
@@ -121,7 +121,7 @@ Let's try this. Double-click ``ball.tscn`` in the FileSystem to open it.
 
 .. image:: img/instancing_ball_scene_open.webp
 
-Select the Ball node. In the Inspector on the right, click on the PhysicsMaterial
+In the Scene dock on the left, select the Ball node. Then, in the Inspector on the right, click on the PhysicsMaterial
 property to expand it.
 
 .. image:: img/instancing_physics_material_expand.webp


### PR DESCRIPTION
Added some clarifying text to help make the transition from double clicking Ball.tscn to editing the specific Ball node itself. Now it is clear to first click within the left nav before moving over to the inspector tab.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
