### PR TITLE
Document Patch PCK files

### DIFF
--- a/tutorials/export/exporting_pcks.rst
+++ b/tutorials/export/exporting_pcks.rst
@@ -64,7 +64,7 @@ See :ref:`doc_exporting_projects_pck_versus_zip` for a comparison of the two for
     The downside of this approach is that it's less transparent to the game logic,
     as it will not benefit from the same resource management as PCK/ZIP files.
 
-Security Concerns
+Security concerns
 -----------------
 
 It is important to note that loading PCK files for patches, mods, or extra content
@@ -81,8 +81,8 @@ asymmetric cryptography. You could store the public key in the main PCK, and sig
 patch or expansion PCK files with the private key. See the :ref:`class_Crypto` class
 for more information.
 
-Piracy Concerns
----------------
+Copyright concerns
+------------------
 
 If you want to use PCK files to distribute extra paid content, such as expansions,
 keep in mind that Godot provides no out-of-the-box way to prevent someone from
@@ -127,13 +127,15 @@ You can also add any patches you export to your base packs for future use. For
 example, adding ``patch.pck`` will ensure that ``patch2.pck`` will not include any
 resources from that first patch.
 
-Delta Encoding
+Delta encoding
 ~~~~~~~~~~~~~~
 
 Patch PCK files can be made smaller through the use of delta encoding. This makes it
 so that only the parts of a file that have been changed are updated. This does have a
-drawback of longer load times for the patch PCK files. There are two settings for
-delta encoding in addition to the filters:
+drawback of longer load times for the resources that are updated, and each patch for
+a resource cumulatively increases its load time.
+
+There are two settings for delta encoding in addition to the filters:
 
 - **Delta Encoding Compression Level:** Controls how much compression is applied to
   the files. We do not recommend any more than the default of 19. Beyond that more
@@ -148,6 +150,31 @@ delta encoding in addition to the filters:
   delta encoding.
 
 The default compression level, 19, is the highest recommended level.
+
+For the smallest patch size possible we recommend turning off compression for any
+resources you want to patch. Even if your base PCK files were compressed that
+shouldn't cause an issue.
+
+There are several places compression can be disabled for different resources:
+
+- Import settings related to compression on individually imported resources, such as
+  translation or 3D model files
+- :ui:`Compress Binary Resources` in the editor settings
+- :ui:`GDScript Export Mode` in the :button:`Scripts` tab of an export preset
+
+.. Note::
+
+    After disabling :ui:`Compress Binary Resources` you must delete the contents of
+    your projects ``.godot/imported/`` folder, then closing and open the project
+    again to re-generate it.
+
+It's important to note that when you export a delta encoded patch on top of previous
+patches, the packs you list under :ui:`Base Packs` in the :Button:`Patching` tab
+must be the exact same files that are loaded by the game at runtime, in the exact
+order they are loaded in. Re-exporting previous versions may end up being slightly
+different, due to non-determinism in Godot's export process, which can cause the
+patching to fail. This only applies to delta encoded patches, regular ones don't
+have this issue.
 
 Opening PCK or ZIP files at runtime
 -----------------------------------

--- a/tutorials/export/exporting_pcks.rst
+++ b/tutorials/export/exporting_pcks.rst
@@ -64,12 +64,37 @@ See :ref:`doc_exporting_projects_pck_versus_zip` for a comparison of the two for
     The downside of this approach is that it's less transparent to the game logic,
     as it will not benefit from the same resource management as PCK/ZIP files.
 
+Security Concerns
+-----------------
+
+It is important to note that loading PCK files for patches, mods, or extra content
+like expansions, will require you to code a system to automatically load files based
+on their location, and possibly name. This is a security vulnerability in three
+scenarios. One, a user downloads a mod with malicious code. Two, a malicious program
+already exists on an end user's PC and has replaced the PCK file with a malicious
+copy. Three, you are distributing patch PCK files through a game launcher and the
+system has become compromised.
+
+Take this into consideration when determining how to use PCK files in a project.
+For situations where you have a patching system via a launcher, consider using
+asymmetric cryptography. You could store the public key in the main PCK, and sign
+patch or expansion PCK files with the private key. See the :ref:`class_Crypto` class
+for more information.
+
+Piracy Concerns
+---------------
+
+If you want to use PCK files to distribute extra paid content, such as expansions,
+keep in mind that Godot provides no out-of-the-box way to prevent someone from
+copying the PCK file, and putting it on another person's computer. Any kind of DRM
+system is your responsibility to implement if that's what you want.
+
 Generating PCK files
 --------------------
 
 In order to pack all resources of a project into a PCK file, open the project
-and go to **Project > Export** and click on **Export PCK/ZIP**. Also, make sure
-to have an export preset selected while doing so.
+and go to :menu:`Project > Export`, select an export preset, and click on
+:button:`Export PCK/ZIP`.
 
 .. image:: img/export_pck.webp
 
@@ -78,27 +103,51 @@ with ``--export-pack``. The output file must with a ``.pck`` or ``.zip``
 file extension. The export process will build that type of file for the
 chosen platform.
 
