### PR TITLE
Update release policy for 4.6-stable / estimate for 4.7

### DIFF
--- a/about/release_policy.rst
+++ b/about/release_policy.rst
@@ -84,8 +84,11 @@ on GitHub.
 +--------------+----------------------+--------------------------------------------------------------------------+
 | **Version**  | **Release date**     | **Support level**                                                        |
 +--------------+----------------------+--------------------------------------------------------------------------+
-| Godot 4.6    | Q1 2026 (estimate)   | |unstable| *Development.* Receives new features, usability and           |
+| Godot 4.7    | Q2/Q3 2026 (estimate)| |unstable| *Development.* Receives new features, usability and           |
 | (`master`)   |                      | performance improvements, as well as bug fixes, while under development. |
++--------------+----------------------+--------------------------------------------------------------------------+
+| Godot 4.6    | January 2026         | |supported| Receives fixes for bugs and security issues, as well as      |
+|              |                      | patches that enable platform support.                                    |
 +--------------+----------------------+--------------------------------------------------------------------------+
 | Godot 4.5    | September 2025       | |supported| Receives fixes for bugs and security issues, as well as      |
 |              |                      | patches that enable platform support.                                    |


### PR DESCRIPTION
Not marking 4.4 EOL and 4.5 as limited support yet as I'm preparing 4.5.2 (big update) and maybe 4.4.2 (critical fixes only).