### PR TITLE
Document `optimize=size_extra` SCons option

### DIFF
--- a/contributing/development/compiling/introduction_to_the_buildsystem.rst
+++ b/contributing/development/compiling/introduction_to_the_buildsystem.rst
@@ -237,6 +237,8 @@ Several compiler optimization levels can be chosen from:
   optimizations available.
 - ``optimize=size`` *(default when targeting the Web platform)*: Favors small
   binaries at the cost of slower execution speed.
+- ``optimize=size_extra``: Favors even smaller binaries, at the cost of even
+  slower execution speed compared to ``optimize=size``. Available in Godot 4.5+.
 - ``optimize=debug``: Only enables optimizations that do not impact debugging in
   any way. This results in faster binaries than ``optimize=none``, but slower
   binaries than ``optimize=speed_trace``.

--- a/contributing/development/compiling/introduction_to_the_buildsystem.rst
+++ b/contributing/development/compiling/introduction_to_the_buildsystem.rst
@@ -238,7 +238,7 @@ Several compiler optimization levels can be chosen from:
 - ``optimize=size`` *(default when targeting the Web platform)*: Favors small
   binaries at the cost of slower execution speed.
 - ``optimize=size_extra``: Favors even smaller binaries, at the cost of even
-  slower execution speed compared to ``optimize=size``. Available in Godot 4.5+.
+  slower execution speed compared to ``optimize=size``.
 - ``optimize=debug``: Only enables optimizations that do not impact debugging in
   any way. This results in faster binaries than ``optimize=none``, but slower
   binaries than ``optimize=speed_trace``.

--- a/contributing/development/compiling/optimizing_for_size.rst
+++ b/contributing/development/compiling/optimizing_for_size.rst
@@ -89,6 +89,12 @@ To enable this, set the ``optimize`` flag to ``size``:
 
 Some platforms such as WebAssembly already use this mode by default.
 
+Godot 4.5 introduced the ``size_extra`` option, which can further reduce size.
+
+::
+
+    scons target=template_release optimize=size_extra
+
 Disabling advanced text server
 ------------------------------
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Godot 4.5 adds the ability to set the `optimize` SCons flag to `size_extra` (see godotengine/godot#101964). This PR documents this change in the compiling documentation.

Closes #10844