### PR TITLE
Clarify the license link method on "Complying with licenses" page

### DIFF
--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -123,6 +123,15 @@ Link to the license
 The Godot Engine developers consider that a link to ``godotengine.org/license``
 in your game documentation or credits would be an acceptable way to satisfy
 the license terms.
+Also note that by opening the mentioned link the user may
+navigate to the licensing terms of the thirdparty libraries that Godot Engine uses,
+and, from our own understanding of the licensing terms, this may also enough to
+satisfy the thirdparty licenses as well.
+
+.. warning::
+
+    Again, the recommendations in this page **are not legal advice.**
+    If you have any questions, please speak to a professional lawyer.
 
 .. tip::
 


### PR DESCRIPTION
The previous description didn't make it clear that linking to godotengine.org/license/ is also (may or may not be, legally speaking) enough to satisfy thirdparty licenses.
I would like to have a simple way to satisfy the licenses (or a method that is "good enough" to satisfy the developers), and linking to the Godot license web page sounds simple and convenient enough, but I was confused if it was "good enough" for thirdparty components too (for someone who's just a small game developer).
Personally, when I was reading this part of the documentation, I felt that it wasn't good enough even for a small game developer because I felt like it doesn't cover the thirdparty licenses (even though the page links to them), so I decided to clarify this (again, for small game developers, and that it's not legal advice).

If the clarification I made doesn't sound good enough for the Godot documentation or it doesn't fit the docs, please let me know 😅 

This PR is a follow-up to my messages from https://github.com/godotengine/godot/pull/109168 and https://github.com/godotengine/godot-proposals/issues/12850