### PR TITLE
Clarify implying of only GCC supporting LTO and explicitly state for godot specifically.

### DIFF
--- a/engine_details/development/compiling/compiling_for_linuxbsd.rst
+++ b/engine_details/development/compiling/compiling_for_linuxbsd.rst
@@ -532,8 +532,8 @@ then use the following SCons command:
 After the build is completed, a new binary with a ``.llvm`` suffix will be
 created in the ``bin/`` folder.
 
-It's still recommended to use GCC for production builds as it produces smaller and
-faster binaries for godot.
+It's still recommended to use GCC for production builds as it's the compiler used
+for official builds and is more rigorously tested.
 
 If this error occurs:
 

--- a/engine_details/development/compiling/compiling_for_linuxbsd.rst
+++ b/engine_details/development/compiling/compiling_for_linuxbsd.rst
@@ -532,8 +532,8 @@ then use the following SCons command:
 After the build is completed, a new binary with a ``.llvm`` suffix will be
 created in the ``bin/`` folder.
 
-It's still recommended to use GCC for production builds as they can be compiled using
-link-time optimization, making the resulting binaries smaller and faster.
+It's still recommended to use GCC for production builds as it produces smaller and
+faster binaries for godot.
 
 If this error occurs:
 


### PR DESCRIPTION
This PR changes the old quote:
`
It's still recommended to use GCC for production builds as they can be compiled using link-time optimization, making the resulting binaries smaller and faster.
`

To:
`
It's still recommended to use GCC for production builds as it's the compiler used
for official builds and is more rigorously tested.
`

This is because the older quote created confusion that clang doesn't support LTO, while still implying that GCC is the preferred compiler. This also implies that either LLVM or GCC can beat each other in different tests, therefore the performance angle isn't really that valid.