### PR TITLE
Docs: Add GDScript example for Theme Type Variation

### DIFF
--- a/tutorials/ui/gui_theme_type_variations.rst
+++ b/tutorials/ui/gui_theme_type_variations.rst
@@ -73,3 +73,27 @@ any other case you have to input the name of the variation manually. Click on
 the pencil icon to the right. Then type in the name of the type variation and click the
 check mark icon or press enter. If a type variation with that name exists it
 will now be used by the node.
+
+The same workflow can also be performed from code.
+
+.. code-block:: gdscript
+
+    extends Control
+
+    func _ready():
+        var theme := Theme.new()
+        theme.add_type_variation("MyButton", "Button")
+        theme.set_color("font_color", "MyButton", Color.RED)
+
+        self.theme = theme
+
+        var button := Button.new()
+        button.text = "Type Variation Button"
+        button.theme_type_variation = "MyButton"
+        add_child(button)
+
+This example creates a ``Theme`` in code, defines a type variation based on
+``Button``, and assigns it to a newly created button using
+``theme_type_variation``. This mirrors the same workflow available in the
+Inspector.
+

--- a/tutorials/ui/gui_theme_type_variations.rst
+++ b/tutorials/ui/gui_theme_type_variations.rst
@@ -82,8 +82,8 @@ The same workflow can also be performed from code.
 
     func _ready():
         var new_theme := Theme.new()
-        theme.add_type_variation("GrayButton", "Button")
-        theme.set_color("font_color", "GrayButton", Color.GRAY)
+        new_theme.add_type_variation(&"GrayButton", &"Button")
+        new_theme.set_color(&"font_color", &"GrayButton", Color.GRAY)
 
         self.theme = theme
 

--- a/tutorials/ui/gui_theme_type_variations.rst
+++ b/tutorials/ui/gui_theme_type_variations.rst
@@ -81,7 +81,7 @@ The same workflow can also be performed from code.
     extends Control
 
     func _ready():
-        var theme := Theme.new()
+        var new_theme := Theme.new()
         theme.add_type_variation("GrayButton", "Button")
         theme.set_color("font_color", "GrayButton", Color.GRAY)
 

--- a/tutorials/ui/gui_theme_type_variations.rst
+++ b/tutorials/ui/gui_theme_type_variations.rst
@@ -89,7 +89,7 @@ The same workflow can also be performed from code.
 
         var button := Button.new()
         button.text = "Type Variation Button"
-        button.theme_type_variation = "GrayButton"
+        button.theme_type_variation = &"GrayButton"
         add_child(button)
 
 This example creates a ``Theme`` in code, defines a type variation based on

--- a/tutorials/ui/gui_theme_type_variations.rst
+++ b/tutorials/ui/gui_theme_type_variations.rst
@@ -82,14 +82,14 @@ The same workflow can also be performed from code.
 
     func _ready():
         var theme := Theme.new()
-        theme.add_type_variation("MyButton", "Button")
-        theme.set_color("font_color", "MyButton", Color.RED)
+        theme.add_type_variation("GrayButton", "Button")
+        theme.set_color("font_color", "GrayButton", Color.GRAY)
 
         self.theme = theme
 
         var button := Button.new()
         button.text = "Type Variation Button"
-        button.theme_type_variation = "MyButton"
+        button.theme_type_variation = "GrayButton"
         add_child(button)
 
 This example creates a ``Theme`` in code, defines a type variation based on

--- a/tutorials/ui/gui_theme_type_variations.rst
+++ b/tutorials/ui/gui_theme_type_variations.rst
@@ -85,7 +85,7 @@ The same workflow can also be performed from code.
         new_theme.add_type_variation(&"GrayButton", &"Button")
         new_theme.set_color(&"font_color", &"GrayButton", Color.GRAY)
 
-        self.theme = theme
+        theme = new_theme
 
         var button := Button.new()
         button.text = "Type Variation Button"


### PR DESCRIPTION
This PR adds GDScript example demonstrating how to create a Theme,
define a type variation, and apply it to a Control from code.

This mirrors the same steps shown in the Inspector, but implemented in code.
Refs  #11504
