### PR TITLE
Remove outdated note referencing a file which no longer exists

### DIFF
--- a/contributing/development/core_and_modules/custom_modules_in_cpp.rst
+++ b/contributing/development/core_and_modules/custom_modules_in_cpp.rst
@@ -223,10 +223,6 @@ You can then zip it and share the module with everyone else. When
 building for every platform (instructions in the previous sections),
 your module will be included.
 
-.. note:: There is a parameter limit of 5 in C++ modules for things such
-          as subclasses. This can be raised to 13 by including the header
-          file ``core/method_bind_ext.gen.inc``.
-
 Using the module
 ----------------
 


### PR DESCRIPTION
`core/method_bind_ext.gen.inc` is no longer a file, and the parameter limit for `ClassDB::bind_method` is now greater than 5 (although I'm not sure exactly what it is). This note doesn't make any sense anymore.