### PR TITLE
Update shading_language.rst

### DIFF
--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -1104,7 +1104,7 @@ method on a node that inherits from :ref:`class_GeometryInstance3D`:
 
 When using per-instance uniforms, there are some restrictions you should be aware of:
 
-- **Per-instance uniforms do not support textures**, only regular scalar and
+- **Per-instance uniforms do not support textures or arrays**, only regular scalar and
   vector types. As a workaround, you can pass a texture array as a regular
   uniform, then pass the index of the texture to be drawn using a per-instance
   uniform.


### PR DESCRIPTION
I'm proposing a small change to the shading language reference docs to make it clear that per-instance uniform *arrays* are not supported. Currently the docs mention that per-instance uniforms do not support *textures* and proceeds to give an example involving uniform texture arrays. However when I read the docs, it wasn't clear to me that non-texture uniform arrays (e.g: `instance uniform vec3 my_arr[3]`) are also not supported. 
