### PR TITLE
Fix reference link to Godot XR Tools introduction

### DIFF
--- a/tutorials/xr/xr_next_steps.rst
+++ b/tutorials/xr/xr_next_steps.rst
@@ -24,7 +24,7 @@ XR Toolkits
 -----------
 
 There are various XR toolkits available that implement more complex XR logic ready for you to use.
-We have a :Ref:`small introduction to Godot XR Tools <godot-xr-tools>` that you can look at,
+We have a :Ref:`small introduction to Godot XR Tools <doc_introducing_xr_tools>` that you can look at,
 a toolkit developed by core contributors of Godot.
 
 There are more toolkits available for Godot:


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
