### PR TITLE
Add note on pressing F6 for current scene vs. F5 for default scene

### DIFF
--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -252,7 +252,7 @@ Your complete ``sprite_2d.gd`` code should look like the following.
         }
     }
 
-Run the currrent scene by pressing :kbd:`F6` (:kbd:`Cmd + R` on macOS),
+Run the current scene by pressing :kbd:`F6` (:kbd:`Cmd + R` on macOS),
 and click the button to see the sprite start and stop.
 
 Connecting a signal via code

--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -252,12 +252,8 @@ Your complete ``sprite_2d.gd`` code should look like the following.
         }
     }
 
-Run the scene now and click the button to see the sprite start and stop.
-
-.. note:: If you try to run your scene and you don't see the button you created, you may have
-          run the default scene by pressing :kbd:`F5` (:kbd:`Cmd + B` on macOS) rather than the 
-          current scene by pressing :kbd:`F6` (:kbd:`Cmd + R` on macOS).  Make sure you have the
-          ``node_2d`` scene selected and then press :kbd:`F6` (:kbd:`Cmd + R` on macOS).
+Run the currrent scene by pressing :kbd:`F6` (:kbd:`Cmd + R` on macOS),
+and click the button to see the sprite start and stop.
 
 Connecting a signal via code
 ----------------------------

--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -254,6 +254,11 @@ Your complete ``sprite_2d.gd`` code should look like the following.
 
 Run the scene now and click the button to see the sprite start and stop.
 
+.. note:: If you try to run your scene and you don't see the button you created, you may have
+          run the default scene by pressing :kbd:`F5` (:kbd:`Cmd + B` on macOS) rather than the 
+          current scene by pressing :kbd:`F6` (:kbd:`Cmd + R` on macOS).  Make sure you have the
+          ``node_2d`` scene selected and then press :kbd:`F6` (:kbd:`Cmd + R` on macOS).
+
 Connecting a signal via code
 ----------------------------
 


### PR DESCRIPTION
Add note within the "Using Signals" tutorial to clarify usage of F5 (run default scene) vs. F6 (run current scene) #10650
Adds a note within the "Using Signals" tutorial to clarify usage of F5 (run default scene) vs. F6 (run current scene).

When following the tutorial instructions explicitly, the user will have the node_2d scene selected and be instructed to run the scene. If the user chooses to do so by pressing F5 or the Play button, the default scene will run, which does not contain the button and creates confusion.

This change will add a note immediately following those instructions to explain the difference in behavior between F5 and F6. This should ease people over a possible stumbling block without having to seek additional resources beyond the documentation.

This issue has been encountered by others as well, as seen here:
https://www.reddit.com/r/godot/comments/16regpg/godot_411_button_not_showing_up/