### PR TITLE
Clarify UTF encoding between C# strings and Godot Strings

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_differences.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_differences.rst
@@ -381,7 +381,7 @@ Use ``System.String`` (``string``). Most of Godot's String methods have an
 equivalent in ``System.String`` or are provided by the ``StringExtensions``
 class as extension methods.
 
-Note that C# strings uses UTF-16 encoding, while Godot Strings uses UTF-32 encoding.
+Note that C# strings use UTF-16 encoding, while Godot Strings use UTF-32 encoding.
 
 Example:
 


### PR DESCRIPTION
Fix #7682 

Updated c_sharp_differences.rst to include the difference between the UTF encoding for C# strings and Godot Strings.