### PR TITLE
Expand list of supported architectures on Linux

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -36,6 +36,13 @@ Platforms
 - :ref:`Web browsers <doc_using_the_web_editor>`. Experimental in 4.0,
   using Godot 3.x is recommended instead when targeting HTML5.
 
+.. note::
+
+    Linux supports rv64 (RISC-V), ppc64 & ppc32 (PowerPC), and loongarch64. However
+    you must compile the editor for that platform (as well as export templates)
+    yourself, no official downloads are currently provided. RISC-V compiling
+    instructions can be found on the :ref:`doc_compiling_for_linuxbsd` page.
+
 **Runs exported projects:**
 
 - iOS.

--- a/about/system_requirements.rst
+++ b/about/system_requirements.rst
@@ -62,9 +62,11 @@ Desktop or laptop PC - Minimum
 
 .. note::
 
-    Vulkan drivers for these Windows versions are known to have issues with
-    memory leaks. As a result, it's recommended to stick to the Compatibility
-    renderer when running Godot on a Windows version older than 10.
+    While supported on Linux, we have no official minimum requirements for running on
+    rv64 (RISC-V), ppc64 & ppc32 (PowerPC), and loongarch64. In addition you must
+    compile the editor for that platform (as well as export templates) yourself,
+    no official downloads are currently provided. RISC-V compiling instructions can
+    be found on the :ref:`doc_compiling_for_linuxbsd` page.
 
 Mobile device (smartphone/tablet) - Minimum
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Does what the title says, we've supported these platforms for a while but never had it listed before. Also points towards the compilation instructions for Risc-V. Also the note I'm removing is a leftover from when we said we supported Windows 7 and 8, it should have been removed in the PR that removed the earlier part of that note.