### PR TITLE
Improve create node tutorial in the plugins section to use `class_name` instead

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -163,10 +163,10 @@ clicked. For that, we'll need a script that extends from
         @tool
 
         # Icons are optional.
-        # Alternativelly, you may use the UID of the icon or the absolute path.
+        # Alternatively, you may use the UID of the icon or the absolute path.
         @icon("icon.png")
 
-        # Automatically register the node in the Add Child dialog
+        # Automatically register the node in the Create New Node dialog
         # and make it available for use with other scripts.
         class_name MyButton
         extends Button
@@ -187,10 +187,10 @@ clicked. For that, we'll need a script that extends from
         [Tool]
 
         // Icons are optional.
-        // Alternativelly, you may use the UID of the icon or the absolute path.
+        // Alternatively, you may use the UID of the icon or the absolute path.
         [Icon("icon.png")]
 
-        // Automatically register the node in the Add Child dialog
+        // Automatically register the node in the Create New Node dialog
         // and make it available for use with other scripts.
         [GlobalClass]
         public partial class MyButton : Button


### PR DESCRIPTION
Creating nodes trough `class_name` is a more straight forward way to register then to the engine and less confusing, needing to edit just a single file instead of needing to register then trough `add_custom_type`.

I also transferred the old example with `add_custom_type` as a note.

You can check the discussion in rocket chat: https://chat.godotengine.org/channel/documentation/thread/uTBoFy259DZSFHrwN