### PR TITLE
Explicitly destroy Vector2

### DIFF
--- a/tutorials/scripting/gdextension/gdextension_c_example.rst
+++ b/tutorials/scripting/gdextension/gdextension_c_example.rst
@@ -2010,8 +2010,9 @@ implement the helper function.
         // Call the function.
         api.object_method_bind_call(p_method_bind, p_instance, args, 2, &ret, NULL);
 
-        // Destroy the arguments that need it.
+        // Destroy the arguments.
         destructors.variant_destroy(&arg1);
+        destructors.variant_destroy(&arg2);
         destructors.variant_destroy(&ret);
     }
 


### PR DESCRIPTION
Close #11414 


Tried this locally, my example still works.

@AThousandShips Interesting to note, I also tested the extension with no destruction whatsoever with Godot running `verbose` stdout. I've left it running for over 10 minutes, No warnings of any kind, Godot's built-in monitors show static memory has not changed at all. :shrug: 