### PR TITLE
fix: Remove Night Quest Games Blog from resources

### DIFF
--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -35,7 +35,6 @@ Text tutorials
 - `Godot Tutorials by SomethingLikeGames <https://www.somethinglikegames.de/en/tags/godot-engine/>`__
 - `GameDev Academy by Zenva <https://gamedevacademy.org/category/godot-tutorials/godot-4/>`__
 - `Game Dev Artisan website <https://gamedevartisan.com/>`__
-- `Night Quest Games Blog <https://www.nightquestgames.com/blog-articles/>`__
 
 Resources
 ---------


### PR DESCRIPTION
Removed Night Quest Games Blog link from tutorials since the blog does no longer exists

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
