### PR TITLE
2D game: Use global position for mob spawn location

### DIFF
--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -218,7 +218,7 @@ Note that a new instance must be added to the scene using ``add_child()``.
         mob_spawn_location.progress_ratio = randf()
 
         # Set the mob's position to the random location.
-        mob.position = mob_spawn_location.position
+        mob.position = mob_spawn_location.global_position
 
         # Set the mob's direction perpendicular to the path direction.
         var direction = mob_spawn_location.rotation + PI / 2


### PR DESCRIPTION
Fixes #6372 by correcting the spawn location of creeps, accounting for the MobPath's position in the main scene.

Without this change, creeps spawn from an offset position around the origin 0,0, resulting in creeps appearing in the middle of the screen when they spawn from the right edge, killing the player without a chance for them to dodge.

Using global_position ensures creeps spawn on actual screen edges using the world position of the MobSpawnLocation instead of its relative position to its parent MobPath.

Docs page:
https://docs.godotengine.org/en/stable/getting_started/first_2d_game/05.the_main_game_scene.html

| Before (.position) | After (.global_position)
| - | - |
| ![Using position](https://github.com/user-attachments/assets/3c0eea70-41d5-4b04-a127-efa5c76c6acf) | ![Using global_position](https://github.com/user-attachments/assets/06f3d37b-f654-4590-8f1c-afbf4390be46) |


![CleanShot 2025-02-17 at 19 21 00@2x](https://github.com/user-attachments/assets/941552ea-cc64-49d3-8e8b-6d82a1a24715)

![CleanShot 2025-02-17 at 19 21 18@2x](https://github.com/user-attachments/assets/f3ae6343-6c62-4e57-8427-1b99bc3a4d04)
