### PR TITLE
Add note about bug when exporting with custom boot splash on Godot 4.3 and 4.4.

### DIFF
--- a/classes/class_projectsettings.rst
+++ b/classes/class_projectsettings.rst
@@ -2022,6 +2022,8 @@ Path to an image used as the boot splash. If left empty, the default Godot Engin
 
 \ **Note:** The image will also show when opening the project in the editor. If you want to display the default splash image in the editor, add an empty override for ``editor_hint`` feature.
 
+\ **Note:** Due to a bug in Godot 4.3 and 4.4 when using a differrent or no image for the ``editor_hint`` feature the boot splash image may not always be included in the exported PCK. The image must be imported with the option **Keep File (exported as is)** in the Import dock, rather than as a :ref:`Texture2D<class_Texture2D>`.
+
 .. rst-class:: classref-item-separator
 
 ----


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

This addresses the bug in https://github.com/godotengine/godot/issues/109355 that had already been unknowingly fixed in 4.5, and doesn't affect 4.2 and earlier as it needs the `editor_hint` feature. I suggested in that issue only noting in the docs rather than backporting the fix as it is easy to work around. 