### PR TITLE
Replace deprecated `Color8`

### DIFF
--- a/classes/class_color.rst
+++ b/classes/class_color.rst
@@ -19,7 +19,7 @@ Description
 
 A color represented in RGBA format by a red (:ref:`r<class_Color_property_r>`), green (:ref:`g<class_Color_property_g>`), blue (:ref:`b<class_Color_property_b>`), and alpha (:ref:`a<class_Color_property_a>`) component. Each component is a 32-bit floating-point value, usually ranging from ``0.0`` to ``1.0``. Some properties (such as :ref:`CanvasItem.modulate<class_CanvasItem_property_modulate>`) may support values greater than ``1.0``, for overbright or HDR (High Dynamic Range) colors.
 
-Colors can be created in various ways: By the various **Color** constructors, by static methods such as :ref:`from_hsv()<class_Color_method_from_hsv>`, and by using a name from the set of standardized colors based on `X11 color names <https://en.wikipedia.org/wiki/X11_color_names>`__ with the addition of :ref:`TRANSPARENT<class_Color_constant_TRANSPARENT>`.
+Colors can be created in various ways: By the various **Color** constructors, by static methods such as :ref:`from_hsv()<class_Color_method_from_hsv>`, and by using a name from the set of standardized colors based on `X11 color names <https://en.wikipedia.org/wiki/X11_color_names>`__ with the addition of :ref:`TRANSPARENT<class_Color_constant_TRANSPARENT>`. GDScript also provides :ref:`@GDScript.Color8()<class_@GDScript_method_Color8>`, which uses integers from ``0`` to ``255`` and doesn't support overbright colors.
 
 Color data may be stored in many color spaces and encodings. The :ref:`srgb_to_linear()<class_Color_method_srgb_to_linear>` and :ref:`linear_to_srgb()<class_Color_method_linear_to_srgb>` methods can convert between nonlinear sRGB encoding and linear RGB encoding.
 
@@ -1641,7 +1641,7 @@ Constructs a **Color** from RGB values, typically between 0.0 and 1.0. :ref:`a<c
 
  .. code-tab:: gdscript
 
-    var color = Color(0.2, 1.0, 0.7) # Similar to `Color8.from_rgba8(51, 255, 178, 255)`
+    var color = Color(0.2, 1.0, 0.7) # Similar to `Color8(51, 255, 178, 255)`
 
  .. code-tab:: csharp
 
@@ -1664,7 +1664,7 @@ Constructs a **Color** from RGBA values, typically between 0.0 and 1.0.
 
  .. code-tab:: gdscript
 
-    var color = Color(0.2, 1.0, 0.7, 0.8) # Similar to `Color8.from_rgba8(51, 255, 178, 204)`
+    var color = Color(0.2, 1.0, 0.7, 0.8) # Similar to `Color8(51, 255, 178, 204)`
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
Fixes #11360

Not sure if C# has to be changed as well.
Code tabs (2): https://docs.godotengine.org/en/latest/classes/class_color.html
Also mentioned here: https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/c_sharp_differences.html
If so, let me know and I'll update it.
