### PR TITLE
doc: Clarify that @tool script changes do not auto-mark scene as unsaved

### DIFF
--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -719,8 +719,8 @@ If you are using :ref:`EditorScript <class_EditorScript>`:
 
 .. note::
 
-    Changes made by tool scripts (e.g., adding nodes, modifying properties) do
-    **not** automatically mark the scene as unsaved. To show the asterisk (*)
+    Changes made by tool scripts and EditorScript (such as adding nodes or modifying properties)
+    do **not** automatically mark the scene as unsaved. To show the asterisk ``(*)``
     and prevent accidental data loss, call
     :ref:`EditorInterface.mark_scene_as_unsaved() <class_EditorInterface_method_mark_scene_as_unsaved>`
     after modifications, or use :ref:`EditorUndoRedoManager <class_EditorUndoRedoManager>` for undo support.


### PR DESCRIPTION
Adds reminder to call `EditorInterface.mark_scene_as_unsaved()` after modifications.

Fixes godotengine/godot#115367
