### PR TITLE
Add reminder to update VCS ignore settings on upgrading from Godot 3 …

### DIFF
--- a/tutorials/migrating/upgrading_to_godot_4.rst
+++ b/tutorials/migrating/upgrading_to_godot_4.rst
@@ -787,7 +787,7 @@ editor is closed.
 
 
 Updating version control settings
------------------------
+---------------------------------
 
-Godot 3.x and 4.0 have entirely different lists of files and folders that should
-be ignored by your :ref:`version control systems <doc_version_control_systems>`.
+Godot 3.x and 4.x have entirely different lists of files and folders that should
+be ignored by your :ref:`version control system<doc_version_control_systems>`.

--- a/tutorials/migrating/upgrading_to_godot_4.rst
+++ b/tutorials/migrating/upgrading_to_godot_4.rst
@@ -784,3 +784,10 @@ editor is closed.
     Many settings' names and categories have changed since Godot 3.x. Editor settings
     whose name or category has changed won't carry over to Godot 4.0; you will
     have to set their values again.
+
+
+Updating version control settings
+-----------------------
+
+Godot 3.x and 4.0 have entirely different lists of files and folders that should
+be ignored by your :ref:`version control systems <doc_version_control_systems>`.


### PR DESCRIPTION
…to Godot 4

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
