### PR TITLE
Add "moving directories and files" section to file loading manual

### DIFF
--- a/tutorials/io/runtime_file_loading_and_saving.rst
+++ b/tutorials/io/runtime_file_loading_and_saving.rst
@@ -85,6 +85,28 @@ strings and more. These PackedByteArray methods have names that start with
 
 .. _doc_runtime_file_loading_and_saving_images:
 
+Moving directories and files
+----------------------------
+
+Godot's :ref:`class_DirAccess` class provides methods to manage directories and their content.
+
+DirAccess' :ref:`DirAccess.copy <class_DirAccess_method_load_copy>` can be used to copy files. If ``chmod_flags`` is different than ``-1``, then it will set the new file's permissions based on the provided value of ``chmod_flags``. These align with the octal flags provided by Unix, which are:
+
++------------+--------------------------+
+| chmod_flag | Granted Operations       |
++============+==========================+
+| 7          | Read, write and execute. |
+| 6          | Read, write.             |
+| 5          | Read, execute.           |
+| 4          | Read.                    |
+| 3          | Write, execute.          |
+| 2          | Write.                   |
+| 1          | Execute.                 |
+| 0          | None.                    |
++------------+--------------------------+
+
+Note that these permissions will only be set if available on the current operating system.
+
 Images
 ------
 


### PR DESCRIPTION
This section's current purpose is to list the values that chmod_flags can take, so that the class reference for DirAccess.copy() can link to here.

This is for https://github.com/godotengine/godot-docs/issues/11720 (but does not resolve it).

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
