### PR TITLE
Add Z_CLIP_SCALE to Spatial Shaders reference vertex built-ins

### DIFF
--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -266,6 +266,9 @@ shader, this value can be used as desired.
 +----------------------------------------+--------------------------------------------------------+
 | in vec4 **CUSTOM3**                    | Custom value from vertex primitive.                    |
 +----------------------------------------+--------------------------------------------------------+
+| out float **Z_CLIP_SCALE**             | If written to, scales the vertex towards the camera to |
+|                                        | avoid clipping into things like walls.                 |
++----------------------------------------+--------------------------------------------------------+
 
 .. note::
 


### PR DESCRIPTION
This feature was originally implemented in: https://github.com/godotengine/godot/pull/93142

I attempted to match the brevity of the other descriptions, shortening the description from the Material 3D class reference: https://docs.godotengine.org/en/latest/classes/class_basematerial3d.html#class-basematerial3d-property-z-clip-scale

First docs contribution 🤞 hope I did ok!