### PR TITLE
Allow the character to flip in both directions

### DIFF
--- a/getting_started/first_2d_game/03.coding_the_player.rst
+++ b/getting_started/first_2d_game/03.coding_the_player.rst
@@ -271,16 +271,22 @@ movement. Let's place this code at the end of the ``_process()`` function:
 
 .. tabs::
  .. code-tab:: gdscript GDScript
+        # to allow the 
+        
 
+        
         if velocity.x != 0:
             $AnimatedSprite2D.animation = "walk"
-            $AnimatedSprite2D.flip_v = false
-            # See the note below about the following boolean assignment.
-            $AnimatedSprite2D.flip_h = velocity.x < 0
         elif velocity.y != 0:
             $AnimatedSprite2D.animation = "up"
-            $AnimatedSprite2D.flip_v = velocity.y > 0
 
+        # Allow the character to flip in both directions 
+        if velocity.x != 0:
+            # See the note below about the following boolean assignment.
+    		$AnimatedSprite2D.flip_v = false
+    		$AnimatedSprite2D.flip_h = velocity.x < 0
+    	if velocity.y != 0:
+    		$AnimatedSprite2D.flip_v = velocity.y > 0
  .. code-tab:: csharp
 
         if (velocity.X != 0)


### PR DESCRIPTION
Problem: the character when moving down with angle  the sprite was looking up not down
so i seperated the code responsible of the flipping

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
