### PR TITLE
Update contributing links to contributing.godotengine.org.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,5 +4,5 @@ PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in
 PRs must not target `stable`, as that branch is updated manually.
 
 The type of content accepted into the documentation is explained here:
-https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
+https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
 -->

--- a/README.md
+++ b/README.md
@@ -33,15 +33,15 @@ add-on.
 
 All contributors are welcome to help on the Godot documentation.
 
-To get started, head to the [Contributing section](https://docs.godotengine.org/en/latest/contributing/how_to_contribute.html) of the online manual. There, you will find all the information you need to write and submit changes.
+To get started, head to the [Contributing documentation](https://contributing.godotengine.org/en/latest/organization/how_to_contribute.html). There, you will find all the information you need to write and submit changes.
 
 Here are some quick links to the areas you might be interested in:
 
-1. [Contributing to the online manual](https://docs.godotengine.org/en/latest/contributing/documentation/contributing_to_the_documentation.html)
-2. [Contributing to the class reference](https://docs.godotengine.org/en/latest/contributing/documentation/updating_the_class_reference.html)
-3. [Content guidelines](https://docs.godotengine.org/en/latest/contributing/documentation/content_guidelines.html)
-4. [Writing guidelines](https://docs.godotengine.org/en/latest/contributing/documentation/docs_writing_guidelines.html)
-5. [Building the manual](https://docs.godotengine.org/en/latest/contributing/documentation/building_the_manual.html)
+1. [Contributing to the online manual](https://contributing.godotengine.org/en/latest/documentation/manual/index.html)
+2. [Contributing to the class reference](https://contributing.godotengine.org/en/latest/documentation/class_reference.html)
+3. [Content guidelines](https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html)
+4. [Writing guidelines](https://contributing.godotengine.org/en/latest/documentation/guidelines/docs_writing_guidelines.html)
+5. [Building the manual](https://contributing.godotengine.org/en/latest/documentation/manual/building_the_manual.html)
 6. [Translating the documentation](https://contributing.godotengine.org/en/latest/documentation/translation/index.html)
 
 ## License

--- a/_tools/redirects/redirects.csv
+++ b/_tools/redirects/redirects.csv
@@ -42,7 +42,7 @@ source,destination
 /development/cpp/custom_audiostreams.html,/engine_details/development/core_and_modules/custom_audiostreams.html
 /development/cpp/custom_godot_servers.html,/engine_details/development/core_and_modules/custom_godot_servers.html
 /development/cpp/custom_modules_in_cpp.html,/engine_details/development/core_and_modules/custom_modules_in_cpp.html
-/development/cpp/custom_resource_format_loaders.html,/contributing/development/core_and_modules/custom_resource_format_loaders.html
+/development/cpp/custom_resource_format_loaders.html,/engine_details/development/core_and_modules/custom_resource_format_loaders.html
 /development/cpp/index.html,/engine_details/development/core_and_modules/index.html
 /development/cpp/inheritance_class_tree.html,/engine_details/development/core_and_modules/inheritance_class_tree.html
 /development/cpp/introduction_to_godot_development.html,/engine_details/development/core_and_modules/introduction_to_godot_development.html


### PR DESCRIPTION
Quick follow-up after #11188. The old links will be outdated with the next build.