### PR TITLE
Remove outdated disadvantages to upgrading to Godot 4

### DIFF
--- a/tutorials/migrating/upgrading_to_godot_4.rst
+++ b/tutorials/migrating/upgrading_to_godot_4.rst
@@ -28,18 +28,9 @@ Godot 4.0, and :ref:`doc_list_of_features` for a list of all features in Godot.
 Disadvantages of upgrading
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you don't *need* any features present in Godot 4.0, you may want to stay on
+If you don't *need* any features present in Godot 4.x, you may want to stay on
 Godot 3.x for the following reasons:
 
-- `Godot 3.x is tried and true, while Godot 4 remains in its early stages. <https://godotengine.org/article/release-management-4-0-and-beyond>`__
-
-  - Godot 4.0 is expected to contain workflow and performance issues that Godot
-    3.x doesn't have. These issues will be ironed out over time in future
-    Godot 4.x releases.
-
-- Godot 4 has fewer third-party tutorials available compared to Godot 3.x.
-  If you're new to game engines, you may have a better experience using Godot 3.x
-  as a result.
 - Godot 4's baseline hardware requirements (such as memory usage) are slightly
   higher, both for the editor and exported projects. This was required for the
   implementation of some core optimizations.


### PR DESCRIPTION
- Godot 4 is no longer in "the early stages". However, we may want to add back in a bullet point about Godot 3.x/3.6's focus on stability, and that it is still a good choice *if you already have a 3.x project* that is shipped or near to shipping. I'm not sure if such projects would need us to tell them that, though 🙂 
- There are now plenty of Godot 4 tutorials.

This page and https://docs.godotengine.org/en/latest/about/release_policy.html#which-version-should-i-use-for-a-new-project do need a more extensive update, tweaking wording and recommendations. I split out these two bullet points because they seemed like clear removals.