### PR TITLE
Fix BBCode Matrix effect example

### DIFF
--- a/tutorials/ui/bbcode_in_richtextlabel.rst
+++ b/tutorials/ui/bbcode_in_richtextlabel.rst
@@ -1209,7 +1209,7 @@ Matrix
         var dirty_time = char_fx.env.get("dirty", 1.0)
         var text_span = char_fx.env.get("span", 50)
 
-        var value = char_fx.glyph_index
+        var value = get_text_server().font_get_char_from_glyph_index(char_fx.font, 1, char_fx.glyph_index)
 
         var matrix_time = fmod(char_fx.elapsed_time + (char_fx.range.x / float(text_span)), \
                                clear_time + dirty_time)


### PR DESCRIPTION
In #5982, when the BBCode tutorial was updated after CharFX API changes, the Matrix effect example was broken. This fixes it by first converting the glyph index to a character, so that when it gets converted back into a glyph index, it's the right one. Here's a video showing the before and after:

https://github.com/user-attachments/assets/1eb96440-08c6-46d6-bd9f-d1e3a64ddb9b
