### PR TITLE
Clarify that `Tree.create_item()` may fail and when

### DIFF
--- a/classes/class_tree.rst
+++ b/classes/class_tree.rst
@@ -863,6 +863,8 @@ If ``parent`` is ``null``, the root item will be the parent, or the new item wil
 
 The new item will be the ``index``-th child of parent, or it will be the last child if there are not enough siblings.
 
+Returns ``null`` if called while a mouse selection occurs.
+
 .. rst-class:: classref-item-separator
 
 ----


### PR DESCRIPTION
This change addresses [`_OnTreeItemSelected()` signal receiver method using C# doesn't allow adding of items #103101](https://github.com/godotengine/godot/issues/103101). 

This update clarifies the `Tree.create_item()` documentation to indicate that the method returns null if called during a mouse selection event.

Note: This is my first time contributing, so I apologize for any mistakes!