### PR TITLE
Revert "Fix video alignment after dependency update"

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1844,11 +1844,3 @@ p + .classref-constant {
 #godot-giscus {
     margin-bottom: 1em;
 }
-
-/** Center videos embedded using the sphinxcontrib-video plugin.
- * That plugin makes assumptions about `align-center` and `align-left` that our
- * theme does not follow, so we set the `align-default` class instead to avoid
- * collisions and have full control of how videos are aligned. */
-.align-default {
-    text-align: center
-}

--- a/contributing/documentation/docs_image_guidelines.rst
+++ b/contributing/documentation/docs_image_guidelines.rst
@@ -242,7 +242,6 @@ videos should be included with the following code snippet::
        :autoplay:
        :loop:
        :muted:
-       :align: default
 
 Where ``documentation_video.webp`` would be changed to the name of the video you
 created. Name your videos in a way that makes their meaning clear, possibly with

--- a/tutorials/2d/2d_parallax.rst
+++ b/tutorials/2d/2d_parallax.rst
@@ -54,7 +54,6 @@ The video below displays how these values affect scrolling while in-game:
    :autoplay:
    :loop:
    :muted:
-   :align: default
 
 Infinite repeat
 ---------------

--- a/tutorials/3d/csg_tools.rst
+++ b/tutorials/3d/csg_tools.rst
@@ -27,7 +27,6 @@ Interior environments can be created by using inverted primitives.
    :autoplay:
    :loop:
    :muted:
-   :align: default
 
 .. seealso::
 

--- a/tutorials/3d/spring_arm.rst
+++ b/tutorials/3d/spring_arm.rst
@@ -121,4 +121,3 @@ Run the game and notice that mouse movement now rotates the camera around the ch
    :autoplay:
    :loop:
    :muted:
-   :align: default


### PR DESCRIPTION
This reverts https://github.com/godotengine/godot-docs/pull/10566 (commit 0e878494156e26e429b22b10ca31326156891cff).

That PR changed `align-default` to centered for the whole docs, which includes tables in the class reference:
![image](https://github.com/user-attachments/assets/648618bd-e514-4acc-98f4-d2d6b18e55b4)

Reverting while we look for a different solution to the video alignment problem.