### PR TITLE
Tweak wording in Renderers to avoid ambiguity with material normal/roughness maps

### DIFF
--- a/tutorials/rendering/renderers.rst
+++ b/tutorials/rendering/renderers.rst
@@ -331,7 +331,7 @@ See :ref:`doc_shading_reference` for more information.
 | Depth texture           | ✔️ Supported.            | ✔️ Supported.            | ✔️ Supported.            |
 |                         |                          |                          |                          |
 +-------------------------+--------------------------+--------------------------+--------------------------+
-| Normal/Roughness texture| ❌ Not supported.        | ❌ Not supported.        | ✔️ Supported.            |
+| Normal/Roughness buffer | ❌ Not supported.        | ❌ Not supported.        | ✔️ Supported.            |
 +-------------------------+--------------------------+--------------------------+--------------------------+
 | Compute shaders         | ❌ Not supported.        | ⚠️ Supported, but comes  | ✔️ Supported.            |
 |                         |                          | with a performance       |                          |


### PR DESCRIPTION
- See https://github.com/godotengine/godot-docs-user-notes/discussions/431#discussioncomment-15314646.
