### PR TITLE
Fix typo in C# example in Running code in the editor

### DIFF
--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -237,7 +237,7 @@ angle add a setter ``set(new_speed)`` which is executed with the input from the 
 
         public override void _Process(double delta)
         {
-            Rotation += Mathf.Pi * (float)delta * speed;
+            Rotation += Mathf.Pi * (float)delta * _speed;
         }
     }
 


### PR DESCRIPTION
- See https://github.com/godotengine/godot-docs-user-notes/discussions/400#discussioncomment-12907957.
