### PR TITLE
Update setting_up_xr.rst to reflect Main node name

### DIFF
--- a/tutorials/xr/setting_up_xr.rst
+++ b/tutorials/xr/setting_up_xr.rst
@@ -108,7 +108,7 @@ Next we need to add a script to our root node. Add the following code into this 
 
     using Godot;
 
-    public partial class MyNode3D : Node3D
+    public partial class Main : Node3D
     {
         private XRInterface _xrInterface;
 


### PR DESCRIPTION
The screen shows the default node as `Main`, the C# code should reflect that.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
