### PR TITLE
Fix Contribute tile link on homepage

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -101,7 +101,7 @@ To begin reading the relevant documentation, select the tile that matches your p
             I know how to use Godot,<br>
             <strong>I want to learn more advanced Godot topics.</strong>
         </a>
-        <a class="grid-item contribute-to-godot" href="contributing/how_to_contribute.html">
+        <a class="grid-item contribute-to-godot" href="https://contributing.godotengine.org/en/latest/organization/how_to_contribute.html">
             I know how to use Godot,<br>
             <strong>I want to contribute to Godot.</strong>
         </a>

--- a/tutorials/index.rst
+++ b/tutorials/index.rst
@@ -1,4 +1,5 @@
 :orphan:
+:allow_comments: False
 
 .. Silence warning about the document not being included in any toctree.
    This page is linked from the top-level `index.rst` file in raw HTML,


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-docs/pull/10810.

___

- Disallow user notes on the tutorials index page (like on other index pages).

This avoids a redirect, speeding up loading.