### PR TITLE
Fix @export_custom hint format in gdscript_exports.rst

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_exports.rst
+++ b/tutorials/scripting/gdscript/gdscript_exports.rst
@@ -475,7 +475,7 @@ For example, this exposes the ``altitude`` property with no range limits but a
 
 ::
 
-    @export_custom(PROPERTY_HINT_NONE, "suffix:m") var altitude: Vector3
+    @export_custom(PROPERTY_HINT_NONE, "suffix:m") var altitude: float
 
 The above is normally not feasible with the standard ``@export_range`` syntax,
 since it requires defining a range.

--- a/tutorials/scripting/gdscript/gdscript_exports.rst
+++ b/tutorials/scripting/gdscript/gdscript_exports.rst
@@ -475,7 +475,7 @@ For example, this exposes the ``altitude`` property with no range limits but a
 
 ::
 
-    @export_custom(PROPERTY_HINT_NONE, "altitude:m") var altitude: Vector3
+    @export_custom(PROPERTY_HINT_NONE, "suffix:m") var altitude: Vector3
 
 The above is normally not feasible with the standard ``@export_range`` syntax,
 since it requires defining a range.


### PR DESCRIPTION
Corrects the `@export_custom` example to use `"suffix:m"` instead of `"altitude:m"`.
The engine seems to define a suffix if the comma delimited hint string has a slice which starts with `suffix:`.