### PR TITLE
Update Visual Studio Code configuration for macOS systems

### DIFF
--- a/contributing/development/configuring_an_ide/visual_studio_code.rst
+++ b/contributing/development/configuring_an_ide/visual_studio_code.rst
@@ -146,20 +146,32 @@ To run and debug the project you need to create a new configuration in the ``lau
       "preLaunchTask": "build"
     }
 
-  .. code-tab:: js Mac
+  .. code-tab:: js macOS_x86_64
 
     {
       "name": "Launch Project",
       "type": "lldb",
-      "request": "custom",
-      "targetCreateCommands": [
-        "target create ${workspaceFolder}/bin/godot.macos.editor.dev.x86_64"
-      ],
+      "request": "launch",
+      "program": "${workspaceFolder}/bin/godot.macos.editor.x86_64",
       // Change the arguments below for the project you want to test with.
       // To run the project instead of editing it, remove the "--editor" argument.
-      "processCreateCommands": [
-        "process launch -- --editor --path path-to-your-godot-project-folder"
-      ]
+      "args": ["--editor", "--path", "path-to-your-godot-project-folder"],
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": "build"
+    }
+
+  .. code-tab:: js macOS_arm64
+
+    {
+      "name": "Launch Project",
+      "type": "lldb",
+      "request": "launch",
+      "program": "${workspaceFolder}/bin/godot.macos.editor.arm64",
+      // Change the arguments below for the project you want to test with.
+      // To run the project instead of editing it, remove the "--editor" argument.
+      "args": ["--editor", "--path", "path-to-your-godot-project-folder"],
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": "build"
     }
 
 .. figure:: img/vscode_2_launch.json.png
@@ -173,7 +185,7 @@ To run and debug the project you need to create a new configuration in the ``lau
 
     Due to sporadic performance issues, it is recommended to use LLDB over GDB on Unix-based systems.
     Make sure that the `CodeLLDB extension <https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb>`_
-    is installed.
+    is installed for configurations using `lldb`.
 
     If you encounter issues with lldb, you may consider using gdb (see the LinuxBSD_gdb configuration).
 


### PR DESCRIPTION
Following the [instructions to configure Visual Studio Code for engine development](https://docs.godotengine.org/en/stable/contributing/development/configuring_an_ide/visual_studio_code.html) was not working for me. I thought I would propose and update to the documentation with my working setup.