### PR TITLE
Fix outdated notice about reflection probes not being supported in Compatibility

### DIFF
--- a/tutorials/3d/global_illumination/reflection_probes.rst
+++ b/tutorials/3d/global_illumination/reflection_probes.rst
@@ -3,11 +3,6 @@
 Reflection probes
 =================
 
-.. note::
-
-    Reflection probes are only supported in the Forward+ and Mobile renderers,
-    not the Compatibility renderer.
-
 As stated in the :ref:`doc_standard_material_3d`, objects can show reflected and/or
 diffuse light. Reflection probes are used as a source of reflected *and* ambient
 light for objects inside their area of influence. They can be used to provide


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-docs/pull/9928.
- See https://github.com/godotengine/godot-docs-user-notes/discussions/405#discussioncomment-12706722.