### PR TITLE
Add missing feature tags `threads` and `nothreads` in documentation table

### DIFF
--- a/tutorials/export/feature_tags.rst
+++ b/tutorials/export/feature_tags.rst
@@ -108,6 +108,10 @@ Here is a list of most feature tags in Godot. Keep in mind they are **case-sensi
 +--------------------+----------------------------------------------------------+
 | **web**            | Host OS is a Web browser                                 |
 +--------------------+----------------------------------------------------------+
+| **nothreads**      | Running without threading support                        |
++--------------------+----------------------------------------------------------+
+| **threads**        | Running with threading support                           |
++--------------------+----------------------------------------------------------+
 | **web_android**    | Host OS is a Web browser running on Android              |
 +--------------------+----------------------------------------------------------+
 | **web_ios**        | Host OS is a Web browser running on iOS                  |

--- a/tutorials/scripting/gdextension/gdextension_file.rst
+++ b/tutorials/scripting/gdextension/gdextension_file.rst
@@ -66,6 +66,16 @@ Here is an example of what that can look like:
     linux.release.rv64 = "res://bin/libgdexample.linux.template_release.rv64.so"
 
 
+Entries are matched in order, so if two sets of feature tags could match
+the same system, be sure to put the more specific ones first:
+
+.. code-block:: none
+
+    [libraries]
+
+    linux.release.editor.x86_64 = "res://bin/libgdexample.linux.template_release.x86_64.so"
+    linux.release.x86_64 = "res://bin/libgdexample.linux.noeditor.template_release.x86_64.so"
+
 Here are lists of some of the available built-in options (for more look at the :ref:`feature tags <doc_feature_tags>`):
 
 Running system


### PR DESCRIPTION
The tag `nothread` was added by https://github.com/godotengine/godot/pull/93563, however [this table](https://docs.godotengine.org/en/stable/tutorials/export/feature_tags.html#default-features) does not have both threads tags, this PR adds `threads` and `nothreads` to it.

This PR also adds a note to the gdextension tutorial explaining the order of operation and how they should work.

Discussion about the subject in rocket chat in this link: https://chat.godotengine.org/channel/gdextension/thread/kkLYt23hP93n2xvtP