### PR TITLE
Add Needed Signal Connection Steps for Timers

### DIFF
--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -154,13 +154,10 @@ everything up for a new game:
 
 Now to connect the ``timeout()`` signal of each Timer node (``StartTimer``,
 ``ScoreTimer``, and ``MobTimer``) to the main script. For each of the three
-timers, select the timer within the Main node in the Scene dock, and then
-access the Node dock on the sidebar, making sure to have the Signals tab
-selected in the Node dock, then find and double-click the ``timeout`` signal
-in the list (or right-click and select "Connect..."). This will open a new
-signal connection dialog. The default settings in this dialog should be fine,
-so select 'Connect' to resolve the dialog box and create a new signal
-connection.
+timers, select the timer in the Scene dock, open the Signals tab of the Node
+dock, then double-click the ``timeout()`` signal in the list. This will open a new
+signal connection dialog. The default settings in this dialog should be fine, so
+select **Connect** to create a new signal connection.
 
 Once all three timers have this set up, you should be able to see each timer
 have a Signal connection for their respective ``timeout()`` signal, showing in

--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -152,7 +152,7 @@ everything up for a new game:
         GetNode<Timer>("StartTimer").Start();
     }
 
-Now to connect the ``timeout()`` signal of each Timer node (``StartTimer``,
+Now we'll connect the ``timeout()`` signal of each Timer node (``StartTimer``,
 ``ScoreTimer``, and ``MobTimer``) to the main script. For each of the three
 timers, select the timer in the Scene dock, open the Signals tab of the Node
 dock, then double-click the ``timeout()`` signal in the list. This will open a new

--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -163,7 +163,7 @@ so select 'Connect' to resolve the dialog box and create a new signal
 connection.
 
 Once all three timers have this set up, you should be able to see each timer
-have a Signal connection for their respective ``timeout`` signal, showing in
+have a Signal connection for their respective ``timeout()`` signal, showing in
 green, within their respective Signals tabs:
 
 - (For MobTimer): ``_on_mob_timer_timeout()``

--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -155,11 +155,12 @@ everything up for a new game:
 Now to connect the ``timeout()`` signal of each Timer node (``StartTimer``,
 ``ScoreTimer``, and ``MobTimer``) to the main script. For each of the three
 timers, select the timer within the Main node in the Scene dock, and then
-access the Node dock on the sidebar, making to have the Signals tab selected
-in the Node dock, then find and double-click the ``timeout`` signal in the
-list (or right-click and select "Connect..."). This will open a new signal
-connection dialog. The default settings in this dialog should be fine, so
-select 'Connect' to resolve the dialog box and make a new signal connection.
+access the Node dock on the sidebar, making sure to have the Signals tab
+selected in the Node dock, then find and double-click the ``timeout`` signal
+in the list (or right-click and select "Connect..."). This will open a new
+signal connection dialog. The default settings in this dialog should be fine,
+so select 'Connect' to resolve the dialog box and create a new signal
+connection.
 
 Once all three timers have this set up, you should be able to see each timer
 have a Signal connection for their respective ``timeout`` signal, showing in

--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -152,9 +152,26 @@ everything up for a new game:
         GetNode<Timer>("StartTimer").Start();
     }
 
-Now connect the ``timeout()`` signal of each of the Timer nodes (``StartTimer``,
-``ScoreTimer``, and ``MobTimer``) to the main script. ``StartTimer`` will start
-the other two timers. ``ScoreTimer`` will increment the score by 1.
+Now to connect the ``timeout()`` signal of each Timer node (``StartTimer``,
+``ScoreTimer``, and ``MobTimer``) to the main script. For each of the three
+timers, select the timer within the Main node in the Scene dock, and then
+access the Node dock on the sidebar, making to have the Signals tab selected
+in the Node dock, then find and double-click the ``timeout`` signal in the
+list (or right-click and select "Connect..."). This will open a new signal
+connection dialog. The default settings in this dialog should be fine, so
+select 'Connect' to resolve the dialog box and make a new signal connection.
+
+Once all three timers have this set up, you should be able to see each timer
+have a Signal connection for their respective ``timeout`` signal, showing in
+green, within their respective Signals tabs:
+
+- (For MobTimer): ``_on_mob_timer_timeout()``
+- (For ScoreTimer): ``_on_score_timer_timeout()``
+- (For StartTimer): ``_on_start_timer_timeout()``
+
+Now we define how each of these timers operate by adding the code below. Notice
+that ``StartTimer`` will start the other two timers, and that ``ScoreTimer``
+will increment the score by 1.
 
 .. tabs::
  .. code-tab:: gdscript GDScript


### PR DESCRIPTION
### What's New?
This PR adds a few needed signal connection steps for setting up timers, steps that are mentioned in passing but not explained in detail;  this PR adds these details.

In going through the tutorial, I found these more detailed steps were required to follow in order to correctly proceed. I tested and verified this behavior myself, and thought I would contribute to make the (already good) instructions more clear.

Some commentators also noted that these steps could/ should be added.