### PR TITLE
Document MP3 runtime loading

### DIFF
--- a/tutorials/io/runtime_file_loading_and_saving.rst
+++ b/tutorials/io/runtime_file_loading_and_saving.rst
@@ -168,7 +168,7 @@ Example of loading an image and displaying it in a :ref:`class_TextureRect` node
 Audio/video files
 -----------------
 
-Godot supports loading Ogg Vorbis and WAV audio at runtime. Note that not *all*
+Godot supports loading Ogg Vorbis, MP3, and WAV audio at runtime. Note that not *all*
 files with an ``.ogg`` extension are Ogg Vorbis files. Some may be Ogg Theora
 videos, or contain Opus audio within an Ogg container. These files will **not**
 load correctly as audio files in Godot.
@@ -210,10 +210,6 @@ Example of loading an Ogg Theora video file in a :ref:`class_VideoStreamPlayer` 
     // VideoStreamPlayer's Autoplay property won't work if the stream is empty
     // before this property is set, so call `Play()` after setting `Stream`.
     GetNode<VideoStreamPlayer>("VideoStreamPlayer").Play();
-
-.. note::
-
-    Godot doesn't support runtime loading of MP3 files yet.
 
 .. _doc_runtime_file_loading_and_saving_3d_scenes:
 


### PR DESCRIPTION
Found out while browsing merged PRs that we added runtime loading for MP3s in this PR: https://github.com/godotengine/godot/pull/100307. Updates the documentation to reflect that