### PR TITLE
Add 4.5 upgrade Navigation notes

### DIFF
--- a/tutorials/migrating/upgrading_to_godot_4.5.rst
+++ b/tutorials/migrating/upgrading_to_godot_4.5.rst
@@ -231,6 +231,25 @@ Core
     the shortest arc between the two input vectors. Previously, it would return incorrect values for certain inputs
     (`GH-107618`_).
 
+Navigation
+~~~~~~~~~~
+
+.. note::
+
+    By default, the regions in a NavigationServer map now update asynchronously using threads to improve performance.
+    This can cause additional delay in the update due to thread synchronisation.
+    The asynchronous region update can be toggled with the ``navigation/world/region_use_async_iterations`` project setting.
+
+.. note::
+    The merging of navmeshes in the NavigationServer has changed processing order. Regions now merge and cache
+    internal navmeshes first, then the remaining free edges are merged by the navigation map.
+    If a project had navigation map synchronisation errors before, it might now have shifted
+    affected edges, making already existing errors in a layout more noticeable in the pathfinding.
+    The ``navigation/2d_or_3d/merge_rasterizer_cell_scale`` project setting can be set to a lower value
+    to increase the detail of the rasterization grid (with `0.01` being the smallest cell size possible).
+    If edge merge errors still persist with the lowest possible rasterization scale value,
+    the error may be caused by overlap: two navmeshes are stacked on top of each other, causing geometry conflict.
+
 Physics
 ~~~~~~~
 


### PR DESCRIPTION
Adds 4.5 upgrade Navigation notes.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
