### PR TITLE
using transform.basis.orthonormalized() instead of transform.basis wh…

### DIFF
--- a/tutorials/3d/using_transforms.rst
+++ b/tutorials/3d/using_transforms.rst
@@ -375,8 +375,8 @@ Converting a rotation to quaternion is straightforward.
  .. code-tab:: gdscript GDScript
 
     # Convert basis to quaternion, keep in mind scale is lost
-    var a = Quaternion(transform.basis)
-    var b = Quaternion(transform2.basis)
+    var a = Quaternion(transform.basis.orthonormalized())
+    var b = Quaternion(transform2.basis.orthonormalized())
     # Interpolate using spherical-linear interpolation (SLERP).
     var c = a.slerp(b,0.5) # find halfway point between a and b
     # Apply back
@@ -385,8 +385,8 @@ Converting a rotation to quaternion is straightforward.
  .. code-tab:: csharp
 
     // Convert basis to quaternion, keep in mind scale is lost
-    var a = new Quaternion(transform.Basis);
-    var b = new Quaternion(transform2.Basis);
+    var a = new Quaternion(transform.Basis.Orthonormalized());
+    var b = new Quaternion(transform2.Basis.Orthonormalized());
     // Interpolate using spherical-linear interpolation (SLERP).
     var c = a.Slerp(b, 0.5f); // find halfway point between a and b
     // Apply back


### PR DESCRIPTION
…en creating Quaternion

In the Interpolating with quaternions section, add the .orthonormalized() function to the creation of the Quaternion. While Quaternion(Basis) usually works fine, it fails when the basis is not orthonormalized, as stated in the Quaternion documentation (see below) : 


Quaternion Quaternion(from: Basis)

Constructs a Quaternion from the given rotation Basis.

This constructor is faster than Basis.get_rotation_quaternion(), but the given basis must be orthonormalized (see Basis.orthonormalized()). Otherwise, the constructor fails and returns IDENTITY.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
