### PR TITLE
Document the unit for `REGION_RECT` and `POINT_COORD` in CanvasItem shaders

### DIFF
--- a/tutorials/shaders/shader_reference/canvas_item_shader.rst
+++ b/tutorials/shaders/shader_reference/canvas_item_shader.rst
@@ -126,8 +126,8 @@ is usually:
 | in bool **AT_LIGHT_PASS**      | Always ``false``.                                              |
 +--------------------------------+----------------------------------------------------------------+
 | in vec2 **TEXTURE_PIXEL_SIZE** | Normalized pixel size of the default 2D texture.               |
-|                                | For a Sprite2D with a texture of size 64x32px,                 |
-|                                | **TEXTURE_PIXEL_SIZE** = ``vec2(1.0/64.0, 1.0/32.0)``          |
+|                                | For a Sprite2D with a texture of size 64×32 pixels,            |
+|                                | ``TEXTURE_PIXEL_SIZE`` = ``vec2(1.0 / 64.0, 1.0 / 32.0)``.     |
 +--------------------------------+----------------------------------------------------------------+
 | inout vec2 **VERTEX**          | Vertex position, in local space.                               |
 +--------------------------------+----------------------------------------------------------------+
@@ -219,21 +219,27 @@ it to the ``NORMAL_MAP`` property. Godot will handle converting it for use in 2D
 +=============================================+===============================================================+
 | in vec4 **FRAGCOORD**                       | Coordinate of pixel center. In screen space. ``xy`` specifies |
 |                                             | position in viewport. Upper-left of the viewport is the       |
-|                                             | origin, ``(0.0, 0.0)``.                                       |
+|                                             | origin, ``(0.0, 0.0)``. Bottom-right of the viewport is       |
+|                                             | ``(1.0, 1.0)``.                                               |
 +---------------------------------------------+---------------------------------------------------------------+
 | in vec2 **SCREEN_PIXEL_SIZE**               | Size of individual pixels. Equal to the inverse of resolution.|
 +---------------------------------------------+---------------------------------------------------------------+
 | in vec4 **REGION_RECT**                     | Visible area of the sprite region in format                   |
 |                                             | ``(x, y, width, height)``. Varies according to                |
-|                                             | Sprite2D's ``region_enabled`` property.                       |
+|                                             | Sprite2D's ``region_enabled`` property. Values are            |
+|                                             | normalized; for example, a 600×400 region on a 1000×800       |
+|                                             | texture with a 100×100 offset would be                        |
+|                                             | ``vec4(0.1, 0.125, 0.6, 0.5)``. Values may exceed the 0.0 to  |
+|                                             | 1.0 range if the X/Y offset is negative, or if the size       |
+|                                             | exceeds the texture's size.                                   |
 +---------------------------------------------+---------------------------------------------------------------+
-| in vec2 **POINT_COORD**                     | Coordinate for drawing points.                                |
+| in vec2 **POINT_COORD**                     | Coordinate for drawing points in the 0.0 to 1.0 range.        |
 +---------------------------------------------+---------------------------------------------------------------+
 | sampler2D **TEXTURE**                       | Default 2D texture.                                           |
 +---------------------------------------------+---------------------------------------------------------------+
 | in vec2 **TEXTURE_PIXEL_SIZE**              | Normalized pixel size of the default 2D texture.              |
-|                                             | For a Sprite2D with a texture of size 64x32px,                |
-|                                             | ``TEXTURE_PIXEL_SIZE`` = ``vec2(1/64, 1/32)``                 |
+|                                             | For a Sprite2D with a texture of size 64×32 pixels,           |
+|                                             | ``TEXTURE_PIXEL_SIZE`` = ``vec2(1.0 / 64.0, 1.0 / 32.0)``.    |
 +---------------------------------------------+---------------------------------------------------------------+
 | in bool **AT_LIGHT_PASS**                   | Always ``false``.                                             |
 +---------------------------------------------+---------------------------------------------------------------+
