### PR TITLE
Update required Emscripten version for Godot 4.5

### DIFF
--- a/engine_details/development/compiling/compiling_for_web.rst
+++ b/engine_details/development/compiling/compiling_for_web.rst
@@ -15,7 +15,7 @@ Requirements
 
 To compile export templates for the Web, the following is required:
 
-- `Emscripten 3.1.62+ <https://emscripten.org>`__.
+- `Emscripten 4.0.0+ <https://emscripten.org>`__.
 - `Python 3.8+ <https://www.python.org/>`__.
 - `SCons 4.0+ <https://scons.org/pages/download.html>`__ build system.
 


### PR DESCRIPTION
The version requirement was increased by https://github.com/godotengine/godot/pull/107460.

- This closes https://github.com/godotengine/godot-docs/issues/11351.
