### PR TITLE
Update gdscript_exports.rst - Add info on how to create property descriptions

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_exports.rst
+++ b/tutorials/scripting/gdscript/gdscript_exports.rst
@@ -22,7 +22,7 @@ in the variable. Some of the export annotations have a specific type and don't n
 One of the fundamental benefits of exporting member variables is to have
 them visible and editable in the editor. This way, artists and game designers
 can modify values that later influence how the program runs. For this, a
-special export syntax is provided. Additionally, :ref:`documentation<doc_gdscript_documentation_comments>` can be 
+special export syntax is provided. Additionally, :ref:`documentation comments <doc_gdscript_documentation_comments>` can be 
 used for tooltip descriptions, visible on mouse over.
 
 .. note::


### PR DESCRIPTION
Added a description comment to the first example.

I couldn't find information on how to add a description to an export property and I though here was as good a place as any.

If this is an undesired change, I will look for a more appropriate place for it.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
