### PR TITLE
Add note for fixing invisible player in Finishing up page of first 2D game tutorial

### DIFF
--- a/getting_started/first_2d_game/07.finishing-up.rst
+++ b/getting_started/first_2d_game/07.finishing-up.rst
@@ -21,6 +21,7 @@ You could also add a background image, if you have one, by using a
 :ref:`TextureRect <class_TextureRect>` node instead.
 
 .. note::
+
     The ``Player`` may be invisible if the background is drawn on top of it. 
     Select the ``Player`` instance, then set **Ordering > Z Index** to ``1``.
 


### PR DESCRIPTION
Final page in the first 2D game tutorial proposes a couple ways to make a background. Due to z ordering issues, the player may be invisible. A small note is added to the background section on how to fix this.