### PR TITLE
Rewrote parts distance alpha section for clarity

### DIFF
--- a/tutorials/3d/standard_material_3d.rst
+++ b/tutorials/3d/standard_material_3d.rst
@@ -732,18 +732,18 @@ features such as the ability to cast shadows.
     **Pixel Dither**).
 
 **Pixel Alpha** mode: The actual transparency of a pixel of the object changes
-with distance to the camera. This is the most effect, but forces the material
+with distance to the camera. This is the smoothest fade, but forces the material
 into the transparency pipeline (which leads, for example, to no shadows).
 
 .. image:: img/standart_material_distance_fade_pixel_alpha_mode.webp
 
-**Pixel Dither** mode: What this does is sort of approximate the transparency
-by only having a fraction of the pixels rendered.
+**Pixel Dither** mode: This approximates transparency by only having a fraction 
+of the pixels rendered using a 4x4 Bayer matrix (ordered dithering).
 
 .. image:: img/standart_material_distance_fade_pixel_dither_mode.webp
 
-**Object Dither** mode: Like the previous mode, but the calculated transparency
-is the same across the entire object's surface.
+**Object Dither** mode: Like the previous mode, but the calculated transparency, 
+and therefore dither pattern, is the same across the entire object's surface.
 
 .. image:: img/standart_material_distance_fade_object_dither_mode.webp
 


### PR DESCRIPTION
"This is the most effect" doesn't make much sense, and saying it's the most effective doesn't make it clear on what it's most effective in doing. 
Clarified that the pixel dither uses a 4x4 Bayer matrix. My saying that is based on simply looking at the example image up close and comparing it to the Wikipedia image example, so I'm pretty sure that's what it's using but if someone knows bettter then I'll change it.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
