### PR TITLE
Fix typo - gdexample.cpp should be gdexample.c in the C documentation

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_c_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_c_example.rst
@@ -760,7 +760,7 @@ the destructor.
 
     ...
 
-In the ``gdexample.cpp`` file, we will initialize these values in the constructor
+In the ``gdexample.c`` file, we will initialize these values in the constructor
 and add the implementations for those new functions, which are quite trivial:
 
 .. code-block:: c


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
