### PR TITLE
Change the tutorial to use `get_gravity` instead of getting it from the settings

### DIFF
--- a/tutorials/physics/using_character_body_2d.rst
+++ b/tutorials/physics/using_character_body_2d.rst
@@ -469,13 +469,9 @@ Here's the code for the player body:
     var speed = 300.0
     var jump_speed = -400.0
 
-    # Get the gravity from the project settings so you can sync with rigid body nodes.
-    var gravity = ProjectSettings.get_setting("physics/2d/default_gravity")
-
-
     func _physics_process(delta):
         # Add the gravity.
-        velocity.y += gravity * delta
+        velocity.y += get_gravity() * delta
 
         # Handle Jump.
         if Input.is_action_just_pressed("jump") and is_on_floor():
@@ -497,14 +493,13 @@ Here's the code for the player body:
         private float _jumpSpeed = -400.0f;
 
         // Get the gravity from the project settings so you can sync with rigid body nodes.
-        public float Gravity = ProjectSettings.GetSetting("physics/2d/default_gravity").AsSingle();
 
         public override void _PhysicsProcess(double delta)
         {
             Vector2 velocity = Velocity;
 
             // Add the gravity.
-            velocity.Y += Gravity * (float)delta;
+            velocity.Y += GetGravity() * (float)delta;
 
             // Handle jump.
             if (Input.IsActionJustPressed("jump") && IsOnFloor())


### PR DESCRIPTION
This changes the tutorial to use `get_gravity` instead of needing to get it in the project settings.

This makes the code more straightforward and simpler to parse overall.