### PR TITLE
Document how to opt out of name suffix customization in 3D import

### DIFF
--- a/tutorials/assets_pipeline/importing_3d_scenes/node_type_customization.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/node_type_customization.rst
@@ -156,13 +156,13 @@ In Blender, this requires using the NLA Editor and naming the Action with the ``
 ``cycle`` prefix or suffix.
 
 Material alpha (-alpha)
------------------------------------------------
+-----------------------
 
 A material with the ``-alpha`` suffix will be imported with the
 :ref:`TRANSPARENCY_ALPHA<class_BaseMaterial3D_constant_TRANSPARENCY_ALPHA>` transparency mode.
 
 Material vertex color (-vcol)
------------------------------------------------
+-----------------------------
 
 A material with the ``-vcol`` suffix will be imported with the
 :ref:`FLAG_ALBEDO_FROM_VERTEX_COLOR<class_BaseMaterial3D_constant_FLAG_ALBEDO_FROM_VERTEX_COLOR>` and

--- a/tutorials/assets_pipeline/importing_3d_scenes/node_type_customization.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/node_type_customization.rst
@@ -20,11 +20,33 @@ will detect suffixes in object names and will perform actions automatically.
     All the suffixes described below can be used with ``-``, ``$``, and ``_`` and are
     **case-insensitive**.
 
-Remove nodes (-noimp)
----------------------
+Opting out
+----------
 
-Objects that have the ``-noimp`` suffix will be removed at import-time no matter
-what their type is. They will not appear in the imported scene.
+If you do not want Godot to perform any of the actions described below, you
+can set the ``nodes/use_node_type_suffixes`` import option to ``false``.
+This will disable all node type suffixes, which keeps nodes the same type
+as the original file indicated. However, the ``-noimp`` suffix will still
+be respected, as well as non-node suffixes like ``-vcol`` or ``-loop``.
+
+Alternatively, you can completely opt out of all name suffixes by setting
+the ``nodes/use_name_suffixes`` import option to ``false``. This will
+completely stop the general scene import code from looking at name suffixes.
+However, the format-specific import code may still look at name suffixes,
+such as the glTF importer checking for the ``-loop`` suffix.
+
+Disabling these options makes editor-imported files more similar to the
+original files, and more similar to importing files at runtime.
+For an import workflow that works at runtime, gives more predictable
+results, and only has explicitly defined behavior, consider setting these
+options to ``false`` and using :ref:`class_GLTFDocumentExtension` instead.
+
+Remove nodes and animations (-noimp)
+------------------------------------
+
+Nodes and animations that have the ``-noimp`` suffix will be removed at
+import time no matter what their type is. They will not appear in the
+imported scene.
 
 This is equivalent to enabling **Skip Import** for a node in the Advanced Import
 Settings dialog.
@@ -132,3 +154,16 @@ will be imported as a Godot :ref:`class_Animation` with the loop flag set.
 
 In Blender, this requires using the NLA Editor and naming the Action with the ``loop`` or
 ``cycle`` prefix or suffix.
+
+Material alpha (-alpha)
+-----------------------------------------------
+
+A material with the ``-alpha`` suffix will be imported with the
+:ref:`TRANSPARENCY_ALPHA<class_BaseMaterial3D_constant_TRANSPARENCY_ALPHA>` transparency mode.
+
+Material vertex color (-vcol)
+-----------------------------------------------
+
+A material with the ``-vcol`` suffix will be imported with the
+:ref:`FLAG_ALBEDO_FROM_VERTEX_COLOR<class_BaseMaterial3D_constant_FLAG_ALBEDO_FROM_VERTEX_COLOR>` and
+:ref:`FLAG_SRGB_VERTEX_COLOR<class_BaseMaterial3D_constant_FLAG_SRGB_VERTEX_COLOR>` flags set.


### PR DESCRIPTION
The Blender Project DogWalk team and @akien-mga noticed some information missing from the docs. Specifically, how to opt out of the node name suffixes, and there was also missing documentation about the name suffixes for material alpha transparency mode and vertex colors. Also, I documented that `-noimp` applies to both nodes and animations.

Note: This docs PR assumes that https://github.com/godotengine/godot/pull/105014 will be merged for Godot 4.5. We can cherry-pick these docs to Godot 4.4 if we remove the paragraph about `nodes/use_name_suffixes`.