### PR TITLE
Add additional information about the Godot XR Vendor Plugin

### DIFF
--- a/tutorials/xr/deploying_to_android.rst
+++ b/tutorials/xr/deploying_to_android.rst
@@ -16,6 +16,7 @@ Before following the OpenXR-specific instructions here, you'll need to first set
 See :ref:`doc_exporting_for_android` for the full details, and return here when you've finished these steps.
 
 .. warning::
+
     While the Mobile Vulkan renderer has many optimizations targeted at mobile devices, we're still working out the kinks.
     It is highly advisable to use the compatibility renderer (OpenGL) for the time being when targeting Android based XR devices.
 
@@ -23,6 +24,7 @@ Gradle Android build
 --------------------
 
 .. note::
+
     Official support for the Android platform wasn't added to the OpenXR specification initially resulting in various vendors creating custom loaders to make OpenXR available on their headsets.
     While the long term expectation is that all vendors will adopt the official OpenXR loader, for now these loaders need to be added to your project.
 
@@ -51,6 +53,13 @@ file into your projects `addons` folder.
 
 You can find the main repository of the vendors plugin `here <https://github.com/GodotVR/godot_openxr_vendors>`__.
 
+.. note::
+
+    From Godot 4.6 onwards, the vendor plugin is now an optional but recommended plugin.
+    Godot can export directly to most Android-compatible devices.
+    This can be useful for demonstration and tutorial projects where a single APK can be deployed to multiple devices.
+    The vendor plugin unlocks vendor specific implementations and settings, and may be required to release on app stores.
+
 Creating the export presets
 ---------------------------
 You will need to setup a separate export preset for each device, as each device will need its own loader included.
@@ -59,12 +68,12 @@ Open **Project** and select **Export..**.
 Click on **Add..** and select **Android**.
 Next change the name of the export preset for the device you're setting this up for, say **Meta Quest**.
 And enable **Use Gradle Build**.
+Next change the **XR Mode** to **OpenXR**.
 If you want to use one-click deploy (described below), ensure that **Runnable** is enabled.
 
-If the vendors plugins were installed correctly you should find entries for the
-different headsets under **XR Features**. Change the **XR Mode** to **OpenXR**, then
-select the entry for your headset if you see one. If you don't see one enable the
-Khronos plugin.
+If you've installed the vendor plugin you will also find entries for the different headsets under **XR Features**.
+Select the entry for your headset, if you see one.
+Otherwise, enable the Khronos plugin.
 
 .. image:: img/android_meta_quest.webp
 

--- a/tutorials/xr/setting_up_xr.rst
+++ b/tutorials/xr/setting_up_xr.rst
@@ -45,7 +45,7 @@ well optimized for XR right now compared to the other two.
 OpenXR
 ------
 
-OpenXR is a new industry standard that allows different XR platforms to present themselves through a standardised API to XR applications. This standard is an open standard maintained by the Khronos Group and thus aligns very well with Godot's interests.
+OpenXR is a new industry standard that allows different XR platforms to present themselves through a standardized API to XR applications. This standard is an open standard maintained by the Khronos Group and thus aligns very well with Godot's interests.
 
 The Vulkan implementation of OpenXR is closely integrated with Vulkan, taking over part of the Vulkan system. This requires tight integration of certain core graphics features in the Vulkan renderer which are needed before the XR system is setup. This was one of the main deciding factors to include OpenXR as a core interface.
 

--- a/tutorials/xr/xr_next_steps.rst
+++ b/tutorials/xr/xr_next_steps.rst
@@ -9,6 +9,17 @@ Now that we have the basics covered there are several options to look at for you
 * You can look at a number of `XR demos here <https://github.com/godotengine/godot-demo-projects/tree/master/xr>`_.
 * You can find 3rd party tutorials on our :ref:`Tutorials and resources <doc_community_tutorials>` page.
 
+Godot OpenXR vendor plugin
+--------------------------
+
+The vendor plugin isn't just for :ref:`deploying to Android <doc_deploying_to_android>`.
+In the vendor plugin, we implement many OpenXR vendor extensions that unlock unique features on certain devices,
+or features that are new enough that a standardized implementation is not available yet.
+
+Together with the OpenXR working group we maintain a 
+`client support matrix <https://github.khronos.org/OpenXR-Inventory/extension_support.html#client_matrix>`_ that lists
+all the OpenXR extensions Godot supports and whether they require the vendor plugin.
+
 XR Toolkits
 -----------
 


### PR DESCRIPTION
Now that the vendor plugin is optional, added a note to that in the documentation making clear the vendor plugin is still important.

Also added a section in next steps to underline that the vendor plugin isn't just useful on AOSP devices, but also to unlock vendor extensions on other platforms.

This includes a link to the client support matrix where users can find which OpenXR extensions are supported in core, and which require the vendor plugin.