### PR TITLE
Remove outdated note on .app not being supported, and minor improvements to macOS export notes

### DIFF
--- a/tutorials/export/exporting_for_macos.rst
+++ b/tutorials/export/exporting_for_macos.rst
@@ -10,13 +10,18 @@ Exporting for macOS
     read :ref:`doc_compiling_for_macos`.
 
 macOS apps exported with the official export templates are exported as a single "Universal 2" binary ``.app`` bundle, a folder with a specific structure which stores the executable, libraries and all the project files.
-This bundle can be exported as is, packed in a ZIP archive or DMG disk image (only supported when exporting from a computer running macOS).
+This bundle can be exported as is, packed in a ZIP archive, or packed in a DMG disk image (only supported when exporting from macOS).
 `Universal binaries for macOS support both Intel x86_64 and ARM64 (Apple Silicon) architectures <https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary>`__.
 
 .. warning::
-    Due to file system limitations, raw ``.app`` bundles exported from Windows lack ``executable`` flag and won't run on macOS.
-    To fix it, use the ``chmod +x {executable_name}`` command after transferring the exported ``.app`` to macOS or Linux. Projects exported as ``.zip`` aren't affected by this issue.
-    The main executable located in the ``Contents/MacOS/`` subfolder, as well as optional helper executables in the ``Contents/Helpers/`` subfolder, should have ``executable`` permission for the ``.app`` bundle to be valid.
+    Due to file system limitations, ``.app`` bundles exported from Windows lack the 
+    ``executable`` flag and won't run on macOS. Projects exported as ``.zip`` are not 
+    affected by this issue. To run ``.app`` bundles exported from Windows on macOS,
+    transfer the ``.app`` to a device running macOS or Linux and use the
+    ``chmod +x {executable_name}`` terminal command to add the ``executable`` permission.
+    The main executable located in the ``Contents/MacOS/`` subfolder, as well
+    as optional helper executables in the ``Contents/Helpers/`` subfolder, should have
+    the ``executable`` permission for the ``.app`` bundle to be valid.
 
 Requirements
 ------------

--- a/tutorials/export/exporting_projects.rst
+++ b/tutorials/export/exporting_projects.rst
@@ -193,8 +193,7 @@ The output path is *relative to the project path* or *absolute*;
 The output file extension should match the one used by the Godot export process:
 
 - Windows: ``.exe``
-- macOS: ``.zip`` (from all platforms) or ``.dmg`` (only when exporting *from* macOS).
-  ``.app`` is not supported directly, although the generated ZIP archive contains an ``.app`` bundle.
+- macOS: ``.app`` or ``.zip`` (or ``.dmg`` when exporting *from* macOS)
 - Linux: Any extension (including none). ``.x86_64`` is typically used for 64-bit x86 binaries.
 - HTML5: ``.zip``
 - Android: ``.apk``


### PR DESCRIPTION
I removed an outdated note on .app not being supported and rewrote / added a few minor improvements to macOS' export notes.