### PR TITLE
Add note to reset physics interpolation on first frame

### DIFF
--- a/tutorials/performance/using_servers.rst
+++ b/tutorials/performance/using_servers.rst
@@ -97,7 +97,7 @@ This is an example of how to create a sprite from code and move it using the low
 
 .. note:: When creating canvas items using the RenderingServer, you should reset physics 
           interpolation on the first frame using 
-          :ref:`RenderingServer.canvas_item_reset_physics_interpolation <class_RenderingServer_method_canvas_item_reset_physics_interpolation>`.
+          :ref:`RenderingServer.canvas_item_reset_physics_interpolation() <class_RenderingServer_method_canvas_item_reset_physics_interpolation>`.
           This ensures proper synchronization between the rendering and physics systems.
 
 .. tabs::


### PR DESCRIPTION
### Changes made:
- [**In tutorials\performance\using_servers.rst**](https://github.com/godotengine/godot-docs/blob/master/tutorials/performance/using_servers.rst): Added note letting users know they should reset physics interpolation on first frame object is created.

This came from [issue #94988](https://github.com/godotengine/godot/issues/94988). Specifically, the recommendation in this [comment](https://github.com/godotengine/godot/issues/94988#issuecomment-2377796699) by [clayjohn](https://github.com/clayjohn).

### Testing:
<img width="480" alt="Added note" src="https://github.com/user-attachments/assets/f61c0c61-aeed-42ab-b29c-5bd820813d5b" />

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
