### PR TITLE
Update beziers_and_curves.rst

### DIFF
--- a/tutorials/math/beziers_and_curves.rst
+++ b/tutorials/math/beziers_and_curves.rst
@@ -175,8 +175,8 @@ control the shape of our curve freely. Instead of having ``p0``, ``p1``, ``p2``
 and ``p3``, we will store them as:
 
 * ``point0 = p0``: Is the first point, the source
-* ``control0 = p1 - p0``: Is a vector relative to the first control point
-* ``control1 = p3 - p2``: Is a vector relative to the second control point
+* ``control0 = p1 - p0``: Is a vector relative to the first point 
+* ``control1 = p2 - p3``: Is a vector relative to the second point
 * ``point1 = p3``: Is the second point, the destination
 
 This way, we have two points and two control points which are relative vectors


### PR DESCRIPTION
Issue description: In the Math->Beziers, Curves and Path->Adding Control Point section, I believe the Control1 calculation should be Control1 = P2 - P3 instead of P3 - P2. Also, the text of the second and third bullets there should probably be reworded as follows:

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
