### PR TITLE
Update resources.rst to remove stray whitespace

### DIFF
--- a/tutorials/scripting/resources.rst
+++ b/tutorials/scripting/resources.rst
@@ -213,7 +213,7 @@ Attach a script to it named ``bot_stats.gd`` (or just create a new script, and t
 
 .. tabs::
   .. code-tab:: gdscript GDScript
-    
+
     class_name BotStats
     extends Resource
 


### PR DESCRIPTION
Whitespace on line 216 was causing code to merge into the tab name:

<img width="533" height="299" alt="image" src="https://github.com/user-attachments/assets/43cd863e-44ae-4545-98ea-4e11736dbe0e" />

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
