### PR TITLE
Update release policy for 4.4 release

### DIFF
--- a/about/release_policy.rst
+++ b/about/release_policy.rst
@@ -84,17 +84,18 @@ on GitHub.
 +--------------+----------------------+--------------------------------------------------------------------------+
 | **Version**  | **Release date**     | **Support level**                                                        |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 4.4    | Q1 2025 (estimate)   | |unstable| *Development.* Receives new features, usability and           |
+| Godot 4.5    | Q3 2025 (estimate)   | |unstable| *Development.* Receives new features, usability and           |
 | (`master`)   |                      | performance improvements, as well as bug fixes, while under development. |
++--------------+----------------------+--------------------------------------------------------------------------+
+| Godot 4.4    | March 2025           | |supported| Receives fixes for bugs and security issues, as well as      |
+|              |                      | patches that enable platform support.                                    |
 +--------------+----------------------+--------------------------------------------------------------------------+
 | Godot 4.3    | August 2024          | |supported| Receives fixes for bugs and security issues, as well as      |
 |              |                      | patches that enable platform support.                                    |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 4.2    | November 2023        | |supported| Receives fixes for bugs and security issues, as well as      |
-|              |                      | patches that enable platform support.                                    |
+| Godot 4.2    | November 2023        | |partial| Receives fixes for security and platform support issues only.  |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 4.1    | July 2023            | |supported| Receives fixes for bugs and security issues, as well as      |
-|              |                      | patches that enable platform support.                                    |
+| Godot 4.1    | July 2023            | |eol| No longer supported (last update: 4.1.4).                          |
 +--------------+----------------------+--------------------------------------------------------------------------+
 | Godot 4.0    | March 2023           | |eol| No longer supported (last update: 4.0.4).                          |
 +--------------+----------------------+--------------------------------------------------------------------------+
@@ -104,8 +105,7 @@ on GitHub.
 | Godot 3.6    | September 2024       | |supported| Receives fixes for bugs and security issues, as well as      |
 |              |                      | patches that enable platform support.                                    |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 3.5    | August 2022          | |supported| Receives fixes for bugs and security issues, as well as      |
-|              |                      | patches that enable platform support.                                    |
+| Godot 3.5    | August 2022          | |partial| Receives fixes for security and platform support issues only.  |
 +--------------+----------------------+--------------------------------------------------------------------------+
 | Godot 3.4    | November 2021        | |eol| No longer supported (last update: 3.4.5).                          |
 +--------------+----------------------+--------------------------------------------------------------------------+


### PR DESCRIPTION
Should be cherry-picked for `4.3` at least.

For older branches, they all have even more outdated states. I would suggest we drop any dynamic content from any branch that's not `latest`/`stable`, so we don't need to constantly cherry-pick this.