### PR TITLE
Style: Integrate new `#pragma once` syntax

### DIFF
--- a/contributing/development/code_style_guidelines.rst
+++ b/contributing/development/code_style_guidelines.rst
@@ -203,18 +203,13 @@ Example:
     /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
     /**************************************************************************/
 
-    #ifndef MY_NEW_FILE_H
-    #define MY_NEW_FILE_H
+    #pragma once
 
     #include "core/hash_map.h"
     #include "core/list.h"
     #include "scene/gui/control.h"
 
     #include <png.h>
-
-    ...
-
-    #endif // MY_NEW_FILE_H
 
 .. code-block:: cpp
     :caption: my_new_file.cpp

--- a/contributing/development/core_and_modules/binding_to_external_libraries.rst
+++ b/contributing/development/core_and_modules/binding_to_external_libraries.rst
@@ -22,8 +22,7 @@ Next, you will create a header file with a TTS class:
 .. code-block:: cpp
     :caption: godot/modules/tts/tts.h
 
-    #ifndef GODOT_TTS_H
-    #define GODOT_TTS_H
+    #pragma once
 
     #include "core/object/ref_counted.h"
 
@@ -38,8 +37,6 @@ Next, you will create a header file with a TTS class:
 
         TTS();
     };
-
-    #endif // GODOT_TTS_H
 
 And then you'll add the cpp file.
 

--- a/contributing/development/core_and_modules/custom_godot_servers.rst
+++ b/contributing/development/core_and_modules/custom_godot_servers.rst
@@ -41,8 +41,7 @@ an initialization state and a cleanup procedure.
 .. code-block:: cpp
     :caption: hilbert_hotel.h
 
-    #ifndef HILBERT_HOTEL_H
-    #define HILBERT_HOTEL_H
+    #pragma once
 
     #include "core/object/object.h"
     #include "core/os/thread.h"
@@ -90,8 +89,6 @@ an initialization state and a cleanup procedure.
         void register_rooms();
         HilbertHotel();
     };
-
-    #endif
 
 .. code-block:: cpp
     :caption: hilbert_hotel.cpp

--- a/contributing/development/core_and_modules/custom_modules_in_cpp.rst
+++ b/contributing/development/core_and_modules/custom_modules_in_cpp.rst
@@ -47,8 +47,7 @@ Inside we will create a summator class:
 .. code-block:: cpp
     :caption: godot/modules/summator/summator.h
 
-    #ifndef SUMMATOR_H
-    #define SUMMATOR_H
+    #pragma once
 
     #include "core/object/ref_counted.h"
 
@@ -67,8 +66,6 @@ Inside we will create a summator class:
 
         Summator();
     };
-
-    #endif // SUMMATOR_H
 
 And then the cpp file.
 
@@ -621,8 +618,7 @@ The procedure is the following:
 .. code-block:: cpp
     :caption: godot/modules/summator/tests/test_summator.h
 
-    #ifndef TEST_SUMMATOR_H
-    #define TEST_SUMMATOR_H
+    #pragma once
 
     #include "tests/test_macros.h"
 
@@ -648,8 +644,6 @@ The procedure is the following:
     }
 
     } // namespace TestSummator
-
-    #endif // TEST_SUMMATOR_H
 
 4. Compile the engine with ``scons tests=yes``, and run the tests with the
    following command:

--- a/contributing/development/core_and_modules/custom_resource_format_loaders.rst
+++ b/contributing/development/core_and_modules/custom_resource_format_loaders.rst
@@ -58,8 +58,7 @@ read and handle data serialization.
 .. code-block:: cpp
     :caption: resource_loader_json.h
 
-    #ifndef RESOURCE_LOADER_JSON_H
-    #define RESOURCE_LOADER_JSON_H
+    #pragma once
 
     #include "core/io/resource_loader.h"
 
@@ -71,7 +70,6 @@ read and handle data serialization.
         virtual bool handles_type(const String &p_type) const;
         virtual String get_resource_type(const String &p_path) const;
     };
-    #endif // RESOURCE_LOADER_JSON_H
 
 .. code-block:: cpp
     :caption: resource_loader_json.cpp
@@ -112,8 +110,7 @@ If you'd like to be able to edit and save a resource, you can implement a
 .. code-block:: cpp
     :caption: resource_saver_json.h
 
-    #ifndef RESOURCE_SAVER_JSON_H
-    #define RESOURCE_SAVER_JSON_H
+    #pragma once
 
     #include "core/io/resource_saver.h"
 
