### PR TITLE
Link to GDExtension articles from the Godot introduction.

### DIFF
--- a/getting_started/introduction/introduction_to_godot.rst
+++ b/getting_started/introduction/introduction_to_godot.rst
@@ -89,9 +89,10 @@ Godot-specific and tightly integrated language with a lightweight syntax, or
 :ref:`C# <doc_c_sharp>`, which is popular in the games industry.
 These are the two main scripting languages we support.
 
-With the GDExtension technology, you can also write
-gameplay or high-performance algorithms in C or C++ without recompiling the
-engine. You can use this technology to integrate third-party libraries and other
+With the :ref:`GDExtension <doc_what_is_gdextension>` technology, you can also
+write gameplay or high-performance algorithms in :ref:`C++ <doc_godot_cpp>` or
+:ref:`other languages <doc_scripting_languages>` without recompiling the engine.
+You can use this technology to integrate third-party libraries and other
 Software Development Kits (SDK) in the engine.
 
 Of course, you can also directly add modules and features to the engine, as it's


### PR DESCRIPTION
Ran across this. I think it's worth it linking to these technologies here, especially since it's intended for new users who are probably not familiar with all this.

I changes the wording somewhat too. C++ is an officially supported binding through godot-cpp, but C is not (we merely have a tutorial for it, for GDExtension binding authors, which is not intended for general use). Other languages are likely more interesting to many people, so I also link the article that contains links to those (e.g. Rust or Swift).