### PR TITLE
Document LightmapGI rendering limits in Mobile and Compatibility renderers

### DIFF
--- a/tutorials/3d/global_illumination/using_lightmap_gi.rst
+++ b/tutorials/3d/global_illumination/using_lightmap_gi.rst
@@ -645,6 +645,14 @@ Reducing LightmapGI artifacts
 
 If you notice LightmapGI nodes popping in and out of existence as the camera
 moves, this is most likely because the engine is rendering too many LightmapGI
-instances at once. Godot is limited to rendering 8 LightmapGI nodes at once,
-which means up to 8 instances can be in the camera view before some of them will
-start flickering.
+instances at once.
+
+Here are the limits for each renderer:
+
+- **Forward+**: Up to 8 LightmapGI nodes can be rendered at once.
+- **Forward Mobile**: Up to 2 LightmapGI nodes can be rendered at once.
+- **Compatibility**: An unlimited number of LightmapGI nodes can be rendered at once.
+
+If this limit is exceeded, meshes that use lightmaps from extraneous LightmapGI
+nodes will not display lightmaps on them. Dynamic objects within their bounds also
+won't receive lighting.


### PR DESCRIPTION
The limit in Compatibility was determined through testing on 4.4.1.stable. The testing project with 144 LightmapGI instances is able to render all of them at once when using Compatibility, but only 8 in Forward+ and 2 in Mobile.

- See https://github.com/godotengine/godot-proposals/issues/12577#issuecomment-2960734329.

**Testing project:** [test-lightmap-count.zip](https://github.com/user-attachments/files/20681506/test-lightmap-count.zip)
