### PR TITLE
Change sidebar navigation depth from 4 to 5

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -170,6 +170,10 @@ html_theme_options = {
     "logo_only": True,
     # Collapse navigation (False makes it tree-like)
     "collapse_navigation": False,
+    # An extra level of navigation depth over the default.
+    # This allows deeply nested pages to appear in the sidebar at all,
+    # and allows headers within pages to appear in the sidebar more often.
+    'navigation_depth': 5,
     # Remove version and language picker beneath the title
     "version_selector": False,
     "language_selector": False,


### PR DESCRIPTION
In https://github.com/godotengine/godot-docs/pull/9989 and followups, we fixed pages that were unreachable from the sidebar by using fake headers within some index pages. Even with that change, the limited nesting of the sidebar requires us to perform some awkward organization to ensure that every page is reachable, and occasionally avoid semantic organization within pages and sections to avoid too deep nesting. Many pages, specificially those within the `Scripting`, `Particle systems (3D)`, and `Engine development` sections, only have *pages* appear in the sidebar, but not the sub-page headers which are useful for navigation.

I propose increasing the allowed [navigation depth](https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html#confval-navigation_depth) at the RTD theme level, *along with* our existing organization principles and use of non-semantic headers, to allow more pages to have visible subpage headers. This will also give us some breathing room for the inevitable deeper nesting that is *always* desired to better organize content (see https://github.com/godotengine/godot-docs/pull/10617, for example).

### Examples
| Before | After |
| - | - |
| ![Screenshot 2025-02-04 173808](https://github.com/user-attachments/assets/392d0675-ab84-4f32-93a0-08fe35c0c45b) | ![Screenshot 2025-02-04 173735](https://github.com/user-attachments/assets/0979254a-7ef3-4e48-83dd-5b80cf30385d) |
| ![Screenshot 2025-02-04 174010](https://github.com/user-attachments/assets/527b8e86-e1f6-41e7-9204-d9bd37bab8e5) | ![Screenshot 2025-02-04 173939](https://github.com/user-attachments/assets/b750d5bb-eb75-47dd-9d9f-5f43789f164b) |

### Downsides
#### Visually busy sidebar
While adding the subpage headers to the sidebar aids navigation for the most deeply nested pages, it does cause a busy-looking sidebar for less deeply nested pages since subheaders within a page now appear in the sidebar. In some cases this is desired, as in the `Shading language` example above. In other cases it might be unneeded visual noise.

I don't *think* that Sphinx gives us the tools to control this more finely, for example only ever showing a single *sub-page* level of nesting in the sidebar, but I'll look into it along with further testing.

#### Performance
The docs for [collapse_navigation](https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html#confval-collapse_navigation) which we also use mention:
> Setting [collapse_navigation](https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html#confval-collapse_navigation) to False and using a high value for [navigation_depth](https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html#confval-navigation_depth) on projects with many files and a deep file structure can cause long compilation times and can result in HTML files that are significantly larger in file size.

I think we may already qualify for those long compilation times and large HTML files, even with 4-deep nesting 🙂.

Basic testing:
4-deep nesting (current): 1.89 GB folder for html build.
5-deep nesting (this PR): 2.12 GB folder for html build.

I need to do some more rigorous testing on compile times and size of the build.

### See also
https://github.com/godotengine/godot-docs/issues/8535 argues *against* having subpage headers visible in the sidebar. I disagree, but it's useful context.
https://github.com/godotengine/godot-docs/issues/8792 for the unreachable pages.
https://github.com/godotengine/godot-docs/issues/5701 for the desire to have *some* TOC or navigation for long pages.