### PR TITLE
Remove mention of SoftBody3D overlap events in list of Jolt differences

### DIFF
--- a/tutorials/physics/using_jolt_physics.rst
+++ b/tutorials/physics/using_jolt_physics.rst
@@ -186,7 +186,7 @@ Area3D and SoftBody3D
 ~~~~~~~~~~~~~~~~~~~~~
 
 Jolt does not currently support any interactions between :ref:`class_SoftBody3D`
-and :ref:`class_Area3D`, such as overlap events, or the wind properties found on
+and :ref:`class_Area3D`, such as the wind and gravity properties found on
 :ref:`class_Area3D`.
 
 WorldBoundaryShape3D


### PR DESCRIPTION
Related to godotengine/godot#111993.

In the list of differences between Jolt Physics and Godot Physics it's mentioned that Jolt does not support overlap events between `Area3D` and `SoftBody3D`, but Godot Physics does not in fact support those either, so might be confusing to have that mentioned there.