### PR TITLE
Redesign homepage into a landing page for various user profiles

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -31,8 +31,86 @@ to this documentation, we recommend that you read the
 :ref:`introduction page <doc_about_intro>` to get an overview of what this
 documentation has to offer.
 
-The table of contents in the sidebar should let you easily access the documentation
-for your topic of interest. You can also use the search function in the top-left corner.
+To begin reading the relevant documentation, select the tile that matches your profile:
+
+.. raw:: html
+
+    <style>
+        .grid-container {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            grid-template-rows: 1fr 1fr;
+            gap: 0.375rem;
+            grid-auto-flow: row;
+            grid-template-areas:
+            "new-to-game know-game-learn-godot"
+            "know-godot-learn-godot contribute-to-godot";
+        }
+
+        .grid-item {
+            color: hsla(0, 0%, 100%, 0.9);
+            padding: 1rem;
+            border-radius: 0.375rem;
+            text-align: center;
+        }
+
+        .grid-item:visited {
+            color: unset;
+        }
+
+        .grid-item:hover,
+        .grid-item:focus {
+            text-decoration: none;
+            filter: brightness(120%);
+        }
+
+        .grid-item:active {
+            filter: brightness(80%);
+        }
+
+        .new-to-game {
+            grid-area: new-to-game;
+            background-color: #166534;
+        }
+
+        .know-game-learn-godot {
+            grid-area: know-game-learn-godot;
+            background-color: #115e59;
+        }
+
+        .know-godot-learn-godot {
+            grid-area: know-godot-learn-godot;
+            background-color: #1e3a8a;
+        }
+
+        .contribute-to-godot {
+            grid-area: contribute-to-godot;
+            background-color: #831843;
+        }
+    </style>
+    <div class="grid-container">
+        <a class="grid-item new-to-game" href="about/introduction.html">
+            I've never made a game before,<br>
+            <strong>I want to make a game.</strong>
+        </a>
+        <a class="grid-item know-game-learn-godot" href="getting_started/step_by_step/index.html">
+            I know how to make a game,<br>
+            <strong>I want to know how to use Godot.</strong>
+            </a>
+        <a class="grid-item know-godot-learn-godot" href="tutorials/index.html">
+            I know how to use Godot,<br>
+            <strong>I want to learn more advanced Godot topics.</strong>
+        </a>
+        <a class="grid-item contribute-to-godot" href="contributing/how_to_contribute.html">
+            I know how to use Godot,<br>
+            <strong>I want to contribute to Godot.</strong>
+        </a>
+    </div>
+    <br>
+
+You can also use the table of contents in the sidebar to access easily access
+any section of the documentation for your topic of interest. You can also use
+the search function in the top-left corner.
 
 Get involved
 ------------

--- a/tutorials/index.rst
+++ b/tutorials/index.rst
@@ -1,0 +1,55 @@
+:orphan:
+
+.. Silence warning about the document not being included in any toctree.
+   This page is linked from the top-level `index.rst` file in raw HTML,
+   so Sphinx is not aware of the link.
+
+.. _doc_tutorials:
+
+Tutorials
+=========
+
+.. Sections below are split into two groups. First come meta sections, covering
+   general matters. Below that different areas of the engine are listed.
+   These sections are sorted alphabetically. Please keep them that way.
+
+General
+-------
+
+.. toctree::
+    :maxdepth: 1
+    :name: toc-learn-tutorials-general
+
+    best_practices/index
+    editor/index
+    migrating/index
+    troubleshooting
+
+Topics
+------
+
+.. toctree::
+    :maxdepth: 1
+    :name: toc-learn-tutorials-topics
+
+    2d/index
+    3d/index
+    animation/index
+    assets_pipeline/index
+    audio/index
+    export/index
+    io/index
+    i18n/index
+    inputs/index
+    math/index
+    navigation/index
+    networking/index
+    performance/index
+    physics/index
+    platform/index
+    plugins/index
+    rendering/index
+    scripting/index
+    shaders/index
+    ui/index
+    xr/index


### PR DESCRIPTION
- Simplified version of https://github.com/godotengine/godot-docs/pull/7508 (doesn't change the visual design of the tutorials list page).

The landing page was simplified and now points to several home pages.

## Preview

![image](https://github.com/user-attachments/assets/c1e84d9e-8ba7-40f3-badd-8216eee380ee)
