### PR TITLE
Move godot-cpp custom bindings information from "Getting Started" to build system information

### DIFF
--- a/tutorials/scripting/cpp/build_system/scons.rst
+++ b/tutorials/scripting/cpp/build_system/scons.rst
@@ -73,3 +73,37 @@ There are two popular ways by which cross platform builds can be achieved:
 `godot-cpp-template <https://github.com/godotengine/godot-cpp-template>`__ contains an
 `example setup <https://github.com/godotengine/godot-cpp-template/tree/main/.github/workflows>`__
 for a GitHub based CI workflow.
+
+Using custom bindings
+---------------------
+
+Every branch of godot-cpp comes with bindings appropriate for the respective Godot version
+(e.g. the ``4.3`` branch comes with bindings compatible with Godot version ``4.3`` and
+later).
+
+However, you may want to use custom bindings, for example:
+
+* If you want to use the latest bindings from Godot ``master``.
+* If you want to use bindings exposed by custom modules.
+
+To use custom bindings, you first have to generate them from the appropriate Godot
+executable:
+
+.. code-block:: shell
+
+    godot --dump-extension-api
+
+The resulting ``extension_api.json`` file will be created in the executable's
+directory. To use these custom bindings, you can add ``custom_api_file`` to
+your build command:
+
+.. code-block:: shell
+
+    scons platform=<platform> custom_api_file=<PATH_TO_FILE>
+
+Alternatively, you can add them as the default bindings to your project by adding
+the following line to your SConstruct file:
+
+.. code-block:: python
+
+    localEnv["custom_api_file"] = "extension_api.json"

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -97,44 +97,6 @@ following commands:
 
 This will initialize the repository in your project folder.
 
-Building the C++ bindings
--------------------------
-
-Now that we've downloaded our prerequisites, it is time to build the C++
-bindings.
-
-The repository contains a copy of the metadata for the current Godot release,
-but if you need to build these bindings for a newer version of Godot, call
-the Godot executable:
-
-.. code-block:: none
-
-    godot --dump-extension-api
-
-The resulting ``extension_api.json`` file will be created in the executable's
-directory. Copy it to the project folder and add ``custom_api_file=<PATH_TO_FILE>``
-to the scons command below.
-
-To generate and compile the bindings, use this command (replacing ``<platform>``
-with ``windows``, ``linux`` or ``macos`` depending on your OS):
-
-The build process automatically detects the number of CPU threads to use for
-parallel builds. To specify a number of CPU threads to use, add ``-jN`` at the
-end of the SCons command line where ``N`` is the number of CPU threads to use.
-
-.. code-block:: none
-
-    cd godot-cpp
-    scons platform=<platform> custom_api_file=<PATH_TO_FILE>
-    cd ..
-
-This step will take a while. When it is completed, you should have static
-libraries that can be compiled into your project stored in ``godot-cpp/bin/``.
-
-.. note::
-
-    You may need to add ``bits=64`` to the command on Windows or Linux.
-
 Creating a simple plugin
 ------------------------
 


### PR DESCRIPTION
On Discord, we regularly get people asking about or being directed to the "Getting Started" section of godot-cpp. This is great, because that means it's really useful!

However, we also regularly get people building with custom bindings, although they do not intend to target the latest `master` or a custom branch. I think they just do it because nobody reads the text carefully enough to realize that this step is optional.

Since most people do not need to build custom bindings, and will target a stable branch instead, I don't think this information should be part of the "Getting Started" doc. I therefore propose to move it to "Build system" in a dedicated subsection instead.