### PR TITLE
Split GDExtension category

### DIFF
--- a/tutorials/scripting/gdextension/index.rst
+++ b/tutorials/scripting/gdextension/index.rst
@@ -8,7 +8,30 @@ GDExtension
    :name: toc-tutorials-gdnative
 
    what_is_gdextension
-   gdextension_cpp_example
-   gdextension_c_example
    gdextension_file
+
+C++ (godot-cpp)
+---------------
+
+This section describes how to get started with
+`godot-cpp <https://github.com/godotengine/godot-cpp>`__,
+the official C++ GDExtension bindings maintained as part of the Godot project.
+
+.. toctree::
+   :maxdepth: 1
+   :name: toc-tutorials-godot-cpp
+
+   gdextension_cpp_example
    gdextension_docs_system
+
+GDExtension Internals
+---------------------
+
+This section is aimed at people who want to make a new GDExtension from scratch.
+This is mainly people creating new language bindings.
+
+.. toctree::
+   :maxdepth: 1
+   :name: toc-tutorials-gdextension-internals
+
+   gdextension_c_example


### PR DESCRIPTION
Alternate to https://github.com/godotengine/godot-docs/pull/10617. Reference implemtation of reorganization discussed in https://github.com/godotengine/godot-docs/pull/10617#issuecomment-2635333025. Try to keep general discussion of the reorganization in that PR, not this one

The text would need to be reworded to reflect the fact that it's in a single index page and not multiple pages.

Looks like this, just like the other implementation:
![image](https://github.com/user-attachments/assets/f080f057-50f7-4b6a-8a91-6a8358c932af)

But unlike that implementation, it avoids creating extra directories, keeping everything in the base `gdextension` folder, which should avoid the need for extra redirects.