### PR TITLE
GDExtension: Fix typo on `compatibility_minimum` property

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -417,7 +417,7 @@ loaded for each platform and the entry function for the module. It is called ``g
     }
 
 This file contains a ``configuration`` section that controls the entry function of the module.
-You should also set the minimum compatible Godot version with ``compatability_minimum``,
+You should also set the minimum compatible Godot version with ``compatibility_minimum``,
 which prevents older version of Godot from trying to load your extension.
 The ``reloadable`` flag enables automatic reloading of your extension by the editor every time you recompile it,
 without needing to restart the editor. This only works if you compile your extension in debug mode (default).

--- a/tutorials/scripting/gdextension/gdextension_docs_system.rst
+++ b/tutorials/scripting/gdextension/gdextension_docs_system.rst
@@ -7,7 +7,7 @@ GDExtension documentation system
 
     Adding documentation for GDExtensions is only possible for Godot 4.3 and later. The support can be integrated into your project
     regardless because the snippet will check if you use the appropriate godot-cpp version.
-    If you set the ``compatability_minimum`` to 4.2 and you load a project with the extension through a 4.2 editor, the
+    If you set the ``compatibility_minimum`` to 4.2 and you load a project with the extension through a 4.2 editor, the
     documentation page for that class will be empty. The extension itself will still work.
 
 The GDExtension documentation system works in a similar manner to the built-in engine documentation. It uses a series of


### PR DESCRIPTION
For `4.2` and `4.1` cherrypicks, there's only one of the two changes which is relevant.