@@ -300,7 +306,7 @@ Below is an example of a light shader that takes a CanvasItem's normal map into 
 +==================================+==============================================================================+
 | in vec4 **FRAGCOORD**            | Coordinate of pixel center. In screen space. ``xy`` specifies                |
 |                                  | position in viewport. Upper-left of the viewport is the origin,              |
-|                                  | ``(0.0, 0.0)``.                                                              |
+|                                  | ``(0.0, 0.0)``. Bottom-right of the viewport is ``(1.0, 1.0)``.              |
 +----------------------------------+------------------------------------------------------------------------------+
 | in vec3 **NORMAL**               | Input normal.                                                                |
 +----------------------------------+------------------------------------------------------------------------------+
@@ -312,8 +318,8 @@ Below is an example of a light shader that takes a CanvasItem's normal map into 
 | sampler2D **TEXTURE**            | Current texture in use for the CanvasItem.                                   |
 +----------------------------------+------------------------------------------------------------------------------+
 | in vec2 **TEXTURE_PIXEL_SIZE**   | Normalized pixel size of ``TEXTURE``.                                        |
-|                                  | For a Sprite2D with a ``TEXTURE`` of size ``64x32`` pixels,                  |
-|                                  | **TEXTURE_PIXEL_SIZE** = ``vec2(1/64, 1/32)``                                |
+|                                  | For a Sprite2D with a ``TEXTURE`` of size 64×32 pixels,                      |
+|                                  | ``TEXTURE_PIXEL_SIZE`` = ``vec2(1.0 / 64.0, 1.0 / 32.0)``.                   |
 +----------------------------------+------------------------------------------------------------------------------+
 | in vec2 **SCREEN_UV**            | Screen UV coordinate for the current pixel.                                  |
 +----------------------------------+------------------------------------------------------------------------------+

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -360,8 +360,9 @@ these properties, and if you don't write to them, Godot will optimize away the c
 +========================================+==================================================================================================+
 | in vec2 **VIEWPORT_SIZE**              | Size of viewport (in pixels).                                                                    |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
-| in vec4 **FRAGCOORD**                  | Coordinate of pixel center in screen space. ``xy`` specifies position in window. Origin is upper |
-|                                        | left. ``z`` specifies fragment depth. It is also used as the output value for the fragment depth |
+| in vec4 **FRAGCOORD**                  | Coordinate of pixel center in screen space. ``xy`` specifies position in window. Upper-left of   |
+|                                        | the viewport is the origin, ``(0.0, 0.0)``. Bottom-right of the viewport is ``(1.0, 1.0)``.      |
+|                                        | ``z`` specifies fragment depth. It is also used as the output value for the fragment depth       |
 |                                        | unless ``DEPTH`` is written to.                                                                  |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
 | in bool **FRONT_FACING**               | ``true`` if current face is front facing, ``false`` otherwise.                                   |
@@ -550,10 +551,11 @@ If you want the lights to add together, add the light contribution to ``DIFFUSE_
 +===================================+========================================================================+
 | in vec2 **VIEWPORT_SIZE**         | Size of viewport (in pixels).                                          |
 +-----------------------------------+------------------------------------------------------------------------+
-| in vec4 **FRAGCOORD**             | Coordinate of pixel center in screen space.                            |
-|                                   | ``xy`` specifies position in window, ``z``                             |
-|                                   | specifies fragment depth if ``DEPTH`` is not used.                     |
-|                                   | Origin is lower-left.                                                  |
+| in vec4 **FRAGCOORD**             | Coordinate of pixel center in screen space. ``xy`` specifies position  |
+|                                   | in window. Upper-left of the viewport is the origin, ``(0.0, 0.0)``.   |
+|                                   | Bottom-right of the viewport is ``(1.0, 1.0)``.                        |
+|                                   | ``z`` specifies fragment depth. It is also used as the output value    |
+|                                   | for the fragment depth unless ``DEPTH`` is written to.                 |
 +-----------------------------------+------------------------------------------------------------------------+
 | in mat4 **MODEL_MATRIX**          | Model/local space to world space transform.                            |
 +-----------------------------------+------------------------------------------------------------------------+


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-docs/pull/11225.
- This closes https://github.com/godotengine/godot-docs/issues/11792.
