### PR TITLE
Tweak suggested energy values to simulate volumetric lighting in Volumetric fog

### DIFF
--- a/tutorials/3d/volumetric_fog.rst
+++ b/tutorials/3d/volumetric_fog.rst
@@ -125,7 +125,7 @@ make fog brighter in specific areas.
 This can be done by setting volumetric fog density to the lowest permitted value
 *greater than zero* (``0.0001``), then increasing the **Volumetric Fog Energy**
 property on lights to much higher values than the default to compensate. Values
-between ``10000`` and ``100000`` usually work well for this.
+between ``200.0`` and ``5000.0`` usually work well for this.
 
 .. image:: img/volumetric_fog_lighting.png
 


### PR DESCRIPTION
4.6 has fixed the previously incorrect volumetric fog blending behavior. This has the side-effect of making bright volumetric fog look significantly brighter than before. To get a result similar to the previous look, the Volumetric Fog Energy property on Light3D nodes needs to be reduced significantly (often by a factor of 10, if not more).

- See https://github.com/godotengine/godot/pull/112494.

Not cherry-pickable to `4.5`, as this change will only be in 4.6.