### PR TITLE
Switch terms *error* and *warning* in output panel debug docs.

### DIFF
--- a/tutorials/scripting/debug/output_panel.rst
+++ b/tutorials/scripting/debug/output_panel.rst
@@ -23,9 +23,9 @@ Four message categories are available:
 
 - **Log:** Standard messages printed by the project. Displayed in white or black
   (depending on the editor theme).
-- **Error:** Messages printed by the project or editor that report important
+- **Warning:** Messages printed by the project or editor that report important
   information, but do not indicate a failure. Displayed in yellow.
-- **Warning:** Messages printed by the project or editor that indicate a failure
+- **Error:** Messages printed by the project or editor that indicate a failure
   of some kind. Displayed in red.
 - **Editor:** Messages printed by the editor, typically intended to be traces of
   undo/redo actions. Displayed in gray.


### PR DESCRIPTION
In the output panel docs, *Error* and *Warning* were incorrectly given each-other's descriptions. This change switches the sub-titles for each section.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
