### PR TITLE
Update SSR info for 4.6

### DIFF
--- a/engine_details/architecture/internal_rendering_architecture.rst
+++ b/engine_details/architecture/internal_rendering_architecture.rst
@@ -648,8 +648,7 @@ indirect lighting.
 When both SSAO and SSIL are enabled, parts of SSAO and SSIL are shared to reduce
 the performance impact.
 
-SSAO and SSIL are performed at half resolution by default to improve performance.
-SSR is always performed at half resolution to improve performance.
+SSAO, SSIL, and SSR are performed at half resolution by default to improve performance.
 
 **Screen-space effects C++ code:**
 


### PR DESCRIPTION
Does what the title says, SSR was overhauled in 4.6 and can now be rendered at full resolution. PR that made the change: https://github.com/godotengine/godot/pull/111210