### PR TITLE
Updated GPUParticles3D typo on the 2d particle systems page

### DIFF
--- a/tutorials/2d/particle_systems_2d.rst
+++ b/tutorials/2d/particle_systems_2d.rst
@@ -34,7 +34,7 @@ node properties in CPUParticles2D (with the exception of the trail settings).
 
 Going forward there are no plans to add new features to CPUParticles2D, though
 pull requests to add features already in GPUParticles2D will be accepted. For
-that reason we recommend using GPUParticles3D unless you have an explicit reason
+that reason we recommend using GPUParticles2D unless you have an explicit reason
 not to.
 
 You can convert a CPUParticles2D node into a GPUParticles2D node by clicking on


### PR DESCRIPTION
This sentence is about preferring GPUParticles2D instead of CPUParticles2D. The mention of GPUParticles3D doesn't make sense in the context of the sentence or the page. As such I assumed this to be a typo and am submitting a fix to it.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
