### PR TITLE
Keep consistent with previous text to avoid misleading

### DIFF
--- a/contributing/development/compiling/compiling_with_dotnet.rst
+++ b/contributing/development/compiling/compiling_with_dotnet.rst
@@ -170,7 +170,7 @@ Example (Windows)
     # Generate glue sources
     bin/godot.windows.editor.x86_64.mono --headless --generate-mono-glue modules/mono/glue
     # Build .NET assemblies
-    ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=windows
+    ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir ./bin --push-nupkgs-local <my_local_source> --godot-platform=windows
 
 
 Example (Linux, \*BSD)
@@ -187,7 +187,7 @@ Example (Linux, \*BSD)
     # Generate glue sources
     bin/godot.linuxbsd.editor.x86_64.mono --headless --generate-mono-glue modules/mono/glue
     # Generate binaries
-    ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=linuxbsd
+    ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir ./bin --push-nupkgs-local <my_local_source> --godot-platform=linuxbsd
 
 .. _compiling_with_dotnet_data_directory:
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

[The previous text](https://github.com/31/godot-docs/blob/f26f1a9bb2c8b5efcc5fb12bba6c36481e90830d/contributing/development/compiling/compiling_with_dotnet.rst?plain=1#L119C1-L130C38):

```rst
When you run the ``build_assemblies.py`` script, pass ``<my_local_source>`` to
the ``--push-nupkgs-local`` option:

::

    ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir ./bin --push-nupkgs-local <my_local_source>

This option ensures the packages will be added to the specified local NuGet
source and that conflicting versions of the package are removed from the NuGet
cache. It's recommended to always use this option when building the C# solutions
during development to avoid mistakes.
```

Without `--push-nupkgs-local <my_local_source>` option, this step may fail.