### PR TITLE
Update doctest links from onqtam/doctest to doctest/doctest

### DIFF
--- a/contributing/development/core_and_modules/unit_testing.rst
+++ b/contributing/development/core_and_modules/unit_testing.rst
@@ -4,7 +4,7 @@ Unit testing
 ============
 
 Godot Engine allows to write unit tests directly in C++. The engine integrates
-the `doctest <https://github.com/onqtam/doctest>`_ unit testing framework which
+the `doctest <https://github.com/doctest/doctest>`_ unit testing framework which
 gives ability to write test suites and test cases next to production code, but
 since the tests in Godot go through a different ``main`` entry point, the tests
 reside in a dedicated ``tests/`` directory instead, which is located at the root
@@ -208,7 +208,7 @@ for more complex ones if you think that it deserves a better explanation.
 
 .. seealso::
 
-    `doctest: Assertion macros <https://github.com/onqtam/doctest/blob/master/doc/markdown/assertions.md>`_.
+    `doctest: Assertion macros <https://github.com/doctest/doctest/blob/master/doc/markdown/assertions.md>`_.
 
 Logging
 ~~~~~~~
@@ -236,7 +236,7 @@ output can be redirected to an XML file:
 
 .. seealso::
 
-    `doctest: Logging macros <https://github.com/onqtam/doctest/blob/master/doc/markdown/logging.md>`_.
+    `doctest: Logging macros <https://github.com/doctest/doctest/blob/master/doc/markdown/logging.md>`_.
 
 Testing failure paths
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Recently noticed while reading the unit testing docs [here](https://docs.godotengine.org/en/stable/contributing/development/core_and_modules/unit_testing.html) that the links to the `doctest` repo are still referring to the old (pre-rename?) organization/user repo `onqtam/doctest`. While the links aren't broken, I think it would be preferable to have the links go directly to the current `doctest/doctest` repo. Hence, I've updated the three references in the `godot-docs` repo, which are all on the unit testing page.