### PR TITLE
2D game: Help people create MobPath as a child of Main

### DIFF
--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -38,9 +38,9 @@ Spawning mobs
 -------------
 
 The Main node will be spawning new mobs, and we want them to appear at a random
-location on the edge of the screen. Add a :ref:`Path2D <class_Path2D>` node
-named ``MobPath`` as a child of ``Main``. When you select ``Path2D``, you will
-see some new buttons at the top of the editor:
+location on the edge of the screen. Click the ``Main`` node in the Scene dock, then
+add a child :ref:`Path2D <class_Path2D>` node named ``MobPath``. When you select
+``Path2D``, you will see some new buttons at the top of the editor:
 
 .. image:: img/path2d_buttons.webp
 


### PR DESCRIPTION
Better steer people to create MobPath as a child of Main, so that they don't accidentally create it as a child of StartPosition (the previously selected item), which has a transform.

If they happen to re-parent to Main after creating the Path2D as a child of StartPosition, they end up with a transform on the Path2D, which breaks the expected spawn point of mobs.

Docs page: https://docs.godotengine.org/en/stable/getting_started/first_2d_game/05.the_main_game_scene.html

For context: https://github.com/godotengine/godot-docs/pull/10698#issuecomment-2664002759

Past evidence of people who have stumbled on this step:
- https://github.com/godotengine/godot-docs/pull/10698
- https://github.com/godotengine/godot-docs/issues/6372
- https://github.com/godotengine/godot-docs/pull/8700
- [Reddit thread](https://www.reddit.com/r/godot/comments/80z47c/path_placing_creeps_in_center_of_scene/)

I think it's not uncommon to see this because:

- Users are still learning that the selected node in the scene tree becomes the parent of new nodes.
- Users are yet to learn that changing a node's parent can make its position non-zero if the original parent had a non-zero position.

Closes #6372, closes #10698.