### PR TITLE
Mention importance of thread-safety in `Logger` example

### DIFF
--- a/tutorials/scripting/logging.rst
+++ b/tutorials/scripting/logging.rst
@@ -225,6 +225,8 @@ Here is a minimal working example of a custom logger, with the script added as a
         func _log_message(message: String, error: bool) -> void:
             # Do something with `message`.
             # `error` is `true` for messages printed to the standard error stream (stderr) with `print_error()`.
+            # Note that this method will be called from threads other than the main thread, possibly at the same
+            # time, so you will need to have some kind of thread-safety as part of it, like a Mutex.
             pass
 
         func _log_error(
@@ -239,6 +241,8 @@ Here is a minimal working example of a custom logger, with the script added as a
         ) -> void:
             # Do something with the error. The error text is in `rationale`.
             # See the Logger class reference for details on other parameters.
+            # Note that this method will be called from threads other than the main thread, possibly at the same
+            # time, so you will need to have some kind of thread-safety as part of it, like a Mutex.
             pass
 
     # Use `_init()` to initialize the logger as early as possible, which ensures that messages


### PR DESCRIPTION
Follow-up to #11266.

Given that not accommodating for the potential thread-safety concerns in these methods can crash the entire engine in the worst case, even when the user doesn't spin up any threads of their own, we should probably mention it in our example implementation.