### PR TITLE
Add documentation on shader baking

### DIFF
--- a/tutorials/export/feature_tags.rst
+++ b/tutorials/export/feature_tags.rst
@@ -132,8 +132,8 @@ Here is a list of most feature tags in Godot. Keep in mind they are **case-sensi
 +----------------------+-----------------------------------------------------------------------------------------+
 | **movie**            | :ref:`Movie Maker mode <doc_creating_movies>` is active                                 |
 +----------------------+-----------------------------------------------------------------------------------------+
-| **shader_baker**     | Project was exported with shader baking enabled                                         |
-|                      | (only applies to the exported project, not when running in the editor)                  |
+| **shader_baker**     | Project was exported with :ref:`shader baking <doc_pipeline_compilations_shader_baker>` |
+|                      | enabled (only applies to the exported project, not when running in the editor)          |
 +----------------------+-----------------------------------------------------------------------------------------+
 | **dedicated_server** | Project was exported as a :ref:`dedicated server <doc_exporting_for_dedicated_servers>` |
 |                      | (only applies to the exported project, not when running in the editor)                  |

--- a/tutorials/performance/pipeline_compilations.rst
+++ b/tutorials/performance/pipeline_compilations.rst
@@ -208,3 +208,56 @@ you can attach the effect as a child of the player as an invisible node. Make
 sure to disable the script attached to the hidden node or to hide any other
 nodes that could cause issues, which can be done by enabling **Editable
 Children** on the node.
+
+.. _doc_pipeline_compilations_shader_baker:
+
+Shader baker
+------------
+
+Since Godot 4.5, you can choose to bake shaders on export to improve initial
+startup time. This will generally not resolve existing stutters, but it will
+reduce the time it takes to load the game for the first time. This is especially
+the case when using Direct3D 12 or Metal, which have significantly slower initial
+shader compilation times than Vulkan due to the conversion step required.
+Godot's own shaders use GLSL and SPIR-V, but Direct3D 12 and Metal use
+different formats.
+
+.. note::
+
+    The shader baker can only bake the source into the intermediate format
+    (SPIR-V for Vulkan, DXIL for Direct3D 12, MIL for Metal). It cannot bake
+    the intermediate format into the final pipeline, as this is
+    dependent on the GPU driver and the hardware.
+
+    The shader baker is not a replacement for pipeline precompilation,
+    but it aims to complement it.
+
+When enabled, the shader baker will bundle compiled shader code into the PCK,
+which results in the shader compilation step being skipped entirely.
+The downside is that exporting will take slightly longer. The PCK file
+will be larger by a few megabytes.
+
+The shader baker is disabled by default, but you can enable it in each
+export preset in the Export dialog by ticking the :ui:`Shader Baker > Enabled`
+export option.
+
+Note that shader baking will only be able to export shaders for drivers supported
+by the platform the editor is currently running on:
+
+- The editor running on Windows can export shaders for Vulkan and Direct3D 12.
+- The editor running on macOS can export shaders for Vulkan and Metal.
+- The editor running on Linux can export shaders for Vulkan only.
+- The editor running on Android can export shaders for Vulkan only.
+
+The shader baker will only export shaders that match the
+``rendering/rendering_device/driver`` project setting for the target platform.
+
+.. note::
+
+    The shader baker is only supported for the Forward+ and Mobile renderers.
+    It will have no effect if the project uses the Compatibility renderer,
+    or for users who make use of the Compatibility fallback due to their
+    hardware not supporting the Forward+ or Mobile renderer.
+
+    This also means the shader baker is not supported on the web platform,
+    as the web platform only supports the Compatibility renderer.


### PR DESCRIPTION
- See https://github.com/godotengine/godot/pull/102552.

It's part of the pipeline compilations page currently, but maybe we should move it to a separate page if we consider it's different enough.

cc @dariosamo