-.. note::
+Patch PCK files
+---------------
 
-    If one wishes to support mods for their game, they will need their users to
-    create similarly exported files. Assuming the original game expects a
-    certain structure for the PCK's resources and/or a certain interface for
-    its scripts, then either...
+Generating Patch PCK files
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    1. The developer must publicize documentation of these expected structures/
-       interfaces, expect modders to install Godot Engine, and then also expect
-       those modders to conform to the documentation's defined API when building
-       mod content for the game (so that it will work). Users would then use
-       Godot's built in exporting tools to create a PCK file, as detailed
-       above.
-    2. The developer uses Godot to build a GUI tool for adding their exact API
-       content to a project. This Godot tool must either run on a tools-enabled
-       build of the engine or have access to one (distributed alongside or
-       perhaps in the original game's files). The tool can then use the Godot
-       executable to export a PCK file from the command line with
-       :ref:`OS.execute() <class_OS_method_execute>`. The game itself shouldn't
-       use a tool-build of the engine (for security), so it's best to keep
-       the modding tool and game separate.
+To create a PCK file that only contains resources not present in the original
+release of a project, you would create a patch PCK file. This could be used for
+patches, mods, or expansions. For this to work you'll first need to have a PCK file
+for your project at the point of its initial release.
+
+To generate a patch PCK file, within the export menu, and with your desired preset
+selected, click on the :Button:`Patching` tab. At the bottom is the :ui:`Base Packs`
+section. Click on the :Button:`Add Pack` button, then navigate to the PCK file you
+exported that contains everything in your project for its initial release.
+
+Now, when you go to export a PCK file of your project again, if you have the
+:Button:`Export as Patch` button selected, only resources that have changed
+will be exported in the PCK file.
+
+You can also add any patches you export to your base packs for future use. For
+example, adding ``patch.pck`` will ensure that ``patch2.pck`` will not include any
+resources from that first patch.
+
+Delta Encoding
+~~~~~~~~~~~~~~
+
+Patch PCK files can be made smaller through the use of delta encoding. This makes it
+so that only the parts of a file that have been changed are updated. This does have a
+drawback of longer load times for the patch PCK files. There are two settings for
+delta encoding in addition to the filters:
+
+- **Delta Encoding Compression Level:** Controls how much compression is applied to
+  the files. We do not recommend any more than the default of 19. Beyond that more
+  memory is needed for export and import for significantly fewer gains. Any positive
+  values will have the same decompression speed, however export will take
+  longer the higher the number is. Negative values enable fast mode, which
+  means larger files, but the decompression speed is higher.
+
+- **Delta Encoding Minimum Size Reduction:** Controls how much size has to be saved
+  at minimum for compression to be used on an individual file. For example, at a
+  level of 10%, if the file size can only be reduced by 5%, then the file won't use
+  delta encoding.
+
+The default compression level, 19, is the highest recommended level.
 
 Opening PCK or ZIP files at runtime
 -----------------------------------
@@ -153,7 +202,7 @@ The PCK or ZIP file contains a ``mod_scene.tscn`` test scene in its root.
     ``Assembly.LoadFile("mod.dll")``
 
 Troubleshooting
-^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~
 
 If you are loading a resource pack and are not noticing any changes, it may be
 due to the pack being loaded too late. This is particularly the case with menu
@@ -167,11 +216,25 @@ call :ref:`ProjectSettings.load_resource_pack() <class_ProjectSettings_method_lo
 in the autoload script's ``_init()`` function, rather than ``_enter_tree()``
 or ``_ready()``.
 
-Summary
--------
+Modding considerations
+----------------------
 
-This tutorial explains how to add mods, patches, or DLC to a game.
-The most important thing is to identify how one plans to distribute future
-content for their game and develop a workflow that is customized for that
-purpose. Godot should make that process smooth regardless of which route a
-developer pursues.
+If one wishes to support mods for their game, they will need their users to
+create similarly exported files. Assuming the original game expects a
+certain structure for the PCK's resources, and/or a certain interface for
+its scripts, then one of two things has to be done.
+
+1. The developer must document these expected structures/
+    interfaces, expect modders to install Godot Engine, and then also expect
+    those modders to conform to the documentation's defined API when building
+    mod content for the game (so that it will work). Users would then use
+    Godot's built in exporting tools to create a PCK file, as detailed
+    above.
+2. The developer uses Godot to build a GUI tool for adding their exact API
+    content to a project. This Godot tool must either run on a tools-enabled
+    build of the engine or have access to one (distributed alongside or
+    perhaps in the original game's files). The tool can then use the Godot
+    executable to export a PCK file from the command line with
+    :ref:`OS.execute() <class_OS_method_execute>`. The game itself shouldn't
+    use a tool-build of the engine (for security), so it's best to keep
+    the modding tool and game separate.


### PR DESCRIPTION
Documents Patch PCK export functionality as well as Delta Encoding for Patch PCK files.

Patch PCKs were added in https://github.com/godotengine/godot/pull/97118
Delta Encoding was added in https://github.com/godotengine/godot/pull/112011

Security recommendations came from dalexeev in a rocket chat discussion.