### PR TITLE
Reference "Using an external text editor" in the "Visual Studio Code" page

### DIFF
--- a/contributing/development/configuring_an_ide/visual_studio_code.rst
+++ b/contributing/development/configuring_an_ide/visual_studio_code.rst
@@ -7,7 +7,8 @@ Visual Studio Code
 
     This documentation is for contributions to the game engine, and not using
     Visual Studio Code as a C# or GDScript editor. To code C# or GDScript in an external editor, see
-    :ref:`the C# guide to configure an external editor <doc_c_sharp_setup_external_editor>`.
+    :ref:`the C# guide to configure an external editor <doc_c_sharp_setup_external_editor>`, or
+    :ref:`the GDScript guide to using an external text editor <doc_external_editor>`.
 
 `Visual Studio Code <https://code.visualstudio.com>`_ is a free cross-platform code editor
 by `Microsoft <https://microsoft.com>`_ (not to be confused with :ref:`doc_configuring_an_ide_vs`).

--- a/contributing/development/configuring_an_ide/visual_studio_code.rst
+++ b/contributing/development/configuring_an_ide/visual_studio_code.rst
@@ -7,7 +7,7 @@ Visual Studio Code
 
     This documentation is for contributions to the game engine, and not using
     Visual Studio Code as a C# or GDScript editor. To code C# or GDScript in an external editor, see
-    :ref:`the C# guide to configure an external editor <doc_c_sharp_setup_external_editor>`, or
+    :ref:`the C# guide to configure an external editor <doc_c_sharp_setup_external_editor>` or
     :ref:`the GDScript guide to using an external text editor <doc_external_editor>`.
 
 `Visual Studio Code <https://code.visualstudio.com>`_ is a free cross-platform code editor


### PR DESCRIPTION
Right now, it says that the Visual Studio Code page is the page for contributing to the engine, and refers the user to the C# guide to use an external editor. This commit also includes the general text editor page.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
