### PR TITLE
GitHub Actions: Increase timeout to 240 minutes for offline documentation builds

### DIFF
--- a/.github/workflows/build_offline_docs.yml
+++ b/.github/workflows/build_offline_docs.yml
@@ -12,7 +12,7 @@ jobs:
     # Manual runs can still be triggered as normal.
     if: ${{ github.repository_owner == 'godotengine' || github.event_name != 'schedule' || vars.CI_OFFLINE_DOCS_CRON == 'true' }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 180
+    timeout-minutes: 240
     strategy:
       max-parallel: 1
       fail-fast: false


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-docs/pull/10474.

Building the offline documentation 6 times (3 HTML, 3 ePub) takes a long time on a GitHub Actions shared runner. 3 hours doesn't always suffice anymore, so increasing it to 4 hours should fix CI failures for the foreseeable future.

- This closes #11398.
