### PR TITLE
Update recording_with_microphone.rst for iOS audio settings

### DIFF
--- a/tutorials/audio/recording_with_microphone.rst
+++ b/tutorials/audio/recording_with_microphone.rst
@@ -14,8 +14,7 @@ support for this tutorial:
 
 You will need to enable audio input in the :ref:`Audio > Driver > Enable Input<class_ProjectSettings_property_audio/driver/enable_input>` project setting, or you'll just get empty audio files.
 
-On iOS and iPadOS, it is also important to set the correct "Session Category" to include
-"Record" or "Play and Record", this is an advanced project setting under Audio/General/ios
+On iOS and iPadOS, it is also important to set the advanced **Audio > General > iOS > Session Category** setting to include **Record** or **Play and Record**.
 
 The structure of the demo
 -------------------------


### PR DESCRIPTION
Added information about setting the correct 'Session Category' for audio input on iOS and iPadOS.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
