### PR TITLE
Update links to C# and GDScript sections

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -451,16 +451,16 @@ Scripting
 - Support for :ref:`cross-language scripting <doc_cross_language_scripting>`.
 - Many 2D, 3D and 4D linear algebra data types such as vectors and transforms.
 
-:ref:`GDScript: <toc-learn-scripting-gdscript>`
+:ref:`GDScript: <doc_gdscript>`
 
-- :ref:`High-level interpreted language <doc_gdscript>` with
+- :ref:`High-level interpreted language <doc_gdscript_reference>` with
   :ref:`optional static typing <doc_gdscript_static_typing>`.
 - Syntax inspired by Python. However, GDScript is **not** based on Python.
 - Syntax highlighting is provided on GitHub.
 - :ref:`Use threads <doc_using_multiple_threads>` to perform asynchronous actions
   or make use of multiple processor cores.
 
-:ref:`C#: <toc-learn-scripting-C#>`
+:ref:`C#: <doc_c_sharp>`
 
 - Packaged in a separate binary to keep file sizes and dependencies down.
 - Supports .NET 8 and higher.

--- a/getting_started/introduction/introduction_to_godot.rst
+++ b/getting_started/introduction/introduction_to_godot.rst
@@ -71,9 +71,9 @@ Programming languages
 
 Let's talk about the available programming languages.
 
-You can code your games using :ref:`GDScript <toc-learn-scripting-gdscript>`, a
+You can code your games using :ref:`GDScript <doc_gdscript>`, a
 Godot-specific and tightly integrated language with a lightweight syntax, or
-:ref:`C# <toc-learn-scripting-C#>`, which is popular in the games industry.
+:ref:`C# <doc_c_sharp>`, which is popular in the games industry.
 These are the two main scripting languages we support.
 
 With the GDExtension technology, you can also write

--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -26,9 +26,8 @@ The equivalent C# code has been included in another tab for convenience.
 .. image:: img/scripting_first_script_rotating_godot.gif
 
 .. seealso:: To learn more about GDScript, its keywords, and its syntax, head to
-             the :ref:`GDScript reference<doc_gdscript>`.
-
-.. seealso:: To learn more about C#, head to the :ref:`C# basics <doc_c_sharp>` page.
+             the :ref:`doc_gdscript` section. To learn more about C#,
+             head to the :ref:`doc_c_sharp` section.
 
 Project setup
 -------------

--- a/getting_started/step_by_step/scripting_languages.rst
+++ b/getting_started/step_by_step/scripting_languages.rst
@@ -133,7 +133,7 @@ officially supported .NET option.
     Android and iOS platform support is available as of Godot 4.2, but is
     experimental and :ref:`some limitations apply <doc_c_sharp_platforms>`.
 
-.. seealso:: To learn more about C#, head to the :ref:`C# basics <doc_c_sharp>` page.
+.. seealso:: To learn more about C#, head to the :ref:`doc_c_sharp` section.
 
 C++ via GDExtension
 ~~~~~~~~~~~~~~~~~~~

--- a/tutorials/performance/cpu_optimization.rst
+++ b/tutorials/performance/cpu_optimization.rst
@@ -170,7 +170,7 @@ code, consider moving those calculations to a faster language.
 GDScript
 ~~~~~~~~
 
-:ref:`GDScript <toc-learn-scripting-gdscript>` is designed to be easy to use and iterate,
+:ref:`GDScript <doc_gdscript>` is designed to be easy to use and iterate,
 and is ideal for making many types of games. However, in this language, ease of
 use is considered more important than performance. If you need to make heavy
 calculations, consider moving some of your project to one of the other
@@ -179,7 +179,7 @@ languages.
 C#
 ~~
 
-:ref:`C# <toc-learn-scripting-C#>` is popular and has first-class support in Godot. It
+:ref:`C# <doc_c_sharp>` is popular and has first-class support in Godot. It
 offers a good compromise between speed and ease of use. Beware of possible
 garbage collection pauses and leaks that can occur during gameplay, though. A
 common approach to workaround issues with garbage collection is to use *object

--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -1,5 +1,3 @@
-.. _doc_c_sharp:
-
 C# basics
 =========
 

--- a/tutorials/scripting/c_sharp/index.rst
+++ b/tutorials/scripting/c_sharp/index.rst
@@ -1,10 +1,13 @@
 :allow_comments: False
 
+.. _doc_c_sharp:
+
 C#/.NET
 =======
 
 C# is a high-level programming language developed by Microsoft. Godot supports
-C# as an option for a scripting language, alongside Godot's own :ref:`GDScript<toc-learn-scripting-gdscript>`.
+C# as an option for a scripting language, alongside Godot's own
+:ref:`GDScript <doc_gdscript>`.
 
 The standard Godot executable does not contain C# support out of the box. Instead,
 to enable C# support for your project you need to `download a .NET version <https://godotengine.org/download/>`_

--- a/tutorials/scripting/cross_language_scripting.rst
+++ b/tutorials/scripting/cross_language_scripting.rst
@@ -166,7 +166,8 @@ and :ref:`GodotObject.Set() <class_Object_method_set>`. The first argument is th
 
 Keep in mind that when setting a field value you should only use types the
 GDScript side knows about.
-Essentially, you want to work with built-in types as described in :ref:`doc_gdscript` or classes extending :ref:`class_Object`.
+Essentially, you want to work with built-in types as described in
+:ref:`doc_gdscript_builtin_types` or classes extending :ref:`class_Object`.
 
 Calling methods
 ---------------

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1,4 +1,4 @@
-.. _doc_gdscript:
+.. _doc_gdscript_reference:
 
 GDScript reference
 ==================

--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -817,7 +817,7 @@ first line of the script.
 
 Follow with the optional ``@icon`` then the ``class_name`` if necessary. You can turn a
 GDScript file into a global type in your project using ``class_name``. For more
-information, see :ref:`doc_gdscript`.
+information, see :ref:`doc_gdscript_basics_class_name`.
 
 Then, add the ``extends`` keyword if the class extends a built-in type.
 

--- a/tutorials/scripting/gdscript/index.rst
+++ b/tutorials/scripting/gdscript/index.rst
@@ -1,5 +1,7 @@
 :allow_comments: False
 
+.. _doc_gdscript:
+
 GDScript
 ========
 


### PR DESCRIPTION
- Change all links to `_doc` anchors instead of `toc`s. Referencing `toc`s directly really isn't idiomatic anymore, since we have intro pages with additional intro paragraphs. It usually doesn't come up since the index pages are short, but these links technically point to the middle of the page not the top.
- Move `doc_c_sharp` and `doc_gdscript` to the index pages. In most cases, when linking to the GDScript or C# language in general, it should go to the general index page, not the introductory page within a section. Making these two anchors be on the index page is also more resilient to future doc reorganization.
- Add `doc_gdscript_reference` anchor. In some cases we do want to point to the reference page specifically, though.
- Update all existing links to point to the right place, updating grammar if needed. In most cases I pointed links at the section, not the GDScript reference page. In some cases I specified a specific header in the *long* GDScript reference page which was previously unspecified.
