### PR TITLE
Add missing brackets in c# code

### DIFF
--- a/tutorials/3d/using_transforms.rst
+++ b/tutorials/3d/using_transforms.rst
@@ -305,7 +305,9 @@ Jump:
 
     // Keep in mind Y is up-axis
     if (Input.IsActionJustPressed("jump"))
+    {
         velocity.Y = JumpSpeed;
+    }
 
     MoveAndSlide();
 

--- a/tutorials/best_practices/godot_notifications.rst
+++ b/tutorials/best_practices/godot_notifications.rst
@@ -166,7 +166,9 @@ delta time methods as needed.
         public void _Process(double delta)
         {
             if (Input.IsActionJustPressed("ui_select"))
+            {
                 GD.Print(delta);
+            }
         }
 
         // Called during every input event. Equally true for _input().
@@ -176,7 +178,9 @@ delta time methods as needed.
             {
                 case InputEventKey:
                     if (Input.IsActionJustPressed("ui_accept"))
+                    {
                         GD.Print(GetProcessDeltaTime());
+                    }
                     break;
             }
         }

--- a/tutorials/inputs/handling_quit_requests.rst
+++ b/tutorials/inputs/handling_quit_requests.rst
@@ -32,7 +32,9 @@ Handling the notification is done as follows (on any node):
     public override void _Notification(int what)
     {
         if (what == NotificationWMCloseRequest)
+        {
             GetTree().Quit(); // default behavior
+        }
     }
 
 It is important to note that by default, Godot apps have the built-in

--- a/tutorials/inputs/inputevent.rst
+++ b/tutorials/inputs/inputevent.rst
@@ -27,8 +27,12 @@ Here is a quick example, closing your game if the escape key is hit:
     public override void _UnhandledInput(InputEvent @event)
     {
         if (@event is InputEventKey eventKey)
+        {
             if (eventKey.Pressed && eventKey.Keycode == Key.Escape)
+            {
                 GetTree().Quit();
+            }
+        }
     }
 
 However, it is cleaner and more flexible to use the provided :ref:`InputMap <class_InputMap>` feature,

--- a/tutorials/physics/physics_introduction.rst
+++ b/tutorials/physics/physics_introduction.rst
@@ -316,15 +316,23 @@ For example, here is the code for an "Asteroids" style spaceship:
         public override void _IntegrateForces(PhysicsDirectBodyState2D state)
         {
             if (Input.IsActionPressed("ui_up"))
+            {
                 state.ApplyForce(_thrust.Rotated(Rotation));
+            }
             else
+            {
                 state.ApplyForce(new Vector2());
+            }
 
             var rotationDir = 0;
             if (Input.IsActionPressed("ui_right"))
+            {
                 rotationDir += 1;
+            }
             if (Input.IsActionPressed("ui_left"))
+            {
                 rotationDir -= 1;
+            }
             state.ApplyTorque(rotationDir * _torque);
         }
     }
@@ -441,7 +449,9 @@ Or to bounce off of the colliding object:
         {
             var collisionInfo = MoveAndCollide(_velocity * (float)delta);
             if (collisionInfo != null)
+            {
                 _velocity = _velocity.Bounce(collisionInfo.GetNormal());
+            }
         }
     }
 
@@ -510,11 +520,17 @@ the ground (including slopes) and jump when standing on the ground:
             var jump = Input.IsActionPressed("ui_select");
 
             if (IsOnFloor() && jump)
+            {
                 velocity.Y = _jumpSpeed;
+            }
             if (right)
+            {
                 velocity.X += _runSpeed;
+            }
             if (left)
+            {
                 velocity.X -= _runSpeed;
+            }
 
             Velocity = velocity;
         }

--- a/tutorials/physics/ray-casting.rst
+++ b/tutorials/physics/ray-casting.rst
@@ -134,7 +134,9 @@ be empty. If it did hit something, it will contain collision information:
  .. code-tab:: csharp
 
         if (result.Count > 0)
+        {
             GD.Print("Hit at point: ", result["position"]);
+        }
 
 The ``result`` dictionary when a collision occurs contains the following
 data:

--- a/tutorials/physics/using_character_body_2d.rst
+++ b/tutorials/physics/using_character_body_2d.rst
@@ -508,7 +508,9 @@ Here's the code for the player body:
 
             // Handle jump.
             if (Input.IsActionJustPressed("jump") && IsOnFloor())
+            {
                 velocity.Y = _jumpSpeed;
+            }
 
             // Get the input direction.
             float direction = Input.GetAxis("ui_left", "ui_right");

--- a/tutorials/xr/a_better_xr_start_script.rst
+++ b/tutorials/xr/a_better_xr_start_script.rst
@@ -170,9 +170,13 @@ it is nicer to exit on failure than to hang the system.
 
                 // Enable VRS
                 if (RenderingServer.GetRenderingDevice() != null)
+                {
                     vp.VrsMode = Viewport.VrsModeEnum.XR;
+                }
                 else if ((int)ProjectSettings.GetSetting("xr/openxr/foveation_level") == 0)
+                {
                     GD.PushWarning("OpenXR: Recommend setting Foveation level to High in Project Settings");
+                }
 
                 // Connect the OpenXR events
                 _xrInterface.SessionBegun += OnOpenXRSessionBegun;
@@ -276,8 +280,12 @@ Not matching the physics update rate will cause stuttering as frames are rendere
             {
                 GD.Print("OpenXR: Available refresh rates: ", availableRates);
                 foreach (float rate in availableRates)
+                {
                     if (rate > newRate && rate <= MaximumRefreshRate)
+                    {
                         newRate = rate;
+                    }
+                }
             }
 
             // Did we find a better rate?


### PR DESCRIPTION
continuation of #11092 
Added curly brackets to all examples.