### PR TITLE
Remove mentions of mobile platforms from godot-cpp "Getting started" document

### DIFF
--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -313,19 +313,6 @@ structure alongside ``godot-cpp``, ``src`` and ``demo``, then run:
 
 You should now be able to find the module in ``demo/bin/<platform>``.
 
-When building for iOS, package the module as a static `.xcframework`, you can use
-following commands to do so:
-
-::
-
-    # compile simulator and device modules
-    scons arch=universal ios_simulator=yes platform=ios target=<target>
-    scons arch=arm64 ios_simulator=no platform=ios target=<target>
-
-    # assemble xcframeworks
-    xcodebuild -create-xcframework -library demo/bin/libgdexample.ios.<target>.a -library demo/bin/libgdexample.ios.<target>.simulator.a -output demo/bin/libgdexample.ios.<target>.xcframework
-    xcodebuild -create-xcframework -library godot-cpp/bin/libgodot-cpp.ios.<target>.arm64.a -library godot-cpp/bin/libgodot-cpp.ios.<target>.universal.simulator.a  -output demo/bin/libgodot-cpp.ios.<target>.xcframework
-
 .. note::
 
     Here, we've compiled both godot-cpp and our gdexample library as debug
@@ -353,8 +340,6 @@ loaded for each platform and the entry function for the module. It is called ``g
 
     macos.debug = "res://bin/libgdexample.macos.template_debug.framework"
     macos.release = "res://bin/libgdexample.macos.template_release.framework"
-    ios.debug = "res://bin/libgdexample.ios.template_debug.xcframework"
-    ios.release = "res://bin/libgdexample.ios.template_release.xcframework"
     windows.debug.x86_32 = "res://bin/libgdexample.windows.template_debug.x86_32.dll"
     windows.release.x86_32 = "res://bin/libgdexample.windows.template_release.x86_32.dll"
     windows.debug.x86_64 = "res://bin/libgdexample.windows.template_debug.x86_64.dll"
@@ -365,18 +350,6 @@ loaded for each platform and the entry function for the module. It is called ``g
     linux.release.arm64 = "res://bin/libgdexample.linux.template_release.arm64.so"
     linux.debug.rv64 = "res://bin/libgdexample.linux.template_debug.rv64.so"
     linux.release.rv64 = "res://bin/libgdexample.linux.template_release.rv64.so"
-    android.debug.x86_64 = "res://bin/libgdexample.android.template_debug.x86_64.so"
-    android.release.x86_64 = "res://bin/libgdexample.android.template_release.x86_64.so"
-    android.debug.arm64 = "res://bin/libgdexample.android.template_debug.arm64.so"
-    android.release.arm64 = "res://bin/libgdexample.android.template_release.arm64.so"
-
-    [dependencies]
-    ios.debug = {
-        "res://bin/libgodot-cpp.ios.template_debug.xcframework": ""
-    }
-    ios.release = {
-        "res://bin/libgodot-cpp.ios.template_release.xcframework": ""
-    }
 
 This file contains a ``configuration`` section that controls the entry function of the module.
 You should also set the minimum compatible Godot version with ``compatibility_minimum``,


### PR DESCRIPTION
Since this article was written, we've figured out that `.framework` and `.xcframework` is actually created from GDExtensions automatically, and the GDExtension does not (necessarily) have to provide the frameworks itself. It is simpler to just build and link the binaries, as with other platforms. Hence, I have removed this information from the article.

Furthermore, I have removed some entries from the `.gdextension` file. The file is incomplete anyway, and does not reflect our latest naming schemes. It is better to provide a short file that will suffice for the purposes of the article, and refer people to the template for a full file template.