### PR TITLE
Fix URL check errors

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -12,6 +12,8 @@ tcp:\/\/.*
 .*asecuritysite\.com.*
 .*intel\.com.*
 .*reddit\.com.*
+.*inkscape.org.*
+.*computerhope.com*
 
 # Don't check URLs from these websites due to frequent rate limits (error 429) or timeouts.
 .*adobe\.com.*


### PR DESCRIPTION
Adds two more websites to the list of ignored ones. We keep getting 403 errors even though the link is good.