### PR TITLE
Add reference to the new "Logger" class

### DIFF
--- a/tutorials/migrating/upgrading_to_godot_4.5.rst
+++ b/tutorials/migrating/upgrading_to_godot_4.5.rst
@@ -43,6 +43,8 @@ Method ``set_scope`` replaced by ``set_method`` optional parameter              
 **Node**
 Method ``get_rpc_config`` renamed to ``get_node_rpc_config``                                                              |❌|                 |✔️ with compat|      |✔️ with compat|      `GH-106848`_
 Method ``set_name`` changes ``name`` parameter type from ``String`` to ``StringName``                                     |✔️|                 |✔️ with compat|      |✔️ with compat|      `GH-76560`_
+**Logger**
+New built-in class ``Logger`` introduced.                                                                                 |❌|                 |❌|                  |❌|                  `GH-91006`_
 ========================================================================================================================  ===================  ====================  ====================  ============
 
 Rendering


### PR DESCRIPTION
If you already use a global script or custom class named ``Logger``, it will conflict with the built-in one and produce errors such as "Static function not found". You must rename your global (e.g. from ``Logger`` to ``Log``) and update references.
