### PR TITLE
Remove "outdated article" banner on index pages

### DIFF
--- a/tutorials/audio/index.rst
+++ b/tutorials/audio/index.rst
@@ -1,7 +1,5 @@
 :allow_comments: False
 
-:article_outdated: True
-
 Audio
 =====
 

--- a/tutorials/editor/index.rst
+++ b/tutorials/editor/index.rst
@@ -1,5 +1,4 @@
 :allow_comments: False
-:article_outdated: True
 
 .. _doc_editor_introduction:
 

--- a/tutorials/networking/index.rst
+++ b/tutorials/networking/index.rst
@@ -1,5 +1,4 @@
 :allow_comments: False
-:article_outdated: True
 
 Networking
 ==========

--- a/tutorials/performance/vertex_animation/index.rst
+++ b/tutorials/performance/vertex_animation/index.rst
@@ -1,5 +1,4 @@
 :allow_comments: False
-:article_outdated: True
 
 Animating thousands of objects
 ==============================

--- a/tutorials/platform/ios/index.rst
+++ b/tutorials/platform/ios/index.rst
@@ -1,5 +1,4 @@
 :allow_comments: False
-:article_outdated: True
 
 iOS plugins
 ===========

--- a/tutorials/platform/web/index.rst
+++ b/tutorials/platform/web/index.rst
@@ -1,5 +1,4 @@
 :allow_comments: False
-:article_outdated: True
 
 .. _doc_platform_web:
 


### PR DESCRIPTION
The warnings are relevant on the pages themselves, but not so much on the pages listing them (especially since in most of these index pages, not all pages are outdated).
