### PR TITLE
Update data preferences code block to match style guide

### DIFF
--- a/tutorials/best_practices/data_preferences.rst
+++ b/tutorials/best_practices/data_preferences.rst
@@ -236,8 +236,8 @@ tree structures.
 .. tabs::
   .. code-tab:: gdscript GDScript
 
-    extends Object
     class_name TreeNode
+    extends Object
 
     var _parent: TreeNode = null
     var _children := []


### PR DESCRIPTION
Swaps the order of the class_name and extends to match the GDScript style guide.

https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html#code-order

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
