### PR TITLE
Fix leftover deprecated method call in C# code sample in Making plugins

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -343,7 +343,6 @@ The script could look like this:
         public override void _EnterTree()
         {
             var _dock_scene = GD.Load<PackedScene>("res://addons/MyCustomDock/MyDock.tscn").Instantiate<Control>();
-            AddControlToDock(DockSlot.LeftUl, _dock);
 
             // Create the dock and add the loaded scene to it.
             _dock = new EditorDock();


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-docs/pull/11530.

This line isn't present in the GDScript code sample.

cc @lodetrick