### PR TITLE
Update gdscript_exports.rst

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_exports.rst
+++ b/tutorials/scripting/gdscript/gdscript_exports.rst
@@ -542,6 +542,8 @@ automatically. To update it, call
 :ref:`notify_property_list_changed() <class_Object_method_notify_property_list_changed>`
 after setting the exported variable's value.
 
+.. warning:: For `export_tool_button` you must restart the scene upon first creation for it to work properly
+
 Advanced exports
 ----------------
 


### PR DESCRIPTION
Took me more than an hour to find this somewhere hidden on the internet. This is really bad user experience and I would suggest fixing it. But for now at least add a warning.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
