### PR TITLE
Use SpeedScale in Player.cs in part 9 of 3d tutorial

### DIFF
--- a/getting_started/first_3d_game/09.adding_animations.rst
+++ b/getting_started/first_3d_game/09.adding_animations.rst
@@ -451,11 +451,11 @@ Here's the *Player* script.
                 direction = direction.Normalized();
                 // Setting the basis property will affect the rotation of the node.
                 GetNode<Node3D>("Pivot").Basis = Basis.LookingAt(direction);
-                GetNode<AnimationPlayer>("AnimationPlayer").PlaybackSpeed = 4;
+                GetNode<AnimationPlayer>("AnimationPlayer").SpeedScale = 4;
             }
             else
             {
-                GetNode<AnimationPlayer>("AnimationPlayer").PlaybackSpeed = 1;
+                GetNode<AnimationPlayer>("AnimationPlayer").SpeedScale = 1;
             }
 
             // Ground velocity


### PR DESCRIPTION
The C# alternative for the Godot code, was using a non existing `PlaybackSpeed` property instead of the same property used by the GDScript alternative: speed_scale (SpeedScale in C#).

As a result the C# alternative would not run, while the GDScript alternative worked just fine.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
