### PR TITLE
Recommend GPU Screen Recorder instead of SimpleScreenRecorder for recording on Linux

### DIFF
--- a/classes/class_moviewriter.rst
+++ b/classes/class_moviewriter.rst
@@ -31,7 +31,7 @@ If you need to encode to a different format or pipe a stream through third-party
 
 \ **Editor usage:** A default movie file path can be specified in :ref:`ProjectSettings.editor/movie_writer/movie_file<class_ProjectSettings_property_editor/movie_writer/movie_file>`. Alternatively, for running single scenes, a ``movie_file`` metadata can be added to the root node, specifying the path to a movie file that will be used when recording that scene. Once a path is set, click the video reel icon in the top-right corner of the editor to enable Movie Maker mode, then run any scene as usual. The engine will start recording as soon as the splash screen is finished, and it will only stop recording when the engine quits. Click the video reel icon again to disable Movie Maker mode. Note that toggling Movie Maker mode does not affect project instances that are already running.
 
-\ **Note:** MovieWriter is available for use in both the editor and exported projects, but it is *not* designed for use by end users to record videos while playing. Players wishing to record gameplay videos should install tools such as `OBS Studio <https://obsproject.com/>`__ or `SimpleScreenRecorder <https://www.maartenbaert.be/simplescreenrecorder/>`__ instead.
+\ **Note:** MovieWriter is available for use in both the editor and exported projects, but it is *not* designed for use by end users to record videos while playing. Players wishing to record gameplay videos should install tools such as `OBS Studio <https://obsproject.com/>`__ or `GPU Screen Recorder <https://git.dec05eba.com/gpu-screen-recorder/about/>`__ instead.
 
 .. rst-class:: classref-reftable-group
 

--- a/contributing/documentation/docs_image_guidelines.rst
+++ b/contributing/documentation/docs_image_guidelines.rst
@@ -181,7 +181,7 @@ Operating systems generally don't come with tools that are flexible enough
 for this, so you'll need to install a third-party utility.
 
 `OBS Studio <https://obsproject.com/>`__ is the most popular option, but
-`SimpleScreenRecorder <https://www.maartenbaert.be/simplescreenrecorder/>`__
+`GPU Screen Recorder <https://git.dec05eba.com/gpu-screen-recorder/about/>`__
 can be used as an alternative on Linux. `ShareX <https://getsharex.com/>`__
 can be used as an alternative on Windows. All these tools can be configured
 to record the entire screen, a specific window or a predetermined rectangle.

--- a/tutorials/animation/creating_movies.rst
+++ b/tutorials/animation/creating_movies.rst
@@ -46,7 +46,7 @@ Compared to real-time video recording, some advantages of non-real-time recordin
     **This feature is not designed for capturing real-time footage during gameplay.**
 
     Players should use something like `OBS Studio <https://obsproject.com/>`__ or
-    `SimpleScreenRecorder <https://www.maartenbaert.be/simplescreenrecorder/>`__
+    `GPU Screen Recorder <https://git.dec05eba.com/gpu-screen-recorder/about/>`__
     to record gameplay videos, as they do a much better job at intercepting the
     compositor than Godot can do using Vulkan or OpenGL natively.
 


### PR DESCRIPTION
Switch to recommending GPU Screen Recorder instead of SimpleScreenRecorder for recording for Linux. It's a newer project that offers the following features over SSR:

1. Full Wayland support, including Wayland hotkeys. X11 is supported as well.
2. Very efficient utilization of GPU encoding across all GPU vendors, even better than OBS Studio
3. Not quite relevant for Godot at the moment, but HDR recording support
4. Importantly for end users, it's [available](https://flathub.org/apps/com.dec05eba.gpu_screen_recorder) as a Flatpak, meaning it's easy to install on about every distro out there

Other than that, GPU Screen Recorder is just generally the go-to solution for screen recording on Linux these days due to being both efficient and easy to use, so it makes sense to recommend it.