### PR TITLE
Ensure mobile <abbr> tooltips don't appear off-screen

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -703,6 +703,8 @@ footer {
 
 .wy-nav-content-wrap {
     background-color: var(--content-wrap-background-color);
+    position: relative;
+    overflow-x: auto;
 }
 
 .wy-nav-content {
@@ -1814,30 +1816,22 @@ p + .classref-constant {
     padding: 0.5em 0.75em;
 }
 
-/* Allow :abbr: tags' content to be displayed on mobile platforms by tapping the word */
-@media (hover: none), (hover: on-demand), (-moz-touch-enabled: 1), (pointer:coarse) {
-    /* Do not enable on desktop platforms to avoid doubling the tooltip */
-    abbr[title] {
-        position: relative;
-    }
-
-    abbr[title]:hover::after,
-    abbr[title]:focus::after {
-        content: attr(title);
-
-        position: absolute;
-        left: 0;
-        bottom: -32px;
-        width: auto;
-        white-space: nowrap;
-
-        background-color: #1e1e1e;
-        color: #fff;
-        border-radius: 3px;
-        box-shadow: 1px 1px 5px 0 rgba(0, 0, 0, 0.4);
-        font-size: 14px;
-        padding: 3px 5px;
-    }
+.abbr-tooltip {
+    position: absolute;
+    transform: translate(var(--offset-x), var(--offset-y));
+    width: max-content;
+    max-width: 100vw;
+    padding: 0 1rem;
+    z-index: 1;
+}
+.abbr-tooltip > div {
+    background-color: #1e1e1e;
+    color: #fff;
+    border-radius: 3px;
+    box-shadow: 1px 1px 5px 0 rgba(0, 0, 0, 0.4);
+    font-size: 14px;
+    padding: 3px 5px;
+    white-space: normal;
 }
 
 /* Giscus */

--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -477,6 +477,39 @@ $(document).ready(() => {
       }
   });
 
+  /** @type HTMLElement */
+  let currentlyShownTooltip = null;
+  const touchDeviceQuery = window.matchMedia('(hover: none), (hover: on-demand), (-moz-touch-enabled: 1), (pointer:coarse)');
+  
+  /* Allow :abbr: tags' content to be displayed on mobile platforms by tapping the word */
+  document.addEventListener('click', (event) => {
+    if (currentlyShownTooltip) {
+      currentlyShownTooltip.remove();
+      currentlyShownTooltip = null;
+    }
+
+    /* Do not enable on desktop platforms to avoid doubling the tooltip */
+    if (!touchDeviceQuery.matches) {
+      return;
+    }
+
+    /** @type HTMLElement */
+    const abbr = event.target;
+
+    if (abbr.matches('abbr[title]')) {
+      currentlyShownTooltip = document.createElement('div');
+      currentlyShownTooltip.classList.add('abbr-tooltip')
+      currentlyShownTooltip.appendChild(document.createElement('div')).innerText = abbr.getAttribute('title');
+      abbr.appendChild(currentlyShownTooltip);
+
+      const tooltipRect = currentlyShownTooltip.getBoundingClientRect();
+      const distanceOffScreenX = Math.max(0, tooltipRect.right - window.innerWidth);
+      const distanceOffScreenY = Math.max(0, tooltipRect.bottom - window.innerHeight);
+      currentlyShownTooltip.style.setProperty('--offset-x', -distanceOffScreenX + 'px');
+      currentlyShownTooltip.style.setProperty('--offset-y', -distanceOffScreenY + 'px');
+    }
+  });
+
   // Unfold the first (general information) section on the home page.
   if (!hasCurrent && menuHeaders.length > 0) {
     menuHeaders[0].classList.add('active');


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Closes https://github.com/godotengine/godot-docs/issues/10917

To solve this, the tooltips need to be positioned based on their own size and the size of the viewport while remaining anchored to the clicked `<abbr>` element. This isn't possible with only CSS (at least not what is currently widely supported by browsers), so we need to calculate and apply some positioning adjustments in JS. Since pseudo elements can't be accessed from JS, the creation of the tooltip elements also has to move there.

The move from CSS to JS gives more flexibility in how to handle showing and hiding the tooltips, so they're now closed even when you tap again on the same word or on the tooltip (though if we want to keep the old behaviour there that would be possible too).

Mobile browsers have some non-standardized quirks when the size of the webpage is bigger than the window. This means the viewport used for layouting and reported to scripts may be bigger than the actual visual viewport, which poses a problem when we need to tell if an element is off-screen. To avoid these issues I set `overflow-x` on one of the inner divs so that the body element itself never overflows horizontally. As a side effect I think this also fixes an issue with the floating ReadTheDocs flyout being off-screen on pages that overflow on mobile.