### PR TITLE
Update the class reference guide for tab indentation 

### DIFF
--- a/contributing/documentation/class_reference_primer.rst
+++ b/contributing/documentation/class_reference_primer.rst
@@ -242,8 +242,9 @@ the ``lang`` attribute. Currently supported options are:
 
 .. warning::
 
-    Use ``[codeblock]`` for pre-formatted code blocks. Inside ``[codeblock]``,
-    always use **four spaces** for indentation. The parser will delete tabs.
+    Use ``[codeblock]`` for pre-formatted code blocks. Since Godot 4.5,
+    **tabs** should be used for indentation. Four spaces are still 
+    supported, but not recommended.
 
 For example:
 

--- a/contributing/documentation/class_reference_primer.rst
+++ b/contributing/documentation/class_reference_primer.rst
@@ -243,8 +243,7 @@ the ``lang`` attribute. Currently supported options are:
 .. warning::
 
     Use ``[codeblock]`` for pre-formatted code blocks. Since Godot 4.5,
-    **tabs** should be used for indentation. Four spaces are still 
-    supported, but not recommended.
+    **tabs** should be used for indentation.
 
 For example:
 


### PR DESCRIPTION
This PR updates the "Class reference primer" page for tab indentation in `[codeblock]`, introduced in godotengine/godot#89819
