### PR TITLE
Fix code tab title in `SurfaceTool` tutorial

### DIFF
--- a/tutorials/3d/procedural_geometry/surfacetool.rst
+++ b/tutorials/3d/procedural_geometry/surfacetool.rst
@@ -111,6 +111,7 @@ shrinks the vertex array to remove duplicate vertices.
 
 .. tabs::
  .. code-tab:: gdscript GDScript
+
     # Suppose we have a quad defined by 6 vertices as follows
     st.add_vertex(Vector3(-1, 1, 0))
     st.add_vertex(Vector3(1, 1, 0))


### PR DESCRIPTION
There was a missing empty line after the `.. code-tab::` line from #6405, causing all following lines to be part of the tab name.
I took this opportunity to have a look through the docs, and this was the only instance I found; there are some places where spaces are left in the empty line, but they don't cause issues, so I left them.