### PR TITLE
Update `SConstruct` and `.gdextension` file of the godot-cpp example with newest conventions

### DIFF
--- a/tutorials/scripting/cpp/files/cpp_example/SConstruct
+++ b/tutorials/scripting/cpp/files/cpp_example/SConstruct
@@ -2,42 +2,31 @@
 import os
 import sys
 
+# You can find documentation for SCons and SConstruct files at:
+# https://scons.org/documentation.html
+
+# This lets SCons know that we're using godot-cpp, from the godot-cpp folder.
 env = SConscript("godot-cpp/SConstruct")
 
-# For reference:
-# - CCFLAGS are compilation flags shared between C and C++
-# - CFLAGS are for C-specific compilation flags
-# - CXXFLAGS are for C++-specific compilation flags
-# - CPPFLAGS are for pre-processor flags
-# - CPPDEFINES are for pre-processor defines
-# - LINKFLAGS are for linking flags
-
-# tweak this if you want to use different folders, or more folders, to store your source code in.
+# Configures the 'src' directory as a source for header files.
 env.Append(CPPPATH=["src/"])
+
+# Collects all .cpp files in the 'src' folder as compile targets.
 sources = Glob("src/*.cpp")
 
-if env["platform"] == "macos":
-    library = env.SharedLibrary(
-        "demo/bin/libgdexample.{}.{}.framework/libgdexample.{}.{}".format(
-            env["platform"], env["target"], env["platform"], env["target"]
-        ),
-        source=sources,
-    )
-elif env["platform"] == "ios":
-    if env["ios_simulator"]:
-        library = env.StaticLibrary(
-            "demo/bin/libgdexample.{}.{}.simulator.a".format(env["platform"], env["target"]),
-            source=sources,
-        )
-    else:
-        library = env.StaticLibrary(
-            "demo/bin/libgdexample.{}.{}.a".format(env["platform"], env["target"]),
-            source=sources,
-        )
-else:
-    library = env.SharedLibrary(
-        "demo/bin/libgdexample{}{}".format(env["suffix"], env["SHLIBSUFFIX"]),
-        source=sources,
-    )
+# The filename for the dynamic library for this GDExtension.
+# $SHLIBPREFIX is a platform specific prefix for the dynamic library ('lib' on Unix, '' on Windows).
+# $SHLIBSUFFIX is the platform specific suffix for the dynamic library (for example '.dll' on Windows).
+# env["suffix"] includes the build's feature tags (e.g. '.windows.template_debug.x86_64')
+# (see https://docs.godotengine.org/en/stable/tutorials/export/feature_tags.html).
+# The final path should match a path in the '.gdextension' file.
+lib_filename = "{}gdexample{}{}".format(env.subst('$SHLIBPREFIX'), env["suffix"], env.subst('$SHLIBSUFFIX'))
 
+# Creates a SCons target for the path with our sources.
+library = env.SharedLibrary(
+    "demo/bin/{}".format(lib_filename),
+    source=sources,
+)
+
+# Selects the shared library as the default target.
 Default(library)

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -338,18 +338,18 @@ loaded for each platform and the entry function for the module. It is called ``g
 
     [libraries]
 
-    macos.debug = "./bin/libgdexample.macos.template_debug.dylib"
-    macos.release = "./bin/libgdexample.macos.template_release.dylib"
-    windows.debug.x86_32 = "./bin/libgdexample.windows.template_debug.x86_32.dll"
-    windows.release.x86_32 = "./bin/libgdexample.windows.template_release.x86_32.dll"
-    windows.debug.x86_64 = "./bin/libgdexample.windows.template_debug.x86_64.dll"
-    windows.release.x86_64 = "./bin/libgdexample.windows.template_release.x86_64.dll"
-    linux.debug.x86_64 = "./bin/libgdexample.linux.template_debug.x86_64.so"
-    linux.release.x86_64 = "./bin/libgdexample.linux.template_release.x86_64.so"
-    linux.debug.arm64 = "./bin/libgdexample.linux.template_debug.arm64.so"
-    linux.release.arm64 = "./bin/libgdexample.linux.template_release.arm64.so"
-    linux.debug.rv64 = "./bin/libgdexample.linux.template_debug.rv64.so"
-    linux.release.rv64 = "./bin/libgdexample.linux.template_release.rv64.so"
+    macos.debug = "./libgdexample.macos.template_debug.dylib"
+    macos.release = "./libgdexample.macos.template_release.dylib"
+    windows.debug.x86_32 = "./gdexample.windows.template_debug.x86_32.dll"
+    windows.release.x86_32 = "./gdexample.windows.template_release.x86_32.dll"
+    windows.debug.x86_64 = "./gdexample.windows.template_debug.x86_64.dll"
+    windows.release.x86_64 = "./gdexample.windows.template_release.x86_64.dll"
+    linux.debug.x86_64 = "./libgdexample.linux.template_debug.x86_64.so"
+    linux.release.x86_64 = "./libgdexample.linux.template_release.x86_64.so"
+    linux.debug.arm64 = "./libgdexample.linux.template_debug.arm64.so"
+    linux.release.arm64 = "./libgdexample.linux.template_release.arm64.so"
+    linux.debug.rv64 = "./libgdexample.linux.template_debug.rv64.so"
+    linux.release.rv64 = "./libgdexample.linux.template_release.rv64.so"
 
 This file contains a ``configuration`` section that controls the entry function of the module.
 You should also set the minimum compatible Godot version with ``compatibility_minimum``,
@@ -363,10 +363,7 @@ also result in *just* that file being exported when you export the project,
 which means the data pack won't contain libraries that are incompatible with the
 target platform.
 
-Finally, the ``dependencies`` section allows you to name additional dynamic
-libraries that should be included as well. This is important when your GDExtension
-plugin implements someone else's library and requires you to supply a
-third-party dynamic library with your project.
+You can learn more about ``.gdextension`` files at :ref:`doc_gdextension_file`.
 
 Here is another overview to check the correct file structure:
 


### PR DESCRIPTION
The changes:

- The `SConstruct` file currently lists properties. I don't think this is very useful, because a non-SCons user will not understand how to use this information anyway. Instead, I add a link to the SCons docs.
- Add more comments to the `SConstruct` file.
- Remove `.framework` logic from `SConstruct` and `.gdextension` file. We've figured some months that this wasn't needed (matching godot-cpp-template)
- Use `SHLIBPREFIX` along with `SHLIBSUFFIX`, to remove `lib` prefix from DLL files (matching godot-cpp-template).
- Use relative paths for `.gdextension` files. This makes it possible to rename the folders they are in, leading to fewer problems. It also solves an unfixed hot reload problem on macOS.
- Removed the `dependencies` section since it's no longer necessary, add a link to the `.gdextension` file docs instead.