### PR TITLE
Remove `use_*` suffix from SCons options in compiling pages

### DIFF
--- a/engine_details/development/compiling/compiling_for_linuxbsd.rst
+++ b/engine_details/development/compiling/compiling_for_linuxbsd.rst
@@ -277,7 +277,7 @@ Manager.
 
     ::
 
-        scons platform=linuxbsd use_llvm=yes
+        scons platform=linuxbsd llvm=yes
 
     Using Clang appears to be a requirement for OpenBSD, otherwise fonts
     would not build.
@@ -470,7 +470,7 @@ Go to the root of the source code, and execute the following build command:
 ::
 
     PATH="$RISCV_TOOLCHAIN_PATH/bin:$PATH" \
-    scons arch=rv64 use_llvm=yes linker=mold lto=none target=editor \
+    scons arch=rv64 llvm=yes linker=mold lto=none target=editor \
         ccflags="--sysroot=$RISCV_TOOLCHAIN_PATH/sysroot --gcc-toolchain=$RISCV_TOOLCHAIN_PATH -target riscv64-unknown-linux-gnu" \
         linkflags="--sysroot=$RISCV_TOOLCHAIN_PATH/sysroot --gcc-toolchain=$RISCV_TOOLCHAIN_PATH -target riscv64-unknown-linux-gnu"
 
@@ -527,7 +527,7 @@ then use the following SCons command:
 
 ::
 
-    scons platform=linuxbsd use_llvm=yes linker=lld
+    scons platform=linuxbsd llvm=yes linker=lld
 
 After the build is completed, a new binary with a ``.llvm`` suffix will be
 created in the ``bin/`` folder.
@@ -543,7 +543,7 @@ If this error occurs:
 
 There are two solutions:
 
-- In your SCons command, add the parameter ``use_static_cpp=no``.
+- In your SCons command, add the parameter ``static_cpp=no``.
 - Follow `these instructions <https://github.com/ivmai/libatomic_ops#installation-and-usage>`__ to configure, build, and
   install ``libatomic_ops``. Then, copy ``/usr/lib/libatomic_ops.a`` to ``/usr/lib/libatomic.a``, or create a soft link
   to ``libatomic_ops`` by command ``ln -s /usr/lib/libatomic_ops.a /usr/lib/libatomic.a``. The soft link can ensure the

--- a/engine_details/development/compiling/compiling_for_macos.rst
+++ b/engine_details/development/compiling/compiling_for_macos.rst
@@ -160,7 +160,7 @@ editor binary built with ``dev_build=yes``:
     If you are building the ``master`` branch, you also need to include support
     for the MoltenVK Vulkan portability library. By default, it will be linked
     statically from your installation of the Vulkan SDK for macOS.
-    You can also choose to link it dynamically by passing ``use_volk=yes`` and
+    You can also choose to link it dynamically by passing ``volk=yes`` and
     including the dynamic library in your ``.app`` bundle:
 
     ::
@@ -235,7 +235,7 @@ ARM64 and x86_64 binaries (if both were compiled beforehand).
     You also need to include support for the MoltenVK Vulkan portability
     library. By default, it will be linked statically from your installation of
     the Vulkan SDK for macOS. You can also choose to link it dynamically by
-    passing ``use_volk=yes`` and including the dynamic library in your ``.app``
+    passing ``volk=yes`` and including the dynamic library in your ``.app``
     bundle:
 
     ::

--- a/engine_details/development/compiling/compiling_for_windows.rst
+++ b/engine_details/development/compiling/compiling_for_windows.rst
@@ -121,10 +121,10 @@ Selecting a compiler
 SCons will automatically find and use an existing Visual Studio installation.
 If you do not have Visual Studio installed, it will attempt to use
 MinGW instead. If you already have Visual Studio installed and want to
-use MinGW-w64, pass ``use_mingw=yes`` to the SCons command line. Note that MSVC
+use MinGW-w64, pass ``mingw=yes`` to the SCons command line. Note that MSVC
 builds cannot be performed from the MSYS2 or MinGW shells. Use either
 ``cmd.exe`` or PowerShell instead. If you are using MinGW-LLVM, pass both
