### PR TITLE
Update Optimizing for size for Godot 4.5

### DIFF
--- a/contributing/development/compiling/optimizing_for_size.rst
+++ b/contributing/development/compiling/optimizing_for_size.rst
@@ -66,12 +66,10 @@ and MSVC compilers:
     scons target=template_release lto=full
 
 Linking becomes much slower and more RAM-consuming with this option,
-so it should be used only for release builds:
-
-- When compiling the ``master`` branch, you need to have at least 8 GB of RAM
-  available for successful linking with LTO enabled.
-- When compiling the ``3.x`` branch, you need to have at least 6 GB of RAM
-  available for successful linking with LTO enabled.
+so it should be used only for release builds. You need to have at least
+8 GB of RAM available for successful linking with LTO enabled. Since the operating
+system and programs will take up some RAM, in practice, you need 12 GB of RAM
+installed in your system (preferably 16 GB) to compile Godot with LTO enabled.
 
 Optimizing for size instead of speed
 ------------------------------------
@@ -170,10 +168,12 @@ This is everything that will be disabled:
 - :ref:`class_CharFXTransform`
 - :ref:`class_CodeEdit`
 - :ref:`class_CodeHighlighter`
-- :ref:`class_ColorPickerButton`
 - :ref:`class_ColorPicker`
+- :ref:`class_ColorPickerButton`
 - :ref:`class_ConfirmationDialog`
 - :ref:`class_FileDialog`
+- :ref:`class_FoldableContainer`
+- :ref:`class_FoldableGroup`
 - :ref:`class_GraphEdit`
 - :ref:`class_GraphElement`
 - :ref:`class_GraphFrame`
@@ -191,9 +191,41 @@ This is everything that will be disabled:
 - :ref:`class_SubViewportContainer`
 - :ref:`class_SyntaxHighlighter`
 - :ref:`class_TextEdit`
-- :ref:`class_TreeItem`
 - :ref:`class_Tree`
+- :ref:`class_TreeItem`
 - :ref:`class_VSplitContainer`
+
+Disabling physics engines
+-------------------------
+
+- **Space savings:** Low to moderate
+- **Difficulty:** Easy
+- **Performed in official builds:** No
+
+If your 3D project uses Jolt Physics, you can disable GodotPhysics3D at compile-time as
+it will never be used:
+
+::
+
+    scons target=template_release module_godot_physics_3d_enabled=no
+
+Inversely, if your 3D project uses GodotPhysics3D, you can disable Jolt Physics at compile-time:
+
+::
+
+    scons target=template_release module_jolt_enabled=no
+
+If your project uses 3D rendering but not physics (or 2D rendering but not physics),
+you can also disable 2D or 3D physics entirely. Most 3D projects can take advantage
+of this, as they don't make use of 2D physics:
+
+::
+
+    scons target=template_release disable_physics_2d=yes
+
+::
+
+    scons target=template_release disable_physics_3d=yes
 
 Disabling unwanted modules
 --------------------------
@@ -215,7 +247,7 @@ a lot of them:
 
 ::
 
-    scons target=template_release module_basis_universal_enabled=no module_bmp_enabled=no module_camera_enabled=no module_csg_enabled=no module_dds_enabled=no module_enet_enabled=no module_gridmap_enabled=no module_hdr_enabled=no module_jsonrpc_enabled=no module_ktx_enabled=no module_mbedtls_enabled=no module_meshoptimizer_enabled=no module_minimp3_enabled=no module_mobile_vr_enabled=no module_msdfgen_enabled=no module_multiplayer_enabled=no module_noise_enabled=no module_navigation_3d_enabled=no module_ogg_enabled=no module_openxr_enabled=no module_raycast_enabled=no module_regex_enabled=no module_squish_enabled=no module_svg_enabled=no module_tga_enabled=no module_theora_enabled=no module_tinyexr_enabled=no module_upnp_enabled=no module_vhacd_enabled=no module_vorbis_enabled=no module_webrtc_enabled=no module_websocket_enabled=no module_webxr_enabled=no module_zip_enabled=no
+    scons target=template_release module_astcenc_enabled=no module_basis_universal_enabled=no module_bcdec_enabled=no module_bmp_enabled=no module_camera_enabled=no module_csg_enabled=no module_dds_enabled=no module_enet_enabled=no module_etcpak_enabled=no module_fbx_enabled=no module_gltf_enabled=no module_gridmap_enabled=no module_hdr_enabled=no module_interactive_music_enabled=no module_jsonrpc_enabled=no module_ktx_enabled=no module_mbedtls_enabled=no module_meshoptimizer_enabled=no module_minimp3_enabled=no module_mobile_vr_enabled=no module_msdfgen_enabled=no module_multiplayer_enabled=no module_noise_enabled=no module_navigation_2d_enabled=no module_navigation_3d_enabled=no module_ogg_enabled=no module_openxr_enabled=no module_raycast_enabled=no module_regex_enabled=no module_svg_enabled=no module_tga_enabled=no module_theora_enabled=no module_tinyexr_enabled=no module_upnp_enabled=no module_vhacd_enabled=no module_vorbis_enabled=no module_webrtc_enabled=no module_websocket_enabled=no module_webxr_enabled=no module_zip_enabled=no
 
 If this proves not to work for your use case, you should review the list of
 modules and see which ones you actually still need for your game (e.g. you might
@@ -229,29 +261,35 @@ following:
 .. code-block:: python
     :caption: custom.py
 
+    module_astcenc_enabled = "no"
     module_basis_universal_enabled = "no"
+    module_bcdec_enabled = "no"
     module_bmp_enabled = "no"
     module_camera_enabled = "no"
     module_csg_enabled = "no"
     module_dds_enabled = "no"
     module_enet_enabled = "no"
+    module_etcpak_enabled = "no"
+    module_fbx_enabled = "no"
+    module_gltf_enabled = "no"
     module_gridmap_enabled = "no"
     module_hdr_enabled = "no"
+    module_interactive_music_enabled = "no"
     module_jsonrpc_enabled = "no"
     module_ktx_enabled = "no"
     module_mbedtls_enabled = "no"
     module_meshoptimizer_enabled = "no"
     module_minimp3_enabled = "no"
     module_mobile_vr_enabled = "no"
-    module_msdfgen_enabled= "no"
+    module_msdfgen_enabled = "no"
     module_multiplayer_enabled = "no"
     module_noise_enabled = "no"
+    module_navigation_2d_enabled = "no"
     module_navigation_3d_enabled = "no"
     module_ogg_enabled = "no"
     module_openxr_enabled = "no"
     module_raycast_enabled = "no"
     module_regex_enabled = "no"
-    module_squish_enabled = "no"
     module_svg_enabled = "no"
     module_tga_enabled = "no"
     module_theora_enabled = "no"


### PR DESCRIPTION
- Document disabling physics engines (and 2D/3D physics altogether).
- Mention disabling 2D navigation separately from 3D.
- Improve LTO minimum RAM notice and remove reference to Godot 3.x.
- Update list of modules that can be disabled in a minimal 2D game.
- Update list of nodes that are disabled with `disable_advanced_gui=yes`.
