### PR TITLE
Fix visited profile buttons on homepage breaking in light theme

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -55,7 +55,7 @@ To begin reading the relevant documentation, select the tile that matches your p
         }
 
         .grid-item:visited {
-            color: unset;
+            color: hsla(0, 0%, 100%, 0.9);
         }
 
         .grid-item:hover,


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
Right now, visited "Profile buttons" ("I'm new to Godot", "I'm experienced with Godot", etc.) in light theme will use dark text, which doesn't contrast well with Profile button color.

This is because setting color to `unset` for their `visited` state made them inherit their color from `body`. This doesn't cause any issues on dark theme, but breaks on light theme.

This PR sets visited link color to the same color as normal one, fixing this issue.

---

The way page appears right now

<img width="1299" height="983" alt="image" src="https://github.com/user-attachments/assets/ccd1ee61-3d71-4c29-b280-d6e2e6d29a36" />

Note dark text on 2 profile buttons

---

The way this page appears with this change applied

<img width="1297" height="979" alt="image" src="https://github.com/user-attachments/assets/5c3e0e05-3944-4a17-9623-69e15b61824d" />
