### PR TITLE
Grammar: change singular possessive to plural possessive

### DIFF
--- a/tutorials/best_practices/logic_preferences.rst
+++ b/tutorials/best_practices/logic_preferences.rst
@@ -14,7 +14,7 @@ properties such as the node's name or position. A common dilemma is, when
 should you change those values?
 
 It is the best practice to change values on a node before adding it to the
-scene tree. Some property's setters have code to update other
+scene tree. Some properties' setters have code to update other
 corresponding values, and that code can be slow! For most cases, this code
 has no impact on your game's performance, but in heavy use cases such as
 procedural generation, it can bring your game to a crawl.


### PR DESCRIPTION
On the page ["Logic preferences"](https://docs.godotengine.org/en/stable/tutorials/best_practices/logic_preferences.html), the second sentence of the third paragraph currently reads:

> Some property's setters have code to update other corresponding values, and that code can be slow!

In this case, because it is talking about multiple properties, not a single property, it should use the plural possessive ("properties' ") instead of the singular possessive ("property's"). I have made this change.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
