### PR TITLE
Clean up "GDScript" extension use from conf.py.

### DIFF
--- a/_extensions/gdscript.py
+++ b/_extensions/gdscript.py
@@ -1578,7 +1578,10 @@ class GDScriptLexer(RegexLexer):
 
 
 def setup(sphinx):
+    from sphinx.highlighting import lexers
+
     sphinx.add_lexer("gdscript", GDScriptLexer)
+    lexers["gdscript"] = GDScriptLexer()
 
     return {
         "parallel_read_safe": True,

--- a/conf.py
+++ b/conf.py
@@ -19,6 +19,7 @@ extensions = [
     "sphinxext.opengraph",
     "sphinx_copybutton",
     "sphinxcontrib.video",
+    "gdscript",
 ]
 
 # Warning when the Sphinx Tabs extension is used with unknown
@@ -43,9 +44,6 @@ ogp_site_name = "Godot Engine documentation"
 ogp_social_cards = {
     "enable": False
 }
-
-if not os.getenv("SPHINX_NO_GDSCRIPT"):
-    extensions.append("gdscript")
 
 if not os.getenv("SPHINX_NO_DESCRIPTIONS"):
     extensions.append("godot_descriptions")
@@ -118,16 +116,6 @@ is_i18n = tags.has("i18n")  # noqa: F821
 print("Build language: {}, i18n tag: {}".format(language, is_i18n))
 
 exclude_patterns = [".*", "**/.*", "_build", "_tools"]
-
-# fmt: off
-# These imports should *not* be moved to the start of the file,
-# they depend on the sys.path.append call registering "_extensions".
-# GDScript syntax highlighting
-from gdscript import GDScriptLexer
-from sphinx.highlighting import lexers
-
-lexers["gdscript"] = GDScriptLexer()
-# fmt: on
 
 smartquotes = False
 


### PR DESCRIPTION
Came across this code from https://github.com/godotengine/godot-contributing-docs/pull/47.

SPHINX_NO_GDSCRIPT was introduced for CI, but appears to be unused now.

The 'include trick' need not be done (and should not), since we can just run the code in the extension implementation.
(i'm not even sure if the `lexers` insertion is needed, but I chose to be agnostic for it)