### PR TITLE
Update rtd-search for dark mode

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -5,6 +5,9 @@
  * based on browser preferences.
  */
 
+/** override rtd layer */
+@layer defaults, godot;
+
 @font-face {
     font-family: "JetBrains Mono";
     font-weight: 400;
@@ -329,6 +332,23 @@
         --btn-neutral-background-color: #404040;
         --btn-neutral-hover-background-color: #505050;
         --footer-color: #aaa;
+
+        @layer godot {
+            --readthedocs-search-color: var(--body-color);
+            --readthedocs-search-content-background-color: var(--navbar-background-color);
+            --readthedocs-search-content-border-color: var(--navbar-current-background-color);
+            --readthedocs-search-result-icon-color: var(--body-color);
+            --readthedocs-search-result-heading-color: var(--body-color);
+            --readthedocs-search-link-color: var(--link-color);
+            --readthedocs-search-result-subheading-color: var(--body-color);
+            --readthedocs-search-result-highlight-color: var(--navbar-heading-color);
+            --readthedocs-search-result-color:  var(--body-color);
+            --readthedocs-search-result-active-background-color: var(--navbar-current-background-color);
+            --readthedocs-search-footer-background-color: var(--navbar-current-background-color);
+            --readthedocs-search-footer-color: var(--body-color);
+            --readthedocs-search-footer-code-background-color: var(--code-tabs-background-color);
+            --readthedocs-search-input-background-color: var(--input-background-color);
+        }
     }
 }
 

--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -486,6 +486,17 @@ $(document).ready(() => {
 
   // Giscus
   registerGiscus();
+
+  // invert rtd's search logo in dark mode
+  if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    let rtdSearch = document.querySelector("readthedocs-search");
+    if (rtdSearch) {
+      let rtdLogo = rtdSearch.shadowRoot.querySelector('.footer a img');
+      if (rtdLogo) {
+        rtdLogo.style.filter = 'brightness(0) invert(1)';
+      }
+    }
+  }
 });
 
 // Override the default implementation from doctools.js to avoid this behavior.


### PR DESCRIPTION
Adds an colour override for the read-the-docs search plugin in dark mode.
I did test it by overriding the css file in the browser and running the js in the console, but I not 100% sure it will work, as I don't think I can test the rtd plugin locally.

<img width="700" height="438" alt="darkSearch" src="https://github.com/user-attachments/assets/d83e228f-84cc-4c03-9dfa-a7bc6e2a7681" />
