### PR TITLE
Added a note with link to an Inkscape tools for Godot

### DIFF
--- a/engine_details/editor/creating_icons.rst
+++ b/engine_details/editor/creating_icons.rst
@@ -48,6 +48,16 @@ Otherwise, your icon may become difficult to read on a light background.
 		1. :ui:`Import > Import As > Texture2D`
 		2. Set ``editor/convert_colors_with_editor_theme`` to ``true``
 
+.. note::
+
+	To simplify designing process, you can use tools from this
+	`unofficial project <https://github.com/OS-of-S/Inkscape-Tools-for-Godot-Editor-Designing>`__,
+	that provides Godot palettes, which can be imported into Inkscape,
+	and an Inkscape extension to check its look for different themes.
+	
+	But priority for relevance remains with official
+	`color mappings file <https://github.com/godotengine/godot/blob/master/editor/themes/editor_color_map.cpp>`__.
+
 Icon optimization
 ~~~~~~~~~~~~~~~~~
 

--- a/engine_details/editor/creating_icons.rst
+++ b/engine_details/editor/creating_icons.rst
@@ -50,7 +50,7 @@ Otherwise, your icon may become difficult to read on a light background.
 
 .. note::
 
-	To simplify designing process, you can use tools from this
+	To simplify the design process, you can use tools from this
 	`unofficial project <https://github.com/OS-of-S/Inkscape-Tools-for-Godot-Editor-Designing>`__,
 	that provides Godot palettes, which can be imported into Inkscape,
 	and an Inkscape extension to check its look for different themes.


### PR DESCRIPTION
I've set up a [convenient pipeline for creating editor graphics](https://github.com/OS-of-S/Inkscape-Tools-for-Godot-Editor-Designing), and I'd like to add a link to it in the documentation. It's not so easy to use the bare hex-codes for colors provided by documentation right now. So I believe my tools would lower the barrier for beginners and would help to improve the appearance of tools they create.