### PR TITLE
Update descriptions of `AHashMap` and `HashMap`. Recommend `AHashMap` over `HashMap` by default.

### DIFF
--- a/contributing/development/core_and_modules/core_types.rst
+++ b/contributing/development/core_and_modules/core_types.rst
@@ -149,7 +149,9 @@ scripting API.
 +-----------------------+--------------------------+---------------------------------------------------------------------------------------+
 | |hash_set|            | ``std::unordered_set``   | **Use this as the "default" set type.**                                               |
 +-----------------------+--------------------------+---------------------------------------------------------------------------------------+
-| |hash_map|            | ``std::unordered_map``   | **Use this as the "default" map type.** Preserves insertion order.                    |
+| |a_hash_map|          | ``std::unordered_map``   | **Use this as the "default" map type.** Does not preserve insertion order.            |
+|                       |                          | Note that pointers into the map, as well as iterators, are not stable under mutations.|
+|                       |                          | If either of these affordances are needed, use ``HashMap`` instead.                   |
 +-----------------------+--------------------------+---------------------------------------------------------------------------------------+
 | |string_name| 📜      | ``std::string``          | Uses string interning for fast comparisons. Use this for static strings that are      |
 |                       |                          | referenced frequently and used in multiple locations in the engine.                   |
@@ -186,7 +188,10 @@ scripting API.
 |                       |                          | This means it's generally slower but can be copied around almost for free.            |
 |                       |                          | The performance benefits of ``VSet`` aren't established, so prefer using other types. |
 +-----------------------+--------------------------+---------------------------------------------------------------------------------------+
-| |a_hash_map|          | ``std::unordered_map``   | Array-based implementation of a hash map. Does not preserve insertion order.          |
+| |hash_map|            | ``std::unordered_map``   | Defensive (robust but slow) map type. Preserves insertion order.                      |
+|                       |                          | Pointers to keys and values, as well as iterators, are stable under mutation.         |
+|                       |                          | Use this map type when either of these affordances are needed. Use ``AHashMap``       |
+|                       |                          | otherwise.                                                                            |
 +-----------------------+--------------------------+---------------------------------------------------------------------------------------+
 | |rb_map|              | ``std::map``             | Uses a `red-black tree <https://en.wikipedia.org/wiki/Red-black-tree>`__              |
 |                       |                          | for faster access.                                                                    |


### PR DESCRIPTION
**Note:** Will need to go through a core meeting before this can be merged. (Edit: Approved in core meeting)

`AHashMap` is _way_ faster than `HashMap` in nearly all circumstances. `HashMap` on the other hand has some 'defensive' affordances built in. However, these affordances are not expected for C++ map types: No `std` map type grants these, probably because they are what makes `HashMap` so slow. In addition, most users of map types do not need these affordances. 
In the interest of performance, this changes the recommended map type to `AHashMap`.