### PR TITLE
Remove warning on build caused by non-existent pygment

### DIFF
--- a/tutorials/best_practices/version_control_systems.rst
+++ b/tutorials/best_practices/version_control_systems.rst
@@ -130,7 +130,7 @@ order to access the LFS files.
 Below is an example ``.gitattributes`` file that you can use as a starting point for Git LFS. 
 These file types were chosen because they are commonly used, but you can modify the list to include any binary types you may have in your project.
 
-.. code-block:: gitignore
+.. code-block:: unixconfig
 
     # Normalize EOL for all files that Git considers text files.
     * text=auto eol=lf


### PR DESCRIPTION
At #10857 a gitignore codeblock was added. Addition seems correct, but a pygment formatting was defined as:

.. code-block:: gitignore

No such a pygment exists, and although there is an aditional package that could parse git-related files, we chose to not add an extra package dependency for building the docs.

Fallback to unixconfig instead.

Closes #10989

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
