### PR TITLE
Update common_engine_methods_and_macros.rst

### DIFF
--- a/engine_details/architecture/common_engine_methods_and_macros.rst
+++ b/engine_details/architecture/common_engine_methods_and_macros.rst
@@ -53,6 +53,7 @@ in a way similar to C's ``sprintf()``:
     vformat("My name is %s.", "Godette");
     vformat("%d bugs on the wall!", 1234);
     vformat("Pi is approximately %f.", 3.1416);
+
     // Converts the resulting String into a `const char *`.
     // You may need to do this if passing the result as an argument
     // to a method that expects a `const char *` instead of a String.


### PR DESCRIPTION
the .cstr() function on String appears to be removed. code does not compile when used in a C++ Module. in 4.5

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
