### PR TITLE
Edit per-instance texture array workaround

### DIFF
--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -1112,21 +1112,22 @@ method on a node that inherits from :ref:`class_GeometryInstance3D`:
 
 When using per-instance uniforms, there are some restrictions you should be aware of:
 
-- **Per-instance uniforms do not support textures or arrays**, only regular scalar and vector types.
+- **Per-instance uniforms do not support textures or arrays**, only regular scalar and
+  vector types. As a workaround, you can pass a texture array as a regular uniform,
+  then pass the index of the texture to be drawn using a per-instance uniform.
 
 .. note::
 
-    Due to GLSL limitations, you cannot directly index a texture array
-    using a per-instance uniform. Sampler arrays can only be indexed by
-    compile-time constant expressions.
+    In GLSL versions before 4.0 (i.e. GLSL 3.3 and lower), you cannot directly index
+    a texture array using a per-instance uniform, as sampler arrays can only be indexed by
+    compile-time constant expressions. This affects shaders compiled with the Compatibility
+    renderer.
 
-    As a workaround, pass a texture array as a regular uniform and the
-    desired texture index as a per-instance uniform. Then use a ``switch``
-    statement to select the texture:
+    If you are affected, use the ``switch`` statement to select the texture:
 
    .. code-block:: glsl
 
-      uniform sampler2D texture_array[4];
+      uniform sampler2D texture_array[2];
       instance uniform int texture_index;
 
       void fragment() {
@@ -1137,12 +1138,6 @@ When using per-instance uniforms, there are some restrictions you should be awar
                   break;
               case 1:
                   color = texture(texture_array[1], UV);
-                  break;
-              case 2:
-                  color = texture(texture_array[2], UV);
-                  break;
-              case 3:
-                  color = texture(texture_array[3], UV);
                   break;
           }
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->

Follow-up on https://github.com/godotengine/godot-docs/pull/11350 due to research from https://github.com/godotengine/godot-docs/issues/11331 - this workaround is only needed for very specific cases and is largely not needed for up-to-date setups. As such, the docs should describe precisely when it's needed, so that users in general don't use it when it's not strictly necessary for them.

I also reduced the amount of branches in the example switch from 4 to 2 - it showcases the idiom in exactly the same way, but doesn't fluff the docs.

CC @Calinou @mhilbrunner @JellyBoonz
 (I wanted to ping everybody directly involved in the original PR, sorry if it's excessive)