### PR TITLE
Fix redirects in pages with other base paths than the default (`/en/stable`).

### DIFF
--- a/404.rst
+++ b/404.rst
@@ -38,7 +38,7 @@ Page not found
 
     const currentPathSegments = window.location.pathname.split('/').filter(segment => segment !== '');
     // Use the base path (e.g. "/en/latest") when available.
-    const currentBasePath = (currentPathSegments.length >= 2) ? ("/" + currentPathSegments.slice(0, 2).join("/")) : "/";
+    const currentBasePath = (currentPathSegments.length >= 2) ? ("/" + currentPathSegments.slice(0, 2).join("/")) : "";
 
     fetch(currentBasePath + "/_static/redirects.csv")
       .then(response => response.text())
@@ -54,7 +54,7 @@ Page not found
               if (to.startsWith('https://')) {
                 window.location.replace(to);
               } else {
-                const newUrl = window.location.href.replace(window.location.pathname, to);
+                const newUrl = window.location.href.replace(window.location.pathname, currentBasePath + to);
                 window.location.replace(newUrl);
               }
             }


### PR DESCRIPTION
Not sure how this slipped us by, but redirects are currently broken.
For example:

https://docs.godotengine.org/en/latest/engine_details/development/debugging/using_cpp_profilers.html

redirects to:

https://docs.godotengine.org/engine_details/development/profiling/index.html

instead of:

https://docs.godotengine.org/en/latest/engine_details/development/profiling/index.html

I don't have a good way to test this locally, since the local version does not have `/en/latest` etc in the pathname. But logically this should be correct.

- Follow-up to https://github.com/godotengine/godot-docs/pull/11304