### PR TITLE
Document `IN_SHADOW_PASS` global built-in in Spatial shader

### DIFF
--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -196,6 +196,9 @@ Global built-ins are available everywhere, including custom functions.
 +-----------------------------+-----------------------------------------------------------------------------------------------------+
 | in bool **IS_MULTIVIEW**    | ``true`` when output is stereoscopic (XR), ``false`` when output is monoscopic.                     |
 +-----------------------------+-----------------------------------------------------------------------------------------------------+
+| in bool **IN_SHADOW_PASS**  | ``true`` when the shader is being rendered in a shadow mapping pass, ``false`` otherwise.           |
+|                             | This can be used to render objects differently in shadow maps compared to their regular rendering.  |
++-----------------------------+-----------------------------------------------------------------------------------------------------+
 
 Vertex built-ins
 ----------------


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-docs/pull/11659.
- See https://github.com/godotengine/godot-proposals/issues/4443.
