### PR TITLE
Update wording in nodes_and_scenes.rst

### DIFF
--- a/getting_started/step_by_step/nodes_and_scenes.rst
+++ b/getting_started/step_by_step/nodes_and_scenes.rst
@@ -52,7 +52,7 @@ that runs and jumps, a life bar, a chest with which you can interact, and more.
 
 The Godot editor essentially is a **scene editor**. It has plenty of tools for
 editing 2D and 3D scenes, as well as user interfaces. A Godot project can
-contain as many of these scenes as you need. The engine only requires one as
+contain as many of these scenes as your computer can handle. The engine only requires one as
 your application's **main scene**. This is the scene Godot will first load when
 you or a player runs the game.
 


### PR DESCRIPTION
Amount of scenes limited by c++ integer limit depending on host machine. Reference:
https://github.com/godotengine/godot/blob/56f3e2611daadb0b1894b46737ee3000e82e33f9/scene/resources/2d/tile_set.h#L794-L810

Further change would be choosing intx_t in shown code snippet for specific number in docs

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
