### PR TITLE
Bent normals are not available on Compatibility renderer

### DIFF
--- a/tutorials/3d/standard_material_3d.rst
+++ b/tutorials/3d/standard_material_3d.rst
@@ -435,6 +435,9 @@ and wider compatibility.
 Bent normal map
 ---------------
 
+*This is only available in the Forward+ and Mobile renderers, not the Compatibility
+renderer.*
+
 A bent normal map describes the average direction of ambient lighting. Unlike a
 regular normal map, this is used to improve how a material reacts to lighting
 rather than add surface detail.


### PR DESCRIPTION
Looking at the pull request that added bent normals (godotengine/godot#89988 [comment](https://github.com/godotengine/godot/pull/89988#issuecomment-3096892631)), the feature was added only for Forward+ and Mobile for the time being.