### PR TITLE
Update links to Q&A site to forum

### DIFF
--- a/contributing/documentation/updating_the_class_reference.rst
+++ b/contributing/documentation/updating_the_class_reference.rst
@@ -73,7 +73,7 @@ worry. Leave it for now, and list the methods you skipped when you open a pull r
 with your changes. Another writer will take care of it.
 
 You can still look at the methods' implementation in Godot's source code on GitHub.
-If you have doubts, feel free to ask on the `Q&A website <https://ask.godotengine.org/>`_
+If you have doubts, feel free to ask on the `Godot Forum <https://forum.godotengine.org/>`_
 and `Godot Contributors Chat <https://chat.godotengine.org/>`_.
 
 .. warning::

--- a/getting_started/introduction/learning_new_features.rst
+++ b/getting_started/introduction/learning_new_features.rst
@@ -85,7 +85,7 @@ help on one of the many `active
 communities <https://godotengine.org/community>`_.
 
 The best place to ask questions and find already answered ones is the
-official `Questions & Answers <https://ask.godotengine.org/>`_ site. These
+official `Godot Forum <https://forum.godotengine.org/>`_. These
 responses show up in search engine results and get saved, allowing other users
 to benefit from discussions on the platform. Once you have asked a question there,
 you can share its link on other social platforms. Before asking a question, be


### PR DESCRIPTION
As far as I can tell, it's "Godot Forum" not "Godot Forums" in official communication, according to the pinned post in the forum itself, and the link on https://godotengine.org/community/.

Suggested for cherrypicking since it's technically a broken link, but the old link does redirect.