### PR TITLE
Fix Sublime Text arguments in Using an external editor

### DIFF
--- a/tutorials/editor/external_editor.rst
+++ b/tutorials/editor/external_editor.rst
@@ -54,10 +54,17 @@ Some example **Exec Flags** for various editors include:
 +---------------------+-----------------------------------------------------+
 | Emacs               | ``emacs +{line}:{col} {file}``                      |
 +---------------------+-----------------------------------------------------+
-| Sublime Text        | ``{project} {file}:{line}:{column}``                |
+| Sublime Text        | ``{project} {file}:{line}:{col}``                   |
 +---------------------+-----------------------------------------------------+
-| Visual Studio       | ``/edit "file"``                                    |
+| Visual Studio*      | ``/edit "file"``                                    |
 +---------------------+-----------------------------------------------------+
+
+\*: Arguments are not automatically detected, so you must fill them in manually.
+
+Since Godot 4.5, **Exec Flags** are automatically detected for all editors
+listed above (unless denoted with an asterisk). You don't need to paste them
+from this page for it to work, unless your editor has an executable name not
+recognized automatically (e.g. a fork of an editor listed here).
 
 .. note::
 


### PR DESCRIPTION
- Companion PR to https://github.com/godotengine/godot/pull/105442.

___

- Mention automatic Exec Flags setting in 4.5.

___

- See https://github.com/godotengine/godot-docs-user-notes/discussions/31#discussioncomment-12819013.
