### PR TITLE
Make Mobile Nav Top Bar Sticky

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1565,6 +1565,7 @@ p + .classref-constant {
 .wy-nav-top {
     position: sticky;
     top: 0;
+    z-index: 100;
 }
 
 .wy-nav-top,


### PR DESCRIPTION
Make the mobile only Navbar sticky.
```
.wy-nav-top {
    position: sticky;
    top: 0;
    z-index: 100;
}

.wy-nav-top,
.wy-nav-top a {
    background-color: var(--navbar-background-color);
    color: var(--navbar-level-1-color);
}
```