### PR TITLE
Correct number of extra methods in making_main_screen_plugins

### DIFF
--- a/tutorials/plugins/editor/making_main_screen_plugins.rst
+++ b/tutorials/plugins/editor/making_main_screen_plugins.rst
@@ -23,7 +23,7 @@ it in a folder called ``main_screen``, but you can use any name you'd like.
 
 The plugin script will come with ``_enter_tree()`` and ``_exit_tree()``
 methods, but for a main screen plugin we need to add a few extra methods.
-Add five extra methods such that the script looks like this:
+Add four extra methods such that the script looks like this:
 
 .. tabs::
  .. code-tab:: gdscript GDScript


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->

Literally fixes one wrong word, that the method count in the code block below is **four** extra methods, not **five**.