### PR TITLE
Add i18n (internationalization) label to Bug triage guidelines

### DIFF
--- a/contributing/workflow/bug_triage_guidelines.rst
+++ b/contributing/workflow/bug_triage_guidelines.rst
@@ -127,6 +127,7 @@ describe an issue or pull request.
 -  *GUI*: relates to GUI (Control) nodes or to Nodes that compose user interfaces.
 -  *Import*: relates to the resource import system.
 -  *Input*: relates to the input system.
+-  *I18n*: relates to internationalization.
 -  *Multiplayer*: relates to multiplayer (high-level networking) systems.
 -  *Navigation*: relates to the navigation system (including A* and navmeshes).
 -  *Network*: relates to (low-level) networking.


### PR DESCRIPTION
See comments in https://github.com/godotengine/godot-proposals/issues/10993.