### PR TITLE
Change path to "Export Deformation Bones Only"

### DIFF
--- a/tutorials/assets_pipeline/importing_3d_scenes/available_formats.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/available_formats.rst
@@ -71,8 +71,8 @@ a Godot scene file, which is what gets used when you run/export your game.
 .. warning::
 
     If your model contains blend shapes (also known as "shape keys" and "morph
-    targets"), your glTF export setting **Export Deformation Bones Only** needs
-    to be configured to **Enabled** under the Animation export configurations.
+    targets"), your glTF export setting **Data > Armature > Export Deformation
+    Bones Only** needs to be configured to **Enabled**.
 
     Exporting non-deforming bones anyway will lead to incorrect shading.
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
Path to setting changed in recent Blender versions.

![Screenshot from 2025-02-08 22-32-04](https://github.com/user-attachments/assets/77dc6822-d8b3-41f1-b12d-ec7da7e768ba)
