### PR TITLE
Document limitation of Visual Profiler on macOS in Compatibility

### DIFF
--- a/tutorials/scripting/debug/debugger_panel.rst
+++ b/tutorials/scripting/debug/debugger_panel.rst
@@ -197,6 +197,11 @@ parallel on the GPU. This generally means that disabling only one of the
 features involved won't improve performance as much as anticipated, as the other
 task still needs to be performed sequentially.
 
+.. note::
+
+    The Visual Profiler is not supported when using the Compatibility renderer
+    on macOS, due to platform limitations.
+
 Network Profiler
 ----------------
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/102634 by documenting the limitation.

I placed the note at the *end* of the section, rather near the middle where it says:
> Visual Profiler is supported when using any rendering method (Forward+, Mobile
or Compatibility), but the reported categories will vary depending on the
current rendering method as well as the enabled graphics features.

Since this limitation is such a niche combination of platform and renderer, I don't think it's worth putting in the paragraph itself. Any note immediately before or after that paragraph seems awkward and interrupts the flow of the page.