### PR TITLE
GitHub Actions: Check URLs using lychee

### DIFF
--- a/.github/workflows/check_urls.yml
+++ b/.github/workflows/check_urls.yml
@@ -1,0 +1,38 @@
+name: 🌐 Check URLs
+on:
+  push:
+  pull_request:
+  schedule:
+    # Every day at 18:00 UTC.
+    # URLs can decay over time. Setting up a schedule makes it possible to be warned
+    # about dead links as soon as possible.
+    - cron: "0 18 * * *"
+
+jobs:
+  check-urls:
+    runs-on: ubuntu-24.04
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
+      - name: Run lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >
+            --base .
+            --no-progress
+            --cache
+            --max-cache-age 1d
+            --exclude-path _templates/
+            --exclude-path classes/
+            "**/*.md" "**/*.html" "**/*.rst"
+
+      - name: Fail if there were link errors
+        run: exit ${{ steps.lc.outputs.exit_code }}

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,30 @@
+# Don't read Godot's own URL schemes as web URLs.
+user:\/\/.*
+res:\/\/.*
+uid:\/\/.*
+
+# Don't read WebSockets or TCP URLs as web URLs.
+ws(s?):\/\/.*
+tcp:\/\/.*
+
+# Security checks prevent checking the URLs of these websites automatically,
+# typically returning 403 errors.
+.*asecuritysite\.com.*
+.*intel\.com.*
+.*reddit\.com.*
+
+# Don't check URLs from these websites due to frequent rate limits (error 429) or timeouts.
+.*adobe\.com.*
+.*gamedevartisan\.com.*
+.*github\.com.*
+.*gnu\.org.*
+.*loopit\.dk.*
+.*meta\.com.*
+.*sourceforge\.io.*
+
+# Not a valid URL with the GET method, which lychee always sends.
+# Mentioned in the class reference.
+.*httpbin\.org\/post
+
+# Class reference mentions `example.com/index.php` in an example, which is 404.
+.*example\.com.*

--- a/tutorials/shaders/shader_reference/shader_functions.rst
+++ b/tutorials/shaders/shader_reference/shader_functions.rst
@@ -287,7 +287,7 @@ Trigonometric function descriptions
 
     :return:
         The angle whose trigonometric cosine is ``x``.
-        
+
     https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/acos.xhtml
 
 .. rst-class:: classref-item-separator
@@ -795,7 +795,7 @@ Exponential and math function descriptions
 
     |componentwise|
 
-    Returns the absolute value of ``x``. Returns ``x`` if ``x`` is positive, otherwise returns ``-1 * x``. 
+    Returns the absolute value of ``x``. Returns ``x`` if ``x`` is positive, otherwise returns ``-1 * x``.
 
     :param x:
         The value of which to return the absolute.
@@ -872,7 +872,7 @@ Exponential and math function descriptions
 
     .. note::
         Rounding of values with a fractional part of ``0.5`` is implementation-dependent.
-        This includes the possibility that ``round(x)`` returns the same value as 
+        This includes the possibility that ``round(x)`` returns the same value as
         ``roundEven(x)``for all values of ``x``.
 
     :param x:
@@ -2911,7 +2911,7 @@ vec4 **textureGather**\ (\ samplerCube s, vec3 p [, int comps] ) :ref:`🔗<shad
     :return:
         The partial derivative of ``p``.
 
-    https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/dFdxCoarse.xhtml
+    https://registry.khronos.org/OpenGL-Refpages/gl4/html/dFdx.xhtml
 
 .. rst-class:: classref-item-separator
 
@@ -2946,7 +2946,7 @@ vec4 **textureGather**\ (\ samplerCube s, vec3 p [, int comps] ) :ref:`🔗<shad
     :return:
         The partial derivative of ``p``.
 
-    https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/dFdxFine.xhtml
+    https://registry.khronos.org/OpenGL-Refpages/gl4/html/dFdx.xhtml
 
 .. rst-class:: classref-item-separator
 
@@ -2981,7 +2981,7 @@ vec4 **textureGather**\ (\ samplerCube s, vec3 p [, int comps] ) :ref:`🔗<shad
     :return:
         The partial derivative of ``p``.
 
-    https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/dFdy.xhtml
+    https://registry.khronos.org/OpenGL-Refpages/gl4/html/dFdx.xhtml
 
 .. rst-class:: classref-item-separator
 
@@ -3016,7 +3016,7 @@ vec4 **textureGather**\ (\ samplerCube s, vec3 p [, int comps] ) :ref:`🔗<shad
     :return:
         The partial derivative of ``p``.
 
-    https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/dFdyCoarse.xhtml
+    https://registry.khronos.org/OpenGL-Refpages/gl4/html/dFdx.xhtml
 
 .. rst-class:: classref-item-separator
 
@@ -3049,7 +3049,7 @@ vec4 **textureGather**\ (\ samplerCube s, vec3 p [, int comps] ) :ref:`🔗<shad
     :return:
         The partial derivative of ``p``.
 
-    https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/dFdyFine.xhtml
+    https://registry.khronos.org/OpenGL-Refpages/gl4/html/dFdx.xhtml
 
 .. rst-class:: classref-item-separator
 
@@ -3107,7 +3107,7 @@ vec4 **textureGather**\ (\ samplerCube s, vec3 p [, int comps] ) :ref:`🔗<shad
     :return:
         The partial derivative.
 
-    https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/fwidthCoarse.xhtml
+    https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/fwidth.xhtml
 
 .. rst-class:: classref-item-separator
 
@@ -3138,7 +3138,7 @@ vec4 **textureGather**\ (\ samplerCube s, vec3 p [, int comps] ) :ref:`🔗<shad
     :return:
         The partial derivative.
 
-    https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/fwidthFine.xhtml
+    https://registry.khronos.org/OpenGL-Refpages/gl4/html/fwidth.xhtml
 
 
 .. rst-class:: classref-section-separator
@@ -3566,7 +3566,7 @@ Bitwise function descriptions
 
     .. warning::
         The result will be undefined if:
-        
+
         - offset or bits is negative.
         - if the sum of offset and bits is greater than the number of bits used to store the operand.
 


### PR DESCRIPTION
This makes it possible to be aware of dead links and replace them with other resources (such as archived versions) as soon as possible.

Note that class reference URLs not checked within this repository, as I plan to also integrate lychee into [godotengine/godot](https://github.com/godotengine/godot)'s CI (which has the source of the class reference files).

> [!NOTE]
>
> CI will fail until we resolve https://github.com/godotengine/godot-docs/issues/10674, so that we remove the `download.tuxfamily.org` links from the docs.
