### PR TITLE
Update running_code_in_the_editor.rst to fix misplaced method defs

### DIFF
--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -309,13 +309,13 @@ not be called.
                 OnResourceSet();
             }
         }
-    }
 
-    // This will only be called when you create, delete, or paste a resource.
-    // You will not get an update when tweaking properties of it.
-    private void OnResourceSet()
-    {
-        GD.Print("My resource was set!");
+        // This will only be called when you create, delete, or paste a resource.
+        // You will not get an update when tweaking properties of it.
+        private void OnResourceSet()
+        {
+            GD.Print("My resource was set!");
+        }
     }
 
 To get around this problem you first have to make your resource a tool and make it
@@ -399,11 +399,11 @@ You then want to connect the signal when a new resource is set:
                 }
             }
         }
-    }
 
-    private void OnResourceChanged()
-    {
-        GD.Print("My resource just changed!");
+        private void OnResourceChanged()
+        {
+            GD.Print("My resource just changed!");
+        }
     }
 
 Lastly, remember to disconnect the signal as the old resource being used and changed somewhere else


### PR DESCRIPTION
Another small fix for section "Getting notified when resources change":

The C# examples were putting `OnResourceSet()` and `OnResourceChanged()` outside of class definitions, likely to match the placement of `_on_resource_set()` and `_on_resource_changed()` in the GDScript examples. But C# class scopes are _not_ the entire file, so these placements are invalid. I moved them to right before the closing bracket of MyTool.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
