### PR TITLE
Clarify local normal is returned in global coordinate space for physicsdirectbodystate2d/3d

### DIFF
--- a/classes/class_physicsdirectbodystate2d.rst
+++ b/classes/class_physicsdirectbodystate2d.rst
@@ -604,7 +604,7 @@ Returns the impulse created by the contact.
 
 :ref:`Vector2<class_Vector2>` **get_contact_local_normal**\ (\ contact_idx\: :ref:`int<class_int>`\ ) |const| :ref:`🔗<class_PhysicsDirectBodyState2D_method_get_contact_local_normal>`
 
-Returns the local normal at the contact point.
+Returns the local normal in the global coordinate system at the contact point.
 
 .. rst-class:: classref-item-separator
 

--- a/classes/class_physicsdirectbodystate3d.rst
+++ b/classes/class_physicsdirectbodystate3d.rst
@@ -642,7 +642,7 @@ Impulse created by the contact.
 
 :ref:`Vector3<class_Vector3>` **get_contact_local_normal**\ (\ contact_idx\: :ref:`int<class_int>`\ ) |const| :ref:`🔗<class_PhysicsDirectBodyState3D_method_get_contact_local_normal>`
 
-Returns the local normal at the contact point.
+Returns the local normal in the global coordinate system at the contact point.
 
 .. rst-class:: classref-item-separator
 


### PR DESCRIPTION
Fixes [#10678](https://github.com/godotengine/godot-docs/issues/10678).

Originally did not specify the coordinate space that the normal was returned in, which could lead to confusion as the function returns the local normal.