### PR TITLE
Clarify type-safety of as

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -1053,7 +1053,7 @@ that type will be used to infer the type of the var.
 
 .. note::
 
-    This option is considered less :ref:`type-safe<doc_gdscript_static_typing_safe_lines>` than type hints, as it silently casts the variable to null in case of a type mismatch at runtime, without an error/warning
+    This option is considered more :ref:`type-safe<doc_gdscript_static_typing_safe_lines>` than type hints, but also less null-safe as it silently casts the variable to null in case of a type mismatch at runtime, without an error/warning.
 
 **Bad**:
 

--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -1050,7 +1050,10 @@ that type will be used to infer the type of the var.
     @onready var health_bar := get_node("UI/LifeBar") as ProgressBar
     # health_bar will be typed as ProgressBar
 
-This option is also considered more :ref:`type-safe<doc_gdscript_static_typing_safe_lines>` than the first.
+
+.. note::
+
+    This option is considered less :ref:`type-safe<doc_gdscript_static_typing_safe_lines>` than type hints, as it silently casts the variable to null in case of a type mismatch at runtime, without an error/warning
 
 **Bad**:
 

--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -1053,7 +1053,9 @@ that type will be used to infer the type of the var.
 
 .. note::
 
-    This option is considered more :ref:`type-safe<doc_gdscript_static_typing_safe_lines>` than type hints, but also less null-safe as it silently casts the variable to ``null`` in case of a type mismatch at runtime, without an error/warning.
+    This option is considered more :ref:`type-safe<doc_gdscript_static_typing_safe_lines>` than type hints,
+    but also less null-safe as it silently casts the variable to ``null`` in case of a type mismatch at runtime,
+    without an error/warning.
 
 **Bad**:
 

--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -1053,7 +1053,7 @@ that type will be used to infer the type of the var.
 
 .. note::
 
-    This option is considered more :ref:`type-safe<doc_gdscript_static_typing_safe_lines>` than type hints, but also less null-safe as it silently casts the variable to null in case of a type mismatch at runtime, without an error/warning.
+    This option is considered more :ref:`type-safe<doc_gdscript_static_typing_safe_lines>` than type hints, but also less null-safe as it silently casts the variable to ``null`` in case of a type mismatch at runtime, without an error/warning.
 
 **Bad**:
 


### PR DESCRIPTION
Changed the statement about the as keyword's type-safety to clarify that it is less type-safe than type hints.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
