### PR TITLE
Clarify the global registration of named_classes 

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1951,6 +1951,20 @@ If you want to use ``extends`` too, you can keep both on the same line::
 
     class_name MyNode extends Node
 
+Named classes are globally registered, hence they become available in other scripts without the need to `load` or `preload` them. For example::
+
+    # In a file 'game.gd'.
+
+    # If you uncomment the next line, you will trigger a warning:
+    # The variable "Character" has the same name as a global class defined in "character.gd".
+    # var Character = load("character.gd")
+
+    var player: Character
+
+    func new_game() -> void:
+        player = Character.new()
+
+
 .. note::
 
     Godot initializes non-static variables every time you create an instance,

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1951,19 +1951,24 @@ If you want to use ``extends`` too, you can keep both on the same line::
 
     class_name MyNode extends Node
 
-Named classes are globally registered, hence they become available in other scripts without the need to `load` or `preload` them. For example::
+Named classes are globally registered, which means they become available to use
+in other scripts without the need to ``load`` or ``preload`` them:
 
-    # In a file 'game.gd'.
+.. code-block:: gdscript
 
-    # If you uncomment the next line, you will trigger a warning:
-    # The variable "Character" has the same name as a global class defined in "character.gd".
-    # var Character = load("character.gd")
+    var player
 
-    var player: Character
-
-    func new_game() -> void:
+    func _ready():
         player = Character.new()
 
+Using the name of a named class as a variable name will cause a
+:ref:`SHADOWED_GLOBAL_IDENTIFIER <class_ProjectSettings_property_debug/gdscript/warnings/shadowed_global_identifier>`
+warning. For example, using ``Character`` as a variable name will shadow the
+``Character`` class you just defined, and cause a warning:
+
+.. code-block:: gdscript
+
+    var Character
 
 .. note::
 

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1961,15 +1961,6 @@ in other scripts without the need to ``load`` or ``preload`` them:
     func _ready():
         player = Character.new()
 
-Using the name of a named class as a variable name will cause a
-:ref:`SHADOWED_GLOBAL_IDENTIFIER <class_ProjectSettings_property_debug/gdscript/warnings/shadowed_global_identifier>`
-warning. For example, using ``Character`` as a variable name will shadow the
-``Character`` class you just defined, and cause a warning:
-
-.. code-block:: gdscript
-
-    var Character
-
 .. note::
 
     Godot initializes non-static variables every time you create an instance,


### PR DESCRIPTION
Hi,

This is my first constribution to the great Godot's documentation, I hope it will be useful.

While reading the doc about gdscript classes, I found the usage of the keyword `class_name` confusing. Notably, the fact that a named class becomes available globally does not seem intuitive to me, as it's not clearly stated.

Seing that gdscript draws some inspiration from Python, as a newcomer it seems reasonable to think that any class must be imported before being used, and that was my first assumption.

Here is a clarification suggestion for the documentation. Feel free to tell me if you think it is a useful addition.