### PR TITLE
LightmapGI note light leak issue double-sided materials

### DIFF
--- a/classes/class_lightmapgi.rst
+++ b/classes/class_lightmapgi.rst
@@ -29,6 +29,8 @@ The **LightmapGI** node is used to compute and store baked lightmaps. Lightmaps 
 
 \ **Note:** Lightmap baking on :ref:`CSGShape3D<class_CSGShape3D>`\ s and :ref:`PrimitiveMesh<class_PrimitiveMesh>`\ es is not supported, as these cannot store UV2 data required for baking.
 
+\ **Note:** Double-sided materials can be a reason for light leaking and should be avoided if possible.
+
 \ **Note:** If no custom lightmappers are installed, **LightmapGI** can only be baked from devices that support the Forward+ or Mobile renderers.
 
 \ **Note:** The **LightmapGI** node only bakes light data for child nodes of its parent. Nodes further up the hierarchy of the scene will not be baked.


### PR DESCRIPTION
Using double-sided materials for e.g. a simple room with overlapping walls will create light leaks.
Also walls that dont overlap but touch.
Reason for this is the bounce light inside the mesh and the over-bright inside of said mesh.
If a beginner (like me) is using Blender the material cull mode is disabled by default (for imported materials) resulting in a frustrating issue that is not obvious at first.