-``use_mingw=yes`` and ``use_llvm=yes`` to the SCons command line.
+``mingw=yes`` and ``llvm=yes`` to the SCons command line.
 
 .. tip::
 
@@ -223,10 +223,10 @@ optional PIX and Agility SDK components).
               ./update_mesa.sh
               scons
 
-          If you are building with MinGW-w64, add ``use_mingw=yes`` to the ``scons``
+          If you are building with MinGW-w64, add ``mingw=yes`` to the ``scons``
           command, you can also specify the build architecture using ``arch={architecture}``.
-          If you are building with MinGW-LLVM, add both ``use_mingw=yes`` and
-          ``use_llvm=yes`` to the ``scons`` command.
+          If you are building with MinGW-LLVM, add both ``mingw=yes`` and
+          ``llvm=yes`` to the ``scons`` command.
 
           If you are building with MinGW and the binaries are not located in
           the ``PATH``, add ``mingw_prefix="/path/to/mingw"`` to the ``scons``
@@ -364,10 +364,10 @@ To compile Godot with statically linked ANGLE:
               ./update_angle.sh
               scons
 
-          If you are buildng with MinGW, add ``use_mingw=yes`` to the command,
+          If you are buildng with MinGW, add ``mingw=yes`` to the command,
           you can also specify the build architecture using ``arch={architecture}``.
-          If you are building with MinGW-LLVM, add both ``use_mingw=yes`` and
-          ``use_llvm=yes`` to the ``scons`` command.
+          If you are building with MinGW-LLVM, add both ``mingw=yes`` and
+          ``llvm=yes`` to the ``scons`` command.
 
           If you are building with MinGW and the binaries are not located in
           the ``PATH``, add ``mingw_prefix="/path/to/mingw"`` to the ``scons``
@@ -475,7 +475,7 @@ differ based on your system):
     ${MINGW_PREFIX}/bin/x86_64-w64-mingw32-gcc --version
     # x86_64-w64-mingw32-gcc (GCC) 13.2.0
 
-.. note:: If you are building with MinGW-LLVM, add ``use_llvm=yes`` to the ``scons`` command.
+.. note:: If you are building with MinGW-LLVM, add ``llvm=yes`` to the ``scons`` command.
 .. note:: When cross-compiling for Windows using MinGW-w64, keep in mind only
           ``x86_64`` and ``x86_32`` architectures are supported. MinGW-LLVM supports
           ``arm64`` as well. Be sure to specify the right ``arch=`` option when

--- a/engine_details/development/compiling/introduction_to_the_buildsystem.rst
+++ b/engine_details/development/compiling/introduction_to_the_buildsystem.rst
@@ -173,7 +173,7 @@ Godot provides two aliases for this purpose:
   tests=yes``. This enables warnings-as-errors behavior (similar to Godot's
   continuous integration setup) and also builds :ref:`unit tests
   <doc_unit_testing>` so you can run them locally.
-- ``production=yes`` is an alias for ``use_static_cpp=yes debug_symbols=no
+- ``production=yes`` is an alias for ``static_cpp=yes debug_symbols=no
   lto=auto``. Statically linking libstdc++ allows for better binary portability
   when compiling for Linux. This alias also enables link-time optimization when
   compiling for Linux, Web and Windows with MinGW, but keeps LTO disabled when
@@ -350,7 +350,7 @@ source to initialize any SCons build options passed via the command line:
 
     optimize = "size"
     module_mono_enabled = "yes"
-    use_llvm = "yes"
+    llvm = "yes"
     extra_suffix = "game_title"
 
 You can also disable some of the built-in modules before compiling, saving some

--- a/engine_details/development/debugging/using_sanitizers.rst
+++ b/engine_details/development/debugging/using_sanitizers.rst
@@ -60,7 +60,7 @@ It is also possible to detect use-after-return situations by specifying the
 *running* Godot (not when compiling it). This increases the address sanitizer's
 runtime overhead, so only enable this feature when you actually need it.
 
-To enable the address sanitizer in a Godot build, pass the ``use_asan=yes``
+To enable the address sanitizer in a Godot build, pass the ``asan=yes``
 SCons option when compiling. Enabling ASAN generally makes the resulting binary
 about 2× slower.
 
