### PR TITLE
Fix type of 'what' parameter to _Notifications In C# usage example

### DIFF
--- a/tutorials/best_practices/godot_notifications.rst
+++ b/tutorials/best_practices/godot_notifications.rst
@@ -362,7 +362,7 @@ nodes that one might create at runtime.
 
         public override void _Notification(int what)
         {
-            switch (what)
+            switch ((long)what)
             {
                 case NotificationParented:
                     _parentCache = GetParent();


### PR DESCRIPTION
The type is wrong in the example ¯\_(ツ)_/¯