### PR TITLE
Linting: create check for headings which start with a number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
         run: |
           bash ./_tools/check-rst.sh
 
+      - name: Custom RST checks (check_rst_headings.py)
+        run: |
+          python3 _tools/check_rst_headings.py
+
       - name: Get Python version
         id: pythonv
         run: |

--- a/_tools/check_rst_headings.py
+++ b/_tools/check_rst_headings.py
@@ -1,0 +1,38 @@
+import os
+import re
+import sys
+
+def check_headings():
+    search_dir = "tutorials"
+    exclude_path = "tutorials/io/binary_serialization_api.rst"
+    info_message = "Headings which start with a number must have a custom anchor defined before them to prevent malformed link fragments.\nSee here: https://contributing.godotengine.org/en/latest/documentation/manual/contributing_to_the_manual.html \n"
+    
+    pattern = re.compile(r"^(?!\.\. _doc)(.+\n\s*^\d.*\n^[~-].*)", re.M)
+    
+    found_issues = False
+    header_printed = False
+
+    for root, _, files in os.walk(search_dir):
+        for f in files:
+            path = os.path.join(root, f)
+            
+            if not f.endswith(".rst") or path == exclude_path:
+                continue
+            
+            with open(path, "r", encoding="utf-8") as file:
+                content = file.read()
+            
+            for match in pattern.finditer(content):
+                if not header_printed:
+                    print(f"{info_message}\n")
+                    header_printed = True
+                
+                line_no = content[:match.start()].count("\n") + 1
+                print(f"Violation in {path} at line {line_no}:\n{match.group(1)}\n")
+                found_issues = True
+
+    if found_issues:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    check_headings()


### PR DESCRIPTION
- Adds a linting check using python to find any headings which start with a number and do not have a preceding custom anchor. If there is no preceding anchor, the link fragment will appear incorrect as per https://github.com/godotengine/godot-docs/issues/11016

This is a draft PR for a few reasons:
- This check will fail until https://github.com/godotengine/godot-docs/issues/11016 is fixed e.g. by merging https://github.com/godotengine/godot-docs/pull/11811
- I don't know if enforcing this is allowed; maybe its a bad idea
- If this lint is allowed, it should probably be described in the contributing docs e.g. [here](https://contributing.godotengine.org/en/latest/documentation/manual/contributing_to_the_manual.html#adding-new-pages) and that section should be referenced by the error message instead

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->