### PR TITLE
godot-cpp CMake documentation guideline conformance updates

### DIFF
--- a/tutorials/scripting/cpp/build_system/cmake.rst
+++ b/tutorials/scripting/cpp/build_system/cmake.rst
@@ -63,12 +63,12 @@ Debug
 Sets compiler flags so that debug symbols are generated to help godot extension
 developers debug their extension.
 
-``Debug`` is the default build type for CMake projects, to select another it
+``Debug`` is the default build type for CMake projects, the way to select another
 depends on the generator used:
 
 * For single configuration generators, add ``-DCMAKE_BUILD_TYPE=<type>`` to the
   configure command.
-* For multi-config generators add ``--config <type>`` to the build command.
+* For multi-config generators, add ``--config <type>`` to the build command.
 
 Where ``<type>`` is one of ``Debug``, ``Release``, ``RelWithDebInfo``, and
 ``MinSizeRel``.


### PR DESCRIPTION
Sorry I didnt get to these in the last PR, I was away for a day, and I couldnt get offline docs compiling to work till this afternoon.

- added sphinx reference name, matching the scons name
- fix admonition formatting
- use proper headings rather than topic::
- reflow due to change of indent.
- add code block language to fix highlighting
- fix bad formatting for bullet points
-  a couple of full stops, colons, and capitilsation
- added a link to the android documentation in the admonition