### PR TITLE
Clarify the presence and purpose of the indigo default-dimensions rectangle.

### DIFF
--- a/getting_started/step_by_step/nodes_and_scenes.rst
+++ b/getting_started/step_by_step/nodes_and_scenes.rst
@@ -102,10 +102,19 @@ of the window.
 
 .. image:: img/nodes_and_scenes_05_editor_with_label.webp
 
-A lot happens when you add a scene's first node. The scene changes to the 2D
-workspace because Label is a 2D node type. The Label appears, selected, in the
-top-left corner of the viewport. The node appears in the Scene dock on the left,
-and the node's properties appear in the Inspector dock on the right.
+A lot happens when you add a scene's first node:
+
+- The scene changes to the 2D workspace because Label is a 2D node type.
+- The Label appears, selected, in the top-left corner of the viewport.
+- The Label is also in the top-left corner of a larger indigo-colored rectangle
+  that represents the game's default window dimensions.
+- The node appears in the Scene dock on the left.
+- The node's properties appear in the Inspector dock on the right.
+
+If the default-dimensions rectangle appears small relative to the full 2D
+viewport, then scroll around the viewport and use its zoom controls—located in
+the top-left corner of the viewport—so that the rectangle fills most of the
+viewport.
 
 Changing a node's properties
 ----------------------------
@@ -124,13 +133,15 @@ You will see the text draw in the viewport as you type.
              the Text. For a complete reference of the Inspector dock, see
              :ref:`doc_editor_inspector_dock`.
 
-You can move your Label node in the viewport by selecting the move tool in the
-toolbar.
+Move the Label to the center of the indigo default-dimensions rectangle. Follow
+these steps:
+
+1. In the toolbar, select the move tool.
 
 .. image:: img/nodes_and_scenes_07_move_tool.webp
 
-With the Label selected, click and drag anywhere in the viewport to
-move it to the center of the view delimited by the rectangle.
+2. In the Scene dock, select the Label.
+3. Click and drag anywhere in the viewport.
 
 .. image:: img/nodes_and_scenes_08_hello_world_text.webp
 


### PR DESCRIPTION
 Give instruction on what to do if the 2d viewport is initially zoomed way out.

This PR addresses some confusions I ran into when working this tutorial page on version 4.4 on macOS:

* The default zoom is very small, making the "Hello World" text illegible without manual zooming.
* The page needs to be more specific what it means by "the rectangle" on the step about centering the label.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
