### PR TITLE
[First 3D Game] Update player script recaps to use `Basis.looking_at()`

### DIFF
--- a/getting_started/first_3d_game/03.player_movement_code.rst
+++ b/getting_started/first_3d_game/03.player_movement_code.rst
@@ -274,6 +274,7 @@ Here is the complete ``player.gd`` code for reference.
 
         if direction != Vector3.ZERO:
             direction = direction.normalized()
+            # Setting the basis property will affect the rotation of the node.
             $Pivot.basis = Basis.looking_at(direction)
 
         # Ground Velocity
@@ -327,6 +328,7 @@ Here is the complete ``player.gd`` code for reference.
             if (direction != Vector3.Zero)
             {
                 direction = direction.Normalized();
+                // Setting the basis property will affect the rotation of the node.
                 GetNode<Node3D>("Pivot").Basis = Basis.LookingAt(direction);
             }
 

--- a/getting_started/first_3d_game/07.killing_player.rst
+++ b/getting_started/first_3d_game/07.killing_player.rst
@@ -349,7 +349,8 @@ Finally, the longest script, ``player.gd``:
         # Prevent diagonal moving fast af
         if direction != Vector3.ZERO:
             direction = direction.normalized()
-            $Pivot.look_at(position + direction, Vector3.UP)
+            # Setting the basis property will affect the rotation of the node.
+            $Pivot.basis = Basis.looking_at(direction)
 
         # Ground Velocity
         target_velocity.x = direction.x * speed
@@ -450,7 +451,8 @@ Finally, the longest script, ``player.gd``:
             if (direction != Vector3.Zero)
             {
                 direction = direction.Normalized();
-                GetNode<Node3D>("Pivot").LookAt(Position + direction, Vector3.Up);
+                // Setting the basis property will affect the rotation of the node.
+                GetNode<Node3D>("Pivot").Basis = Basis.LookingAt(direction);
             }
 
             // Ground Velocity

--- a/getting_started/first_3d_game/09.adding_animations.rst
+++ b/getting_started/first_3d_game/09.adding_animations.rst
@@ -342,7 +342,8 @@ Here's the *Player* script.
         # Prevent diagonal movement being very fast
         if direction != Vector3.ZERO:
             direction = direction.normalized()
-            $Pivot.look_at(position + direction,Vector3.UP)
+            # Setting the basis property will affect the rotation of the node.
+            $Pivot.basis = Basis.looking_at(direction)
             $AnimationPlayer.speed_scale = 4
         else:
             $AnimationPlayer.speed_scale = 1
@@ -448,7 +449,8 @@ Here's the *Player* script.
             if (direction != Vector3.Zero)
             {
                 direction = direction.Normalized();
-                GetNode<Node3D>("Pivot").LookAt(Position + direction, Vector3.Up);
+                // Setting the basis property will affect the rotation of the node.
+                GetNode<Node3D>("Pivot").Basis = Basis.LookingAt(direction);
                 GetNode<AnimationPlayer>("AnimationPlayer").PlaybackSpeed = 4;
             }
             else


### PR DESCRIPTION
This PR updates the recap sections of the player script (`player.gd`) to be consistent with the player script presented in [Your first 3D game -> Moving the player with code](https://docs.godotengine.org/en/stable/getting_started/first_3d_game/03.player_movement_code.html).

### Changes
#### GDScript
```diff
- $Pivot.look_at(position + direction, Vector3.UP)
+ # Setting the basis property will affect the rotation of the node.
+ $Pivot.basis = Basis.looking_at(direction)
```
#### C#
```diff
- GetNode<Node3D>("Pivot").LookAt(Position + direction, Vector3.Up);
+ // Setting the basis property will affect the rotation of the node.
+ GetNode<Node3D>("Pivot").Basis = Basis.LookingAt(direction);
```

### Context
The demo project was updated to use `Basis.looking_at()` in [this commit](https://github.com/godotengine/godot-demo-projects/commit/0938a485633d10851eb9532f7e3dfdfd16ba1344).
This PR builds on commit 2954936, which started updating the documentation on the page [Moving the player with code](https://docs.godotengine.org/en/stable/getting_started/first_3d_game/03.player_movement_code.html#moving-the-player-with-code).

### Additional
The demo project was later modified in [this commit](https://github.com/godotengine/godot-demo-projects/b8a8670301fd7c51f3900eee96e123d220d0cb36). Should these changes be reflected in the documentation? I am unsure about their impact.

```diff
- $Pivot.basis = Basis.looking_at(direction)
+ basis = Basis.looking_at(direction)
```
```diff
- $Pivot.rotation.x = PI / 6 * velocity.y / jump_impulse
+ rotation.x = PI / 6 * velocity.y / jump_impulse
```