### PR TITLE
Slightly improved the grammar and clarity of a sentence.

### DIFF
--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -126,7 +126,7 @@ our node's ``texture``.
 .. note::
 
     By default, the :ui:`Inspector` displays a node's properties in "Title Case", with
-    capitalized words separated by a space. In GDScript code these properties
+    capitalized words separated by a space. In GDScript code, these properties
     are in "snake_case", which is lowercase with each word separated by an underscore.
 
     You can hover over any property's name in the :ui:`Inspector` to see a description and


### PR DESCRIPTION
I also considered changing "an underscore" to "underscores" to reflect the fact that there are multiple underscores doing the separating (not just one, which in contrast is semantically wrong) but then thought it'd be even clearer if it used "each word" and "an underscore".

I also removed a superfluous comma that added nothing but subtle punctuation friction to the sentence.
