### PR TITLE
Fixed bug origin to upper

### DIFF
--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -360,7 +360,7 @@ these properties, and if you don't write to them, Godot will optimize away the c
 +========================================+==================================================================================================+
 | in vec2 **VIEWPORT_SIZE**              | Size of viewport (in pixels).                                                                    |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
-| in vec4 **FRAGCOORD**                  | Coordinate of pixel center in screen space. ``xy`` specifies position in window. Origin is lower |
+| in vec4 **FRAGCOORD**                  | Coordinate of pixel center in screen space. ``xy`` specifies position in window. Origin is upper |
 |                                        | left. ``z`` specifies fragment depth. It is also used as the output value for the fragment depth |
 |                                        | unless ``DEPTH`` is written to.                                                                  |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
This PR corrects the documentation for the Section Fragments ->  built-in `FRAGCOORD` variable in spatial shaders, mentioned in issue #11572 

In Godot 4.x, screen-space coordinates use an upper-left origin (Y increases downward).
The previous description incorrectly stated a lower-left origin, which could confuse users
working with screen-space shaders.

This change updates the description only, without altering formatting or structure.

**Fixes Issue #11572**