### PR TITLE
Add instructions on how to use a pre-compiled GDExtension, + update a link in the GDExtension class reference

### DIFF
--- a/classes/class_gdextension.rst
+++ b/classes/class_gdextension.rst
@@ -28,7 +28,7 @@ The **GDExtension** resource type represents a `shared library <https://en.wikip
 Tutorials
 ---------
 
-- :doc:`GDExtension overview <../tutorials/scripting/gdextension/what_is_gdextension>`
+- :doc:`GDExtension overview <../tutorials/scripting/gdextension/index>`
 
 - :doc:`GDExtension example in C++ <../tutorials/scripting/cpp/gdextension_cpp_example>`
 

--- a/tutorials/scripting/gdextension/index.rst
+++ b/tutorials/scripting/gdextension/index.rst
@@ -9,6 +9,9 @@ The GDExtension system
 native `shared libraries <https://en.wikipedia.org/wiki/Library_(computing)#Shared_libraries>`__
 at runtime. You can use it to run native code without compiling it with the engine.
 
+In order to use a pre-compiled GDExtension in your Godot project, place the `.gdextension` file somewhere inside your
+project's directory. Godot will then load the extension and you should be able to use it in your project.
+
 .. note:: GDExtension is *not* a scripting language and has no relation to
           :ref:`GDScript <doc_gdscript>`.
 


### PR DESCRIPTION
Currently, a Godot end-user who downloaded a pre-made GDExtension (such as [SG Physics 2D](https://gitlab.com/snopek-games/sg-physics-2d)) would struggle to find out how to use it in their own project. These instructions are not listed anywhere, and the current GDExtension docs only cater to people *writing* a GDExtension.

This PR adds a short section to the main GDExtension page describing this, and also changes the link in the GDExtension class doc to lead to the main GDExtension page instead of a sub-page.

Addresses #9277.