### PR TITLE
Remove reference to non-existent "identity" property in bbcode tutorial

### DIFF
--- a/tutorials/ui/bbcode_in_richtextlabel.rst
+++ b/tutorials/ui/bbcode_in_richtextlabel.rst
@@ -1139,8 +1139,6 @@ This is where the logic of each effect takes place and is called once per glyph
 during the draw phase of text rendering. This passes in a :ref:`class_CharFXTransform`
 object, which holds a few variables to control how the associated glyph is rendered:
 
-- ``identity`` specifies which custom effect is being processed. You should use that for
-  code flow control.
 - ``outline`` is ``true`` if effect is called for drawing text outline.
 - ``range`` tells you how far into a given custom effect block you are in as an
   index.


### PR DESCRIPTION
no identity property exists in CharFXTransform

see #11187 for more

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
