### PR TITLE
Document pipeline precompilation and ubershaders not being available in Compatibility

### DIFF
--- a/tutorials/performance/pipeline_compilations.rst
+++ b/tutorials/performance/pipeline_compilations.rst
@@ -3,6 +3,19 @@
 Reducing stutter from shader (pipeline) compilations
 ====================================================
 
+.. warning::
+
+    This page only applies to the Forward+ and Mobile renderers, not Compatibility.
+    Ubershaders and pipeline precompilation rely on functionality only available
+    in modern low-level graphics APIs (Vulkan, Direct3D 12, Metal). The Compatibility
+    renderer uses OpenGL 3.3, OpenGL ES 3.0, or WebGL 2.0 depending on the platform.
+    These versions lack the functionality to effectively implement ubershaders
+    and pipeline precompilation.
+
+    To avoid shader stutters in Compatibility, you need to use the legacy
+    approach of preloading materials, shaders, and particles by displaying them
+    for at least one frame in the view frustum when the level is loading.
+
 Pipeline compilation, also commonly known as shader compilation, is an expensive
 operation required by the engine to be able to draw any kind of content with the
 GPU.
@@ -116,7 +129,7 @@ yourself without deleting your driver cache or testing on a weaker system.
   yet or a modification that was done to the engine's code. Leads to stutters
   during gameplay. This is identical to Godot versions before 4.4. If you
   see compilations here, please
-  `let the developers know <https://github.com/godotengine/godot/issues>`
+  `let the developers know <https://github.com/godotengine/godot/issues>`__
   as this should never happen with the Ubershader system.
   Make sure to attach a minimal reproduction project when doing so.
 - **Specialization**: Compiled in the background during gameplay to optimize the


### PR DESCRIPTION
**Edit:** This also fixes a broken link in the page.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/615#discussioncomment-15672918.
