### PR TITLE
Remove old Godot version references to simplify documentation

### DIFF
--- a/engine_details/development/compiling/introduction_to_the_buildsystem.rst
+++ b/engine_details/development/compiling/introduction_to_the_buildsystem.rst
@@ -485,7 +485,7 @@ create its own template.
 The ``version.txt`` file should contain the corresponding Godot version
 identifier. This file is used to install export templates in a version-specific
 directory to avoid conflicts. For instance, if you are building export templates
-for Godot 3.1.1, ``version.txt`` should contain ``3.1.1.stable`` on the first
+for Godot 4.4.1, ``version.txt`` should contain ``4.4.1.stable`` on the first
 line (and nothing else). This version identifier is based on the ``major``,
 ``minor``, ``patch`` (if present) and ``status`` lines of the
 `version.py file in the Godot Git repository <https://github.com/godotengine/godot/blob/master/version.py>`__.

--- a/engine_details/development/compiling/optimizing_for_size.rst
+++ b/engine_details/development/compiling/optimizing_for_size.rst
@@ -78,7 +78,7 @@ Optimizing for size instead of speed
 - **Difficulty:** Easy
 - **Performed in official builds:** Yes, but only for web builds
 
-Godot 3.1 onwards allows compiling using size optimizations (instead of speed).
+It is possible to compile Godot using size optimizations (instead of speed).
 To enable this, set the ``optimize`` flag to ``size``:
 
 ::

--- a/tutorials/2d/2d_lights_and_shadows.rst
+++ b/tutorials/2d/2d_lights_and_shadows.rst
@@ -114,10 +114,9 @@ transparent white, and move its starting location to be in the center.
 Directional light
 -----------------
 
-New in Godot 4.0 is the ability to have directional lighting in 2D. Directional
-lighting is used to represent sunlight or moonlight. Light rays are casted
-parallel to each other, as if the sun or moon was infinitely far away from the
-surface that is receiving the light.
+Directional lighting is used to represent sunlight or moonlight. Light rays are
+casted parallel to each other, as if the sun or moon was infinitely far away
+from the surface that is receiving the light.
 
 DirectionalLight2D offers the following properties:
 
@@ -265,8 +264,8 @@ the surface receiving light (on a per-pixel basis). Specular maps further help
 improve visuals by making some of the light reflect back to the viewer.
 
 Both PointLight2D and DirectionalLight2D support normal mapping and specular
-mapping. Since Godot 4.0, normal and specular maps can be assigned to any 2D
-element, including nodes that inherit from Node2D or Control.
+mapping. Normal and specular maps can be assigned to any 2D element,
+including nodes that inherit from Node2D or Control.
 
 A normal map represents the direction in which each pixel is "pointing" towards.
 This information is then used by the engine to correctly apply lighting to 2D

--- a/tutorials/2d/using_tilesets.rst
+++ b/tutorials/2d/using_tilesets.rst
@@ -157,7 +157,7 @@ three vertical dots menu button at the top of the TileSet editor and choose
 Using a collection of scenes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Since Godot 4.0, you can place actual *scenes* as tiles. This allows you to use
