### PR TITLE
Fix incorrect notice about multithreading in Introduction to the buildsystem

### DIFF
--- a/contributing/development/compiling/introduction_to_the_buildsystem.rst
+++ b/contributing/development/compiling/introduction_to_the_buildsystem.rst
@@ -49,12 +49,14 @@ Using multi-threading
 
 The build process may take a while, depending on how powerful your system is. By default, Godot's
 SCons setup is configured to use all CPU threads but one (to keep the system responsive during
-compilation). If you want to adjust how many CPU threads SCons will use, use the ``-j <threads>``
+compilation). If the system has 4 CPU threads or fewer, it will use all threads by default.
+
+If you want to adjust how many CPU threads SCons will use, use the ``-j<threads>``
 parameter to specify how many threads will be used for the build.
 
-Example for using 4 threads::
+Example for using 12 threads::
 
-    scons -j4
+    scons -j12
 
 Platform selection
 ------------------


### PR DESCRIPTION
- Use `-j12` in the example line to reflect the most popular CPU core topology in Steam hardware survey as of writing (6 cores/12 threads).

___

- See https://github.com/godotengine/godot-docs-user-notes/discussions/215#discussioncomment-13656190.
