### PR TITLE
docs: clarify Control layout behavior inside Containers

### DIFF
--- a/tutorials/ui/gui_containers.rst
+++ b/tutorials/ui/gui_containers.rst
@@ -25,7 +25,7 @@ When a Control node is not inside a Container, its position and size are control
 When a Control node is a direct child of a Container, the Container automatically manages its layout. 
 In this case, manual positioning options such as anchors and presets no longer affect the Control, as the Container enforces its own layout rules.
 This behavior is expected. Containers are designed to ensure consistent and predictable layout of their children. To influence layout inside Containers,
- use size flags, minimum size, and the rules specific to the Container type being used.
+use size flags, minimum size, and the rules specific to the Container type being used.
 
 Containers provide a huge amount of layout power (as an example, the Godot editor user interface is entirely done using them):
 


### PR DESCRIPTION
This PR documents the user-visible layout behavior of Control nodes when they are used inside Containers.

When a Control is not inside a Container, it can be positioned manually using anchors, offsets, and presets. However, when a Control is a direct child of a Container, those manual options no longer affect it, and the Container takes over the layout.

This change adds a brief explanation to the online manual to clarify this behavior for users, without exposing internal properties or implementation details.

This PR addresses the user confusion discussed in godotengine/godot#108179 by documenting the observable layout behavior of Controls inside Containers.
