### PR TITLE
Update Playing Videos page for Godot 4.5

### DIFF
--- a/tutorials/animation/playing_videos.rst
+++ b/tutorials/animation/playing_videos.rst
@@ -150,10 +150,8 @@ To ensure your videos decode smoothly on varied hardware:
 Playback limitations
 --------------------
 
-There are several limitations with the current implementation of video playback in Godot:
+There are some limitations with the current implementation of video playback in Godot:
 
-- Changing playback speed is not supported. VideoStreamPlayer also won't follow
-  :ref:`Engine.time_scale<class_Engine_property_time_scale>`.
 - Streaming a video from a URL is not supported.
 - Only mono and stereo audio output is supported. Videos with 4, 5.1 and 7.1
   audio channels are supported but down-mixed to stereo.
@@ -183,7 +181,7 @@ maximize the quality of the output Ogg Theora video, but this can require a lot
 of disk space.
 
 `FFmpeg <https://ffmpeg.org/>`__ (CLI) is a popular open source tool
-for this purpose. FFmpeg has a steep learning curve, but it's powerful tool.
+for this purpose. FFmpeg has a steep learning curve, but it's a powerful tool.
 
 Here are example FFmpeg commands to convert an MP4 video to Ogg Theora. Since
 FFmpeg supports a lot of input formats, you should be able to use the commands
@@ -195,17 +193,20 @@ below with almost any input video format (AVI, MOV, WebM, …).
    You can check this by running ``ffmpeg`` without any arguments, then looking
    at the ``configuration:`` line in the command output.
 
-.. UPDATE: When the FFmpeg bugfixes for https://trac.ffmpeg.org/ticket/11451 and
-.. https://trac.ffmpeg.org/ticket/11454 are included in a stable FFmpeg release,
-.. this note can be removed. That will likely be FFmpeg 7.2 or 8.0, and will
-.. likely happen during the Godot 4.5 or 4.6 release cycle.
-
 .. warning::
 
-   All FFmpeg releases before Feb 20th, 2025 could produce bad video streams
-   due to a couple of bugs. It's highly recommended to use one of the latest
-   static daily builds, or build FFmpeg from their master branch where they're
-   already fixed.
+   Current official FFmpeg releases have some bugs in their Ogg/Theora
+   multiplexer. It's highly recommended to use one of the latest static daily
+   builds, or build from their master branch to get the latest fixes.
+
+.. UPDATE: When the FFmpeg bugfixes for https://trac.ffmpeg.org/ticket/11451 and
+.. https://trac.ffmpeg.org/ticket/11454 are included in a stable FFmpeg release,
+.. this warning can be removed. That will likely be FFmpeg 7.2 or 8.0, and will
+.. likely happen during the Godot 4.5 or 4.6 release cycle.
+.. Commits fixing the issues:
+.. - https://github.org/FFmpeg/FFmpeg@22aa71d4da37a4ad2b0d28deeace64b57aa2ef50
+.. - https://github.org/FFmpeg/FFmpeg@84d85e7ad4ace228265af0c8c5caccc0730042fd
+.. - https://github.org/FFmpeg/FFmpeg@6e26f57f672b05e7b8b052007a83aef99dc81ccb
 
 Balancing quality and file size
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -231,10 +232,9 @@ variable bitrates.
 
 The **GOP (Group of Pictures) size** (``-g:v``) is the max interval between
 keyframes. Increasing this value can improve compression with almost no impact
-on quality. The valid range goes from ``0`` to ``2,147,483,648``, although
-compression benefits will fade away and even be reversed as the GOP size
-increases. The default size (``12``) is too low for most types of content, it's
-therefore recommended to test higher GOP sizes before reducing video quality.
+on quality. The default size (``12``) is too low for most types of content,
+it's therefore recommended using higher GOP values before reducing video
+quality. Compression benefits will fade away as the GOP size increases though.
 Values between ``64`` and ``512`` usually give the best compression.
 
 .. note::


### PR DESCRIPTION
Removed another limitation: change playback speed.

~~Added Shutter Encoder as a FFmpeg GUI. Related to #10942.~~

I've decided to remove the date from the FFmpeg warning since they have already released a point version but without the fix. And I don't know how many more they will release yet. I hoped that the next major version was closer to being released.

Changed the GOP description a bit to hopefully better fit the rest of the documentation.
