### PR TITLE
Wrong function name in documentation

### DIFF
--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -298,7 +298,7 @@ Now all mobs will be in the "mobs" group.
 
 .. image:: img/scene_group_mobs.webp
 
-We can then add the following line to the ``new_game()`` function in ``Main``:
+We can then add the following line to the ``game_over()`` function in ``Main``:
 
 .. tabs::
  .. code-tab:: gdscript GDScript


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
In the [Removing old creeps](https://docs.godotengine.org/en/stable/getting_started/first_2d_game/06.heads_up_display.html#removing-old-creeps) section, the documentation states that the line to remove creeps when the game is over should be added to the `new_game()` function. However, this is incorrect, the creeps should be cleared in the game_over() function instead. This PR corrects that mistake.