### PR TITLE
Document CollisionObject3D requires object visibility

### DIFF
--- a/classes/class_collisionobject3d.rst
+++ b/classes/class_collisionobject3d.rst
@@ -130,7 +130,10 @@ Emitted when the object receives an unhandled :ref:`InputEvent<class_InputEvent>
 
 **mouse_entered**\ (\ ) :ref:`🔗<class_CollisionObject3D_signal_mouse_entered>`
 
-Emitted when the mouse pointer enters any of this object's shapes. Requires :ref:`input_ray_pickable<class_CollisionObject3D_property_input_ray_pickable>` to be ``true`` and at least one :ref:`collision_layer<class_CollisionObject3D_property_collision_layer>` bit to be set.
+Emitted when the mouse pointer enters any of this object's shapes.
+Requires :ref:`is_visible_in_tree()<class_Node3D_method_is_visible_in_tree>` to return ``true``, 
+:ref:`input_ray_pickable<class_CollisionObject3D_property_input_ray_pickable>` to be ``true``,
+and at least one :ref:`collision_layer<class_CollisionObject3D_property_collision_layer>` bit to be set.
 
 \ **Note:** Due to the lack of continuous collision detection, this signal may not be emitted in the expected order if the mouse moves fast enough and the **CollisionObject3D**'s area is small. This signal may also not be emitted if another **CollisionObject3D** is overlapping the **CollisionObject3D** in question.
 
@@ -144,7 +147,11 @@ Emitted when the mouse pointer enters any of this object's shapes. Requires :ref
 
 **mouse_exited**\ (\ ) :ref:`🔗<class_CollisionObject3D_signal_mouse_exited>`
 
-Emitted when the mouse pointer exits all this object's shapes. Requires :ref:`input_ray_pickable<class_CollisionObject3D_property_input_ray_pickable>` to be ``true`` and at least one :ref:`collision_layer<class_CollisionObject3D_property_collision_layer>` bit to be set.
+Emitted when the mouse pointer exits all of this object's shapes.
+
+Requires :ref:`is_visible_in_tree()<class_Node3D_method_is_visible_in_tree>` to return ``true``, 
+:ref:`input_ray_pickable<class_CollisionObject3D_property_input_ray_pickable>` to be ``true``,
+and at least one :ref:`collision_layer<class_CollisionObject3D_property_collision_layer>` bit to be set.
 
 \ **Note:** Due to the lack of continuous collision detection, this signal may not be emitted in the expected order if the mouse moves fast enough and the **CollisionObject3D**'s area is small. This signal may also not be emitted if another **CollisionObject3D** is overlapping the **CollisionObject3D** in question.
 


### PR DESCRIPTION
this is pretty unwieldy; maybe it's _actually_ a bug in how mouse_entered and _exit work. But per https://github.com/godotengine/godot/blob/ce94b26de74a0a0f2463c5dc61b9b683a1e3676b/scene/3d/physics/collision_object_3d.cpp#L338 this is directly how it's implemented, so we might as well be honest about it.

(in general, there's some confusion about how to "turn off" physics objects -- via processing? (there's a setting for that). Via setting a parent object to invisible? (it's not ray pickable anymore, but there's no configuration/notes around it. Probably fine, therefore: doc fix.))

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
