### PR TITLE
Improve clearness in nodes_and_scenes.rst

### DIFF
--- a/getting_started/step_by_step/nodes_and_scenes.rst
+++ b/getting_started/step_by_step/nodes_and_scenes.rst
@@ -30,7 +30,7 @@ All nodes have the following characteristics:
 The last characteristic is important. **Together, nodes form a tree**, which is a powerful
 feature to organize projects. Since different nodes have different functions,
 combining them produces more complex behavior. As we saw before, you can build a
-playable character the camera follows using a :ref:`CharacterBody2D <class_CharacterBody2D>`
+playable character that the camera follows using a :ref:`CharacterBody2D <class_CharacterBody2D>`
 node, a :ref:`Sprite2D <class_Sprite2D>` node,
 a :ref:`Camera2D <class_Camera2D>` node, and a :ref:`CollisionShape2D <class_CollisionShape2D>` node.
 


### PR DESCRIPTION
Add a "that" between the character and the camera makes the sentence structure more clear and easier to follow.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
