### PR TITLE
CI: Check URLs on schedule only to reduce false positives

### DIFF
--- a/.github/workflows/check_urls.yml
+++ b/.github/workflows/check_urls.yml
@@ -1,12 +1,10 @@
 name: 🌐 Check URLs
 on:
-  push:
-  pull_request:
   schedule:
-    # Every day at 18:00 UTC.
+    # Every Friday at 16:27 UTC.
     # URLs can decay over time. Setting up a schedule makes it possible to be warned
     # about dead links as soon as possible.
-    - cron: "0 18 * * *"
+    - cron: "27 16 * * FRI"
 
 jobs:
   check-urls:


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-docs/pull/10680.

Links occasionally fail due to network issues or other transient problems. This should not cause pull requests to fail checks.

The check is now performed weekly at a random-looking time on Fridays (when server load isn't too high).
