### PR TITLE
Remove mention of Handbrake from playing_videos.rst

### DIFF
--- a/tutorials/animation/playing_videos.rst
+++ b/tutorials/animation/playing_videos.rst
@@ -182,7 +182,7 @@ you should use a lossless or uncompressed format as an intermediate format to
 maximize the quality of the output Ogg Theora video, but this can require a lot
 of disk space.
 
-`FFmpeg <https://ffmpeg.org/>`__ (CLI) is popular open source tools
+`FFmpeg <https://ffmpeg.org/>`__ (CLI) is a popular open source tool
 for this purpose. FFmpeg has a steep learning curve, but it's powerful tool.
 
 Here are example FFmpeg commands to convert an MP4 video to Ogg Theora. Since

--- a/tutorials/animation/playing_videos.rst
+++ b/tutorials/animation/playing_videos.rst
@@ -182,9 +182,8 @@ you should use a lossless or uncompressed format as an intermediate format to
 maximize the quality of the output Ogg Theora video, but this can require a lot
 of disk space.
 
-`HandBrake <https://handbrake.fr/>`__
-(GUI) and `FFmpeg <https://ffmpeg.org/>`__ (CLI) are popular open source tools
-for this purpose. FFmpeg has a steeper learning curve, but it's more powerful.
+`FFmpeg <https://ffmpeg.org/>`__ (CLI) is popular open source tools
+for this purpose. FFmpeg has a steep learning curve, but it's powerful tool.
 
 Here are example FFmpeg commands to convert an MP4 video to Ogg Theora. Since
 FFmpeg supports a lot of input formats, you should be able to use the commands


### PR DESCRIPTION
Handbrake removed support for OGG in 2009(!) so it is not valid recommendation of tool for the job. Downloaded Handbrake and confirmed it can't export Ogg Theora

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
