### PR TITLE
Add summary of blender nodes that work with  -col etc

### DIFF
--- a/tutorials/assets_pipeline/importing_3d_scenes/node_type_customization.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/node_type_customization.rst
@@ -54,7 +54,7 @@ Settings dialog.
 Create collisions (-col, -convcol, -colonly, -convcolonly)
 ----------------------------------------------------------
 
-The option ``-col`` will work only for Mesh objects. If it is detected, a child
+If the option ``-col`` is detected, a child
 static collision node will be added, using the same geometry as the mesh. This
 will create a triangle mesh collision shape, which is a slow, but accurate
 option for collision detection. This option is usually what you want for level
@@ -79,6 +79,17 @@ This helps the visual mesh and actual collision to be separated.
 
 The option ``-convcolonly`` works in a similar way, but will create a
 :ref:`class_ConvexPolygonShape3D` instead using convex decomposition.
+
+The types of Blender nodes that the above 4 options work with are summarized below.
+
++--------------+----------------------+--------------------+
+| Suffix       | Works on Mesh object | Works on Mesh data |
++==============+======================+====================+
+| -col         | ✔️                   | ✔️                 |
+| -convcol     | ✔️                   | ✔️                 |
+| -colonly     | ✔️                   | ❌                 |
+| -convcolonly | ✔️                   | ❌                 |
++--------------+----------------------+--------------------+
 
 With Collada files, the option ``-colonly`` can also be used with Blender's
 empty objects. On import, it will create a :ref:`class_StaticBody3D` with a

--- a/tutorials/assets_pipeline/importing_3d_scenes/node_type_customization.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/node_type_customization.rst
@@ -82,14 +82,14 @@ The option ``-convcolonly`` works in a similar way, but will create a
 
 The types of Blender nodes that the above 4 options work with are summarized below.
 
-+--------------+----------------------+--------------------+
-| Suffix       | Works on Mesh object | Works on Mesh data |
-+==============+======================+====================+
-| -col         | ✔️                   | ✔️                 |
-| -convcol     | ✔️                   | ✔️                 |
-| -colonly     | ✔️                   | ❌                 |
-| -convcolonly | ✔️                   | ❌                 |
-+--------------+----------------------+--------------------+
++------------------+----------------------+--------------------+
+| Suffix           | Works on Mesh object | Works on Mesh data |
++==================+======================+====================+
+| ``-col``         | ✔️                   | ✔️                 |
+| ``-convcol``     | ✔️                   | ✔️                 |
+| ``-colonly``     | ✔️                   | ❌                 |
+| ``-convcolonly`` | ✔️                   | ❌                 |
++------------------+----------------------+--------------------+
 
 With Collada files, the option ``-colonly`` can also be used with Blender's
 empty objects. On import, it will create a :ref:`class_StaticBody3D` with a


### PR DESCRIPTION
- This is aimed to close [#115869](https://github.com/godotengine/godot/issues/115869)

---

However this is a draft as I have a few questions:

1. I'm unfamiliar with Collada but wanted to check whether this sentence is definitely correct. Is it saying that if you import a blender object as a COLLADA / DAE file, the -colonly works with blenders empty objects?

> With Collada files, the option ``-colonly`` can also be used with Blender's empty objects.

Maybe it can be made a little clearer by saying "When exporting a Collada [or DAE] file from blender, the option ``-colonly`` can also be used with Blender's empty objects"

2. Do I need to / is it best to clarify what a mesh object / mesh data is in blender?

Also just a general check on my style would be good.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
