### PR TITLE
Improve links to Step by step

### DIFF
--- a/about/introduction.rst
+++ b/about/introduction.rst
@@ -71,10 +71,10 @@ This documentation is organized into several sections:
 - **About** contains this introduction as well as
   information about the engine, its history, its licensing, authors, etc. It
   also contains the :ref:`doc_faq`.
-- **Getting Started** contains all necessary information on using the
-  engine to make games. It starts with the :ref:`Step by step
-  <toc-learn-step_by_step>` tutorial which should be the entry point for all
-  new users. **This is the best place to start if you're new!**
+- **Getting Started** contains all necessary information on using the engine to
+  make games. It starts with the :ref:`doc_getting_started_intro` section which
+  should be the entry point for all new users. **This is the best place to start
+  if you're new!**
 - The **Manual** can be read or referenced as needed,
   in any order. It contains feature-specific tutorials and documentation.
 - **Contributing** gives information related to contributing to

--- a/getting_started/first_2d_game/index.rst
+++ b/getting_started/first_2d_game/index.rst
@@ -48,7 +48,7 @@ Prerequisites
 -------------
 
 This step-by-step tutorial is intended for beginners who followed the complete
-:ref:`Getting Started <toc-learn-step_by_step>`.
+:ref:`doc_step_by_step`.
 
 If you're an experienced programmer, you can find the complete demo's source
 code here: `Dodge the Creeps source code

--- a/getting_started/step_by_step/index.rst
+++ b/getting_started/step_by_step/index.rst
@@ -1,5 +1,7 @@
 :allow_comments: False
 
+.. _doc_step_by_step:
+
 Step by step
 ============
 

--- a/tutorials/networking/http_request_class.rst
+++ b/tutorials/networking/http_request_class.rst
@@ -24,12 +24,6 @@ be loaded using
 So HTTP may be useful for your game's login system, lobby browser,
 to retrieve some information from the web or to download game assets.
 
-This tutorial assumes some familiarity with Godot and the Godot Editor.
-Refer to the :ref:`Introduction <toc-learn-introduction>` and the
-:ref:`Step by step <toc-learn-step_by_step>` tutorial, especially its
-:ref:`Nodes and Scenes <doc_nodes_and_scenes>` and
-:ref:`Creating your first script <doc_scripting_first_script>` pages if needed.
-
 HTTP requests in Godot
 ----------------------
 


### PR DESCRIPTION
This started with the mismatched title and link:
> :ref:`Getting Started <toc-learn-step_by_step>`.

But we don't really link to TOCs as best practice anymore, instead we use Sphinx labels (anchors). So I made one of those, then changed all the references to the TOC to use the anchor instead. And I noticed that `About/Introduction` tells new readers to skip part of `Getting Started` ([the original commit](https://github.com/godotengine/godot-docs/commit/cc27e12768e936c1b76eb0171837e7e9842eb2c9) is ancient and the context has changed), so I fixed that too.