### PR TITLE
velocity.length should not be > but >=

### DIFF
--- a/getting_started/first_2d_game/03.coding_the_player.rst
+++ b/getting_started/first_2d_game/03.coding_the_player.rst
@@ -151,7 +151,7 @@ which returns ``true`` if it's pressed or ``false`` if it isn't.
         if Input.is_action_pressed("move_up"):
             velocity.y -= 1
 
-        if velocity.length() > 0:
+        if velocity.length() >= 0:
             velocity = velocity.normalized() * speed
             $AnimatedSprite2D.play()
         else:


### PR DESCRIPTION
because non diagonal movement is only equal to one

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
