### PR TITLE
Clarify normal-roughness buffer limitation for transparent objects rendering.

### DIFF
--- a/tutorials/3d/3d_rendering_limitations.rst
+++ b/tutorials/3d/3d_rendering_limitations.rst
@@ -119,6 +119,10 @@ other transparent materials, while Sorting Offset will move the object
 forward or backward for the purpose of sorting. Even then, these may not
 always be sufficient.
 
+Transparent objects are not rendered to the normal-roughness buffer, as they are
+drawn after opaque geometry. As a result, features that rely on the normal-roughness
+buffer will not affect transparent materials.
+
 Some rendering engines feature *order-independent transparency* techniques to
 alleviate this, but this is costly on the GPU. Godot currently doesn't provide
 this feature. There are still several ways to avoid this problem:


### PR DESCRIPTION
Added information about transparent objects not being rendered to the normal-roughness buffer and their impact on rendering.

Fixes https://github.com/godotengine/godot/issues/114602

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
