### PR TITLE
Update 01.game_setup.rst to add link to editor navigation docs

### DIFF
--- a/getting_started/first_3d_game/01.game_setup.rst
+++ b/getting_started/first_3d_game/01.game_setup.rst
@@ -160,4 +160,6 @@ and base movement.
 
 .. note::
 
-    Before you move on to the next section, it's recommended to get familiar with navigating the 3D workspace. Be sure to review the `Navigating the 3D environment <https://docs.godotengine.org/en/stable/tutorials/3d/introduction_to_3d.html#navigating-the-3d-environment>`_ section to familiarize yourself with the controls.
+    Before you move on to the next section, it's recommended to get familiar with navigating the 3D workspace.
+    Be sure to review the `Navigating the 3D environment <https://docs.godotengine.org/en/stable/tutorials/3d/introduction_to_3d.html#navigating-the-3d-environment>`_
+    section to familiarize yourself with the controls.


### PR DESCRIPTION
If you follow the 3D tutorial, it assumes you've already read docs on navigating the 3D workspace, which leaves room to entirely skip any reference to that documentation. This adds a link to that resource early in the 3D tutorial to ensure it isn't glossed over.
