### PR TITLE
Remove exception for _get_property_list in _validate_property.

### DIFF
--- a/classes/class_object.rst
+++ b/classes/class_object.rst
@@ -772,7 +772,7 @@ Override this method to customize the return value of :ref:`to_string()<class_Ob
 
 |void| **_validate_property**\ (\ property\: :ref:`Dictionary<class_Dictionary>`\ ) |virtual| :ref:`🔗<class_Object_private_method__validate_property>`
 
-Override this method to customize existing properties. Every property info goes through this method, except properties added with :ref:`_get_property_list()<class_Object_private_method__get_property_list>`. The dictionary contents is the same as in :ref:`_get_property_list()<class_Object_private_method__get_property_list>`.
+Override this method to customize existing properties. Every property info goes through this method. The dictionary contents is the same as in :ref:`_get_property_list()<class_Object_private_method__get_property_list>`.
 
 
 .. tabs::


### PR DESCRIPTION
## Description
According my tests there is no exception, the properties added with `_get_property_list` are validated.

Validation are called from here : 
https://github.com/godotengine/godot/blob/master/modules/gdscript/gdscript.cpp#L1786-L1789

## Test script
```gdscript
@tool
extends Resource
class_name TestResource

@export var number_count = 3:
	set(nc):
		number_count = nc
		numbers.resize(number_count)
		notify_property_list_changed()

var numbers = PackedInt32Array([0, 0, 0])


func _validate_property(property: Dictionary):
	if property.name in ["number_count", "number_1"]:
		prints("%s was validated" % property.name)


func _get_property_list():
	var properties = []

	for i in range(number_count):
		properties.append({
			"name": "number_%d" % i,
			"type": TYPE_INT,
			"hint": PROPERTY_HINT_ENUM,
			"hint_string": "ZERO,ONE,TWO,THREE,FOUR,FIVE",
		})

	return properties


func _get(property):
	if property.begins_with("number_"):
		var index = property.get_slice("_", 1).to_int()
		return numbers[index]

func _set(property, value):
	if property.begins_with("number_"):
		var index = property.get_slice("_", 1).to_int()
		numbers[index] = value
		return true
	return false
```

## Output
```bash
number_count was validated
number_1 was validated
```
