### PR TITLE
Fix return type of _GetOptionVisibility example in c#

### DIFF
--- a/classes/class_editorimportplugin.rst
+++ b/classes/class_editorimportplugin.rst
@@ -281,7 +281,7 @@ Gets whether the import option specified by ``option_name`` should be visible in
 
  .. code-tab:: csharp
 
-    public void _GetOptionVisibility(string option, Godot.Collections.Dictionary options)
+    public bool _GetOptionVisibility(string option, Godot.Collections.Dictionary options)
     {
         // Only show the lossy quality setting if the compression mode is set to "Lossy".
         if (option == "compress/lossy_quality" && options.ContainsKey("compress/mode"))


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
