### PR TITLE
Standard_material_3d.rst - Material Shadow Mode names Updated

### DIFF
--- a/tutorials/3d/standard_material_3d.rst
+++ b/tutorials/3d/standard_material_3d.rst
@@ -676,14 +676,14 @@ for a full list of options and their description.
 Shadows
 -------
 
-Do Not Receive Shadows
-~~~~~~~~~~~~~~~~~~~~~~
+Disable Receive Shadows
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Makes the object not receive any kind of shadow that would otherwise
 be cast onto it.
 
-Use Shadow to Opacity
-~~~~~~~~~~~~~~~~~~~~~
+Shadow to Opacity
+~~~~~~~~~~~~~~~~~
 
 Lighting modifies the alpha so shadowed areas are opaque and non-shadowed
 areas are transparent. Useful for overlaying shadows onto a camera feed in AR.


### PR DESCRIPTION
Material Shadow Mode names were wrong. Documentation read  "Do Not Receive Shadows" And "Use Shadow To Opacity"

As of Godot 4.5, Editor's actual fields read:
"Disable Receive Shadows" and "Shadow To Opacity".

Updated to match.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
