### PR TITLE
Change "transparent" to "translucent" to clarify red dot's colour.

### DIFF
--- a/tutorials/scripting/debug/debugger_panel.rst
+++ b/tutorials/scripting/debug/debugger_panel.rst
@@ -26,7 +26,7 @@ debugger broke on.
 
     You can create a breakpoint by clicking the gutter in the left of the script
     editor (on the left of the line numbers). When hovering this gutter, you
-    will see a transparent red dot appearing, which turns into an opaque red dot
+    will see a translucent red dot appearing, which turns into an opaque red dot
     after the breakpoint is placed by clicking. Click the red dot again to
     remove the breakpoint. Breakpoints created this way persist across editor
     restarts, even if the script wasn't saved when exiting the editor.


### PR DESCRIPTION
This is my first PR ever! So please ignore any ill-etiquette.

Being transparent means fully see through, and the red dot appearing over the panel is not fully see through, as if it was, it would not even be visible. It's translucent, as it's only partially see through.