### PR TITLE
Updated GDScript code from dynamic type to static type

### DIFF
--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -293,7 +293,7 @@ As we already saw, the ``var`` keyword defines a new variable. If you put it at
 the top of the script, it defines a property of the class. Inside a function, it
 defines a local variable: it only exists within the function's scope.
 
-We define a local variable named ``velocity``, a 2D vector (static type: ``: Vector2``) representing both a
+We define a local variable named ``velocity``, a 2D vector representing both a
 direction and a speed. To make the node move forward, we start from the Vector2
 class's constant ``Vector2.UP``, a vector pointing up, and rotate it by calling the
 Vector2 method ``rotated()``. This expression, ``Vector2.UP.rotated(rotation)``,


### PR DESCRIPTION
Refactored GDScript code for full static typing compliance

In the docs, the GDScript code is dynamically type casted as ``var foo = 12``.
I did static type casting for the GDScript code as ``var foo : int = 12``.

Completely refactored the code as mentioned above and also added necessary statements explaining the static types used.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
