### PR TITLE
Edit "Core types" descriptions

### DIFF
--- a/engine_details/architecture/core_types.rst
+++ b/engine_details/architecture/core_types.rst
@@ -142,7 +142,7 @@ scripting API.
 | Godot datatype        | Closest C++ STL datatype | Comment                                                                               |
 +=======================+==========================+=======================================================================================+
 | |string| 📜           | ``std::string``          | **Use this as the "default" string type.** ``String`` uses UTF-32 encoding            |
-|                       |                          | to improve performance thanks to its fixed character size.                            |
+|                       |                          | to simplify processing thanks to its fixed character size.                            |
 +-----------------------+--------------------------+---------------------------------------------------------------------------------------+
 | |vector|              | ``std::vector``          | **Use this as the "default" vector type.** Uses copy-on-write (COW) semantics.        |
 |                       |                          | This means it's generally slower but can be copied around almost for free.            |
@@ -180,8 +180,10 @@ scripting API.
 |                       |                          | no heap allocations.                                                                  |
 +-----------------------+--------------------------+---------------------------------------------------------------------------------------+
 | |span|                | ``std::span``            | Represents read-only access to a contiguous array without needing to copy any data.   |
-|                       |                          | See `pull request description <https://github.com/godotengine/godot/pull/100293>`__   |
-|                       |                          | for details.                                                                          |
+|                       |                          | Note that ``Span`` is designed to be a high performance API: It does not perform      |
+|                       |                          | parameter correctness checks in the same way you might be used to with other Godot    |
+|                       |                          | containers. Use with care.                                                            |
+|                       |                          | `Span` can be constructed from most array-like containers (e.g. ``vector.span()``).   |
 +-----------------------+--------------------------+---------------------------------------------------------------------------------------+
 | |rb_set|              | ``std::set``             | Uses a `red-black tree <https://en.wikipedia.org/wiki/Red-black_tree>`__              |
 |                       |                          | for faster access.                                                                    |
@@ -195,8 +197,9 @@ scripting API.
 |                       |                          | Use this map type when either of these affordances are needed. Use ``AHashMap``       |
 |                       |                          | otherwise.                                                                            |
 +-----------------------+--------------------------+---------------------------------------------------------------------------------------+
-| |rb_map|              | ``std::map``             | Uses a `red-black tree <https://en.wikipedia.org/wiki/Red-black-tree>`__              |
-|                       |                          | for faster access.                                                                    |
+| |rb_map|              | ``std::map``             | Map type that uses a                                                                  |
+|                       |                          | `red-black tree <https://en.wikipedia.org/wiki/Red-black-tree>`__ to find keys.       |
+|                       |                          | The performance benefits of ``RBMap`` aren't established, so prefer using other types.|
 +-----------------------+--------------------------+---------------------------------------------------------------------------------------+
 | |dictionary| 📜       | ``std::unordered_map``   | Keys and values can be of any Variant type. No static typing is imposed.              |
 |                       |                          | Uses shared reference counting, similar to ``std::shared_ptr``.                       |
@@ -204,7 +207,8 @@ scripting API.
 +-----------------------+--------------------------+---------------------------------------------------------------------------------------+
 | |typed_dictionary| 📜 | ``std::unordered_map``   | Subclass of ``Dictionary`` but with static typing for its keys and values.            |
 +-----------------------+--------------------------+---------------------------------------------------------------------------------------+
-| |pair|                | ``std::pair``            | Stores a single key-value pair.                                                       |
+| |pair|                | ``std::pair``            | Stores a single pair. See also ``KeyValue`` in the same file, which uses read-only    |
+|                       |                          | keys.                                                                                 |
 +-----------------------+--------------------------+---------------------------------------------------------------------------------------+
 
 .. |string| replace:: `String <https://github.com/godotengine/godot/blob/master/core/string/ustring.h>`__


### PR DESCRIPTION
- `Pair`: Mention `KeyValue`. `KeyValue` could get its own entry, but there is nothing much to say, and `KeyValue` is unlikely to be used outside of containers.
- `RBMap`: Discourage its use. We might actually phase it out fully in the future.
- `Span`: Make it clear it's low level API. People should be careful when using this.
- `String`: Clarify UTF-32 motivation. UTF-32 isn't actually more performant in all respects (it's a RAM hog), but it _is_ simpler to work with.
