### PR TITLE
Add Odin binding to community GDExtension binding list

### DIFF
--- a/tutorials/scripting/gdextension/what_is_gdextension.rst
+++ b/tutorials/scripting/gdextension/what_is_gdextension.rst
@@ -93,6 +93,7 @@ The bindings below are developed and maintained by the community:
 - `Nim <https://github.com/godot-nim/gdext-nim>`__
 - `Rust <https://github.com/godot-rust/gdext>`__
 - `Swift <https://github.com/migueldeicaza/SwiftGodot>`__
+- `Odin <https://github.com/dresswithpockets/odin-godot>`__
 
 .. note::
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Adds a link to the odin-godot GDExtension binding to the community-maintained binding list. 