### PR TITLE
Add note for Area2D usage over CharacterBody2D

### DIFF
--- a/getting_started/first_2d_game/02.player_scene.rst
+++ b/getting_started/first_2d_game/02.player_scene.rst
@@ -22,7 +22,7 @@ what the object *is*. In the upper-left corner, in the "Scene" tab, click the
 
     Godot also provides the :ref:`CharacterBody2D <class_CharacterBody2D>` node, 
     specifically designed for 2D characters, which includes built-in support for some 
-    of the processes explained in this tutorial. In many real projects, CharacterBody2D 
+    of the processes explained in this tutorial. In many real world projects, CharacterBody2D 
     would be a better choice for players and enemies. However, this tutorial focuses on 
     core concepts that apply to a wider range of nodes and use cases.
 


### PR DESCRIPTION
As I was going through the [Getting Starter Guide for 2D games] (https://docs.godotengine.org/en/stable/getting_started/first_2d_game/02.player_scene.html#node-structure), and asked myself why the use of Area2D instead of CharacterBody2D as the node type for the player, but found the reason later when going through the signals section of the tutorial. Nonetheless, I could see others having the same question, and seemed to have appreciated some mention about it when reading the guide.

This PR intends to provide such context for future readers, making it easier to understand about the existence other node types that might be fit.