### PR TITLE
make mobile nav bar sticky

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1562,6 +1562,11 @@ p + .classref-constant {
 
 /* Navigational top bar (mobile only) */
 
+.wy-nav-top {
+    position: sticky;
+    top: 0;
+}
+
 .wy-nav-top,
 .wy-nav-top a {
     background-color: var(--navbar-background-color);


### PR DESCRIPTION
Explicitly selected .wv-nav-top (Navigational top bar (mobile only) and set its position to sticky and top to 0.

```
.wy-nav-top {
    position: sticky;
    top: 0;
}

.wy-nav-top,
.wy-nav-top a {
    background-color: var(--navbar-background-color);
    color: var(--navbar-level-1-color);
}
```