### PR TITLE
Fetch redirects based on the current URL.

### DIFF
--- a/404.rst
+++ b/404.rst
@@ -37,7 +37,7 @@ Page not found
     // This is done in JavaScript, as we exceed Read the Docs' limit for the amount of redirects configurable.
 
     const currentPathSegments = window.location.pathname.split('/').filter(segment => segment !== '');
-    // Use the base path (e.g. "/en/latest") when available
+    // Use the base path (e.g. "/en/latest") when available.
     const currentBasePath = (currentPathSegments.length >= 2) ? ("/" + currentPathSegments.slice(0, 2).join("/")) : "/";
 
     fetch(currentBasePath + "/_static/redirects.csv")


### PR DESCRIPTION
This rewrites the URL fetch to use the current branch of the docs for redirects (e.g. `/en/4.5`) instead of `latest` for everything.

This will be needed in the future when redirects diverge. For now, we only use the js redirects on 4.5 and `master`, which haven't diverged much yet.

> [!WARNING]  
> I can't fully test this locally, because serving with python doesn't seem to incorporate the 404 page correctly.
> However, testing with the REPL in the browser, this should work correctly (even for local testing, if someone gets it to work fully).

_Bugsquad edit: Followup to https://github.com/godotengine/godot-docs/pull/11304_