### PR TITLE
Update particle builtins description in Spatial shader

### DIFF
--- a/tutorials/shaders/shader_reference/particle_shader.rst
+++ b/tutorials/shaders/shader_reference/particle_shader.rst
@@ -80,6 +80,11 @@ Start and Process built-ins
 
 These properties can be accessed from both the ``start()`` and ``process()`` functions.
 
+When using the built-in :ref:`class_ParticleProcessMaterial`, ``USERDATA1`` is defined
+with the following value in the built-in:
+
+* **w**: Accumulated angle from angular velocity in radians, as applied by the angular velocity texture.
+
 +------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Function                           | Description                                                                                                                             |
 +====================================+=========================================================================================================================================+

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -234,9 +234,16 @@ However, the value passed to the fragment shader still comes from ``VERTEX``.
 For instancing, the ``INSTANCE_CUSTOM`` variable contains the instance custom data. When using particles, this information
 is usually:
 
-* **x**: Rotation angle in radians.
-* **y**: Phase during lifetime (``0.0`` to ``1.0``).
-* **z**: Animation frame.
+* **x**: Current rotation angle in radians.
+* **y**: Time the particle has been active in seconds.
+* **z**: Current animation frame.
+* **w**: Particle lifetime in seconds.
+
+To get the lifetime phase (ranging from ``0.0`` to ``1.0``), use ``CUSTOM.y / CUSTOM.w``.
+
+Additionally, ``USERDATA1`` is defined with the following value in the built-in :ref:`class_ParticleProcessMaterial`:
+
+* **w**: Accumulated angle from angular velocity in radians, as applied by the angular velocity texture.
 
 This allows you to easily adjust the shader to a particle system using default particle material. When writing a custom particle
 shader, this value can be used as desired.

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -234,9 +234,9 @@ However, the value passed to the fragment shader still comes from ``VERTEX``.
 For instancing, the ``INSTANCE_CUSTOM`` variable contains the instance custom data. When using particles, this information
 is usually:
 
-* **x**: Rotation angle in radians.
-* **y**: Phase during lifetime (``0.0`` to ``1.0``).
-* **z**: Animation frame.
+* **x**: Current rotation angle in radians.
+* **z**: Current animation frame.
+* **y / w** (division): Lifetime fraction from ``0.0`` to ``1.0``.
 
 This allows you to easily adjust the shader to a particle system using default particle material. When writing a custom particle
 shader, this value can be used as desired.


### PR DESCRIPTION
- Depends on https://github.com/godotengine/godot/pull/117861.

If we want to merge this now, I can remove the `USERDATA1` note and split it to its own PR.

PS: `USERDATA1-6` aren't documented anywhere in the manual. What would be the best place to introduce it? These are only available in particle shaders.