### PR TITLE
Update OpenJDK download link in exporting_for_android.rst

### DIFF
--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -21,7 +21,7 @@ The following steps detail what is needed to set up the Android SDK and the engi
 Install OpenJDK 17
 ------------------
 
-Download and install `OpenJDK 17 <https://adoptium.net/temurin/releases/?variant=openjdk17>`__.
+Download and install `OpenJDK 17 <https://adoptium.net/temurin/releases/?variant=openjdk17&version=17&os=any&arch=any>`__.
 
 .. note::
 


### PR DESCRIPTION
### Updated the OpenJDK download link in exporting_for_android.rst

Last link was for OpenJDK 21-LTS and is updated to OpenJDK 17-LTS, which is the version needed by Godot to export on Android.

_From personal experience: 
I downloaded the JDK version 21, because I was directed there. I didn't realize until I'm trying to export and get some error telling my to use JDK version 17. I would think it's just more convenient for the link to directly open the correct page._