### PR TITLE
Fix a c# method name in class_control.rst

### DIFF
--- a/classes/class_control.rst
+++ b/classes/class_control.rst
@@ -2230,7 +2230,7 @@ The tooltip popup will use either a default implementation, or a custom one that
     styleBox.SetBgColor(new Color(1, 1, 0));
     styleBox.SetBorderWidthAll(2);
     // We assume here that the `Theme` property has been assigned a custom Theme beforehand.
-    Theme.SetStyleBox("panel", "TooltipPanel", styleBox);
+    Theme.SetStylebox("panel", "TooltipPanel", styleBox);
     Theme.SetColor("font_color", "TooltipLabel", new Color(0, 1, 1));
 
 


### PR DESCRIPTION
As is, the example code fails to compile with `'Theme' does not contain a definition for 'SetStyleBox' and no accessible extension method 'SetStyleBox' accepting a first argument of type 'Theme' could be found`

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
