### PR TITLE
Clarify the purpose of the MIT license.

### DIFF
--- a/getting_started/introduction/godot_design_philosophy.rst
+++ b/getting_started/introduction/godot_design_philosophy.rst
@@ -98,10 +98,11 @@ game code. See `The Godot editor is a Godot game`_ below.
 Open source
 -----------
 
-Godot offers a fully open source codebase under the **MIT license**.
-This means all the technologies that ship with it have to be Free
-(as in freedom) as well.
-For the most part, they're developed from the ground up by contributors.
+Godot offers a fully open source codebase under the **MIT license**. This means
+that the codebase is free for anyone to download, use, modify, or share, as long
+as its license file is kept intact. Thanks to this open source license, most of
+the technologies that define Godot are developed from the ground up by
+community contributors.
 
 Anyone can plug in proprietary tools for the needs of their projects —
 they just won't ship with the engine. This may include Google AdMob,

--- a/getting_started/introduction/godot_design_philosophy.rst
+++ b/getting_started/introduction/godot_design_philosophy.rst
@@ -98,11 +98,13 @@ game code. See `The Godot editor is a Godot game`_ below.
 Open source
 -----------
 
-Godot offers a fully open source codebase under the **MIT license**. This means
-that the codebase is free for anyone to download, use, modify, or share, as long
-as its license file is kept intact. Thanks to this open source license, most of
-the technologies that define Godot are developed from the ground up by
-community contributors.
+Godot offers a fully open source codebase under the **MIT license**.
+This means that the codebase is free for anyone to download, use,
+modify, or share, as long as its license file is kept intact.
+
+All technologies that ship with Godot, including third-party libraries, must
+be legally compatible with this open source license. Therefore, most parts
+of Godot are developed from the ground up by community contributors.
 
 Anyone can plug in proprietary tools for the needs of their projects —
 they just won't ship with the engine. This may include Google AdMob,


### PR DESCRIPTION
This change replaces the jargon of the FSF "Free (as in freedom)" slogan with a more literal and general summary of the rights that the MIT license grants, and clarifies that it's the license itself which allows the contributors to develop Godot.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
