### PR TITLE
Add Navigation entry to thread-safe apis doc

### DIFF
--- a/tutorials/performance/thread_safe_apis.rst
+++ b/tutorials/performance/thread_safe_apis.rst
@@ -109,6 +109,26 @@ on separate threads (making them thread-safe), enable the following project sett
 - **PhysicsServer2D:** :ref:`Physics > 2D > Run on Separate Thread <class_ProjectSettings_property_physics/2d/run_on_separate_thread>`.
 - **PhysicsServer3D:** :ref:`Physics > 3D > Run on Separate Thread <class_ProjectSettings_property_physics/3d/run_on_separate_thread>`.
 
+Navigation
+----------
+
+:ref:`NavigationServer2D<class_NavigationServer2D>` and :ref:`NavigationServer3D<class_NavigationServer3D>` are both thread-safe and thread-friendly.
+
+The navigation-related query functions can be called by threads and run in true parallel.
+
+By default, a conservative number of threads is supported running in true parallel on navigation maps before
+additional threads have to wait for map data access at a semaphore.
+To increase the number of threads that can run simultaneously on map data,
+set :ref:`Navigation > Pathfinding > Max Threads <class_ProjectSettings_property_navigation/pathfinding/max_threads>`.
+
+The navigation server-related resources like NavigationSourceGeometryData, NavigationMesh, and NavigationPolygon are all thread-safe but not necessarily thread-friendly.
+They use internal read-write locks for thread-safety so editing the same resource (e.g. a single big navmesh) on multiple threads at the same time can cause thread congestion.
+
+The navigation-related helper classes like :ref:`AStar2D<class_AStar2D>`, :ref:`AStar3D<class_AStar3D>`, and :ref:`AStarGrid2D<class_AStarGrid2D>` are **not** thread-safe.
+They can be used with threads to some limited capacity, but using two or more threads on the same AStar object causes corruption.
+For example, using a dedicated background thread per AStar object to populate points or do queries works,
+but two threads using the same AStar object would corrupt each other's data.
+
 GDScript arrays and dictionaries
 --------------------------------
 


### PR DESCRIPTION
Adds Navigation entry to thread-safe apis doc.

This is also true for Godot 4.5 but not for 4.4 or earlier versions.
(at least for the NavigationServer part, AStar and stuff has not changed in that regard)

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
