### PR TITLE
Fixed selection tool explanation

### DIFF
--- a/tutorials/2d/using_tilemaps.rst
+++ b/tutorials/2d/using_tilemaps.rst
@@ -202,7 +202,7 @@ select multiple with a rectangle in the 2D editor. Note that empty space cannot 
 selected: if you create a rectangle selection, only non-empty tiles will be selected.
 
 To append to the current selection, hold :kbd:`Shift` then select a tile.
-To remove from the current selection, hold :kbd:`Ctrl` then select a tile.
+To remove from the current selection, hold :kbd:`Shift` then click a tile that is already selected.
 
 The selection can then be used in any other painting mode to quickly create copies
 of an already-placed pattern.


### PR DESCRIPTION
Changed "To remove from the current selection, hold Ctrl then select a tile" to "To remove from the current selection, hold Shift then click a tile that is already selected."

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
