### PR TITLE
Update number of built-in BBCode effects

### DIFF
--- a/tutorials/ui/bbcode_in_richtextlabel.rst
+++ b/tutorials/ui/bbcode_in_richtextlabel.rst
@@ -994,7 +994,7 @@ Text effects
 ------------
 
 BBCode can also be used to create different text effects that can optionally be
-animated. Five customizable effects are provided out of the box, and you can
+animated. Several customizable effects are provided out of the box, and you can
 easily create your own. By default, animated effects will pause
 :ref:`when the SceneTree is paused <doc_pausing_games>`. You can change this
 behavior by adjusting the RichTextLabel's **Process > Mode** property.


### PR DESCRIPTION
The number was not updated when the Pulse effect was added, so the docs currently say there are 5 effects, but then it lists 6.