### PR TITLE
Remove unneeded dependencies from Fedora installation in Compiling for Linux/*BSD

### DIFF
--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -109,20 +109,9 @@ Distro-specific one-liners
             sudo dnf install -y \
               scons \
               pkgconfig \
-              libX11-devel \
-              libXcursor-devel \
-              libXrandr-devel \
-              libXinerama-devel \
-              libXi-devel \
-              wayland-devel \
-              mesa-libGL-devel \
-              mesa-libGLU-devel \
-              alsa-lib-devel \
-              pulseaudio-libs-devel \
-              libudev-devel \
               gcc-c++ \
               libstdc++-static \
-              libatomic-static
+              wayland-devel
 
     .. tab:: FreeBSD
 


### PR DESCRIPTION
Only a few packages are actually needed, as most libraries used by Godot are either embedded or `dlopen()`'d at runtime.
The new list matches what's present in https://github.com/godotengine/godot/pull/43377.

- See https://github.com/godotengine/godot/pull/43377#issuecomment-2126354623.
