### PR TITLE
Update tutorial link for calling Javascript from script

### DIFF
--- a/classes/class_javascriptbridge.rst
+++ b/classes/class_javascriptbridge.rst
@@ -28,7 +28,7 @@ The JavaScriptBridge singleton is implemented only in the Web export. It's used 
 Tutorials
 ---------
 
-- `Exporting for the Web: Calling JavaScript from script <../tutorials/export/exporting_for_web.html#calling-javascript-from-script>`__
+- `The JavaScriptBridge singleton <../tutorials/platform/web/javascript_bridge.html>`__
 
 .. rst-class:: classref-reftable-group
 


### PR DESCRIPTION
Simple link update for the Javascript Bridge tutorial. It seems like currently the `#calling-javascript-from-script` heading doesn't exist on the `exporting_for_web` page, but `Interacting with the browser and JavaScript` does, and that links to this dedicated javascript bridge singleton page.

To ease users navigating the docs, I feel it's appropriate to link to the javascript singleton tutorial from the javascript singleton class.