### PR TITLE
Clarify CharacterBody usage

### DIFF
--- a/tutorials/physics/using_character_body_2d.rst
+++ b/tutorials/physics/using_character_body_2d.rst
@@ -25,6 +25,10 @@ engine physics properties, like gravity or friction. While this means that you
 have to write some code to create their behavior, it also means you have more
 precise control over how they move and react.
 
+Despite it's name ``CharacterBody2D``, it can also be used for other physics objects that requires
+precise manual movement logic and detailed collision information, such as moving
+platforms or complex projectiles.
+
 .. note:: This document assumes you're familiar with Godot's various physics
           bodies. Please read :ref:`doc_physics_introduction` first, for an overview
           of the physics options.

--- a/tutorials/physics/using_character_body_2d.rst
+++ b/tutorials/physics/using_character_body_2d.rst
@@ -25,7 +25,7 @@ engine physics properties, like gravity or friction. While this means that you
 have to write some code to create their behavior, it also means you have more
 precise control over how they move and react.
 
-Despite it's name ``CharacterBody2D``, it can also be used for other physics objects that requires
+Despite its name ``CharacterBody2D``, it can also be used for other physics objects that require
 precise manual movement logic and detailed collision information, such as moving
 platforms or complex projectiles.
 


### PR DESCRIPTION
Fixes #10458

Description
Added a note to the using_character_body_2d.rst tutorial to clarify that the CharacterBody2D node is not strictly for human/NPC characters. It is also the recommended node for any physics object that requires manual movement and detailed collision information, such as moving platforms or complex projectiles.

Changes
Added a .. note:: block in the "Introduction" or "When to use" section of the CharacterBody2D manual page.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
