### PR TITLE
Update Pineapple Works entry in consoles.rst

### DIFF
--- a/tutorials/platform/consoles.rst
+++ b/tutorials/platform/consoles.rst
@@ -66,7 +66,7 @@ The following is a list of some of the providers:
 - `Lone Wolf Technology <https://www.lonewolftechnology.com/>`_ offers
   Switch and Playstation 4 porting and publishing of Godot games.
 - `Pineapple Works <https://pineapple.works/>`_ offers
-  Switch, Xbox One & Xbox Series X/S (GDK) porting and publishing of Godot games (GDScript/C#).
+  Nintendo Switch 1 & 2, Xbox One & Xbox Series X/S, PlayStation 5 porting and publishing of Godot games (GDScript/C#).
 - `RAWRLAB games <https://www.rawrlab.com/>`_ offers
   Switch porting of Godot games.
 - `mazette! games <https://mazette.games/>`_ offers


### PR DESCRIPTION
- UWP got deprecated some time ago by Microsoft so having a GDK native port on Xbox is the only way of doing things now so we remove the GDK highlight next to Xbox platforms
- added Switch 2 and PlayStation 5 to our list of supported platforms

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
