### PR TITLE
[.NET] Document web support and limitations

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -46,10 +46,8 @@ Godot aims to be as platform-independent as possible and can be
 
 .. note::
 
-    Projects written in C# using Godot 4 currently cannot be exported to the
-    web platform. To use C# on that platform, consider Godot 3 instead.
-    Android and iOS platform support is available as of Godot 4.2, but is
-    experimental and :ref:`some limitations apply <doc_c_sharp_platforms>`.
+    Projects written in C# using Godot 4 have experimental support for Android and iOS since 4.2,
+    and for the web platform since 4.5. See :ref:`doc_c_sharp_platforms` for more information.
 
 Editor
 ------
@@ -467,11 +465,10 @@ Scripting
 
    - Full support for the C# 12.0 syntax and features.
 
-- Supports Windows, Linux, and macOS. Since Godot 4.2, experimental support for Android and iOS is also available.
+- Supports Windows, Linux, and macOS. Since Godot 4.2, experimental support for Android and iOS is also available. Since 4.5, experimental support for web is also available.
 
    - On the iOS platform only some architectures are supported: ``arm64``.
-   - The web platform is currently unsupported. To use C# on that platform,
-     consider Godot 3 instead.
+   - The web platform has :ref:`some limitations <doc_c_sharp_platforms>`.
 
 - Using an external editor is recommended to benefit from IDE functionality.
 

--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -16,11 +16,8 @@ in the user's browser.
 
 .. attention::
 
-    Projects written in C# using Godot 4 currently cannot be exported to the
-    web. See `this blog post <https://godotengine.org/article/platform-state-in-csharp-for-godot-4-2/#web>`__
-    for more information.
-
-    To use C# on web platforms, use Godot 3 instead.
+    Projects written in C# using Godot 4 have experimental support for Android and iOS since 4.2,
+    and for the web platform since 4.5. See :ref:`doc_c_sharp_platforms` for more information.
 
 .. tip::
 

--- a/tutorials/scripting/c_sharp/c_sharp_basics.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_basics.rst
@@ -16,10 +16,8 @@ it is implemented with .NET 8.0.
 
 .. attention::
 
-    Projects written in C# using Godot 4 currently cannot be exported to the web
-    platform. To use C# on the web platform, consider Godot 3 instead.
-    Android and iOS platform support is available as of Godot 4.2, but is
-    experimental and :ref:`some limitations apply <doc_c_sharp_platforms>`.
+    Projects written in C# using Godot 4 have experimental support for Android and iOS since 4.2,
+    and for the web platform since 4.5. See :ref:`doc_c_sharp_platforms` for more information.
 
 .. note::
 

--- a/tutorials/scripting/c_sharp/index.rst
+++ b/tutorials/scripting/c_sharp/index.rst
@@ -57,7 +57,7 @@ C# platform support
     See `supported OS <https://github.com/dotnet/core/tree/main/release-notes#supported-os>`_.
 
 Since Godot 4.2, projects written in C# support all desktop platforms (Windows, Linux,
-and macOS), as well as Android and iOS.
+and macOS), as well as Android and iOS. And since 4.5, web is supported too.
 
 Android support is currently experimental.
 
@@ -67,5 +67,10 @@ iOS support is currently experimental and has a few limitations.
 
 - Exporting to iOS can only be done from a MacOS device.
 
-Currently, projects written in C# cannot be exported to the web platform. To use C#
-on that platform, consider Godot 3 instead.
+Web support is currently experimental and has a few limitations.
+
+- The WASM features enabled in the C# project must match the ones enabled by the template used to export the project.
+
+- Globalization is not supported, `invariant mode <https://learn.microsoft.com/en-us/dotnet/core/runtime-config/globalization#invariant-mode>`_ is always enabled on exported games. This does not affect Godot's localization features, only .NET APIs.
+
+- .NET APIs implemented using browser APIs (such as cryptography) are not available and may fail in unexpected ways.


### PR DESCRIPTION
- Documents the new .NET web support added by https://github.com/godotengine/godot/pull/106125.