### PR TITLE
Remove references to reset_physics_interpolation

### DIFF
--- a/tutorials/physics/interpolation/using_physics_interpolation.rst
+++ b/tutorials/physics/interpolation/using_physics_interpolation.rst
@@ -97,7 +97,8 @@ Testing and debugging tips
 
 Even if you intend to run physics at 60 ticks per second, in order to thoroughly test your
 interpolation and get the smoothest gameplay, it is highly recommended to
-temporarily set the physics tick rate to a low value such as 10 ticks per second.
+temporarily set the physics tick rate to a low value such as 10 ticks per second. This can be
+done in the project settings under Physics -> Common -> Physics Ticks per Second.
 
 The gameplay may not work perfectly, but it should enable you to more easily see
 cases where you should be using your own custom interpolation on e.g. a


### PR DESCRIPTION
Closes #11119

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
