### PR TITLE
Add Android Gallery Example to JavaClassWrapper Doc

### DIFF
--- a/tutorials/platform/android/javaclasswrapper_and_androidruntimeplugin.rst
+++ b/tutorials/platform/android/javaclasswrapper_and_androidruntimeplugin.rst
@@ -133,3 +133,28 @@ This example creates an intent to send a text:
         intent.putExtra(Intent.EXTRA_TEXT, "This is a test message.")
         intent.setType("text/plain")
         activity.startActivity(intent)
+
+Example: Saving an image to the Android gallery
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: gdscript
+
+    # Retrieve the AndroidRuntime singleton.
+    var android_runtime = Engine.get_singleton("AndroidRuntime")	
+    if android_runtime:
+        var Intent = JavaClassWrapper.wrap("android.content.Intent")
+        var activity = android_runtime.getActivity()
+        var intent = Intent.Intent()
+
+        # Create the File and Uri.
+        var Uri = JavaClassWrapper.wrap("android.net.Uri")
+        var File = JavaClassWrapper.wrap("java.io.File")
+        var file = File.File(file_path_to_image_here)
+        var uri = Uri.fromFile(file)
+
+        # Set Action and Data of Intent.
+        intent.setAction(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE)
+        intent.setData(uri)
+
+        # Broadcast it.
+        activity.sendBroadcast(intent)


### PR DESCRIPTION
This is just adding an extra example to the Javaclasswrapper and Android Runtime Plugin doc page, showing how to use an Intent to let the Android gallery know that an image has been saved somewhere on the device. 

This is useful when trying to save an image to an Android device, since the image will not show up automatically in the users gallery even if the image has created on the disk. The media scanner must be notified of the image, which is what this code snippet does.

This is also my first godot-docs PR, so apologies if I've missed any requirements to merge. Please let me know and I will address them.
