### PR TITLE
Update wording in "First 3D Game -> Character Animation"

### DIFF
--- a/getting_started/first_3d_game/09.adding_animations.rst
+++ b/getting_started/first_3d_game/09.adding_animations.rst
@@ -266,7 +266,7 @@ Open the *Player* scene, select the AnimationPlayer node and then click on
 (two small squares) alongside the *float* animation. Click OK to close the window.
 
 Then open ``mob.tscn``, create an :ref:`AnimationPlayer <class_AnimationPlayer>` child
-node and select it. Click **Animation > Manage Animations**, then **Add Library**. You
+node and select it. Click **Animation > Manage Animations**, then **New Library**. You
 should see the message "Global library will be created." Leave the text field blank and
 click OK. Click the *Paste* icon (clipboard) and it should appear in the window. Click OK
 to close the window.


### PR DESCRIPTION
This PR updates the wording in Getting Started -> First 3D Game -> Character Animation, changing "Add Library" to "New Library" to match the terminology used in the editor UI.  


Before:
> Click **Animation > Manage Animations**, then **Add Library**.

After:
> Click **Animation > Manage Animations**, then **New Library**.

Reference:
![image](https://github.com/user-attachments/assets/95085ab9-e25c-444d-a9ec-5fa098c83031)