### PR TITLE
Update running_code_in_the_editor.rst to fix error in example code

### DIFF
--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -370,7 +370,8 @@ You then want to connect the signal when a new resource is set:
         set(new_resource):
             resource = new_resource
             # Connect the changed signal as soon as a new resource is being added.
-            resource.changed.connect(_on_resource_changed)
+            if resource != null:
+                resource.changed.connect(_on_resource_changed)
 
     func _on_resource_changed():
         print("My resource just changed!")
@@ -392,7 +393,10 @@ You then want to connect the signal when a new resource is set:
             {
                 _resource = value;
                 // Connect the changed signal as soon as a new resource is being added.
-                _resource.Changed += OnResourceChanged;
+                if (_resource != null)
+                {
+                    _resource.Changed += OnResourceChanged;
+                }
             }
         }
     }
@@ -414,7 +418,8 @@ would cause unneeded updates.
             if resource != null:
                 resource.changed.disconnect(_on_resource_changed)
             resource = new_resource
-            resource.changed.connect(_on_resource_changed)
+            if resource != null:
+                resource.changed.connect(_on_resource_changed)
 
  .. code-tab:: csharp
 
@@ -430,7 +435,10 @@ would cause unneeded updates.
                 _resource.Changed -= OnResourceChanged;
             }
             _resource = value;
-            _resource.Changed += OnResourceChanged;
+            if (_resource != null)
+            {
+                _resource.Changed += OnResourceChanged;
+            }
         }
     }
 


### PR DESCRIPTION
The example code does not account for instances where new_resource/value becomes null, which happens when the resource is cleared or reset in the inspector or through code. This will cause an error: `Invalid access to property or key 'changed' on a base object of type 'Nil'.` whenever the resource becomes null.

The fix checks to make sure the resource has not become null before attempting to connect the new signal, just like it's already doing before attempting to disconnect the old signal.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
