### PR TITLE
fix: update downloads button to point to a valid URL

### DIFF
--- a/_templates/versions.html
+++ b/_templates/versions.html
@@ -44,7 +44,7 @@
           <a href="//{{ PRODUCTION_DOMAIN }}/projects/{{ slug }}/builds/">{{ _('Builds') }}</a>
         </dd>
         <dd>
-          <a href="//{{ PRODUCTION_DOMAIN }}/projects/{{ slug }}/downloads/">{{ _('Downloads') }}</a>
+          <a href="https://github.com/godotengine/godot-docs#download-for-offline-use">{{ _('Downloads') }}</a>
         </dd>
     </dl>
 


### PR DESCRIPTION
This is for #11665.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
