### PR TITLE
Remove suggestion to do a partial upgrade

### DIFF
--- a/contributing/development/compiling/compiling_for_windows.rst
+++ b/contributing/development/compiling/compiling_for_windows.rst
@@ -351,7 +351,7 @@ The package names may differ based on your distribution, here are some known one
 +----------------+--------------------------------------------------------------+
 | **Arch Linux** | ::                                                           |
 |                |                                                              |
-|                |     pacman -Sy mingw-w64                                     |
+|                |     pacman -S mingw-w64                                      |
 +----------------+--------------------------------------------------------------+
 | **Debian** /   | ::                                                           |
 | **Ubuntu**     |                                                              |


### PR DESCRIPTION
The Compiling for Windows page currently suggests doing a partial upgrade on arch, this is potentially dangerous and can lead to a broken system.

See: https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported
