### PR TITLE
Change 'Make Unique' to 'New Physics Material' instruction

### DIFF
--- a/getting_started/step_by_step/instancing.rst
+++ b/getting_started/step_by_step/instancing.rst
@@ -172,7 +172,7 @@ Rerun the game and notice how this ball now falls much faster than the others.
     of the ball. This is because :inspector:`PhysicsMaterial` is a *resource*, and needs
     to be made unique before you can edit it in a scene that is linking to its
     original scene. To make a resource unique for one instance, right-click on
-    the :inspector:`Physics Material` property in the :ui:`Inspector` and click :button:`Make Unique`
+    the :inspector:`Physics Material` property in the :ui:`Inspector` and click :button:`New Physics Material`
     in the context menu.
 
     Resources are another essential building block of Godot games we will cover


### PR DESCRIPTION
The tutorial currently instructs users to click the "Make Unique" button for the PhysicsMaterial, but the button is disabled (grayed out) and cannot be selected.

This update revises the instructions to reflect the correct method for making a PhysicsMaterial unique in the Inspector, so users can modify the ball's PhysicsMaterial properties as intended.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
