### PR TITLE
Update SpaceCast collision_result

### DIFF
--- a/classes/class_shapecast2d.rst
+++ b/classes/class_shapecast2d.rst
@@ -169,7 +169,7 @@ The shape's collision mask. Only objects in at least one collision layer enabled
 
 - :ref:`Array<class_Array>` **get_collision_result**\ (\ )
 
-Returns the complete collision information from the collision sweep. The data returned is the same as in the :ref:`PhysicsDirectSpaceState2D.get_rest_info()<class_PhysicsDirectSpaceState2D_method_get_rest_info>` method.
+Returns the complete collision information from the collision sweep. Returns a :ref:`Dictionary<class_Dictionary>` containing all fields from the :ref:`PhysicsDirectSpaceState2D.get_rest_info()<class_PhysicsDirectSpaceState2D_method_get_rest_info>` method, with an additional `collider` field for the collided :ref:`Object<class_Object>`.
 
 .. rst-class:: classref-item-separator
 

--- a/classes/class_shapecast3d.rst
+++ b/classes/class_shapecast3d.rst
@@ -173,7 +173,7 @@ The shape's collision mask. Only objects in at least one collision layer enabled
 
 - :ref:`Array<class_Array>` **get_collision_result**\ (\ )
 
-Returns the complete collision information from the collision sweep. The data returned is the same as in the :ref:`PhysicsDirectSpaceState3D.get_rest_info()<class_PhysicsDirectSpaceState3D_method_get_rest_info>` method.
+Returns the complete collision information from the collision sweep. Returns a :ref:`Dictionary<class_Dictionary>` containing all fields from the :ref:`PhysicsDirectSpaceState3D.get_rest_info()<class_PhysicsDirectSpaceState3D_method_get_rest_info>` method, with an additional `collider` field for the collided :ref:`Object<class_Object>`.
 
 .. rst-class:: classref-item-separator
 


### PR DESCRIPTION
Resolves #9737

[Shapecast3D.collision_result](https://docs.godotengine.org/en/3.6/classes/class_shapecast.html#class-shapecast-property-collision-result) claims it returns data the same as `PhysicsDirectSpaceState3D.get_rest_info()`

Checking Godot's Core I can see it returns an **additional** collider field: [shape_cast_3d.cpp](https://github.com/godotengine/godot/blob/d7cc121e6469d0d998bf214e3a87e37961e6f1bb/scene/3d/physics/shape_cast_3d.cpp#L477)

```cpp
Array ShapeCast3D::get_collision_result() const {
	Array ret;

	for (int i = 0; i < result.size(); ++i) {
		const PhysicsDirectSpaceState3D::ShapeRestInfo &sri = result[i];

		Dictionary col;
		col["point"] = sri.point;
		col["normal"] = sri.normal;
		col["rid"] = sri.rid;
		col["collider"] = ObjectDB::get_instance(sri.collider_id);
		col["collider_id"] = sri.collider_id;
		col["shape"] = sri.shape;
		col["linear_velocity"] = sri.linear_velocity;

		ret.push_back(col);
	}
	return ret;
}
```

This is the same for Shapecast2d: [shape_cast_2d.cpp](https://github.com/godotengine/godot/blob/d7cc121e6469d0d998bf214e3a87e37961e6f1bb/scene/2d/physics/shape_cast_2d.cpp#L384)

```cpp
Array ShapeCast2D::get_collision_result() const {
	Array ret;

	for (int i = 0; i < result.size(); ++i) {
		const PhysicsDirectSpaceState2D::ShapeRestInfo &sri = result[i];

		Dictionary col;
		col["point"] = sri.point;
		col["normal"] = sri.normal;
		col["rid"] = sri.rid;
		col["collider"] = ObjectDB::get_instance(sri.collider_id);
		col["collider_id"] = sri.collider_id;
		col["shape"] = sri.shape;
		col["linear_velocity"] = sri.linear_velocity;

		ret.push_back(col);
	}
	return ret;
}
```