### PR TITLE
Fix: Correct `%c` format specifier description in GDScript docs. Issue:- #11090

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_format_string.rst
+++ b/tutorials/scripting/gdscript/gdscript_format_string.rst
@@ -86,8 +86,8 @@ specifier. Apart from ``s``, these require certain types of parameters.
 | ``s`` | **Simple** conversion to String by the same method as implicit      |
 |       | String conversion.                                                  |
 +-------+---------------------------------------------------------------------+
-| ``c`` | A single **Unicode character**. Expects an unsigned 8-bit integer   |
-|       | (0-255) for a code point or a single-character string.              |
+| ``c`` | A single **Unicode character**. Accepts a Unicode code point        |
+|       | (integer) or a single-character string. Supports values beyond 255. |
 +-------+---------------------------------------------------------------------+
 | ``d`` | A **decimal integer**. Expects an integer or a real number          |
 |       | (will be floored).                                                  |


### PR DESCRIPTION
### Summary

This PR updates the description of the `%c` format string placeholder in the GDScript documentation to reflect its correct behavior.

### Fixes
Issue [#11090](https://github.com/godotengine/godot-docs/issues/11090)

### Details

The current documentation states that `%c` expects an unsigned 8-bit integer (0–255) or a single-character string. However, `%c` in GDScript actually accepts any valid Unicode code point — not just those in the 0–255 range.