### PR TITLE
Godot 3.6 is compitable with OpenJDK 8

### DIFF
--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -13,10 +13,10 @@ Exporting for Android
 Exporting for Android has fewer requirements than compiling Godot for Android.
 The following steps detail what is needed to set up the Android SDK and the engine.
 
-Install OpenJDK 17
+Install OpenJDK 8
 ------------------
 
-Download and install  `OpenJDK 17 <https://adoptium.net/?variant=openjdk17>`__.
+Download and install  `OpenJDK 8 <https://adoptium.net/?variant=openjdk8>`__.
 
 Download the Android SDK
 ------------------------


### PR DESCRIPTION
Android export using Godot 3.6 supports Java OpenJDK 8, not Java OpenJDK 17 which is supported in the 4. versions only

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
