### PR TITLE
Fixed a small typo

### DIFF
--- a/tutorials/editor/project_settings.rst
+++ b/tutorials/editor/project_settings.rst
@@ -120,7 +120,7 @@ Manually editing project.godot
 You can open the ``project.godot`` file using a text editor and manually
 change project settings. Note that if the ``project.godot`` file does not have a
 stored value for a particular setting, it is implicitly the default value of
-that setting. This means that if you are are manually editing the file, you may
+that setting. This means that if you are manually editing the file, you may
 have to write in both the setting name *and* the value.
 
 In general, it is recommended to use the Project Settings window rather than


### PR DESCRIPTION
This pull request includes a minor change to the `tutorials/editor/project_settings.rst` file, fixing a typographical error in the documentation.

* Typographical correction:
  * Fixed a duplicated word ("are are") in the sentence explaining manual edits to the `project.godot` file. (`tutorials/editor/project_settings.rst`, [tutorials/editor/project_settings.rstL123-R123](diffhunk://#diff-800b9b2027de63a7c4013f1863236516407f36f671419442c5bcc2e783c6c08fL123-R123))