### PR TITLE
Fix misplaced bad example

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -1032,6 +1032,14 @@ the function's return type. For example, ``get_node()`` cannot infer a type
 unless the scene or file of the node is loaded in memory. In this case, you
 should set the type explicitly.
 
+**Good**:
+
+.. rst-class:: code-example-good
+
+::
+
+    @onready var health_bar: ProgressBar = get_node("UI/LifeBar")
+
 **Bad**:
 
 .. rst-class:: code-example-bad
@@ -1042,16 +1050,10 @@ should set the type explicitly.
     # instead of ProgressBar.
     @onready var health_bar := get_node("UI/LifeBar")
 
-**Good**:
-
-.. rst-class:: code-example-good
-
-::
-
-    @onready var health_bar: ProgressBar = get_node("UI/LifeBar")
-
 Alternatively, you can use the ``as`` keyword to cast the return type, and
 that type will be used to infer the type of the var.
+
+**Good**:
 
 .. rst-class:: code-example-good
 

--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -1032,6 +1032,16 @@ the function's return type. For example, ``get_node()`` cannot infer a type
 unless the scene or file of the node is loaded in memory. In this case, you
 should set the type explicitly.
 
+**Bad**:
+
+.. rst-class:: code-example-bad
+
+::
+
+    # The compiler can't infer the exact type and will use Node
+    # instead of ProgressBar.
+    @onready var health_bar := get_node("UI/LifeBar")
+
 **Good**:
 
 .. rst-class:: code-example-good
@@ -1052,12 +1062,4 @@ that type will be used to infer the type of the var.
 
 This option is also considered more :ref:`type-safe<doc_gdscript_static_typing_safe_lines>` than the first.
 
-**Bad**:
 
-.. rst-class:: code-example-bad
-
-::
-
-    # The compiler can't infer the exact type and will use Node
-    # instead of ProgressBar.
-    @onready var health_bar := get_node("UI/LifeBar")

--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -1053,8 +1053,6 @@ should set the type explicitly.
 Alternatively, you can use the ``as`` keyword to cast the return type, and
 that type will be used to infer the type of the var.
 
-**Good**:
-
 .. rst-class:: code-example-good
 
 ::


### PR DESCRIPTION
Moved the bad example for the inferred type for functions that return super types directly after its related statement.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
