### PR TITLE
Remove obsolete paragraph about Linux power-saving inhibition

### DIFF
--- a/tutorials/inputs/controllers_gamepads_joysticks.rst
+++ b/tutorials/inputs/controllers_gamepads_joysticks.rst
@@ -280,10 +280,6 @@ is running. If you notice the system is turning off its display when playing
 with a gamepad, check the value of **Display > Window > Energy Saving > Keep Screen On**
 in the Project Settings.
 
-On Linux, power saving prevention requires the engine to be able to use D-Bus.
-Check whether D-Bus is installed and reachable if running the project within a
-Flatpak, as sandboxing restrictions may make this impossible by default.
-
 Troubleshooting
 ---------------
 


### PR DESCRIPTION
Since https://github.com/godotengine/godot/pull/108704, the sentence about Flatpak is fully obsolete:

1. All standard Flatpak runtimes contain libdbus;
2. With the addition of support for the XDG Inhibit portal, Godot is able to inhibit idle without any sandboxing adjustments.

More generally, I don't think we need to mention that D-Bus is required to inhibit idle, even outside Flatpak: practically speaking, all desktop Linux systems have had libdbus available for 20+ years.

Remove the whole paragraph.