### PR TITLE
Fix Vulkan validation layers on Android

### DIFF
--- a/engine_details/development/debugging/vulkan/vulkan_validation_layers.rst
+++ b/engine_details/development/debugging/vulkan/vulkan_validation_layers.rst
@@ -129,14 +129,6 @@ After installing the package, run Godot with the ``--gpu-validation``
 ``--gpu-abort`` which will make Godot quit as soon as a validation error happens.
 This can prevent your system from freezing if a validation error occurs.
 
-.. _doc_vulkan_validation_layers_android:
-
-Android
--------
-
-After enabling validation layers on Android, a developer can see errors and
-warning messages in the ``adb logcat`` output.
-
 iOS
 ---
 
@@ -147,6 +139,14 @@ Web
 
 Validation layers are **not** supported on the web platform, as there is no support
 for Vulkan there.
+
+.. _doc_vulkan_validation_layers_android:
+
+Android
+-------
+
+After enabling validation layers on Android, a developer can see errors and
+warning messages in the ``adb logcat`` output.
 
 Enabling validation layers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
In this PR, I've only moved the `iOS` and `Web` sections before Android. 
The `Enabling validation layers` section belongs to Android and should follow directly below Android.


https://docs.godotengine.org/en/latest/engine_details/development/debugging/vulkan/vulkan_validation_layers.html


<img width="869" height="501" alt="image" src="https://github.com/user-attachments/assets/470b2b5b-e1f9-4c63-9a52-e5cc6791b0d9" />
