### PR TITLE
Fix img option typo

### DIFF
--- a/tutorials/ui/bbcode_in_richtextlabel.rst
+++ b/tutorials/ui/bbcode_in_richtextlabel.rst
@@ -763,7 +763,7 @@ Image options
 
   Image tooltip.
 
-- **alt**
+- **align**
 
   +-----------+------------------------------------------------------------------------+
   | `Values`  | see :ref:`doc_bbcode_in_richtextlabel_image_and_table_alignment`       |


### PR DESCRIPTION
the "align" option was incorrectly named "alt" for the img options