### PR TITLE
Add `call_deferred` to UI Navigation code example

### DIFF
--- a/tutorials/ui/gui_navigation.rst
+++ b/tutorials/ui/gui_navigation.rst
@@ -58,22 +58,25 @@ have well-defined vertical or horizontal navigation flow.
 Necessary code
 --------------
 
-For keyboard and controller navigation to work correctly, any node must be focused on
+For keyboard and controller navigation to work correctly, any node must be focused by
 using code when the scene starts. Without doing this, pressing buttons or keys won't
-do anything. Here is a basic example of setting initial focus with code:
+do anything.
+
+You can use the :ref:`Control.grab_focus() <class_Control_method_grab_focus>` method
+to focus a control. Here is a basic example of setting initial focus with code:
 
 .. tabs::
  .. code-tab:: gdscript GDScript
 
     func _ready():
-        $StartButton.grab_focus()
+        $StartButton.grab_focus.call_deferred()
 
  .. code-tab:: csharp
 
     public override void _Ready()
     {
-        GetNode<Button>("StartButton").GrabFocus();
+        GetNode<Button>("StartButton").GrabFocus.CallDeferred();
     }
 
-Now when the scene starts the "Start Button" node will be focused, and the keyboard
+Now when the scene starts, the "Start Button" node will be focused, and the keyboard
 or a controller can be used to navigate between it and other UI elements.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Adds `call_deferred` to the code example in the UI Navigation tutorial so that the code works more reliably. Also fixes a couple of small typos.
Closes #10136