### PR TITLE
Fix Export Enum Example in c_sharp_exports.rst ( Line 458)

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_exports.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_exports.rst
@@ -455,7 +455,7 @@ following as "Thing 1", "Thing 2", "Another Thing". The value will be stored as 
     }
 
     [Export]
-    public MyEnum MyEnum { get; set; }
+    public MyEnum MyEnumCurrent { get; set; }
 
 Integer and string members can also be limited to a specific list of values using the
 ``[Export]`` annotation with the ``PropertyHint.Enum`` hint.


### PR DESCRIPTION
changed line 458:
    public MyEnum MyEnum { get; set; }
to:
    public MyEnum MyEnumCurrent { get; set; }

because it throws an error if you reuse the already declared name

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
