### PR TITLE
Fix C# _Process method signatures

### DIFF
--- a/tutorials/2d/2d_sprite_animation.rst
+++ b/tutorials/2d/2d_sprite_animation.rst
@@ -104,7 +104,7 @@ released.
             _animatedSprite = GetNode<AnimatedSprite2D>("AnimatedSprite2D");
         }
 
-        public override _Process(float _delta)
+        public override void _Process(double delta)
         {
             if (Input.IsActionPressed("ui_right"))
             {
@@ -252,7 +252,7 @@ released.
             _animationPlayer = GetNode<AnimationPlayer>("AnimationPlayer");
         }
 
-        public override void _Process(float _delta)
+        public override void _Process(double delta)
         {
             if (Input.IsActionPressed("ui_right"))
             {

--- a/tutorials/audio/sync_with_audio.rst
+++ b/tutorials/audio/sync_with_audio.rst
@@ -72,7 +72,7 @@ Add these two and it's possible to guess almost exactly when sound or music will
         GetNode<AudioStreamPlayer>("Player").Play();
     }
 
-    public override void _Process(float _delta)
+    public override void _Process(double delta)
     {
         double time = (Time.GetTicksUsec() - _timeBegin) / 1000000.0d;
         time = Math.Max(0.0d, time - _timeDelay);
@@ -140,7 +140,7 @@ Here is the same code as before using this approach:
         GetNode<AudioStreamPlayer>("Player").Play();
     }
 
-    public override void _Process(float _delta)
+    public override void _Process(double delta)
     {
         double time = GetNode<AudioStreamPlayer>("Player").GetPlaybackPosition() + AudioServer.GetTimeSinceLastMix();
         // Compensate for output latency.


### PR DESCRIPTION
Fixes _Process method signatures in C# code examples.

Closes #8512, and fixes additional issues found.