### PR TITLE
Updating "Run Current Scene" usage for consistency/clarity

### DIFF
--- a/getting_started/step_by_step/nodes_and_scenes.rst
+++ b/getting_started/step_by_step/nodes_and_scenes.rst
@@ -137,8 +137,8 @@ move it to the center of the view delimited by the rectangle.
 Running the scene
 -----------------
 
-Everything's ready to run the scene! Press the Play Scene button in the
-top-right of the screen or press :kbd:`F6` (:kbd:`Cmd + R` on macOS).
+Everything's ready to run the scene! Press the **Run Current Scene** button in 
+the top-right of the screen or press :kbd:`F6` (:kbd:`Cmd + R` on macOS).
 
 .. image:: img/nodes_and_scenes_09_play_scene_button.webp
 
@@ -162,11 +162,15 @@ Close the window or press :kbd:`F8` (:kbd:`Cmd + .` on macOS) to quit the runnin
 Setting the main scene
 ----------------------
 
-To run our test scene, we used the Run Current Scene button. Another button next to it
-allows you to set and run the project's main scene. You can press :kbd:`F5`
-(:kbd:`Cmd + B` on macOS) to do so.
+To run our test scene, we used the **Run Current Scene** button. Another button 
+next to it allows you to set and run the project's **main scene**. 
+You can press :kbd:`F5` (:kbd:`Cmd + B` on macOS) to do so.
 
 .. image:: img/nodes_and_scenes_12_play_button.webp
+
+.. note:: Running the project's **main scene** is distinct from running the 
+          **current scene**. If you encounter unexpected behavior, check 
+          to ensure you are running the correct scene.
 
 A popup window appears and invites you to select the main scene.
 

--- a/getting_started/step_by_step/nodes_and_scenes.rst
+++ b/getting_started/step_by_step/nodes_and_scenes.rst
@@ -163,13 +163,13 @@ Setting the main scene
 ----------------------
 
 To run our test scene, we used the **Run Current Scene** button. Another button 
-next to it allows you to set and run the project's **main scene**. 
-You can press :kbd:`F5` (:kbd:`Cmd + B` on macOS) to do so.
+next to it, **Run Project**, allows you to set and run the project's 
+**main scene**. You can also press :kbd:`F5` (:kbd:`Cmd + B` on macOS) to do so.
 
 .. image:: img/nodes_and_scenes_12_play_button.webp
 
-.. note:: Running the project's **main scene** is distinct from running the 
-          **current scene**. If you encounter unexpected behavior, check 
+.. note:: Running the project's *main scene* is distinct from running the 
+          *current scene*. If you encounter unexpected behavior, check 
           to ensure you are running the correct scene.
 
 A popup window appears and invites you to select the main scene.


### PR DESCRIPTION
Corrects inconsistent usage of "Play Scene" to refer to "Run Current Scene" button (F6).  Also adds a note distinguishing between the two as this is the first occurrence of usage in the docs and may help address concerns discussed in #10651 