### PR TITLE
Remove erroneous include guard

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_c_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_c_example.rst
@@ -500,8 +500,6 @@ in the appropriately named ``defs.h`` file:
         uint8_t data[STRING_NAME_SIZE];
     } StringName;
 
-    #endif // DEFS_H
-
 As mentioned in the comment, the sizes can be found in the
 ``extension_api.json`` file that we generated earlier, under the
 ``builtin_class_sizes`` property. The ``BUILD_32`` is never defined, as we


### PR DESCRIPTION
The tail end of an include guard is provided
within the defs.h code blocks,
however #pragma once is used at the top instead.

https://github.com/godotengine/godot-docs/blob/e4d463e746f0c15e83da79075d42c23e09bc9ca2/tutorials/scripting/gdextension/gdextension_c_example.rst?plain=1#L156-L172

https://github.com/godotengine/godot-docs/blob/e4d463e746f0c15e83da79075d42c23e09bc9ca2/tutorials/scripting/gdextension/gdextension_c_example.rst?plain=1#L486-L503

I am also failing to compile the example using scons:

```
/bin/ld: src/gdexample.os:/home/john/Godot/gd-extension-c-example/src/api.h:20: multiple definition of `constructors'; src/api.os:/home/john/Godot/gd-extension-c-example/src/api.h:20: first defined here
```

Which is either on my end (and I could use some help :pray: ) or indicative of other problems within this page.