### PR TITLE
Fix typo in GD0001 C# diagnostic example code

### DIFF
--- a/tutorials/scripting/c_sharp/diagnostics/GD0001.rst
+++ b/tutorials/scripting/c_sharp/diagnostics/GD0001.rst
@@ -28,7 +28,7 @@ types that aren't declared partial.
     public class InvalidNode : Node { }
 
     // The source generators can enhance this type to work with Godot.
-    public partial class ValidNode { }
+    public partial class ValidNode : Node { }
 
 How to fix violations
 ---------------------


### PR DESCRIPTION
- See https://github.com/godotengine/godot-docs-user-notes/discussions/568#discussioncomment-14968250 .
