### PR TITLE
[Jolt] Remove reference to removed setting

### DIFF
--- a/tutorials/physics/using_jolt_physics.rst
+++ b/tutorials/physics/using_jolt_physics.rst
@@ -41,12 +41,6 @@ complex static geometry, such as :ref:`class_ConcavePolygonShape3D` or
 :ref:`class_HeightMapShape3D`, you can end up wasting a significant amount of CPU
 performance and memory without realizing it.
 
-For this reason this behavior is opt-in through the project setting
-:ref:`Physics > Jolt Physics 3D > Simulation > Areas Detect Static Bodies<class_ProjectSettings_property_physics/jolt_physics_3d/simulation/areas_detect_static_bodies>`,
-with the recommendation that you set up your collision layers and masks in such a
-way that only a few small :ref:`class_Area3D` are able to detect collisions with
-static bodies.
-
 Joint properties
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The setting was removed in:
* https://github.com/godotengine/godot/pull/105746

And CI will fail until this reference is removed (CI will keep failing until https://github.com/godotengine/godot-docs/pull/10979 is merged as the class reference links to a tutorial that doesn't exist yet)

Unsure if the whole block itself on "Area3D and static bodies" should be deleted, but removed the paragraph that references the now removed setting
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
