### PR TITLE
Update kdevelop.rst

### DIFF
--- a/contributing/development/configuring_an_ide/kdevelop.rst
+++ b/contributing/development/configuring_an_ide/kdevelop.rst
@@ -78,7 +78,7 @@ Debugging the project
 - Select **Executable** option and specify the path to your executable located in
   the ``<Godot root directory>/bin`` folder. The name depends on your build configuration,
   e.g. ``godot.linuxbsd.editor.dev.x86_64`` for 64-bit LinuxBSD platform with
-  ``platform=linuxbsd``, ``target=editor`` and ``dev_build=yes``.
+  ``platform=linuxbsd``, ``target=editor``, and ``dev_build=yes``.
 
 .. figure:: img/kdevelop_configlaunches2.png
    :figclass: figure-w480

--- a/contributing/development/configuring_an_ide/kdevelop.rst
+++ b/contributing/development/configuring_an_ide/kdevelop.rst
@@ -78,7 +78,7 @@ Debugging the project
 - Select **Executable** option and specify the path to your executable located in
   the ``<Godot root directory>/bin`` folder. The name depends on your build configuration,
   e.g. ``godot.linuxbsd.editor.dev.x86_64`` for 64-bit LinuxBSD platform with
-  ``platform=editor`` and ``dev_build=yes``.
+  ``platform=linuxbsd``, ``target=editor`` and ``dev_build=yes``.
 
 .. figure:: img/kdevelop_configlaunches2.png
    :figclass: figure-w480


### PR DESCRIPTION
Fixed compile arguments in example for linuxBSD

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
