### PR TITLE
Remove unmaintained gdextension in what_is_gdextension.rst

### DIFF
--- a/tutorials/scripting/gdextension/what_is_gdextension.rst
+++ b/tutorials/scripting/gdextension/what_is_gdextension.rst
@@ -97,7 +97,6 @@ The bindings below are developed and maintained by the community:
 
 - `D <https://github.com/godot-dlang/godot-dlang>`__
 - `Go <https://github.com/grow-graphics/gd>`__
-- `Haxe <https://hxgodot.github.io/>`__
 - `Rust <https://github.com/godot-rust/gdext>`__
 - `Swift <https://github.com/migueldeicaza/SwiftGodot>`__
 


### PR DESCRIPTION
removing haxe from list of supported languages because the hxgodot project is no longer maintained and the link is dead. The [hxgodot git](https://github.com/HxGodot/hxgodot) says that the project is over.
