### PR TITLE
Release policy: Mark 3.5 and 4.3 as EOL, partial support for 4.4

### DIFF
--- a/about/release_policy.rst
+++ b/about/release_policy.rst
@@ -90,10 +90,9 @@ on GitHub.
 | Godot 4.5    | September 2025       | |supported| Receives fixes for bugs and security issues, as well as      |
 |              |                      | patches that enable platform support.                                    |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 4.4    | March 2025           | |supported| Receives fixes for bugs and security issues, as well as      |
-|              |                      | patches that enable platform support.                                    |
+| Godot 4.4    | March 2025           | |partial| Receives fixes for security and platform support issues only.  |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 4.3    | August 2024          | |partial| Receives fixes for security and platform support issues only.  |
+| Godot 4.3    | August 2024          | |eol| No longer supported (last update: 4.3).                            |
 +--------------+----------------------+--------------------------------------------------------------------------+
 | Godot 4.2    | November 2023        | |eol| No longer supported (last update: 4.2.2).                          |
 +--------------+----------------------+--------------------------------------------------------------------------+
@@ -107,7 +106,7 @@ on GitHub.
 | Godot 3.6    | September 2024       | |supported| Receives fixes for bugs and security issues, as well as      |
 |              |                      | patches that enable platform support.                                    |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 3.5    | August 2022          | |partial| Receives fixes for security and platform support issues only.  |
+| Godot 3.5    | August 2022          | |eol| No longer supported (last update: 3.5.3).                          |
 +--------------+----------------------+--------------------------------------------------------------------------+
 | Godot 3.4    | November 2021        | |eol| No longer supported (last update: 3.4.5).                          |
 +--------------+----------------------+--------------------------------------------------------------------------+


### PR DESCRIPTION
I cherry-picked a bunch of stuff for 4.3.1 many months ago, but never got to making a build and now there would be a ton more work needed to make a useful build (changing platform requirements, etc.).

Since 4.5.1 is out, it's time to EOL the old-old-stable branch (4.3). And since the migration has been pretty successful for most users, there doesn't seem to be a strong need to support 4.4.x for a long time, so we downgrade it to partial support (until 4.6 is released).

As for 3.x, we just released 3.6.2 to support changing platform requirements with some significant delay, so aiming to also release a 3.5.4 is unrealistic with our current resources. So it's also time to end support for 3.5. For 3.x in general I think we should likely pledge to support only the latest stable and not also the previous stable like we do with 4.x.

This needs to be cherry-picked pretty much everywhere - until we finally move this table out of the docs so we don't need to update all versions whenever a new release happens or old releases are EOL.