### PR TITLE
CI: Fix `sync_class_ref.yml` workflow

### DIFF
--- a/.github/workflows/sync_class_ref.yml
+++ b/.github/workflows/sync_class_ref.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build new documentation
         run: |
-          ./.engine-src/doc/tools/make_rst.py --color -o ./classes -l en ./.engine-src/doc/classes ./.engine-src/modules ./.engine-src/platform
+          python ./.engine-src/doc/tools/make_rst.py --color -o ./classes -l en ./.engine-src/doc/classes ./.engine-src/modules ./.engine-src/platform
 
       - name: Submit a pull-request
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
- Relevant RC thread: https://chat.godotengine.org/channel/documentation?msg=vMPsisoLih9MGr7ez

Makes a minor adjustment to the class sync workflow to call `make_rst.py` through Python directly, sidestepping an issue where the executable flag was erroneously removed