### PR TITLE
Document GPUParticles3D precision limitation in Large world coordinates

### DIFF
--- a/tutorials/physics/large_world_coordinates.rst
+++ b/tutorials/physics/large_world_coordinates.rst
@@ -224,28 +224,31 @@ Limitations
 Since 3D rendering shaders don't actually use double-precision floats, there are
 some limitations when it comes to 3D rendering precision:
 
-- Shaders using the ``skip_vertex_transform`` or ``world_vertex_coords`` don't
-  benefit from increased precision.
 - :ref:`Triplanar mapping <doc_standard_material_3d_triplanar_mapping>` doesn't
   benefit from increased precision. Materials using triplanar mapping will exhibit
   visible jittering when far away from the world origin.
+- :ref:`class_GPUParticles3D` nodes with **Local Coords** disabled will not benefit
+  from increased precision. This can cause visible particle snapping to occur
+  when far away from the world origin. Nodes with **Local Coords** enabled,
+  as well as :ref:`class_CPUParticles3D` nodes, will still benefit from increased precision.
+- Shaders using the ``skip_vertex_transform`` or ``world_vertex_coords`` render modes
+  don't benefit from increased precision.
 - In double-precision builds, world space coordinates in a shader ``fragment()``
   function can't be reconstructed from view space, for example:
 
   .. code-block:: glsl
 
     vec3 world = (INV_VIEW_MATRIX * vec4(VERTEX, 1.0)).xyz;
-    
+
   Instead, calculate the world space coordinates in the ``vertex()`` function and
   pass them using a :ref:`varying<doc_shading_language_varyings>`, for example:
 
   .. code-block:: glsl
-  
+
     varying vec3 world;
     void vertex() {
         world = (MODEL_MATRIX * vec4(VERTEX, 1.0)).xyz;
     }
-
 
 2D rendering currently doesn't benefit from increased precision when large world
 coordinates are enabled. This can cause visible model snapping to occur when


### PR DESCRIPTION
This affects particles that use global coordinates (i.e. Local Coords disabled) only.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/564#discussioncomment-14950108.