@@ -85,7 +85,7 @@ enough. Since Godot may run on
 :ref:`dedicated servers <doc_exporting_for_dedicated_servers>` for months or
 even years without a restart, it's important to fix memory leaks when they occur.
 
-To enable the leak sanitizer in a Godot build, pass the ``use_lsan=yes`` SCons
+To enable the leak sanitizer in a Godot build, pass the ``lsan=yes`` SCons
 option when compiling. Enabling LSAN only has a small performance overhead, but
 the program will be much slower to exit as leak detection occurs when the
 program exits.
@@ -103,7 +103,7 @@ The memory sanitizer complements the
 :ref:`doc_using_sanitizers_address_sanitizer`. Unlike the address sanitizer,
 the memory sanitizer can detect uninitialized memory reads.
 
-To enable the memory sanitizer in a Godot build, pass the ``use_msan=yes``
+To enable the memory sanitizer in a Godot build, pass the ``msan=yes``
 SCons option when compiling. Enabling MSAN generally makes the resulting binary
 about 3× slower.
 
@@ -129,7 +129,7 @@ occasionally (and can be difficult to track as a result). To prevent a race
 condition, you need to add a lock to ensure only one thread can access the
 shared data at a given time.
 
-To enable the thread sanitizer in a Godot build, pass the ``use_tsan=yes`` SCons
+To enable the thread sanitizer in a Godot build, pass the ``tsan=yes`` SCons
 option when compiling. Enabling TSAN generally makes the resulting binary 10×
 slower, while also multiplying memory usage by an approximately 8× factor.
 
@@ -188,7 +188,7 @@ different set of optimizations can also change the observed results of undefined
 behavior.
 
 To enable the undefined behavior sanitizer in a Godot build, pass the
-``use_ubsan=yes`` SCons option when compiling. Enabling UBSAN only has a small
+``ubsan=yes`` SCons option when compiling. Enabling UBSAN only has a small
 performance overhead.
 
 .. _doc_using_sanitizers_platform_specific_sanitizers:
@@ -202,9 +202,9 @@ Web
 When :ref:`compiling for the Web <doc_compiling_for_web>`,
 there are 2 additional sanitizer SCons options available:
 
-- ``use_assertions=yes`` enables runtime Emscripten assertions, which can catch
+- ``assertions=yes`` enables runtime Emscripten assertions, which can catch
   various issues.
-- ``use_safe_heap=yes`` enables `Emscripten's SAFE_HEAP sanitizer <https://emscripten.org/docs/debugging/Sanitizers.html>`__.
+- ``safe_heap=yes`` enables `Emscripten's SAFE_HEAP sanitizer <https://emscripten.org/docs/debugging/Sanitizers.html>`__.
   It provides similar functionality to ASAN, but it focuses on issues that
   are specific to WebAssembly. ``SAFE_HEAP`` is not guaranteed to be compatible
   with ASAN and UBSAN in the same binary, so you may have to build it separately.

--- a/engine_details/development/debugging/vulkan/vulkan_validation_layers.rst
+++ b/engine_details/development/debugging/vulkan/vulkan_validation_layers.rst
@@ -36,7 +36,7 @@ macOS
     instead.
 
     In practice, this means that using validation layers on macOS **requires**
-    you to use a Godot build compiled with the ``use_volk=yes`` SCons option.
+    you to use a Godot build compiled with the ``volk=yes`` SCons option.
     :ref:`doc_compiling_for_macos`. If testing validation layers on an exported
     project, you must recompile the export template and specify it as a custom
     export template in your project's macOS export preset.
@@ -48,7 +48,7 @@ don't need to reboot after installing the SDK, but you may need to close and
 reopen your current terminal.
 
 After installing the Vulkan SDK, run a Godot binary that was compiled with
-``use_volk=yes`` SCons option. Specify the ``--gpu-validation``
+``volk=yes`` SCons option. Specify the ``--gpu-validation``
 :ref:`command line argument <doc_command_line_tutorial>`.
 You can also specify ``--gpu-abort`` which will make Godot quit as soon
 as a validation error happens. This can prevent your system from freezing


### PR DESCRIPTION
- Marked as draft, as this depends on https://github.com/godotengine/godot/pull/115214 being merged first.

While the options still work for backward compatibility, these are no longer required and allow for shorter command lines.
