### PR TITLE
Clarify SurfaceTool example with index

### DIFF
--- a/tutorials/3d/procedural_geometry/surfacetool.rst
+++ b/tutorials/3d/procedural_geometry/surfacetool.rst
@@ -144,16 +144,16 @@ shrinks the vertex array to remove duplicate vertices.
 
  .. code-tab:: csharp
 
-    # Suppose we have a quad defined by 6 vertices as follows
-    st.AddVertex(Vector3(-1, 1, 0));
-    st.AddVertex(Vector3(1, 1, 0));
-    st.AddVertex(Vector3(-1, -1, 0));
+    // Suppose we have a quad defined by 6 vertices as follows.
+    st.AddVertex(new Vector3(-1, 1, 0));
+    st.AddVertex(new Vector3(1, 1, 0));
+    st.AddVertex(new Vector3(-1, -1, 0));
 
-    st.AddVertex(Vector3(1, 1, 0));
-    st.AddVertex(Vector3(1, -1, 0));
-    st.AddVertex(Vector3(-1, -1, 0));
+    st.AddVertex(new Vector3(1, 1, 0));
+    st.AddVertex(new Vector3(1, -1, 0));
+    st.AddVertex(new Vector3(-1, -1, 0));
 
-    # We can make the quad more efficient by using an index array and only utilizing 4 vertices:
+    // We can make the quad more efficient by using an index array and only utilizing 4 vertices:
     st.AddVertex(new Vector3(-1, -1, 0));
     st.AddVertex(new Vector3(1, 1, 0));
     st.AddVertex(new Vector3(-1, -1, 0));
@@ -169,7 +169,7 @@ shrinks the vertex array to remove duplicate vertices.
     st.AddIndex(3);
     st.AddIndex(2);
 
-    // Alternatively we can use `st.Index()` which will create the quad for us and remove the duplicate vertices
+    // Alternatively we can use `st.Index()` which will create the quad for us and remove the duplicate vertices.
     st.Index();
 
 Similarly, if you have an index array, but you want each vertex to be unique (e.g. because


### PR DESCRIPTION
The current example looks like an accidental copy paste without adapting the code. I fixed that and made the C# version more consistent.