### PR TITLE
Clarify FileAccess.get_path(): return value, virtual path format, and usage example

### DIFF
--- a/classes/class_fileaccess.rst
+++ b/classes/class_fileaccess.rst
@@ -830,7 +830,22 @@ Text is interpreted as being UTF-8 encoded.
 
 :ref:`String<class_String>` **get_path**\ (\ ) |const| :ref:`🔗<class_FileAccess_method_get_path>`
 
-Returns the path as a :ref:`String<class_String>` for the current open file.
+
+Returns the path that was used to open the current file.
+
+The returned path uses Godot's virtual file system format, such as ``res://`` or ``user://``, depending on how the file was opened using :ref:`FileAccess.open() <class_FileAccess_method_open>`.
+
+If no file is currently open, this method returns an empty string (``""``). It does not throw an error in this case.
+
+This method is useful for verifying which file is in use or debugging file access logic.
+
+**Example:**
+
+.. code-block:: gdscript
+
+    var file := FileAccess.open("user://save_data.json", FileAccess.READ)
+    if file:
+        print(file.get_path()) # Prints: user://save_data.json open file.
 
 .. rst-class:: classref-item-separator
 


### PR DESCRIPTION
This improves the documentation for `FileAccess.get_path()` by:
- Clarifying that the return value uses Godot's virtual file system (e.g., res://, user://)
- Specifying that it returns an empty string if no file is open
- Confirming that it does not throw an error in this case
- Providing an example of typical usage

This brings `get_path()` in line with the documentation style of other FileAccess methods like `get_length()` and `get_open_error()`, and removes ambiguity for new users working with the file system API.

Closes #10966