### PR TITLE
Update Compiling for Windows following Direct3D 12 being enabled by default

### DIFF
--- a/about/faq.rst
+++ b/about/faq.rst
@@ -309,21 +309,6 @@ See :ref:`doc_data_paths` for more information.
 If *true* portable operation is desired (e.g. for use on a USB stick),
 follow the steps in :ref:`doc_data_paths_self_contained_mode`.
 
-Why does Godot prioritize Vulkan and OpenGL over Direct3D?
-----------------------------------------------------------
-
-Godot aims for cross-platform compatibility and open standards first and
-foremost. OpenGL and Vulkan are the technologies that are both open and
-available on (nearly) all platforms. Thanks to this design decision, a project
-developed with Godot on Windows will run out of the box on Linux, macOS, and
-more.
-
-While Vulkan and OpenGL remain our primary focus for their open standard and
-cross-platform benefits, Godot 4.3 introduced experimental support for Direct3D 12.
-This addition aims to enhance performance and compatibility on platforms where
-Direct3D 12 is prevalent, such as Windows and Xbox. However, Vulkan and OpenGL
-will continue as the default rendering drivers on all platforms, including Windows.
-
 Why does Godot aim to keep its core feature set small?
 ------------------------------------------------------
 

--- a/engine_details/class_reference/index.rst
+++ b/engine_details/class_reference/index.rst
@@ -314,7 +314,7 @@ the end of the description:
 
 .. code-block:: none
 
-    [b]Note:[/b] Only available when using the Vulkan renderer.
+    [b]Note:[/b] Only available when using the Forward+ renderer.
 
 To denote crucial information that could cause security issues or loss of data
 if not followed carefully, add a paragraph starting with "[b]Warning:[/b]" at

--- a/engine_details/development/compiling/compiling_for_windows.rst
+++ b/engine_details/development/compiling/compiling_for_windows.rst
@@ -15,7 +15,6 @@ Requirements
 
 For compiling under Windows, the following is required:
 
-
 - A C++ compiler. Use one of the following:
 
     - `Visual Studio Community <https://www.visualstudio.com/vs/community/>`_,
@@ -36,6 +35,8 @@ For compiling under Windows, the following is required:
 - `SCons 4.0+ <https://scons.org/pages/download.html>`_ build system. Using the
   latest release is recommended, especially for proper support of recent Visual
   Studio releases.
+- :ref:`Direct3D 12 dependencies <doc_compiling_for_windows_installing_d3d12_requirements>`
+  (can be skipped with the ``d3d12=no`` SCons option if Direct3D 12 support is not desired).
 
 .. note:: If you have `Scoop <https://scoop.sh/>`_ installed, you can easily
           install MinGW and other dependencies using the following command:
@@ -182,17 +183,21 @@ dependencies. Running it will bring up the Project Manager.
           :ref:`doc_data_paths_self_contained_mode` by creating a file called
           ``._sc_`` or ``_sc_`` in the ``bin/`` folder.
 
-Compiling with support for Direct3D 12
---------------------------------------
+.. _doc_compiling_for_windows_installing_d3d12_requirements:
 
-By default, builds of Godot do not contain support for the Direct3D 12 graphics
-API.
+Installing Direct3D 12 requirements
+-----------------------------------
+
+By default, Windows builds of Godot contain support for the Direct3D 12 graphics
+API. Compiling with Direct3D 12 support requires additional dependencies
+to be installed. If you wish to skip this step, you can use the ``d3d12=no``
+SCons option; Vulkan and OpenGL support will remain available if you do so.
 
 You can install the required dependencies by running
 ``python misc/scripts/install_d3d12_sdk_windows.py``
-in the Godot source repository. After running this script, add the ``d3d12=yes``
-SCons option to enable Direct3D 12 support. This will use the default paths for
-the various dependencies, which match the ones used in the script.
+in the Godot source repository. After running this script, compile Godot as usual.
+This will use the default paths for the various dependencies, which match the
+ones used in the script.
 
 You can find the detailed steps below if you wish to set up dependencies
 manually, but the above script handles everything for you (including the

--- a/tutorials/3d/global_illumination/using_lightmap_gi.rst
+++ b/tutorials/3d/global_illumination/using_lightmap_gi.rst
@@ -522,7 +522,7 @@ JNLM (Non-Local Means with Joint Filtering)
 JNLM is the default denoising method and is included in Godot. It uses a simple
 but efficient denoising algorithm known as *non-local means*. JNLM runs on the
 GPU using a compute shader, and is compatible with any GPU that can run Godot
-4's Vulkan-based rendering methods. No additional setup is required.
+4's RenderingDevice-based renderers. No additional setup is required.
 
 JNLM's denoising can be adjusted using the **Denoiser Strength** property that
 is visible when **Use Denoiser** enabled. Higher values can be more effective at

--- a/tutorials/editor/using_the_android_editor.rst
+++ b/tutorials/editor/using_the_android_editor.rst
@@ -72,7 +72,7 @@ Here are the known limitations and issues of the Android editor:
 - No support for Android plugins as they require gradle build support. GDExtensions plugins are supported.
 - No C#/Mono support.
 - No support for external script editors.
-- While available, the *Vulkan Forward+* renderer is not recommended due to severe performance issues.
+- While available, the Forward+ renderer is not recommended due to severe performance issues.
 - UX not optimized for Android phones form-factor.
 - `Android Go devices <https://developer.android.com/guide/topics/androidgo>`__ lacks
   the *All files access* permission required for device read/write access.

--- a/tutorials/troubleshooting.rst
+++ b/tutorials/troubleshooting.rst
@@ -60,7 +60,7 @@ There are several workarounds for this:
 The editor or project takes a very long time to start
 -----------------------------------------------------
 
-When using one of the Vulkan-based renderers (Forward+ or Mobile), the first
+When using one of the RenderingDevice-based renderers (Forward+ or Mobile), the first
 startup is expected to be relatively long. This is because shaders
 need to be compiled before they can be cached. Shaders also need to be cached
 again after updating Godot, after updating graphics drivers or after switching


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/113213.

The recommendation is now to leave `d3d12` to its default `yes` value, which means installing Direct3D 12 dependencies is considered required by default.

You can still skip the dependencies by compiling with `d3d12=no`, which matches the behavior of self-compiled builds prior to Godot 4.6.

This also removes an outdated FAQ question, since a lot of time has passed since that question was written (Godot only had Vulkan and OpenGL support back then).

*Not cherry-pickable to 4.5.*
