### PR TITLE
Add missing InputEvent.is_echo()

### DIFF
--- a/tutorials/inputs/inputevent.rst
+++ b/tutorials/inputs/inputevent.rst
@@ -217,7 +217,7 @@ Actions can be created from the Project Settings menu in the **Input Map**
 tab and assigned input events.
 
 Any event has the methods :ref:`InputEvent.is_action() <class_InputEvent_method_is_action>`,
-:ref:`InputEvent.is_pressed() <class_InputEvent_method_is_pressed>` and :ref:`InputEvent <class_InputEvent>`.
+:ref:`InputEvent.is_pressed() <class_InputEvent_method_is_pressed>` and :ref:`InputEvent.is_echo() <class_InputEvent_method_is_echo>`.
 
 Alternatively, it may be desired to supply the game back with an action
 from the game code (a good example of this is detecting gestures).


### PR DESCRIPTION
Seems that it was accidentally removed in https://github.com/godotengine/godot-docs/commit/4b8ffe360034dfb70be988cf6b3188f55139e2a9

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
