### PR TITLE
Fix shader_functions.rst - description of pack/unpack for Snorm/Unorm functions

### DIFF
--- a/tutorials/shaders/shader_reference/shader_functions.rst
+++ b/tutorials/shaders/shader_reference/shader_functions.rst
@@ -3188,16 +3188,16 @@ floating-point numbers.
     | | vec2     | | :ref:`unpackHalf2x16<shader_func_unpackHalf2x16>`\ (\ uint v)        |                                                              |
     +------------+------------------------------------------------------------------------+--------------------------------------------------------------+
     | | uint     | | :ref:`packUnorm2x16<shader_func_packUnorm2x16>`\ (\ vec2 v)          | Convert two normalized (range 0..1) 32-bit floats            |
-    | | vec2     | | :ref:`unpackUnorm2x16<shader_func_unpackUnorm2x16>`\ (\ uint v)      | to 16-bit floats and pack them.                              |
+    | | vec2     | | :ref:`unpackUnorm2x16<shader_func_unpackUnorm2x16>`\ (\ uint v)      | to 16-bit unsigned ints and pack them.                       |
     +------------+------------------------------------------------------------------------+--------------------------------------------------------------+
     | | uint     | | :ref:`packSnorm2x16<shader_func_packSnorm2x16>`\ (\ vec2 v)          | Convert two signed normalized (range -1..1) 32-bit floats    |
-    | | vec2     | | :ref:`unpackSnorm2x16<shader_func_unpackSnorm2x16>`\ (\ uint v)      | to 16-bit floats and pack them.                              |
+    | | vec2     | | :ref:`unpackSnorm2x16<shader_func_unpackSnorm2x16>`\ (\ uint v)      | to 16-bit signed ints and pack them.                         |
     +------------+------------------------------------------------------------------------+--------------------------------------------------------------+
     | | uint     | | :ref:`packUnorm4x8<shader_func_packUnorm4x8>`\ (\ vec4 v)            | Convert four normalized (range 0..1) 32-bit floats           |
-    | | vec4     | | :ref:`unpackUnorm4x8<shader_func_unpackUnorm4x8>`\ (\ uint v)        | into 8-bit floats and pack them.                             |
+    | | vec4     | | :ref:`unpackUnorm4x8<shader_func_unpackUnorm4x8>`\ (\ uint v)        | into 8-bit unsigned ints and pack them.                      |
     +------------+------------------------------------------------------------------------+--------------------------------------------------------------+
     | | uint     | | :ref:`packSnorm4x8<shader_func_packSnorm4x8>`\ (\ vec4 v)            | Convert four signed normalized (range -1..1) 32-bit floats   |
-    | | vec4     | | :ref:`unpackSnorm4x8<shader_func_unpackSnorm4x8>`\ (\ uint v)        | into 8-bit floats and pack them.                             |
+    | | vec4     | | :ref:`unpackSnorm4x8<shader_func_unpackSnorm4x8>`\ (\ uint v)        | into 8-bit signed ints and pack them.                        |
     +------------+------------------------------------------------------------------------+--------------------------------------------------------------+
 
 .. rst-class:: classref-descriptions-group


### PR DESCRIPTION
The full description of these functions correctly mentions packing to a signed/unsigned 16b/8b integer, just the table incorrectly mentions "floats".