### PR TITLE
Add pages on exporting and compiling for visionOS

### DIFF
--- a/contributing/development/compiling/compiling_for_visionos.rst
+++ b/contributing/development/compiling/compiling_for_visionos.rst
@@ -1,0 +1,14 @@
+.. _doc_compiling_for_visionos:
+
+Compiling for visionOS
+======================
+
+.. seealso::
+
+    This page describes how to compile visionOS export template binaries from source.
+    If you're looking to export your project to visionOS instead, see :ref:`doc_exporting_for_visionos`.
+
+Compiling instructions for visionOS are currently identical to
+:ref:`doc_compiling_for_ios`, except you should replace instances of
+``platform=ios`` with ``platform=visionos`` in the SCons options.
+See the linked page for details.

--- a/contributing/development/compiling/index.rst
+++ b/contributing/development/compiling/index.rst
@@ -52,8 +52,9 @@ will try their best to cover all possible situations.
    compiling_for_macos
    compiling_for_android
    compiling_for_ios
-   cross-compiling_for_ios_on_linux
+   compiling_for_visionos
    compiling_for_web
+   cross-compiling_for_ios_on_linux
 
 .. rubric:: Other compilation targets and options
    :heading-level: 2

--- a/tutorials/export/exporting_for_visionos.rst
+++ b/tutorials/export/exporting_for_visionos.rst
@@ -1,0 +1,19 @@
+.. _doc_exporting_for_visionos:
+
+Exporting for visionOS
+======================
+
+.. seealso::
+
+    This page describes how to export a Godot project to visionOS.
+    If you're looking to compile export template binaries from source instead,
+    see :ref:`doc_compiling_for_visionos`.
+
+Exporting instructions for visionOS are currently identical to
+:ref:`doc_compiling_for_ios`, except you should add a **visionOS**
+export preset instead of **iOS**. See the linked page for details.
+
+.. note::
+
+    Note that currently, only exporting an application for use on a flat
+    plane within the headset is supported. Immersive experiences are not supported.

--- a/tutorials/export/index.rst
+++ b/tutorials/export/index.rst
@@ -8,7 +8,7 @@ Export
 .. seealso::
 
    This section is about exporting a build of your project. If you're trying
-   to export properties from a script, see :ref:`doc_gdscript_exports` or 
+   to export properties from a script, see :ref:`doc_gdscript_exports` or
    :ref:`doc_c_sharp_exports`.
 
 .. toctree::
@@ -18,14 +18,15 @@ Export
    exporting_projects
    exporting_pcks
    feature_tags
+   exporting_for_windows
    exporting_for_linux
    exporting_for_macos
-   running_on_macos
-   exporting_for_windows
-   changing_application_icon_for_windows
-   exporting_for_ios
    exporting_for_android
-   android_gradle_build
+   exporting_for_ios
+   exporting_for_visionos
    exporting_for_web
-   exporting_for_dedicated_servers
+   changing_application_icon_for_windows
+   running_on_macos
+   android_gradle_build
    one-click_deploy
+   exporting_for_dedicated_servers


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-docs/pull/11140.

Since the instructions are basically identical to iOS, this links to the respective iOS exporting/compiling pages (with a reminder that visionOS support is still limited for now).
