### PR TITLE
Fix change about MP3 module

### DIFF
--- a/engine_details/development/compiling/optimizing_for_size.rst
+++ b/engine_details/development/compiling/optimizing_for_size.rst
@@ -270,12 +270,12 @@ a lot of them:
 
 ::
 
-    scons target=template_release module_astcenc_enabled=no module_basis_universal_enabled=no module_bcdec_enabled=no module_bmp_enabled=no module_camera_enabled=no module_csg_enabled=no module_dds_enabled=no module_enet_enabled=no module_etcpak_enabled=no module_fbx_enabled=no module_gltf_enabled=no module_gridmap_enabled=no module_hdr_enabled=no module_interactive_music_enabled=no module_jsonrpc_enabled=no module_ktx_enabled=no module_mbedtls_enabled=no module_meshoptimizer_enabled=no module_dr_mp3_enabled=no module_mobile_vr_enabled=no module_msdfgen_enabled=no module_multiplayer_enabled=no module_noise_enabled=no module_navigation_2d_enabled=no module_navigation_3d_enabled=no module_ogg_enabled=no module_openxr_enabled=no module_raycast_enabled=no module_regex_enabled=no module_svg_enabled=no module_tga_enabled=no module_theora_enabled=no module_tinyexr_enabled=no module_upnp_enabled=no module_vhacd_enabled=no module_vorbis_enabled=no module_webrtc_enabled=no module_websocket_enabled=no module_webxr_enabled=no module_zip_enabled=no
+    scons target=template_release module_astcenc_enabled=no module_basis_universal_enabled=no module_bcdec_enabled=no module_bmp_enabled=no module_camera_enabled=no module_csg_enabled=no module_dds_enabled=no module_enet_enabled=no module_etcpak_enabled=no module_fbx_enabled=no module_gltf_enabled=no module_gridmap_enabled=no module_hdr_enabled=no module_interactive_music_enabled=no module_jsonrpc_enabled=no module_ktx_enabled=no module_mbedtls_enabled=no module_meshoptimizer_enabled=no module_mp3_enabled=no module_mobile_vr_enabled=no module_msdfgen_enabled=no module_multiplayer_enabled=no module_noise_enabled=no module_navigation_2d_enabled=no module_navigation_3d_enabled=no module_ogg_enabled=no module_openxr_enabled=no module_raycast_enabled=no module_regex_enabled=no module_svg_enabled=no module_tga_enabled=no module_theora_enabled=no module_tinyexr_enabled=no module_upnp_enabled=no module_vhacd_enabled=no module_vorbis_enabled=no module_webrtc_enabled=no module_websocket_enabled=no module_webxr_enabled=no module_zip_enabled=no
 
 If this proves not to work for your use case, you should review the list of
 modules and see which ones you actually still need for your game (e.g. you might
 want to keep networking-related modules, regex support,
-``dr_mp3``/``ogg``/``vorbis`` to play music, or ``theora`` to play videos).
+``mp3``/``ogg``/``vorbis`` to play music, or ``theora`` to play videos).
 
 Alternatively, you can supply a list of disabled modules by creating
 ``custom.py`` at the root of the source, with the contents similar to the
@@ -302,7 +302,7 @@ following:
     module_ktx_enabled = "no"
     module_mbedtls_enabled = "no"
     module_meshoptimizer_enabled = "no"
-    module_dr_mp3_enabled = "no"
+    module_mp3_enabled = "no"
     module_mobile_vr_enabled = "no"
     module_msdfgen_enabled = "no"
     module_multiplayer_enabled = "no"


### PR DESCRIPTION
#11557 changed instances of the `minimp3` module into `dr_mp3`.

While the `minimp3` library was in fact replaced with `dr_mp3`, the module was renamed to `mp3`, not `dr_mp3`, to keep parity with other modules' names being about support for something and not their dependency.

Using `module_dr_mp3_enabled=no` will do nothing. The correct is `module_mp3_enabled=no`.