+You can also place actual *scenes* as tiles. This allows you to use
 any collection of nodes as a tile. For example, you could use scene tiles to
 place gameplay elements, such as shops the player may be able to interact with.
 You could also use scene tiles to place AudioStreamPlayer2Ds (for ambient

--- a/tutorials/3d/global_illumination/using_lightmap_gi.rst
+++ b/tutorials/3d/global_illumination/using_lightmap_gi.rst
@@ -20,9 +20,9 @@ light bleeding, and indirect light will often look better. The downside is that
 baking lightmaps takes longer compared to baking VoxelGI. While baking VoxelGI
 can be done in a matter of seconds, baking lightmaps can take several minutes if
 not more. This can slow down iteration speed significantly, so it is recommended
-to bake lightmaps only when you actually need to see changes in lighting. Since
-Godot 4.0, lightmaps are baked on the GPU, making light baking faster if you
-have a mid-range or high-end dedicated GPU.
+to bake lightmaps only when you actually need to see changes in lighting.
+Lightmaps are baked on the GPU, making light baking faster if you have a
+mid-range or high-end dedicated GPU.
 
 Baking lightmaps will also reserve baked materials' UV2 slot, which means you can
 no longer use it for other purposes in materials (either in the built-in

--- a/tutorials/3d/global_illumination/using_sdfgi.rst
+++ b/tutorials/3d/global_illumination/using_sdfgi.rst
@@ -4,7 +4,7 @@ Signed distance field global illumination (SDFGI)
 =================================================
 
 Signed distance field global illumination (SDFGI) is a novel technique available
-in Godot 4.0. It provides semi-real-time global illumination that scales to any
+in Godot. It provides semi-real-time global illumination that scales to any
 world size and works with procedurally generated levels.
 
 SDFGI supports dynamic lights, but *not* dynamic occluders or dynamic emissive surfaces.

--- a/tutorials/3d/particles/attractors.rst
+++ b/tutorials/3d/particles/attractors.rst
@@ -73,12 +73,6 @@ on each system's :ref:`visibility layers <class_VisualInstance3D>`. A particle s
 affected by an attractor if at least one of the system's visibility layers is enabled in the
 attractor's cull mask.
 
-.. warning::
-
-   There is a `known issue <https://github.com/godotengine/godot/issues/61014>`_ with
-   GPU particle attractors that prevent the cull mask from working properly in Godot 4.0. We will
-   update the documentation as soon as it is fixed.
-
 Box attractors
 ~~~~~~~~~~~~~~
 

--- a/tutorials/3d/particles/collision.rst
+++ b/tutorials/3d/particles/collision.rst
@@ -28,12 +28,6 @@ on each system's :ref:`visibility layers <class_VisualInstance3D>`. A particle s
 collision node only if at least one of the system's visibility layers is enabled in the
 collider's cull mask.
 
-.. warning::
-
-   There is a `known issue <https://github.com/godotengine/godot/issues/61014>`_ with
-   GPU particle collision that prevent the cull mask from working properly in Godot 4.0. We will
-   update the documentation as soon as it is fixed.
-
 Box collision
 ~~~~~~~~~~~~~
 

--- a/tutorials/animation/animation_tree.rst
+++ b/tutorials/animation/animation_tree.rst
@@ -12,14 +12,13 @@ function calling, audio, and sub-animation tracks.
 
 However, the support for blending those animations via ``AnimationPlayer`` is limited, as you can only set a fixed cross-fade transition time.
 
-:ref:`AnimationTree <class_AnimationTree>` is a new node introduced in Godot 3.1 to deal with advanced transitions.
-It replaces the ancient ``AnimationTreePlayer``, while adding a huge amount of features and flexibility.
+:ref:`AnimationTree <class_AnimationTree>` is a node designed to deal with advanced transitions.
 
 AnimationTree and AnimationPlayer
 ---------------------------------
 
 Before starting, know that an ``AnimationTree`` node does not contain its own animations.
-Instead, it uses animations contained in an ``AnimationPlayer`` node. You create, edit, or import your animations in an ``AnimationPlayer`` 
+Instead, it uses animations contained in an ``AnimationPlayer`` node. You create, edit, or import your animations in an ``AnimationPlayer``
 and then use an ``AnimationTree`` to control the playback.
 
 ``AnimationPlayer`` and ``AnimationTree`` can be used in both 2D and 3D scenes. When importing 3D scenes and their animations, you can use
@@ -38,8 +37,8 @@ and an ``AnimationTree`` node was created.
 Creating a tree
 ---------------
 
-To use an ``AnimationTree``, you have to set a root node. An animation root node is a class that contains and evaluates sub-nodes and outputs an animation. 
-There are 3 types of sub-nodes: 
+To use an ``AnimationTree``, you have to set a root node. An animation root node is a class that contains and evaluates sub-nodes and outputs an animation.
+There are 3 types of sub-nodes:
 
 1. Animation nodes, which reference an animation from the linked ``AnimationPlayer``.
 2. Animation Root nodes, which are used to blend sub-nodes and can be nested.
@@ -59,7 +58,7 @@ Blend tree
 ----------
 
 When you make an ``AnimationNodeBlendTree``, you get an empty 2d graph in the bottom panel, under the AnimationTree tab. It contains only an ``Output``
-node by default. 
+node by default.
 
 .. image:: img/animtree_emptyblendtree.webp
 
@@ -202,11 +201,11 @@ StateMachine
 ~~~~~~~~~~~~
 
 When you make an ``AnimationNodeStateMachine``, you get an empty 2d graph in the bottom panel, under the AnimationTree tab. It contains a ``Start`` and ``End``
-state by default. 
+state by default.
 
 .. image:: img/animtree_emptystatemachine.webp
 
-To add states, right click or use the **create new nodes** button, whose icon is a plus in a box. You can add animations, blendspaces, blendtrees, or even 
+To add states, right click or use the **create new nodes** button, whose icon is a plus in a box. You can add animations, blendspaces, blendtrees, or even
 another StateMachine. To edit one of these more complex sub-nodes, click on the pencil icon on the right of the state. To return to the original StateMachine,
 click **Root** on the top left of the panel.
 
@@ -219,7 +218,7 @@ There are 3 types of transitions:
 
 .. image:: img/animtree_transitiontypes.png
 
-* *Immediate*: Will switch to the next state immediately. 
+* *Immediate*: Will switch to the next state immediately.
 * *Sync*: Will switch to the next state immediately, but will seek the new state to the playback position of the old state.
 * *At End*: Will wait for the current state playback to end, then switch to the beginning of the next state animation.
 
@@ -240,12 +239,12 @@ Advance Condition and Advance Expression
 The last 2 properties in a StateMachine transition are ``Advance Condition`` and ``Advance Expression.`` When the Advance Mode is set to *Auto*, these
 determine if the transition will advance or not.
 
-Advance Condition is a true/false check. You may put a custom variable name in the text field, and when the StateMachine reaches this transition, 
-it will check if your variable is *true*. If so, the transition continues. Note that the advance condition **only** checks if a variable is *true*, 
+Advance Condition is a true/false check. You may put a custom variable name in the text field, and when the StateMachine reaches this transition,
+it will check if your variable is *true*. If so, the transition continues. Note that the advance condition **only** checks if a variable is *true*,
 and it cannot check for falseness.
 
-This gives the Advance Condition a very limited capability. If you wanted to make a transition back and forth based on one property, you would need to make 
-2 variables that have opposite values, and check if either of them are true. This is why, in Godot 4, the Advance Expression was added. 
+This gives the Advance Condition a very limited capability. If you wanted to make a transition back and forth based on one property, you would need to make
+2 variables that have opposite values, and check if either of them are true. This is why, in Godot 4, the Advance Expression was added.
 
 The Advance Expression works similar to the Advance Condition, but instead of checking if one variable is true, it evaluates any expression. An expression
 is anything you could put in an ``if`` statement. These are all examples of expressions that would work in the Advance Expression:
@@ -308,14 +307,14 @@ is controlled to determine the blending:
 
 .. image:: img/animtree_blendspace2d.gif
 
-You may place these points anywhere on the graph by right clicking or using the **add point** button, whose icon is a pen and point. 
+You may place these points anywhere on the graph by right clicking or using the **add point** button, whose icon is a pen and point.
 Wherever you place the points, the triangle between them will be generated automatically using Delaunay.
-You may also control and label the ranges in X and Y. 
+You may also control and label the ranges in X and Y.
 
 .. image:: img/animtree_blendspacepoints.gif
 
-Finally, you may also change the blend mode. By default, blending happens by interpolating points inside the closest triangle. When dealing with 2D 
-animations (frame by frame), you may want to switch to *Discrete* mode. Alternatively, if you want to keep the current play position when switching 
+Finally, you may also change the blend mode. By default, blending happens by interpolating points inside the closest triangle. When dealing with 2D
+animations (frame by frame), you may want to switch to *Discrete* mode. Alternatively, if you want to keep the current play position when switching
 between discrete animations, there is a *Carry* mode. This mode can be changed in the *Blend* menu:
 
 .. image:: img/animtree_blendmode.png
@@ -327,7 +326,7 @@ BlendSpace1D works just like BlendSpace2D, but in one dimension (a line). Triang
 For better blending
 -------------------
 
-In Godot 4.0+, in order for the blending results to be deterministic (reproducible and always consistent),
+For the blending results to be deterministic (reproducible and always consistent),
 the blended property values must have a specific initial value.
 For example, in the case of two animations to be blended, if one animation has a property track and the other does not,
 the blended animation is calculated as if the latter animation had a property track with the initial value.
@@ -354,7 +353,7 @@ This problem can be solved by adding a Property track for Position as an initial
           It is assumed to have only one frame and is not expected to be played back using the timeline.
 
 Also keep in mind that the Rotation 3D tracks and the Property tracks for 2D rotation
-with Interpolation Type set to Linear Angle or Cubic Angle will prevent rotations greater than 180 degrees 
+with Interpolation Type set to Linear Angle or Cubic Angle will prevent rotations greater than 180 degrees
 from the initial value as blended animation.
 
 This can be useful for Skeleton3Ds to prevent the bones penetrating the body when blending animations.
@@ -447,5 +446,5 @@ Then you can set or read them:
 
     animationTree.Set("parameters/eye_blend/blend_amount", 1.0);
 
-.. note:: Advance Expressions from a StateMachine will not be found under the parameters. This is because they are held in another script rather than the 
+.. note:: Advance Expressions from a StateMachine will not be found under the parameters. This is because they are held in another script rather than the
          AnimationTree itself. Advance `Conditions` will be found under parameters.

--- a/tutorials/animation/playing_videos.rst
+++ b/tutorials/animation/playing_videos.rst
@@ -47,7 +47,7 @@ Setting up VideoStreamPlayer
 Handling resizing and different aspect ratios
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default in Godot 4.0, the VideoStreamPlayer will automatically be resized to match
+By default, the VideoStreamPlayer will automatically be resized to match
 the video's resolution. You can make it follow usual :ref:`class_Control` sizing
 by enabling **Expand** on the VideoStreamPlayer node.
 

--- a/tutorials/assets_pipeline/importing_3d_scenes/advanced_import_settings.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/advanced_import_settings.rst
@@ -168,7 +168,7 @@ configuration may not be suitable for your needs. For example:
 
 - You want to configure material features not supported by your 3D application.
 - You want to use a different texture filtering mode, as this option is
-  configured in the material since Godot 4.0 (and not in the image).
+  configured in the material (and not in the image).
 - You want to replace one of the materials with an entirely different material,
   such as a custom shader.
 

--- a/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.rst
@@ -288,7 +288,7 @@ To use your script, locate the script in the import tab's "Path" option under th
 Using animation libraries
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As of Godot 4.0, you can choose to import **only** animations from a glTF file and
+You can also choose to import **only** animations from a glTF file and
 nothing else. This is used in some asset pipelines to distribute animations
 separately from models. For example, this allows you to use one set of
 animations for several characters, without having to duplicate animation data in

--- a/tutorials/assets_pipeline/importing_images.rst
+++ b/tutorials/assets_pipeline/importing_images.rst
@@ -139,10 +139,7 @@ Import options
 
 .. seealso::
 
-    In Godot 4.0, changing the texture filter and repeat mode is no longer done
-    in the import options.
-
-    Instead, texture filter and repeat modes are changed in the CanvasItem
+    Since Godot 4.0, texture filter and repeat modes are set in the CanvasItem
     properties in 2D (with a project setting acting as a default), and in a
     :ref:`per-material configuration in 3D <doc_standard_material_3d_sampling>`.
     In custom shaders, filter and repeat mode is changed on the ``sampler2D``

--- a/tutorials/assets_pipeline/retargeting_3d_skeletons.rst
+++ b/tutorials/assets_pipeline/retargeting_3d_skeletons.rst
@@ -18,9 +18,11 @@ have different Transform values.
 The Skeleton stores the Transform values necessary for the default pose as Bone Rest.
 If Bone Pose is equal to Bone Rest, it means that the Skeleton is in the default pose.
 
-.. note:: Godot 3.x and Godot 4.0+ have different Bone Pose behaviors.
-          In Godot 3.x, Bone Pose is relative to Bone Rest, but in Godot 4.0+,
-          it includes Bone Rest. See this `article <https://godotengine.org/article/animation-data-redesign-40>`__.
+.. note:: Godot 3 and Godot 4 have different Bone Pose behaviors.
+          In Godot 3, Bone Pose is relative to Bone Rest, but in Godot 4,
+          it includes Bone Rest. See this
+          `article <https://godotengine.org/article/animation-data-redesign-40>`__
+          for more information.
 
 Skeletal models have different Bone Rests depending on the environment from
 which they were exported. For example, the bones of a glTF model output from Blender
@@ -28,8 +30,7 @@ have "Edit Bone Orientation" as the Bone Rest rotation. However, there are skele
 models without any Bone Rest rotations, such as the glTF model output from Maya.
 
 To share animations in Godot, it is necessary to match Bone Rests as well as Bone Names
-to remove unwanted tracks in some cases. In Godot 4.0+, you can do that using the scene
-importer.
+to remove unwanted tracks in some cases. You can do that using the scene importer.
 
 Options for Retargeting
 -----------------------
@@ -85,7 +86,7 @@ Unimportant Positions
 Removes Position tracks other than ``root_bone`` and ``scale_base_bone``
 defined in :ref:`class_skeletonprofile` from the animations. In :ref:`class_skeletonprofilehumanoid`,
 this means that to remove Position tracks other than "Root" and "Hips".
-Since Godot 4.0+, animations include Bone Rest in the Transform value. If you disable this option,
+Since Godot 4, animations include Bone Rest in the Transform value. If you disable this option,
 the animation may change the body shape unpredictably.
 
 Unmapped Bones
@@ -150,7 +151,7 @@ Overwrite Axis
 
 Unifies the models' Bone Rests by overwriting it to match the reference poses defined in the :ref:`class_skeletonprofile`.
 
-.. note:: This is the most important option for sharing animations in Godot 4.0+,
+.. note:: This is the most important option for sharing animations in Godot 4,
           but be aware that this option can produce horrible results **if the original Bone Rest set externally is important**.
           If you want to share animations with keeping the original Bone Rest,
           consider to use the `Realtime Retarget Module <https://github.com/TokageItLab/realtime_retarget>`__.

--- a/tutorials/best_practices/version_control_systems.rst
+++ b/tutorials/best_practices/version_control_systems.rst
@@ -15,7 +15,7 @@ Godot also supports the use of version control systems in the editor itself.
 However, version control in the editor requires a plugin for the specific VCS
 you're using.
 
-As of July 2023, there is only a Git plugin available, but the community may
+As of October 2025, there is only a Git plugin available, but the community may
 create additional VCS plugins.
 
 Official Git plugin
@@ -41,7 +41,7 @@ Files to exclude from VCS
     3.x and 4.0 may store sensitive credentials in ``export_presets.cfg`` (unlike Godot
     4.1 and later).
 
-    If you are using Godot 3, check the ``3.5`` version of this documentation page
+    If you are using Godot 3, check the ``3.6`` version of this documentation page
     instead.
 
 There are some files and folders Godot automatically creates when opening a
@@ -90,11 +90,11 @@ Git LFS (Large File Storage) is a Git extension that allows you to manage large
 files in your repository. It replaces large files with text pointers inside Git,
 while storing the file contents on a remote server. This is useful for
 managing large assets, such as textures, audio files, and 3D models, without
-bloating your Git repository.  
+bloating your Git repository.
 
 .. note::
 
-    When using Git LFS you will want to ensure it is setup before you commit any files to your repository. 
+    When using Git LFS you will want to ensure it is setup before you commit any files to your repository.
     If you have already committed files to your repository, you will need to
     remove them from the repository and re-add them after setting up Git LFS.
 
@@ -111,13 +111,13 @@ running the following command in your terminal:
 ::
 
     git lfs install
-    
+
 This will create a ``.gitattributes`` file in your repository that tells Git to
 use LFS for the specified file types. You can add more file types by modifying
 the ``.gitattributes`` file. For example, to track all GLB files, you can do this by
 running the following command in your terminal:
 ::
-    
+
     git lfs track "*.glb"
 
 When you add or modify files that are tracked by LFS, Git will automatically
@@ -127,7 +127,7 @@ stored separately from the rest of your Git history. This means that you may
 need to install Git LFS on any machine that you clone the repository to in
 order to access the LFS files.
 
-Below is an example ``.gitattributes`` file that you can use as a starting point for Git LFS. 
+Below is an example ``.gitattributes`` file that you can use as a starting point for Git LFS.
 These file types were chosen because they are commonly used, but you can modify the list to include any binary types you may have in your project.
 
 .. code-block:: unixconfig
@@ -176,4 +176,3 @@ These file types were chosen because they are commonly used, but you can modify 
 
 For more information on Git LFS, check the official documentation:
 https://git-lfs.github.com/ and https://docs.github.com/en/repositories/working-with-files/managing-large-files.
-

--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -73,7 +73,7 @@ parent directory, usually hiding the name of that file.
 WebGL version
 -------------
 
-Godot 4.0 and later can only target WebGL 2.0 (using the Compatibility rendering
+Godot 4 can only target WebGL 2.0 (using the Compatibility rendering
 method). Forward+/Mobile are not supported on the web platform, as these
 rendering methods are designed around modern low-level graphics APIs. Godot
 currently does not support WebGPU, which is a prerequisite for allowing

--- a/tutorials/performance/optimizing_3d_performance.rst
+++ b/tutorials/performance/optimizing_3d_performance.rst
@@ -32,7 +32,7 @@ Compatibility rendering methods. However, unneeded objects are still reducing
 performance.
 
 One way we can potentially reduce the amount to be rendered is to **take advantage
-of occlusion**. Godot 4.0 and later offers a new approach to occlusion culling
+of occlusion**. Godot offers an approach to occlusion culling
 using occluder nodes. See :ref:`doc_occlusion_culling` for instructions on
 setting up occlusion culling in your scene.
 

--- a/tutorials/plugins/editor/3d_gizmos.rst
+++ b/tutorials/plugins/editor/3d_gizmos.rst
@@ -59,8 +59,7 @@ This would be a basic setup:
 
 
 For simple gizmos, inheriting :ref:`EditorNode3DGizmoPlugin <class_EditorNode3DGizmoPlugin>`
-is enough. If you want to store some per-gizmo data or you are porting a Godot 3.0 gizmo
-to 3.1+, you should go with the second approach.
+is enough. If you want to store some per-gizmo data, you should go with the second approach.
 
 
 Simple approach

--- a/tutorials/scripting/c_sharp/c_sharp_exports.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_exports.rst
@@ -305,7 +305,7 @@ Color given as red-green-blue value (alpha will always be 1).
 Nodes
 -----
 
-Since Godot 4.0, nodes can be directly exported without having to use NodePaths.
+Nodes can also be directly exported without having to use NodePaths.
 
 .. code-block:: csharp
 

--- a/tutorials/scripting/debug/custom_performance_monitors.rst
+++ b/tutorials/scripting/debug/custom_performance_monitors.rst
@@ -11,8 +11,8 @@ As explained in the :ref:`doc_debugger_panel` documentation, Godot features a
 graphs showing their evolution over time. The data for those graphs is sourced
 from the engine's :ref:`class_Performance` singleton.
 
-Since Godot 4.0, you can declare custom values to be displayed in the Monitors
-tab. Example use cases for custom performance monitors include:
+Godot lets you declare custom values to be displayed in the Monitors tab.
+Example use cases for custom performance monitors include:
 
 - Displaying performance metrics that are specific to your project. For
   instance, in a voxel game, you could create a performance monitor to track the

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -859,7 +859,7 @@ Negative indices count from the end.
 Typed arrays
 ^^^^^^^^^^^^
 
-Godot 4.0 added support for typed arrays. On write operations, Godot checks that
+Godot also features support for typed arrays. On write operations, Godot checks that
 element values match the specified type, so the array cannot contain invalid values.
 The GDScript static analyzer takes typed arrays into account, however array methods like
 ``front()`` and ``back()`` still have the ``Variant`` return type.

--- a/tutorials/scripting/gdscript/gdscript_exports.rst
+++ b/tutorials/scripting/gdscript/gdscript_exports.rst
@@ -253,8 +253,8 @@ Color given as red-green-blue value (alpha will always be 1). See :ref:`@export_
 Nodes
 -----
 
-Since Godot 4.0, nodes can be directly exported as properties in a script
-without having to use NodePaths:
+Nodes can also be directly exported as properties in a script without
+having to use NodePaths:
 
 ::
 

--- a/tutorials/shaders/shader_reference/shader_preprocessor.rst
+++ b/tutorials/shaders/shader_reference/shader_preprocessor.rst
@@ -14,9 +14,9 @@ starting with a hash symbol (``#``). It is not a *keyword* of the shader
 language (such as ``if`` or ``for``), but a special kind of token within the
 language.
 
-From Godot 4.0 onwards, you can use a shader preprocessor within text-based
-shaders. The syntax is similar to what most GLSL shader compilers support
-(which in turn is similar to the C/C++ preprocessor).
+To avoid repetition and improve code reuse, you can use a shader preprocessor
+within text-based shaders. The syntax is similar to what most GLSL shader
+compilers support (which in turn is similar to the C/C++ preprocessor).
 
 .. note::
 

--- a/tutorials/ui/gui_using_fonts.rst
+++ b/tutorials/ui/gui_using_fonts.rst
@@ -54,7 +54,7 @@ Godot supports the following dynamic font formats:
 - TrueType Font or Collection (``.ttf``, ``.ttc``)
 - OpenType Font or Collection (``.otf``, ``.otc``)
 - Web Open Font Format 1 (``.woff``)
-- Web Open Font Format 2 (``.woff2``, since Godot 3.5)
+- Web Open Font Format 2 (``.woff2``)
 
 While ``.woff`` and especially ``.woff2`` tend to result in smaller file sizes,
 there is no universally "better" font format. In most situations, it's


### PR DESCRIPTION
This follows the documentation writing guidelines, specifically the ["When to refer to a specific Godot version"](https://contributing.godotengine.org/en/latest/documentation/guidelines/docs_writing_guidelines.html#when-to-refer-to-a-specific-godot-version) section.

This also removes warning blocks for a known issue that was resolved in Godot 4.5.
