### PR TITLE
Hide user notes on 404 page

### DIFF
--- a/404.rst
+++ b/404.rst
@@ -1,0 +1,24 @@
+:github_url: hide
+:allow_comments: False
+
+Page not found
+==============
+
+.. https://github.com/readthedocs/sphinx-notfound-page
+
+.. raw:: html
+
+    <p>
+        Sorry, we couldn't find that page. It may have been renamed or removed
+        in the version of the documentation you're currently browsing.
+    </p>
+    <p>
+        If you're currently browsing the
+        <em>latest</em> version of the documentation, try browsing the
+        <a href="/en/stable/"><em>stable</em> version of the documentation</a>.
+    </p>
+    <p>
+        Alternatively, use the
+        <a href="#" onclick="$('#rtd-search-form [name=\\'q\\']').focus()">Search docs</a>
+        box on the left or <a href="/">go to the homepage</a>.
+    </p>

--- a/conf.py
+++ b/conf.py
@@ -29,29 +29,6 @@ sphinx_tabs_nowarn = True
 # Disable collapsing tabs for codeblocks.
 sphinx_tabs_disable_tab_closing = True
 
-# Custom 4O4 page HTML template.
-# https://github.com/readthedocs/sphinx-notfound-page
-notfound_context = {
-    "title": "Page not found",
-    "body": """
-        <h1>Page not found</h1>
-        <p>
-            Sorry, we couldn't find that page. It may have been renamed or removed
-            in the version of the documentation you're currently browsing.
-        </p>
-        <p>
-            If you're currently browsing the
-            <em>latest</em> version of the documentation, try browsing the
-            <a href="/en/stable/"><em>stable</em> version of the documentation</a>.
-        </p>
-        <p>
-            Alternatively, use the
-            <a href="#" onclick="$('#rtd-search-form [name=\\'q\\']').focus()">Search docs</a>
-            box on the left or <a href="/">go to the homepage</a>.
-        </p>
-    """,
-}
-
 # on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
 on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 


### PR DESCRIPTION
This switches to `404.rst` instead of an embedded 404 page in `conf.py`, so we can specify page metadata.

I've tested this change locally and it stops the user notes block from generating on the generated `404.html`.