@@ -124,7 +121,6 @@ If you'd like to be able to edit and save a resource, you can implement a
         virtual bool recognize(const RES &p_resource) const;
         virtual void get_recognized_extensions(const RES &p_resource, List<String> *r_extensions) const;
     };
-    #endif // RESOURCE_SAVER_JSON_H
 
 .. code-block:: cpp
     :caption: resource_saver_json.cpp
@@ -162,8 +158,7 @@ Here is an example of creating a custom datatype:
 .. code-block:: cpp
     :caption: resource_json.h
 
-    #ifndef RESOURCE_JSON_H
-    #define RESOURCE_JSON_H
+    #pragma once
 
     #include "core/io/json.h"
     #include "core/variant_parser.h"
@@ -189,7 +184,6 @@ Here is an example of creating a custom datatype:
         void set_dict(const Dictionary &p_dict);
         Dictionary get_dict();
     };
-    #endif // RESOURCE_JSON_H
 
 .. code-block:: cpp
     :caption: resource_json.cpp

--- a/contributing/development/core_and_modules/unit_testing.rst
+++ b/contributing/development/core_and_modules/unit_testing.rst
@@ -113,8 +113,7 @@ Here's a minimal working test suite with a single test case written:
 
 .. code-block:: cpp
 
-    #ifndef TEST_STRING_H
-    #define TEST_STRING_H
+    #pragma once
 
     #include "tests/test_macros.h"
 
@@ -126,8 +125,6 @@ Here's a minimal working test suite with a single test case written:
     }
 
     } // namespace TestString
-
-    #endif // TEST_STRING_H
 
 .. note::
     You can quickly generate new tests using the ``create_test.py`` script found in the ``tests/`` directory.

--- a/contributing/development/cpp_usage_guidelines.rst
+++ b/contributing/development/cpp_usage_guidelines.rst
@@ -94,11 +94,12 @@ Lambdas should be used conservatively when they make code effectively faster or
 simpler, and do not impede readability. Please ask before using lambdas in a
 pull request.
 
-``#pragma once`` directive
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+``#ifdef``-based include guards
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To follow the existing style, please use standard ``#ifdef``-based include
-guards instead of ``#pragma once`` in new files.
+Starting with 4.5, all files now use the ``#pragma once`` directive, as they
+improve readability and declutter macros. Use of ``#ifdef``-based include
+guards are now actively discouraged.
 
 ``try``-``catch`` blocks
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tutorials/performance/using_multiple_threads.rst
+++ b/tutorials/performance/using_multiple_threads.rst
@@ -49,8 +49,7 @@ To create a thread, use the following code:
 
  .. code-tab:: cpp C++ .H File
 
-    #ifndef MULTITHREADING_DEMO_H
-    #define MULTITHREADING_DEMO_H
+    #pragma once
 
     #include <godot_cpp/classes/node.hpp>
     #include <godot_cpp/classes/thread.hpp>
@@ -73,8 +72,6 @@ To create a thread, use the following code:
             void demo_threaded_function();
         };
     } // namespace godot
-
-    #endif // MULTITHREADING_DEMO_H
 
  .. code-tab:: cpp C++ .CPP File
 
@@ -209,8 +206,7 @@ Here is an example of using a Mutex:
 
  .. code-tab:: cpp C++ .H File
 
-    #ifndef MUTEX_DEMO_H
-    #define MUTEX_DEMO_H
+    #pragma once
 
     #include <godot_cpp/classes/mutex.hpp>
     #include <godot_cpp/classes/node.hpp>
@@ -236,8 +232,6 @@ Here is an example of using a Mutex:
             void thread_function();
         };
     } // namespace godot
-
-    #endif // MUTEX_DEMO_H
 
  .. code-tab:: cpp C++ .CPP File
 
@@ -379,8 +373,7 @@ ready to be processed:
 
  .. code-tab:: cpp C++ .H File
 
-    #ifndef SEMAPHORE_DEMO_H
-    #define SEMAPHORE_DEMO_H
+    #pragma once
 
     #include <godot_cpp/classes/mutex.hpp>
     #include <godot_cpp/classes/node.hpp>
@@ -411,8 +404,6 @@ ready to be processed:
             int get_counter();
         };
     } // namespace godot
-
-    #endif // SEMAPHORE_DEMO_H
 
  .. code-tab:: cpp C++ .CPP File
 

