### PR TITLE
Update CLion IDE Setup Docs with Code Completion Configuration

### DIFF
--- a/contributing/development/configuring_an_ide/clion.rst
+++ b/contributing/development/configuring_an_ide/clion.rst
@@ -17,9 +17,9 @@ CLion can import a project's `compilation database file <https://clang.llvm.org/
 
 Then, open the Godot root directory with CLion and wait for the project to be fully
 indexed. If code completion, parameter information, or refactoring are not enabled,
-you will need to load the project with CMake. To do this, find the `CMakeLists.txt`
-file in the `platform\android\java\nativeSrcsConfigs` directory, right click and
-select `Load CMake Project`. Once the project reloads, a `godot` build configuration
+you will need to load the project with CMake. To do this, find the ``CMakeLists.txt``
+file in the ``platform\android\java\nativeSrcsConfigs`` directory, right click and
+select :button:`Load CMake Project`. Once the project reloads, a ``godot`` build configuration
 will be added. This configuration can be safely deleted as the CMake file will not
 build the project and only exists for loading the project in JetBrains IDEs.
 

--- a/contributing/development/configuring_an_ide/clion.rst
+++ b/contributing/development/configuring_an_ide/clion.rst
@@ -18,7 +18,7 @@ CLion can import a project's `compilation database file <https://clang.llvm.org/
 Then, open the Godot root directory with CLion and wait for the project to be fully
 indexed. If code completion, parameter information, or refactoring are not enabled,
 you will need to load the project with CMake. To do this, find the `CMakeLists.txt`
-file in the `platform\android\java\nativeSrcsConfigs` directory, right click, and
+file in the `platform\android\java\nativeSrcsConfigs` directory, right click and
 select `Load CMake Project`. Once the project reloads, a `godot` build configuration
 will be added. This configuration can be safely deleted as the CMake file will not
 build the project and only exists for loading the project in JetBrains IDEs.

--- a/contributing/development/configuring_an_ide/clion.rst
+++ b/contributing/development/configuring_an_ide/clion.rst
@@ -15,7 +15,7 @@ CLion can import a project's `compilation database file <https://clang.llvm.org/
 
     scons compiledb=yes
 
-Then, open the Godot root directory with CLion. CLion will import the compilation database, index the codebase, and provide autocompletion and other advanced code navigation and refactoring functionality.
+Then, open the Godot root directory with CLion and wait for the project to be fully indexed. If IntelliSense features such as code completion, parameter info, or refactoring are not enabled, you will need to load the project with CMake. To do this, find the `CMakeLists.txt` file in the `platform\android\java\nativeSrcsConfigs` directory, right click, and select `Load CMake Project`. Once the project reloads, a `godot` build configuration will be added. This configuration can be safely deleted as the CMake file will not build the project and only exists for loading the project in JetBrains IDEs.
 
    .. note:: Windows Users:
 

--- a/contributing/development/configuring_an_ide/clion.rst
+++ b/contributing/development/configuring_an_ide/clion.rst
@@ -15,7 +15,13 @@ CLion can import a project's `compilation database file <https://clang.llvm.org/
 
     scons compiledb=yes
 
-Then, open the Godot root directory with CLion and wait for the project to be fully indexed. If IntelliSense features such as code completion, parameter info, or refactoring are not enabled, you will need to load the project with CMake. To do this, find the `CMakeLists.txt` file in the `platform\android\java\nativeSrcsConfigs` directory, right click, and select `Load CMake Project`. Once the project reloads, a `godot` build configuration will be added. This configuration can be safely deleted as the CMake file will not build the project and only exists for loading the project in JetBrains IDEs.
+Then, open the Godot root directory with CLion and wait for the project to be fully
+indexed. If code completion, parameter information, or refactoring are not enabled,
+you will need to load the project with CMake. To do this, find the `CMakeLists.txt`
+file in the `platform\android\java\nativeSrcsConfigs` directory, right click, and
+select `Load CMake Project`. Once the project reloads, a `godot` build configuration
+will be added. This configuration can be safely deleted as the CMake file will not
+build the project and only exists for loading the project in JetBrains IDEs.
 
    .. note:: Windows Users:
 


### PR DESCRIPTION
Update the CLion IDE setup docs to include details on enabling code completion features. Addresses Issue https://github.com/godotengine/godot-docs/issues/11137

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
