### PR TITLE
Fix casing in LoadResourcePack and GetExecutablePath

### DIFF
--- a/tutorials/export/exporting_pcks.rst
+++ b/tutorials/export/exporting_pcks.rst
@@ -123,7 +123,7 @@ The PCK or ZIP file contains a ``mod_scene.tscn`` test scene in its root.
     private void YourFunction()
     {
         // This could fail if, for example, mod.pck cannot be found.
-        var success = ProjectSettings.LoadResourcePack(OS.get_executable_path().get_base_dir().path_join("mod.pck));
+        var success = ProjectSettings.LoadResourcePack(OS.GetExecutablePath().GetBaseDir().PathJoin("mod.pck"));
 
         if (success)
         {


### PR DESCRIPTION
Updated method calls to follow proper casing conventions.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
