### PR TITLE
Reflect the changes to Rider setup after the fix of the project generation logic to support any OS with and without MSVC toolchain

### DIFF
--- a/contributing/development/compiling/index.rst
+++ b/contributing/development/compiling/index.rst
@@ -1,5 +1,7 @@
 :allow_comments: False
 
+.. _doc_compiling_index:
+
 Building from source
 ====================
 

--- a/contributing/development/configuring_an_ide/rider.rst
+++ b/contributing/development/configuring_an_ide/rider.rst
@@ -33,7 +33,9 @@ The ``dev_build`` parameter ensures the debug symbols are included, allowing to 
 
 - Open the generated ``godot.sln`` in Rider.
 
-.. note:: Ensure that the appropriate Solution configuration is selected on the Rider toolbar. It affects resolve of the SDKs, code analysis, build, run, etc.
+.. note:: Ensure that the appropriate Solution configuration is selected on the
+          Rider toolbar. It affects resolve of the SDKs, code analysis, build, run,
+          etc.
 
 Compiling and debugging the project
 -----------------------------------

--- a/contributing/development/configuring_an_ide/rider.rst
+++ b/contributing/development/configuring_an_ide/rider.rst
@@ -4,51 +4,41 @@ JetBrains Rider
 ===============
 
 `JetBrains Rider <https://www.jetbrains.com/rider/>`_ is a commercial
-`JetBrains <https://www.jetbrains.com/>`_ IDE for C# and C++ that uses the same solution system as Visual Studio.
+`JetBrains <https://www.jetbrains.com/>`_ IDE for C++, C# and GDScript that uses the same solution system as Visual Studio.
 
 .. note::
 
-    This documentation is for contributions to the game engine, and not using
+    This documentation is for contributing to the game engine, not for using
     JetBrains Rider as a C# or GDScript editor. To code C# or GDScript in an external editor, see
     :ref:`the C# guide to configure an external editor <doc_c_sharp_setup_external_editor>`.
 
 Importing the project
 ---------------------
 
-You will need to install `Python <https://www.python.org/>`_ in your development environment
-along with `MinGW <https://www.mingw-w64.org/downloads/>`_. You will also need the Visual Studio C++ Build Tools, which
-you can install using the Visual Studio Installer. Ensure all dependencies are installed
-before you continue to the next steps.
-
 .. tip:: If you already use Visual Studio as your main IDE, you can use the same solution file in Rider.
          Rider and Visual Studio use the same solution format, so you can switch between the two IDEs without rebuilding the solution file.
          Debug configurations need to be changed when going from one IDE to another.
 
-Rider requires a solution file to work on a C++ project. While Godot does not come
-with a solution file, it can be generated using SCons.
+If you are starting from the scratch, please follow :ref:`instructions<doc_compiling_index>`, specifically:
 
-- Navigate to the Godot root folder and open a Command Prompt or PowerShell window.
-- Copy, paste and run the next command to generate the solution.
+- Install all the dependencies.
+- Figure out the scons command for compiling to target a specific platform.
 
-::
+Provide scons with additional arguments to request a solution file generation:
 
-    scons platform=windows vsproj=yes dev_build=yes
+- Add `vsproj=yes dev_build=yes` to the scons command
 
 The ``vsproj`` parameter signals that you want Visual Studio solution generated.
-The ``dev_build`` parameter makes sure the debug symbols are included, allowing to e.g. step through code using breakpoints.
+The ``dev_build`` parameter ensures the debug symbols are included, allowing to e.g. step through code using breakpoints.
 
-- If you have Rider setup as your main IDE for .sln, you can now open the project by double-clicking on the ``godot.sln`` in the project root
-  or by using the **Open** option inside of Rider.
+- Open the generated ``godot.sln`` in Rider.
 
-.. note:: Rider could fail to build the solution.
-          If that is the case, try running `git clean -xdf` to remove all traces of the previous build artifacts
-          and regenerate the build files using the `scons` command again. Restarting the terminal and your
-          development environment may help.
+.. note:: Ensure that the appropriate Solution configuration is selected on the Rider toolbar. It affects resolve of the SDKs, code analysis, build, run, etc.
 
 Compiling and debugging the project
 -----------------------------------
 Rider comes with a built-in debugger that can be used to debug the Godot project. You can launch the debugger
-by pressing the **Debug** icon at the top of the screen, this only works for the Project manager,
+by pressing the **Debug** icon at the top of the screen, this only works for the Project Manager,
 if you want to debug the editor, you need to configure the debugger first.
 
 .. figure:: img/rider_run_debug.webp
@@ -66,7 +56,7 @@ if you want to debug the editor, you need to configure the debugger first.
     - Working Directory: ``$(LocalDebuggerWorkingDirectory)``
     - Before Launch has a value of "Build Project"
 
-This will tell the executable to debug the specified project without using the project manager.
+This will tell the executable to debug the specified project without opening the Project Manager.
 Use the root path to the project folder, not ``project.godot`` file path.
 
 .. figure:: img/rider_configurations_changed.webp
@@ -86,4 +76,27 @@ Alternatively you can use **Run > Attach to Process** to attach the debugger to 
 .. figure:: img/rider_attach_to_process_dialog.webp
    :align: center
 
+|
+
+Debug visualizers
+-----------------
+Debug visualizers customize how complex data structures are displayed during debugging.
+For Windows "natvis" (short for "Native Visualization") built-in with Godot are automatically used.
+For other operating systems, similar functionality can be setup manually.
+
+Please follow `RIDER-123535 <https://youtrack.jetbrains.com/issue/RIDER-123535/nix-Debug-Godot-Cpp-from-Rider-pretty-printers-usability>`_.
+
+Unit testing
+------------
+Leverage Rider :ref:`doctest<doc_unit_testing>` support.
+Please follow `RIDER-122019 <https://youtrack.jetbrains.com/issue/RIDER-122019/Godot-doctest-Unit-Tests-Stuck-in-pending>`_.
+
+Profiling
+---------
+Please refer to `the profiling instructions <https://github.com/JetBrains/godot-support/wiki/Profiling-Godot-engine-(native-code)-with-dotTrace-or-JetBrains-Rider>`_.
+
 Please consult the `JetBrains Rider documentation <https://www.jetbrains.com/rider/documentation/>`_ for any specific information about the JetBrains IDE.
+
+Known issues
+------------
+Debugging Windows MinGV build - symbols are not loaded. Reported `RIDER-106816 <https://youtrack.jetbrains.com/issue/RIDER-106816/Upgrade-LLDB-to-actual-version>`_.


### PR DESCRIPTION
I propose to land this after https://github.com/godotengine/godot/pull/103405
