### PR TITLE
Fix inspector_dock.rst - Show inspector menu route was wrong

### DIFF
--- a/tutorials/editor/inspector_dock.rst
+++ b/tutorials/editor/inspector_dock.rst
@@ -18,7 +18,7 @@ Usage
 If the inspector dock is visible, clicking on a node in the scene tree will automatically
 display its properties.
 If it is not visible, you can show it by navigating to
-**Editor > Editor Settings > Editor Docks > Inspector**.
+**Editor > Editor Docks > Inspector**.
 
 At the top of the dock are the file and navigation buttons.
 


### PR DESCRIPTION
When you follow the "Editor > Editor Settings" route an Editor Settings panel opens - without any Editor Docks sub-panel.

This had me stumped at first while following the documentation.

A menu path that actually triggers the Show Inspector function is: "Editor > Editor Docks > Inspector"

I propose updating the menu path for clarity.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
