### PR TITLE
Fix package name for pip in MSYS2

### DIFF
--- a/contributing/development/compiling/compiling_for_windows.rst
+++ b/contributing/development/compiling/compiling_for_windows.rst
@@ -50,8 +50,7 @@ For compiling under Windows, the following is required:
 
           ::
 
-              pacman -S mingw-w64-x86_64-python3-pip mingw-w64-x86_64-gcc  \
-                  mingw-w64-i686-python3-pip mingw-w64-i686-gcc make
+              pacman -S mingw-w64-x86_64-gcc mingw-w64-i686-gcc make python-pip
 
           For each MSYS2 MinGW subsystem, you should then run
           `pip3 install scons` in its shell.


### PR DESCRIPTION
On a fresh MSYS2 install, architecture-specific packages for pip seem to be removed and trying to install them fails with `error: target not found <package_name>`.

This replaces those two packages that produce the error above with the architecture-agnostic `python-pip` package.

Below is the package information from `pacman` as of this writing:

```
Name            : python-pip
Version         : 25.1.1-1
Description     : The PyPA recommended tool for installing Python packages
Architecture    : any
URL             : https://pip.pypa.io/
Licenses        : spdx:MIT
Groups          : None
Provides        : python3-pip
Depends On      : python
Optional Deps   : None
Required By     : None
Optional For    : None
Conflicts With  : python3-pip
Replaces        : python3-pip
Installed Size  : 14.72 MiB
Packager        : CI (msys2/msys2-autobuild/663b7acd/14818807031)
Build Date      : Sun May 4 17:22:41 2025
Install Date    : Sat Aug 9 12:07:36 2025
Install Reason  : Explicitly installed
Install Script  : No
Validated By    : Signature
```

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
