### PR TITLE
Autoload nodes can be accessed in the editor if they're using tool scripts

### DIFF
--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -246,8 +246,7 @@ angle add a setter ``set(new_speed)`` which is executed with the input from the 
     Code from other nodes doesn't run in the editor. Your access to other nodes
     is limited. You can access the tree and nodes, and their default properties,
     but you can't access user variables. If you want to do so, other nodes have
-    to run in the editor too. Autoload nodes cannot be accessed in the editor at
-    all.
+    to run in the editor too.
 
 Getting notified when resources change
 --------------------------------------


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Autoload nodes are not an exception. If a tool script is attached to them, they also can be accessed. They become a child of the root node and can be used in the editor in the same way that they would be used during runtime. 

![image](https://github.com/user-attachments/assets/471e7486-43f1-4cd6-87c4-5ffdd3a6bdb1)