### PR TITLE
chore: Update the link to predefined color mappings for Icons.

### DIFF
--- a/contributing/development/editor/creating_icons.rst
+++ b/contributing/development/editor/creating_icons.rst
@@ -38,7 +38,7 @@ Color conversion for light editor themes
 
 If the user has configured their editor to use a light theme, Godot will
 convert the icon's colors based on a
-`set of predefined color mappings <https://github.com/godotengine/godot/blob/4.4/editor/themes/editor_color_map.cpp#L48-L156>`__.
+`set of predefined color mappings <https://github.com/godotengine/godot/blob/4.4-stable/editor/themes/editor_color_map.cpp#L48-L156>`__.
 This is to ensure the icon always displays with a sufficient contrast rate.
 Try to restrict your icon's color palette to colors found in the list above.
 Otherwise, your icon may become difficult to read on a light background.

--- a/contributing/development/editor/creating_icons.rst
+++ b/contributing/development/editor/creating_icons.rst
@@ -38,7 +38,7 @@ Color conversion for light editor themes
 
 If the user has configured their editor to use a light theme, Godot will
 convert the icon's colors based on a
-`set of predefined color mappings <https://github.com/godotengine/godot/blob/4.4-stable/editor/themes/editor_color_map.cpp#L48-L156>`__.
+`set of predefined color mappings <https://github.com/godotengine/godot/blob/master/editor/themes/editor_color_map.cpp>`__.
 This is to ensure the icon always displays with a sufficient contrast rate.
 Try to restrict your icon's color palette to colors found in the list above.
 Otherwise, your icon may become difficult to read on a light background.

--- a/contributing/development/editor/creating_icons.rst
+++ b/contributing/development/editor/creating_icons.rst
@@ -38,7 +38,7 @@ Color conversion for light editor themes
 
 If the user has configured their editor to use a light theme, Godot will
 convert the icon's colors based on a
-`set of predefined color mappings <https://github.com/godotengine/godot/blob/4.0.2-stable/editor/editor_themes.cpp#L60-L160>`__.
+`set of predefined color mappings <https://github.com/godotengine/godot/blob/4.4/editor/themes/editor_color_map.cpp#L48-L156>`__.
 This is to ensure the icon always displays with a sufficient contrast rate.
 Try to restrict your icon's color palette to colors found in the list above.
 Otherwise, your icon may become difficult to read on a light background.


### PR DESCRIPTION
This PR updates the link which directs the reader to the color mapping from 4.0.2-stable to 4.4.