### PR TITLE
Replace Harvard course recommendation with Learn GDScript from Zero

### DIFF
--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -15,7 +15,7 @@ Where to start
 
 The Godot video tutorials by `GDQuest <https://www.youtube.com/channel/UCxboW7x0jZqFdvMdCFKTMsQ/playlists>`_ are well-regarded in the community and often recommended as a gentle introduction to beginners.
 
-GDQuest's *Learn GDScript From Zero* is a free and open source interactive tutorial for absolute beginners to learn to program with Godot's GDScript language. It is available as a `desktop application <https://gdquest.itch.io/learn-godot-gdscript>`_  or `in the browser <https://gdquest.github.io/learn-gdscript>`_.
+GDQuest's *Learn GDScript From Zero* is a free and open source interactive tutorial for absolute beginners to learn to program with Godot's GDScript language. It is available as a `desktop application <https://gdquest.itch.io/learn-godot-gdscript>`__  or `in the browser <https://gdquest.github.io/learn-gdscript>`__.
 
 Some tutorials mentioned below cover more advanced subjects, e.g. on 3D or shaders.
 

--- a/getting_started/introduction/introduction_to_godot.rst
+++ b/getting_started/introduction/introduction_to_godot.rst
@@ -111,14 +111,11 @@ how to think like a programmer first.
 Godot relies on the object-oriented programming paradigm. Being comfortable with
 concepts such as classes and objects will help you code efficiently in it.
 
-If you are entirely new to programming, we recommend following the `CS50 open
-courseware`_ from Harvard University. It's a great free course that will teach
-you everything you need to know to be off to a good start. It will save you
-countless hours and hurdles learning any game engine afterward.
-
-.. note:: In CS50, you will learn multiple programming languages. Don't be
-          afraid of that: programming languages have many similarities. The
-          skills you learn with one language transfer well to others.
+If you are entirely new to programming, GDQuest's *Learn GDScript From Zero*
+is a free and open source interactive tutorial for absolute beginners to
+learn to program with Godot's GDScript language. It is available as a
+`desktop application <https://gdquest.itch.io/learn-godot-gdscript>`__
+or `in the browser <https://gdquest.github.io/learn-gdscript>`__.
 
 We will provide you with more Godot-specific learning resources in
 :ref:`doc_learning_new_features`.
@@ -129,4 +126,3 @@ In the next part, you will get an overview of the engine's essential concepts.
 .. _VSCode: https://github.com/godotengine/godot-vscode-plugin
 .. _Emacs: https://github.com/godotengine/emacs-gdscript-mode
 .. _official showcase videos: https://www.youtube.com/playlist?list=PLeG_dAglpVo6EpaO9A1nkwJZOwrfiLdQ8
-.. _CS50 open courseware: https://cs50.harvard.edu/x

--- a/getting_started/introduction/learning_new_features.rst
+++ b/getting_started/introduction/learning_new_features.rst
@@ -66,12 +66,11 @@ Teaching programming foundations and how to think like a game developer is
 beyond the scope of Godot's documentation. If you're new to programming, we
 recommend two excellent free resources to get you started:
 
-1. Harvard university offers a free courseware to learn to program, `CS50
-   <https://cs50.harvard.edu/x/>`_. It will teach you programming
-   fundamentals, how code works, and how to think like a programmer. These
-   skills are essential to become a game developer and learn any game engine
-   efficiently. You can see this course as an investment that will save you time
-   and trouble when you learn to create games.
+1. GDQuest's *Learn GDScript From Zero* is a free and open source
+   interactive tutorial for absolute beginners to learn to program
+   with Godot's GDScript language. It is available as a
+   `desktop application <https://gdquest.itch.io/learn-godot-gdscript>`__
+   or `in the browser <https://gdquest.github.io/learn-gdscript>`__.
 
 2. If you prefer books, check out the free ebook `Automate The Boring Stuff With
    Python <https://automatetheboringstuff.com/>`_ by Al Sweigart.


### PR DESCRIPTION
This resource didn't exist back when the Harvard course was added as a recommendation in 2020. It's much easier to follow (shorter, uses less technical terms) and is arguably more motivating for newcomers.

- This closes #11420.
