### PR TITLE
Fix typo in `DEEP_DUPLICATE_ALL` flag in Upgrading to Godot 4.5

### DIFF
--- a/tutorials/migrating/upgrading_to_godot_4.5.rst
+++ b/tutorials/migrating/upgrading_to_godot_4.5.rst
@@ -223,7 +223,7 @@ Core
     it's called on. In 4.4, this duplicated everything instead, including external resources.
     If you were deep-duplicating a resource that contained references to other
     external resources, those external resources aren't duplicated anymore. You must call
-    :ref:`Resource.duplicate_deep(RESOURCE_DEEP_DUPLICATE_ALL) <class_Resource_method_duplicate_deep>`
+    :ref:`Resource.duplicate_deep(DEEP_DUPLICATE_ALL) <class_Resource_method_duplicate_deep>`
     instead to keep the old behavior.
 
 .. note::


### PR DESCRIPTION
- See https://github.com/godotengine/godot-docs-user-notes/discussions/526#discussioncomment-15066106.

The typo may have been due to me referencing https://github.com/godotengine/godot/blob/369afc7b46d87dd28fc70976fc66875e76e36101/core/variant/variant_deep_duplicate.h instead of what's exposed to the scripting API.
