### PR TITLE
Update Android build requirements

### DIFF
--- a/engine_details/development/compiling/compiling_for_android.rst
+++ b/engine_details/development/compiling/compiling_for_android.rst
@@ -76,7 +76,7 @@ Setting up the buildsystem
 
     ::
 
-        cmdline-tools/latest/bin/sdkmanager --sdk_root=<android_sdk_path> "platform-tools" "build-tools;35.0.0" "platforms;android-35" "cmdline-tools;latest" "cmake;3.10.2.4988404" "ndk;28.1.13356709"
+        cmdline-tools/latest/bin/sdkmanager --sdk_root=<android_sdk_path> "platform-tools" "build-tools;35.0.1" "platforms;android-35" "cmdline-tools;latest" "cmake;3.10.2.4988404" "ndk;28.1.13356709"
 
 -  After setting up the SDK and environment variables, be sure to
    **restart your terminal** to apply the changes. If you are using

--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -38,7 +38,7 @@ Download and install the Android SDK.
   - Ensure that the `required packages <https://developer.android.com/studio/intro/update#required>`__ are installed as well.
 
     - Android SDK Platform-Tools version 35.0.0 or later
-    - Android SDK Build-Tools version 35.0.0
+    - Android SDK Build-Tools version 35.0.1
     - Android SDK Platform 35
     - Android SDK Command-line Tools (latest)
 
@@ -54,7 +54,7 @@ Download and install the Android SDK.
 
 ::
 
-    sdkmanager --sdk_root=<android_sdk_path> "platform-tools" "build-tools;35.0.0" "platforms;android-35" "cmdline-tools;latest" "cmake;3.10.2.4988404" "ndk;28.1.13356709"
+    sdkmanager --sdk_root=<android_sdk_path> "platform-tools" "build-tools;35.0.1" "platforms;android-35" "cmdline-tools;latest" "cmake;3.10.2.4988404" "ndk;28.1.13356709"
 
 .. note::
 


### PR DESCRIPTION
Update Android build requirements after https://github.com/godotengine/godot/pull/112437.

Cherrypicking note: Cherrypick if the above PR got cherrypicked.