### PR TITLE
Fix standard_material_3d.rst

### DIFF
--- a/tutorials/3d/standard_material_3d.rst
+++ b/tutorials/3d/standard_material_3d.rst
@@ -185,9 +185,9 @@ other than *Mix* forces the object to go through the transparent pipeline.
 * **Mix:** Default blend mode, alpha controls how much the object is visible.
 * **Add:** The final color of the object is added to the color of the screen,
   nice for flares or some fire-like effects.
-* **Sub:** The final color of the object is subtracted from the color of the
+* **Subtract:** The final color of the object is subtracted from the color of the
   screen.
-* **Mul:** The final color of the object is multiplied with the color of the
+* **Multiply:** The final color of the object is multiplied with the color of the
   screen.
 * **Premultiplied Alpha:** The color of the object is expected to have already been
   multiplied by the alpha. This behaves like **Add** when the alpha is ``0.0``


### PR DESCRIPTION
Blend mode names were spelled differently from the actual godot's interface (v4.5). Updated for clarity: "Subtract" blend mode was spelled "Sub"
"Multiply" blend mode was spelled "Mul"

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