--- a/tutorials/scripting/gdextension/gdextension_c_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_c_example.rst
@@ -133,8 +133,7 @@ Create the file ``init.h`` in the ``src`` folder, with the following contents:
 
 .. code-block:: c
 
-    #ifndef INIT_H
-    #define INIT_H
+    #pragma once
 
     #include "defs.h"
 
@@ -143,8 +142,6 @@ Create the file ``init.h`` in the ``src`` folder, with the following contents:
     void initialize_gdexample_module(void *p_userdata, GDExtensionInitializationLevel p_level);
     void deinitialize_gdexample_module(void *p_userdata, GDExtensionInitializationLevel p_level);
     GDExtensionBool GDE_EXPORT gdexample_library_init(GDExtensionInterfaceGetProcAddress p_get_proc_address, GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization);
-
-    #endif // INIT_H
 
 The functions declared here have the signatures expected by the GDExtension API.
 
@@ -158,8 +155,7 @@ Create the ``defs.h`` file in the ``src`` folder with the following contents:
 
 .. code-block:: c
 
-    #ifndef DEFS_H
-    #define DEFS_H
+    #pragma once
 
     #include <stdbool.h>
     #include <stddef.h>
@@ -174,8 +170,6 @@ Create the ``defs.h`` file in the ``src`` folder with the following contents:
     #define GDE_EXPORT
     #endif
     #endif // ! GDE_EXPORT
-
-    #endif // DEFS_H
 
 We also include some standard headers to make things easier. Now we only have to
 include ``defs.h`` and those will come as a bonus.
@@ -224,8 +218,7 @@ contents:
 
 .. code-block:: c
 
-    #ifndef GDEXAMPLE_H
-    #define GDEXAMPLE_H
+    #pragma once
 
     #include "gdextension_interface.h"
 
@@ -246,8 +239,6 @@ contents:
 
     // Bindings.
     void gdexample_class_bind_methods();
-
-    #endif // GDEXAMPLE_H
 
 Noteworthy here is the ``object`` field, which holds a pointer to
 the Godot object, and the ``gdexample_class_bind_methods()`` function, which will
@@ -299,8 +290,7 @@ We'll start by creating an ``api.h`` file in the ``src`` folder:
 
 .. code-block:: c
 
-    #ifndef API_H
-    #define API_H
+    #pragma once
 
     /*
     This file works as a collection of helpers to call the GDExtension API
@@ -332,10 +322,6 @@ We'll start by creating an ``api.h`` file in the ``src`` folder:
     } api;
 
     void load_api(GDExtensionInterfaceGetProcAddress p_get_proc_address);
-
-
-
-    #endif // API_H
 
 This file will include many other helpers as we fill our extension with
 something useful. For now it only has a pointer to a function that creates a

--- a/tutorials/scripting/gdextension/gdextension_cpp_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_cpp_example.rst
@@ -164,8 +164,7 @@ GDExtension node we'll be creating. We will name it ``gdexample.h``:
 .. code-block:: cpp
     :caption: gdextension_cpp_example/src/gdexample.h
 
-    #ifndef GDEXAMPLE_H
-    #define GDEXAMPLE_H
+    #pragma once
 
     #include <godot_cpp/classes/sprite2d.hpp>
 
@@ -187,9 +186,7 @@ GDExtension node we'll be creating. We will name it ``gdexample.h``:
         void _process(double delta) override;
     };
 
-    }
-
-    #endif
+    } // namespace godot
 
 There are a few things of note to the above. We include ``sprite2d.hpp`` which
 contains bindings to the Sprite2D class. We'll be extending this class in our
@@ -313,8 +310,7 @@ At last, we need the header file for the ``register_types.cpp`` named
 .. code-block:: cpp
     :caption: gdextension_cpp_example/src/register_types.h
 
-    #ifndef GDEXAMPLE_REGISTER_TYPES_H
-    #define GDEXAMPLE_REGISTER_TYPES_H
+    #pragma once
 
     #include <godot_cpp/core/class_db.hpp>
 
@@ -322,9 +318,6 @@ At last, we need the header file for the ``register_types.cpp`` named
 
     void initialize_example_module(ModuleInitializationLevel p_level);
     void uninitialize_example_module(ModuleInitializationLevel p_level);
-
-    #endif // GDEXAMPLE_REGISTER_TYPES_H
-
 
 Compiling the plugin
 --------------------


### PR DESCRIPTION
- See godotengine/godot#102298

With `#pragma once` being the new stylistic syntax utilized in the main repo, this aims to update the docs to reflect that