### PR TITLE
Add middleware section to consoles page and clean up some outdated text

### DIFF
--- a/tutorials/platform/consoles.rst
+++ b/tutorials/platform/consoles.rst
@@ -13,13 +13,9 @@ yourself or someone hired to do it, or provided by a third-party company.
 Currently, the only console Godot officially supports is Steam Deck (through the
 official Linux export templates).
 
-The reason other consoles are not officially supported are:
-
-- To develop for consoles, one must be licensed as a company.
-  As an open source project, Godot has no legal structure to provide console ports.
-- Console SDKs are secret and covered by non-disclosure agreements.
-  Even if we could get access to them, we could not publish the platform-specific
-  code under an open source license.
+The reasons other consoles are not officially supported are the risks of legal
+liability, disproportionate cost, and open source licensing issues. The reasons
+are explained in more detail in this article `About Official Console Ports <https://godotengine.org/article/about-official-console-ports/>`__
 
 As explained, however, it is possible to port your games to consoles thanks to
 services provided by third-party companies.
@@ -46,7 +42,7 @@ to a console platform is as follows:
   be more accepting of smaller developers, but this is not guaranteed.
 - Get access to developer tools and order a console specially made for
   developers (*devkit*). The cost of those devkits is confidential.
-- Port the engine to the console platform or pay a company to do it.
+- Port your game to the console platform or pay a company to do it.
 - To be published, your game needs to be rated in the regions you'd like to sell
   it in. For example, game ratings are handled by `ESRB <https://www.esrb.org/>`__
   in North America, and `PEGI <https://pegi.info/>`__ in Europe. Indie developers
@@ -62,10 +58,10 @@ Third-party support
 -------------------
 
 Console ports of Godot are offered by third-party companies (which have
-ported Godot on their own). These companies also offer publishing of
+ported Godot on their own). Some of these companies also offer publishing of
 your games to various consoles.
 
-Following is the list of providers:
+The following is a list of some of the providers:
 
 - `Lone Wolf Technology <https://www.lonewolftechnology.com/>`_ offers
   Switch and Playstation 4 porting and publishing of Godot games.
@@ -81,10 +77,23 @@ Following is the list of providers:
   Switch porting and publishing of Godot games.
 - `Seaven Studio <https://www.seaven-studio.com/>`_ offers
   Switch, Xbox One, Xbox Series, PlayStation 4 & PlayStation 5 porting of Godot games.
-- `Sickhead Games <https://www.sickhead.com>`_ offers console porting to Nintendo Switch, PlayStation 4, PlayStation 5, Xbox One, and Xbox Series X/S for Godot games.
-- `W4 Games <https://www.w4games.com/>`_ offers console ports for Nintendo Switch, Xbox Series X/S, and Playstation 5 for you to port your game yourself.
+- `Sickhead Games <https://www.sickhead.com>`_ offers 
+  console porting to Nintendo Switch, PlayStation 4, PlayStation 5, Xbox One, and Xbox Series X/S for Godot games.
 
 If your company offers porting, or porting *and* publishing services for Godot games,
 feel free to
 `contact the Godot Foundation <https://godot.foundation/#contact>`_
 to add your company to the list above.
+
+Middleware
+----------
+
+Middleware ports are available through the console vendor's website. They
+provide you with a version of Godot that can natively run on the console.
+Typically, you do the actual work of adapting your game to the various consoles
+yourself. In other words, the middleware provided has ported *Godot* to the
+console, you just need to port your game, which is significantly less work in
+most cases.
+
+- `W4 Games <https://www.w4games.com/>`_ offers official 
+  middleware ports for Nintendo Switch, Xbox Series X/S, and Playstation 5.


### PR DESCRIPTION
This PR does two things:
1. It adds a new middleware section and moves the W4 port there
2. It cleans up some out of date information and improves some grammar 


#### Middleware

At W4, we have had a few people come to us a bit confused as they think we offer porting services, which we do not. When this page was designed, the only way to get Godot onto a console was through a third party porting service (i.e. you design your game for desktop, then the porting company ports it to each console you are targeting). When W4 was added, it was simply added to this list with the caveat that we don't port the game for you. This created an awkward situation, we are on the list of people who will port the game for you, but with a note saying we won't port the game for you.

W4 offers official middleware, which means that you can pay to access a special version of the engine (locked behind the console NDA unfortunately) that allows you to export directly to consoles. Which means that you can do all of the game porting yourself. 

Accordingly, it makes sense to have us listed separately. 

Also note a similar change can be made for the Godot 3 docs since Lone Wolf is an approved middleware provider for Switch for Godot 3. 

#### Cleaning up information

The important part of this is removing the sentence that says that the Godot Foundation can't offer console ports because it is not a legal entity. That isn't accurate since we formed the Godot Foundation. Instead I have linked to a blog post where we explain the situation in detail. 

_note for maintainers. This should target 4.4+. So it would be nice to merge before the 4.4 split_