### PR TITLE
Update c_sharp_exports.rst to remove note about typed dictionary support

### DIFF
--- a/tutorials/scripting/c_sharp/c_sharp_exports.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_exports.rst
@@ -580,12 +580,6 @@ Exporting Godot dictionaries
 Using the generic ``Godot.Collections.Dictionary<TKey, TValue>`` allows specifying
 the types of the key and value elements of the dictionary.
 
-.. note::
-
-    Typed dictionaries are currently unsupported in the Godot editor, so
-    the Inspector will not restrict the types that can be assigned, potentially
-    resulting in runtime exceptions.
-
 .. code-block:: csharp
 
     [Export]


### PR DESCRIPTION
The note,

> Typed dictionaries are currently unsupported in the Godot editor, so the Inspector will not restrict the types that can be assigned, potentially resulting in runtime exceptions.

appears to be obsolete as of the current stable release. I tried various ways to get around inspector type restrictions, but could not.

<img width="487" height="517" alt="image" src="https://github.com/user-attachments/assets/e197c29e-1ce4-40c3-b743-1ff4a4f1479e" />

The dropdown only accepts the specified type.

<img width="504" height="238" alt="image" src="https://github.com/user-attachments/assets/46453e0f-979e-4a65-8c64-9e38cc6f5bfc" />

"Quick Load..." filters for the specified type.

<img width="654" height="115" alt="image" src="https://github.com/user-attachments/assets/8b2aa34e-2c11-4616-ab9c-3a4e34c046f3" />

"Load..." will not allow you to manually insert objects of the wrong type.

Therefore, I believe it's safe to remove this note.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
