### PR TITLE
Fix example code block for custom resources

### DIFF
--- a/tutorials/scripting/resources.rst
+++ b/tutorials/scripting/resources.rst
@@ -213,6 +213,7 @@ Attach a script to it named ``bot_stats.gd`` (or just create a new script, and t
 
 .. tabs::
   .. code-tab:: gdscript GDScript
+    
     class_name BotStats
     extends Resource
 


### PR DESCRIPTION
Fix a missing line break after `.. code-tab::` in `tutorials/scripting/resources.rst`.

Without the line break the first line of the code was included in the tab header :

![image](https://github.com/user-attachments/assets/b3020498-aee2-40b8-9345-8b548aba4881)
