### PR TITLE
Add Java/Kotlin to the list of other language bindings 

### DIFF
--- a/tutorials/scripting/other_languages.rst
+++ b/tutorials/scripting/other_languages.rst
@@ -23,6 +23,7 @@ The bindings below are developed and maintained by the community:
 
 - `D <https://github.com/godot-dlang/godot-dlang>`__
 - `Go <https://github.com/grow-graphics/gd>`__
+- `Java/Kotlin <https://github.com/utopia-rise/godot-kotlin-jvm>`__
 - `Nim <https://github.com/godot-nim/gdext-nim>`__
 - `Rust <https://github.com/godot-rust/gdext>`__
 - `Swift <https://github.com/migueldeicaza/SwiftGodot>`__


### PR DESCRIPTION
Add Java/Kotlin language link

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
