### PR TITLE
Fix incorrect default transfer_mode in high-level multiplayer tutorial

### DIFF
--- a/tutorials/networking/high_level_multiplayer.rst
+++ b/tutorials/networking/high_level_multiplayer.rst
@@ -274,11 +274,11 @@ The annotation can take a number of arguments, which have default values. ``@rpc
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-    @rpc("authority", "call_remote", "unreliable", 0)
+    @rpc("authority", "call_remote", "reliable", 0)
 
  .. code-tab:: csharp
 
-    [Rpc(MultiplayerApi.RpcMode.Authority, CallLocal = false, TransferMode = MultiplayerPeer.TransferModeEnum.Unreliable, TransferChannel = 0)]
+    [Rpc(MultiplayerApi.RpcMode.Authority, CallLocal = false, TransferMode = MultiplayerPeer.TransferModeEnum.Reliable, TransferChannel = 0)]
 
 The parameters and their functions are as follows:
 


### PR DESCRIPTION
The documentation incorrectly stated that the default transfer_mode for `@rpc` is "unreliable", but the actual default in Godot's source code is "reliable".

GDScript ref: https://github.com/godotengine/godot/blob/3b48b0110e04e84db54788ccda4f8f5f7fa1fcf4/modules/multiplayer/scene_rpc_interface.cpp#L90
C# ref: https://github.com/godotengine/godot/blob/3b48b0110e04e84db54788ccda4f8f5f7fa1fcf4/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/RpcAttribute.cs#L27

Fixes #8874

---

Note that the linked issue mentions two issues -- the tutorial (which this fixes), and the original issue that was mentioned, but that's generated from the main godot repository.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
