### PR TITLE
Fix incorrect Intel IGP minimum requirement in System requirements

### DIFF
--- a/about/system_requirements.rst
+++ b/about/system_requirements.rst
@@ -38,11 +38,11 @@ Desktop or laptop PC - Minimum
 +----------------------+-----------------------------------------------------------------------------------------+
 | **GPU**              | - **Forward+ renderer:** Integrated graphics with full Vulkan 1.0 support               |
 |                      |                                                                                         |
-|                      |   - *Example: Intel HD Graphics 5500 (Broadwell), AMD Radeon R5 Graphics (Kaveri)*      |
+|                      |   - *Example: Intel HD Graphics 510 (Skylake), AMD Radeon R5 Graphics (Kaveri)*         |
 |                      |                                                                                         |
 |                      | - **Mobile renderer:** Integrated graphics with full Vulkan 1.0 support                 |
 |                      |                                                                                         |
-|                      |   - *Example: Intel HD Graphics 5500 (Broadwell), AMD Radeon R5 Graphics (Kaveri)*      |
+|                      |   - *Example: Intel HD Graphics 510 (Skylake), AMD Radeon R5 Graphics (Kaveri)*         |
 |                      |                                                                                         |
 |                      | - **Compatibility renderer:** Integrated graphics with full OpenGL 3.3 support          |
 |                      |                                                                                         |
@@ -225,12 +225,12 @@ Desktop or laptop PC - Minimum
 | **GPU**              | - **Forward+ renderer:** Integrated graphics with full Vulkan 1.0 support,              |
 |                      |   Metal 3 support (macOS) or Direct3D 12 (12_0 feature level) support (Windows)         |
 |                      |                                                                                         |
-|                      |   - *Example: Intel HD Graphics 5500 (Broadwell), AMD Radeon R5 Graphics (Kaveri)*      |
+|                      |   - *Example: Intel HD Graphics 510 (Skylake), AMD Radeon R5 Graphics (Kaveri)*         |
 |                      |                                                                                         |
 |                      | - **Mobile renderer:** Integrated graphics with full Vulkan 1.0 support,                |
 |                      |   Metal 3 support (macOS) or Direct3D 12 (12_0 feature level) support (Windows)         |
 |                      |                                                                                         |
-|                      |   - *Example: Intel HD Graphics 5500 (Broadwell), AMD Radeon R5 Graphics (Kaveri)*      |
+|                      |   - *Example: Intel HD Graphics 510 (Skylake), AMD Radeon R5 Graphics (Kaveri)*         |
 |                      |                                                                                         |
 |                      | - **Compatibility renderer:** Integrated graphics with full OpenGL 3.3 support          |
 |                      |   or Direct3D 11 support (Windows).                                                     |


### PR DESCRIPTION
Intel Broadwell IGPs can run Forward+/Mobile on Linux thanks to Mesa drivers, but the Windows driver has never supported Vulkan nor Direct3D 12 with a sufficient feature level (and shader model).

This increases the listed requirement to use Forward+/Mobile to Skylake (released in 2015).

We could opt into listing Broadwell specifically for Linux, but it would make the table a lot more complex for a rare configuration nowadays (and one that's probably better served by Compatibility performance-wise anyway).

- See https://github.com/godotengine/godot/issues/109071.
