### PR TITLE
Update exec flag for Visual Studio

### DIFF
--- a/tutorials/editor/external_editor.rst
+++ b/tutorials/editor/external_editor.rst
@@ -56,7 +56,7 @@ Some example **Exec Flags** for various editors include:
 +---------------------+-----------------------------------------------------+
 | Sublime Text/Zed    | ``{project} {file}:{line}:{col}``                   |
 +---------------------+-----------------------------------------------------+
-| Visual Studio*      | ``/edit "{file}"``                                    |
+| Visual Studio*      | ``/edit "{file}"``                                  |
 +---------------------+-----------------------------------------------------+
 
 \*: Arguments are not automatically detected, so you must fill them in manually.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->

Trying to follow this document to use Visual Studio to open scripts results in an error:
<img width="301" height="294" alt="Screenshot_1" src="https://github.com/user-attachments/assets/a8d4f187-e121-4cbc-b9c7-db73c714cb08" />

Exec flags for Visual Studio isn't using the proper `{file}` field. Using the updated argument opens the file as expected.