### PR TITLE
Removed an extraneous period.

### DIFF
--- a/about/faq.rst
+++ b/about/faq.rst
@@ -160,7 +160,7 @@ The main reasons for creating a custom scripting language for Godot were:
 5. Garbage collector results in stalls or unnecessarily large memory
    usage (Lua, Python, JavaScript, ActionScript, etc.).
 6. Difficulty integrating with the code editor for providing code
-   completion, live editing, etc. (all of them).
+   completion, live editing, etc (all of them).
 
 GDScript was designed to curtail the issues above, and more.
 


### PR DESCRIPTION
The FAQ rationale for GDScript contained an item with improper grammar that tried to start a sentence in parentheses in lowercase, which is improper. 

This commit is just one possible fix.
