### PR TITLE
Fix URL to gamepad tester website

### DIFF
--- a/tutorials/inputs/controllers_gamepads_joysticks.rst
+++ b/tutorials/inputs/controllers_gamepads_joysticks.rst
@@ -284,8 +284,8 @@ My controller isn't recognized by Godot.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 First, check that your controller is recognized by other applications. You can
-use the `Gamepad Tester <https://gamepad-tester.com/>`__ website to confirm that
-your controller is recognized.
+use the `Gamepad Tester <https://hardwaretester.com/gamepad>`__ website to confirm
+that your controller is recognized.
 
 On Windows Godot only supports up to 4 controllers at a time. This is
 because Godot uses the XInput API, which is limited to supporting 4 controllers


### PR DESCRIPTION
URL changed. Old URL is still redirecting, for now.

Cherrypicking recommended