### PR TITLE
Fix video alignment after dependency update without CSS

### DIFF
--- a/contributing/documentation/docs_image_guidelines.rst
+++ b/contributing/documentation/docs_image_guidelines.rst
@@ -242,6 +242,7 @@ videos should be included with the following code snippet::
        :autoplay:
        :loop:
        :muted:
+       :align: default
 
 Where ``documentation_video.webp`` would be changed to the name of the video you
 created. Name your videos in a way that makes their meaning clear, possibly with
@@ -249,3 +250,4 @@ a prefix that makes their relationship to a documentation page explicit.
 
 The ``:autoplay:``, ``:loop:`` and ``:muted:`` flags should always be specified
 unless the video needs to play audio. In this case, do not specify *any* of these flags.
+The ``:align: default`` flag should always be specified.

--- a/tutorials/2d/2d_parallax.rst
+++ b/tutorials/2d/2d_parallax.rst
@@ -54,6 +54,7 @@ The video below displays how these values affect scrolling while in-game:
    :autoplay:
    :loop:
    :muted:
+   :align: default
 
 Infinite repeat
 ---------------

--- a/tutorials/3d/csg_tools.rst
+++ b/tutorials/3d/csg_tools.rst
@@ -27,6 +27,7 @@ Interior environments can be created by using inverted primitives.
    :autoplay:
    :loop:
    :muted:
+   :align: default
 
 .. seealso::
 

--- a/tutorials/3d/spring_arm.rst
+++ b/tutorials/3d/spring_arm.rst
@@ -121,3 +121,4 @@ Run the game and notice that mouse movement now rotates the camera around the ch
    :autoplay:
    :loop:
    :muted:
+   :align: default


### PR DESCRIPTION
Retry of https://github.com/godotengine/godot-docs/pull/10566, see that PR for details of the problem we're solving.

Tested on Firefox and Edge, checked videos and tables.

This time, use `:align: default` for each video, but don't add any custom CSS. This will align videos on the left without floating:
![Screenshot 2025-02-03 112449](https://github.com/user-attachments/assets/6df1f119-e888-4759-9069-8109f1b30599)
![image](https://github.com/user-attachments/assets/49f061c5-30a2-4cd7-bd2e-b17d0d67f32c)
Since no CSS is changed, tables still render correctly:
![Screenshot 2025-02-03 112312](https://github.com/user-attachments/assets/2e2882c3-3d35-432d-bcf4-29a8f230ae49)
![Screenshot 2025-02-03 112408](https://github.com/user-attachments/assets/a45e75c0-68c6-45a6-b385-73bdbe11fb50)

Left alignment matches the behavior of 4.3 videos. While I think center alignment looks a bit better, I don't see a clear way to do it without introducing additional tags at every video usage, and left alignment looks fine and matches existing behavior.

**Why we can't use `:align: left`, as the plugin intends:**
It left-aligns with `float` due to our Sphinx theme, see the original PR for details.

**Why we can't use `:align: center` to center, as the plugin intends:**
It left-aligns due to our Sphinx theme.

**Why we can't use `:align: default` with custom CSS just for videos, to center:**
The video plugin places the video inside a div which only has the `align-default` class, so there's no way to specify `align-default` just for the videos. We could add a class with `:class:`, see [here](https://sphinxcontrib-video.readthedocs.io/en/latest/quickstart.html#options). But after reverting the first fix, I'm not sure trying to maintain custom CSS just to center videos is worth the maintenance, and this would also require the use of an extra tag at every video instance.