### PR TITLE
Fix license text using syntax highlighting in Complying with licenses

### DIFF
--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -44,7 +44,7 @@ text somewhere in your game or derivative project.
 
 This text reads as follows:
 
-::
+.. code-block:: none
 
     This game uses Godot Engine, available under the following license:
 


### PR DESCRIPTION
This is a plain text block, so it shouldn't use syntax highlighting.
