### PR TITLE
Update random_number_generation.rst to reference correct C# random int range method.

### DIFF
--- a/tutorials/math/random_number_generation.rst
+++ b/tutorials/math/random_number_generation.rst
@@ -179,7 +179,7 @@ and ``to``, and returns a random integer between ``from`` and ``to``:
  .. code-tab:: csharp
 
     // Prints a random integer between -10 and 10.
-    GD.Print(GD.RandiRange(-10, 10));
+    GD.Print(GD.RandRange(-10, 10));
 
 Get a random array element
 --------------------------


### PR DESCRIPTION
On Godot 4.3 GD.RandiRange() is not an available method.

master branch has the correct documentation.