### PR TITLE
Added script to play the mob animation

### DIFF
--- a/getting_started/first_2d_game/04.creating_the_enemy.rst
+++ b/getting_started/first_2d_game/04.creating_the_enemy.rst
@@ -87,6 +87,7 @@ and randomly choose one of the three animation types:
     func _ready():
         var mob_types = Array($AnimatedSprite2D.sprite_frames.get_animation_names())
         $AnimatedSprite2D.animation = mob_types.pick_random()
+        $AnimatedSprite2D.play()
 
  .. code-tab:: csharp
 
@@ -105,6 +106,8 @@ In the GDScript code, we use the :ref:`Array.pick_random <class_Array_method_pic
 to select one of these animation names at random. Meanwhile, in the C# code, we pick a random number 
 between ``0`` and ``2`` to select one of these names from the list (array indices start at ``0``). The 
 expression ``GD.Randi() % n`` selects a random integer between ``0`` and ``n-1``.
+
+Finally, we call $AnimatedSprite2D.play() to start playing the chosen animation.
 
 The last piece is to make the mobs delete themselves when they leave the screen.
 Connect the ``screen_exited()`` signal of the ``VisibleOnScreenNotifier2D`` node

--- a/getting_started/first_2d_game/04.creating_the_enemy.rst
+++ b/getting_started/first_2d_game/04.creating_the_enemy.rst
@@ -107,7 +107,7 @@ to select one of these animation names at random. Meanwhile, in the C# code, we 
 between ``0`` and ``2`` to select one of these names from the list (array indices start at ``0``). The 
 expression ``GD.Randi() % n`` selects a random integer between ``0`` and ``n-1``.
 
-Finally, we call $AnimatedSprite2D.play() to start playing the chosen animation.
+Finally, we call ``play()`` to start playing the chosen animation.
 
 The last piece is to make the mobs delete themselves when they leave the screen.
 Connect the ``screen_exited()`` signal of the ``VisibleOnScreenNotifier2D`` node


### PR DESCRIPTION
Added script to play the mob animation, along with its explanation in the docs.

In 'Your first 2D game' in the Getting Started part, the docs tell you how to randomly select mob animation (in creating the enemy), but don't show you how to play it. The '$AnimatedSprite2D.play()' part was missing the the script. This, along with it's docs, has been added in this pull request.
