### PR TITLE
Recommend building just `compile_commands.json` in the `CLion` documentation

### DIFF
--- a/engine_details/development/configuring_an_ide/clion.rst
+++ b/engine_details/development/configuring_an_ide/clion.rst
@@ -13,7 +13,7 @@ CLion can import a project's `compilation database file <https://clang.llvm.org/
 
 ::
 
-    scons compiledb=yes
+    scons compiledb=yes compile_commands.json
 
 Then, open the Godot root directory with CLion and wait for the project to be fully
 indexed. If code completion, parameter information, or refactoring are not enabled,


### PR DESCRIPTION
Running the command without the explicit `compile_commands.json` compiles the entire codebase. This isn't necessary. By providing the target, just the file can be generated.
This version is documented elsewhere too.