### PR TITLE
Documentation: add information about Apple Bundle IDs

### DIFF
--- a/tutorials/export/exporting_for_ios.rst
+++ b/tutorials/export/exporting_for_ios.rst
@@ -36,7 +36,7 @@ are required. Leaving them blank will cause the exporter to throw an error. The 
 .. note::
 
     A valid bundle ID can only contain alphanumeric characters, hyphens, and periods (``A-Z``, ``a-z``, ``0-9``, ``-``, and ``.``).
-    Apple recommends using reverse-DNS format (e.g. com.example) of a domain you own, so that your bundle ID is guaranteed to be unique.
+    Apple recommends using reverse-DNS format (e.g. ``com.example.your-game``) of a domain you own, so that your bundle ID is guaranteed to be unique.
     Bundle IDs are case-insensitive. See `CFBundleIdentifier <https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleidentifier>`__.
     
 .. note:: | If you encounter an error during export similar to

--- a/tutorials/export/exporting_for_macos.rst
+++ b/tutorials/export/exporting_for_macos.rst
@@ -32,9 +32,9 @@ Requirements
 .. note::
 
     A valid bundle ID can only contain alphanumeric characters, hyphens, and periods (``A-Z``, ``a-z``, ``0-9``, ``-``, and ``.``).
-    Apple recommends using reverse-DNS format (e.g. com.example) of a domain you own, so that your bundle ID is guaranteed to be unique.
+    Apple recommends using reverse-DNS format (e.g. ``com.example.your-game``) of a domain you own, so that your bundle ID is guaranteed to be unique.
     Bundle IDs are case-insensitive. See `CFBundleIdentifier <https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleidentifier>`__.
-    
+
 .. warning::
 
     Projects exported without code signing and notarization will be blocked by Gatekeeper if they are downloaded from unknown sources, see the :ref:`Running Godot apps on macOS <doc_running_on_macos>` page for more information.


### PR DESCRIPTION
- This closes godotengine/godot-docs/issues/11734

This adds correct information on bundle IDs to both the manual and the class reference.

The class reference previously implied that the bundle ID had to be in reverse-DNS format, but as far as I can see that isn't the case (it just has to be unique and meet the character requirements listed [here](https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleidentifier)).

I was tempted to add similar information for android exports, but since its `Bundle Identifier` box currently supports auto-generation with `com.example.$genname` as a default, I didn't see this as necessary.
