### PR TITLE
Document `IS_MULTIVIEW` built-in constant in Spatial shaders

### DIFF
--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -190,6 +190,8 @@ Global built-ins are available everywhere, including custom functions.
 |                             | In the Forward+ or Mobile renderers, it's ``0.0``.                                                  |
 |                             | In the Compatibility renderer, it's ``-1.0``.                                                       |
 +-----------------------------+-----------------------------------------------------------------------------------------------------+
+| in bool **IS_MULTIVIEW**    | ``true`` when output is stereoscopic (XR), ``false`` when output is monoscopic.                     |
++-----------------------------+-----------------------------------------------------------------------------------------------------+
 
 Vertex built-ins
 ----------------


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/115147.
