### PR TITLE
Change URL of Autoloads versus regular nodes page to match new title

### DIFF
--- a/about/docs_changelog.rst
+++ b/about/docs_changelog.rst
@@ -470,7 +470,7 @@ Best Practices:
 - :ref:`doc_what_are_godot_classes`
 - :ref:`doc_scene_organization`
 - :ref:`doc_scenes_versus_scripts`
-- :ref:`doc_autoloads_versus_internal_nodes`
+- :ref:`doc_autoloads_versus_regular_nodes`
 - :ref:`doc_node_alternatives`
 - :ref:`doc_godot_interfaces`
 - :ref:`doc_godot_notifications`

--- a/tutorials/best_practices/autoloads_versus_regular_nodes.rst
+++ b/tutorials/best_practices/autoloads_versus_regular_nodes.rst
@@ -1,4 +1,4 @@
-.. _doc_autoloads_versus_internal_nodes:
+.. _doc_autoloads_versus_regular_nodes:
 
 Autoloads versus regular nodes
 ==============================

--- a/tutorials/best_practices/index.rst
+++ b/tutorials/best_practices/index.rst
@@ -11,7 +11,7 @@ Best practices
    what_are_godot_classes
    scene_organization
    scenes_versus_scripts
-   autoloads_versus_internal_nodes
+   autoloads_versus_regular_nodes
    node_alternatives
    godot_interfaces
    godot_notifications

--- a/tutorials/best_practices/scene_organization.rst
+++ b/tutorials/best_practices/scene_organization.rst
@@ -395,7 +395,7 @@ If you have a system that...
 
 If you have systems that modify other systems' data, you should define those as
 their own scripts or scenes, rather than autoloads. For more information, see
-:ref:`Autoloads versus regular nodes <doc_autoloads_versus_internal_nodes>`.
+:ref:`Autoloads versus regular nodes <doc_autoloads_versus_regular_nodes>`.
 
 Each subsystem within your game should have its own section within the
 SceneTree. You should use parent-child relationships only in cases where nodes


### PR DESCRIPTION
The terminology "internal nodes" did not refer to any specific Godot functionality when it was first written, but now that Godot has a notion of internal nodes, it was bound to create confusion.

This adds a redirect for the old URL too.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/540#discussioncomment-15657035.

PS: Do we usually cherry-pick PRs that change URLs? I forgot.