### PR TITLE
Fix path example in creating_script_templates.rst

### DIFF
--- a/tutorials/scripting/creating_script_templates.rst
+++ b/tutorials/scripting/creating_script_templates.rst
@@ -72,8 +72,8 @@ where:
 
 For example:
 
--  ``template_scripts/Node/smooth_camera.gd``
--  ``template_scripts/CharacterBody3D/platformer_movement.gd``
+-  ``script_templates/Node/smooth_camera.gd``
+-  ``script_templates/CharacterBody3D/platformer_movement.gd``
 
 Default behavior and overriding it
 ----------------------------------


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

Fix `template_scripts` to `script_templates` in the example.