### PR TITLE
Remove references to Node dock

### DIFF
--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -108,8 +108,7 @@ You can assign this property's value in two ways:
 - Click the down arrow next to "[empty]" and choose "Load". Select ``mob.tscn``.
 
 Next, select the instance of the ``Player`` scene under ``Main`` node in the Scene dock,
-and access the Node dock on the sidebar. Make sure to have the Signals tab selected
-in the Node dock.
+and access the Signals dock on the sidebar.
 
 You should see a list of the signals for the ``Player`` node. Find and
 double-click the ``hit`` signal in the list (or right-click it and select

--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -135,7 +135,7 @@ methods "_on_node_name_signal_name". Here, it'll be "_on_button_pressed".
 
 .. note::
 
-   When connecting signals via the editor's Node dock, you can use two
+   When connecting signals via the editor's Signals dock, you can use two
    modes. The simple one only allows you to connect to nodes that have a
    script attached to them and creates a new callback function on them.
 
@@ -520,7 +520,7 @@ names between parentheses:
 
 .. note::
 
-    The signal arguments show up in the editor's node dock, and Godot can use
+    The signal arguments show up in the editor's Signals dock, and Godot can use
     them to generate callback functions for you. However, you can still emit any
     number of arguments when you emit signals. So it's up to you to emit the
     correct values.

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -2769,7 +2769,7 @@ You can write optional argument names in parentheses after the signal's definiti
     # Defining a signal that forwards two arguments.
     signal health_changed(old_value, new_value)
 
-These arguments show up in the editor's node dock, and Godot can use them to
+These arguments show up in the editor's Signals dock, and Godot can use them to
 generate callback functions for you. However, you can still emit any number of
 arguments when you emit signals; it's up to you to emit the correct values.
 


### PR DESCRIPTION
Given that Godot 4.6.1 no longer has a Node dock in the sidebar, I'm updating the documents to refer to the Signals dock instead.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
