### PR TITLE
Update static_typing.rst

### DIFF
--- a/tutorials/scripting/gdscript/static_typing.rst
+++ b/tutorials/scripting/gdscript/static_typing.rst
@@ -439,8 +439,7 @@ signal in a dynamic style:
 And the same callback, with type hints:
 
 ::
-
-    func _on_area_entered(area: CollisionObject2D) -> void:
+    func _on_area_2d_body_entered(body: PhysicsBody2D) -> void:
         pass
 
 Warning system


### PR DESCRIPTION
The documentations said it shows the same callback two times, one time with dynamic typing and one time with type hints. In reality, two different callbacks were shown. This has been fixed.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
