### PR TITLE
Document exporting/compiling for the iOS simulator not currently being supported

### DIFF
--- a/engine_details/development/compiling/compiling_for_ios.rst
+++ b/engine_details/development/compiling/compiling_for_ios.rst
@@ -74,6 +74,14 @@ The MoltenVK static ``.xcframework`` folder must also be placed in the
 ``ios_xcode`` folder once it has been created. MoltenVK is always statically
 linked on iOS; there is no dynamic linking option available, unlike macOS.
 
+.. warning::
+
+    Compiling for the iOS simulator is currently not supported as per
+    `GH-102149 <https://github.com/godotengine/godot/issues/102149>`__.
+
+    Apple Silicon Macs can run iOS apps natively, so you can run exported iOS projects
+    directly on an Apple Silicon Mac without needing the iOS simulator.
+
 Run
 ---
 

--- a/tutorials/export/exporting_for_ios.rst
+++ b/tutorials/export/exporting_for_ios.rst
@@ -57,6 +57,15 @@ When the export completes, the output folder should look like this:
 
 .. image:: img/ios_export_output.webp
 
+
+.. warning::
+
+    Exporting for the iOS simulator is currently not supported as per
+    `GH-102149 <https://github.com/godotengine/godot/issues/102149>`__.
+
+    Apple Silicon Macs can run iOS apps natively, so you can run exported iOS projects
+    directly on an Apple Silicon Mac without needing the iOS simulator.
+
 Opening **exported_xcode_project_name.xcodeproj** lets you build and deploy
 like any other iOS app.
 


### PR DESCRIPTION
Once the issue is resolved, it could support Compatibility but not Forward+/Mobile due to [these renderers requiring a feature the iOS simulator doesn't support (image cube arrays)](https://github.com/godotengine/godot/issues/74227).

https://github.com/godotengine/godot/pull/108127 and/or https://github.com/godotengine/godot/pull/107902 might make support for image cube arrays optional to use the Mobile renderer, but I'm not 100% sure.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/159#discussioncomment-14504614.
