### PR TITLE
Fixed minor typo: missing subject noun ("the script").

### DIFF
--- a/tutorials/scripting/gdscript/static_typing.rst
+++ b/tutorials/scripting/gdscript/static_typing.rst
@@ -132,7 +132,7 @@ as a type in a constant:
     const Rifle = preload("res://player/weapons/rifle.gd")
     var my_rifle: Rifle
 
-The second method is to use the ``class_name`` keyword when you create.
+The second method is to use the ``class_name`` keyword when you create the script.
 For the example above, your ``rifle.gd`` would look like this:
 
 ::


### PR DESCRIPTION
This sentence was missing the proper subject of the verb and was slightly grammatically off.
