### PR TITLE
Remove outdated info about differences in 2D and 3D physics interpolation

### DIFF
--- a/tutorials/physics/interpolation/2d_and_3d_physics_interpolation.rst
+++ b/tutorials/physics/interpolation/2d_and_3d_physics_interpolation.rst
@@ -6,50 +6,6 @@
 Generally 2D and 3D physics interpolation work in very similar ways. However, there
 are a few differences, which will be described here.
 
-Global versus local interpolation
----------------------------------
-
-- In 3D, physics interpolation is performed *independently* on the **global
-  transform** of each 3D instance.
-- In 2D by contrast, physics interpolation is performed on the **local transform**
-  of each 2D instance.
-
-This has some implications:
-
-- In 3D, it is easy to turn interpolation on and off at the level of each ``Node``,
-  via the :ref:`physics_interpolation_mode<class_Node_property_physics_interpolation_mode>`
-  property in the Inspector, which can be set to ``On``, ``Off``, or ``Inherited``.
-
-.. figure:: img/physics_interpolation_mode.webp
-    :align: center
-
-- However this means that in 3D, pivots that occur in the ``SceneTree`` (due to
-  parent child relationships) can only be interpolated **approximately** over the
-  physics tick. In most cases this will not matter, but in some situations the
-  interpolation can look slightly wrong.
-- In 2D, interpolated local transforms are passed down to children during
-  rendering. This means that if a parent has ``physics_interpolation_mode`` set to
-  ``On``, but the child is set to ``Off``, the child will still be interpolated if
-  the parent is moving. *Only the child's local transform is uninterpolated.*
-  Controlling the on / off behavior of 2D nodes therefore requires a little more
-  thought and planning.
-- On the positive side, pivot behavior in the scene tree is perfectly preserved
-  during interpolation in 2D, which gives super smooth behavior.
-
-Resetting physics interpolation
--------------------------------
-
-Whenever objects are moved to a completely new position, and interpolation is not
-desired (so as to prevent a "streaking" artefact), it is the responsibility of the
-user to call ``reset_physics_interpolation()``.
-
-The good news is that in 2D, this is automatically done for you when nodes first
-enter the tree. This reduces boiler plate, and reduces the effort required to get
-an existing project working.
-
-.. note:: If you move objects *after* adding to the scene tree, you will still need
-          to call ``reset_physics_interpolation()`` as with 3D.
-
 2D Particles
 ------------
 

--- a/tutorials/physics/interpolation/advanced_physics_interpolation.rst
+++ b/tutorials/physics/interpolation/advanced_physics_interpolation.rst
@@ -21,6 +21,18 @@ for a Node, the children will recursively also be affected (as they default to
 inheriting the parent setting). This means you can easily disable interpolation for
 an entire subscene.
 
+.. figure:: img/physics_interpolation_mode.webp
+
+It is worth noting that, both in 2D and 3D, physics interpolation is performed
+on the **local transform** of each instance. During rendering, interpolated local 
+transforms are passed down to children.
+
+This means that if a parent has ``physics_interpolation_mode`` set to ``On``, 
+but the child is set to ``Off``, the child will still be interpolated if the parent
+is moving. *Only the child's local transform is uninterpolated.*
+Controlling the on / off behavior of nodes therefore requires some 
+thought and planning.
+
 The most common situation where you may want to perform your own interpolation is
 Cameras.
 


### PR DESCRIPTION
The info on the page seems to describe how the engine worked before the SceneTreeFTI was introduced in Godot 4.5.

The "Global versus local interpolation" gives information that looks like the exact opposite of the current logic, where the SceneTreeFTI walks the whole hierarchy of both interpolated nodes and non-interpolated ones, but parented to interpolated, and sums the local transforms accordingly. Just like how the 2D inner workings are described.

The "Resetting physics interpolation" describes a difference that also looks to be no longer there. The code for NOTIFICATION_ENTER_TREE in Node3D::_notification seems to handle the reset automatically. The rest of the information in this section looks correct, but it just reiterates info from the "Using physics interpolation" article about resetting, and since there doesn't seem to be any difference anymore between 2D and 3D with this, it doesn't seem to fit this article anymore.
