### PR TITLE
Update link to Ruff editor integrations

### DIFF
--- a/contributing/development/code_style_guidelines.rst
+++ b/contributing/development/code_style_guidelines.rst
@@ -330,7 +330,7 @@ Editor integration
 
 Many IDEs or code editors have beautifier plugins that can be configured to run
 ruff automatically, for example, each time you save a file. For details, you can
-check `Ruff Integrations <https://docs.astral.sh/ruff/integrations/>`__.
+check `Ruff Editor Integrations <https://docs.astral.sh/ruff/editors/>`__.
 
 Comment style guide
 -------------------


### PR DESCRIPTION
The text here talks about editor integrations for ruff, but links to the general ruff integrations page (written primarily for automated integrations such as GitHub Actions), not the editor integrations page. This just updates the link to point to the right page.