### PR TITLE
Update rotation + movement section of 2d_movement.rst to properly app…

### DIFF
--- a/tutorials/2d/2d_movement.rst
+++ b/tutorials/2d/2d_movement.rst
@@ -124,7 +124,7 @@ while up/down moves it forward or backward in whatever direction it's facing.
 
     func get_input():
         rotation_direction = Input.get_axis("left", "right")
-        velocity = transform.x * Input.get_axis("down", "up") * speed
+        velocity = transform.y * Input.get_axis("down", "up") * speed
 
     func _physics_process(delta):
         get_input()
@@ -148,7 +148,7 @@ while up/down moves it forward or backward in whatever direction it's facing.
         public void GetInput()
         {
             _rotationDirection = Input.GetAxis("left", "right");
-            Velocity = Transform.X * Input.GetAxis("down", "up") * Speed;
+            Velocity = Transform.Y * Input.GetAxis("down", "up") * Speed;
         }
 
         public override void _PhysicsProcess(double delta)
@@ -162,7 +162,7 @@ while up/down moves it forward or backward in whatever direction it's facing.
 Here we've added two variables to track our rotation direction and speed.
 The rotation is applied directly to the body's ``rotation`` property.
 
-To set the velocity, we use the body's ``transform.x`` which is a vector pointing
+To set the velocity, we use the body's ``transform.y`` which is a vector pointing
 in the body's "forward" direction, and multiply that by the speed.
 
 Rotation + movement (mouse)


### PR DESCRIPTION
…ly the movement in the direction the sprite is facing

The code in the rotation + movement section was applying movement perpendicular to the up direction instead of in the direction the sprite is facing. This can be clearly seen in the animation.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
