### PR TITLE
Change "clips" to "slices"

### DIFF
--- a/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.rst
@@ -507,13 +507,13 @@ When animations are imported, an optimizer is run, which reduces the size of the
 animation considerably. In general, this should always be turned on unless you
 suspect that an animation might be broken due to it being enabled.
 
-Clips
-~~~~~
+Slices
+~~~~~~
 
-It is possible to specify multiple animations from a single timeline as clips.
+It is possible to specify multiple animations from a single timeline as slices.
 For this to work, the model must have only one animation that is named
-``default``. To create clips, change the clip amount to something greater than
-zero. You can then name a clip, specify which frames it starts and stops on, and
+``default``. To create slices, change the slice amount to something greater than
+zero. You can then name a slice, specify which frames it starts and stops on, and
 choose whether the animation loops or not.
 
 Scene inheritance


### PR DESCRIPTION
As I understand it, slices were once called clips; they became slices but the name wasn't updated in the docs.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
