### PR TITLE
Fix RTD language switcher redirecting to nonexistent `/en/4.x/` branch

### DIFF
--- a/404.rst
+++ b/404.rst
@@ -24,6 +24,15 @@ Page not found
     </p>
 
     <script>
+    // If we were redirected to `/en/4.x/` as a result of the RTD language selector,
+    // redirect to `/en/stable/` instead, as English does not have a `4.x` branch.
+    // (For maintenance reasons, non-English languages have a single `4.x` branch
+    // that is the counterpart of `4.3`, `4.4`, `4.5`, and so on.)
+    if (window.location.pathname.includes('/en/4.x/')) {
+      const newUrl = window.location.pathname.replace('/en/4.x/', '/en/stable/');
+      window.location.replace(newUrl);
+    }
+
     // Check for redirects if on a currently invalid page.
     // This is done in JavaScript, as we exceed Read the Docs' limit for the amount of redirects configurable.
     // When testing this feature on a local web server, replace the URL below with just `/_static/redirects.csv`.


### PR DESCRIPTION
If we were redirected to `/en/4.x/` as a result of the RTD language selector, redirect to `/en/stable/` instead, as English does not have a `4.x` branch.

For maintenance reasons, non-English languages have a single `4.x` branch that is the counterpart of `4.3`, `4.4`, `4.5` and so on.).

<img width="249" height="76" alt="image" src="https://github.com/user-attachments/assets/22f8d9ab-6230-401b-b790-6cfc50b41f95" />  

_Bugsquad edit:_ Followup to https://github.com/godotengine/godot-docs/pull/11304

- This closes https://github.com/godotengine/godot-docs/issues/11129.