### PR TITLE
Use 4 CPUs on readthedocs by injection.

### DIFF
--- a/_extensions/override_jobs.py
+++ b/_extensions/override_jobs.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+# Hackily injects -j4 into the RTD build process.
+# Can be removed if we find an easier way to inject it.
+
+def setup(app):
+    app.parallel = 4
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/conf.py
+++ b/conf.py
@@ -39,6 +39,9 @@ on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 if not on_rtd:
     notfound_urls_prefix = ''
 
+if on_rtd:
+    extensions.append("override_jobs")
+
 # Specify the site name for the Open Graph extension.
 ogp_site_name = "Godot Engine documentation"
 ogp_social_cards = {


### PR DESCRIPTION
An attempt to improve build times.

I haven't found any easier way to increase the job count, since there is no easy way to alter the build command.

I also tried [using free-threaded python](https://github.com/godotengine/godot-docs/compare/master...Ivorforce:godot-docs:free-threaded), but it turns out while `sphinx` has a unit test for free-threaded python, they aren't making use of it (still creating multiple processes with `-j4` instead of threads).
