### PR TITLE
Fix missing back-ticks on "Shading lanugage" page

### DIFF
--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -1257,7 +1257,7 @@ Built-in variables
 A large number of built-in variables are available, like ``UV``, ``COLOR`` and
 ``VERTEX``. What variables are available depends on the type of shader
 (``spatial``, ``canvas_item``, ``particle``, etc) and the
-function used (``vertex``, ``fragment``, ``light``, ``start``, ``process,
+function used (``vertex``, ``fragment``, ``light``, ``start``, ``process``,
 ``sky``, or ``fog``). For a list of the built-in variables that are available,
 please see the corresponding pages:
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
Some back-ticks for a code section were missing on the "Shading language" page, causing some minor formatting issues.