### PR TITLE
Remove bent normals notice about the compatibility renderer

### DIFF
--- a/tutorials/3d/standard_material_3d.rst
+++ b/tutorials/3d/standard_material_3d.rst
@@ -435,9 +435,6 @@ and wider compatibility.
 Bent normal map
 ---------------
 
-*This is only available in the Forward+ and Mobile renderers, not the Compatibility
-renderer.*
-
 A bent normal map describes the average direction of ambient lighting. Unlike a
 regular normal map, this is used to improve how a material reacts to lighting
 rather than add surface detail.


### PR DESCRIPTION
With https://github.com/godotengine/godot/pull/114336 merged, bent normal map support is now available on all renderers.