### PR TITLE
Object.get_meta & Object.has_meta documentation now link to is_valid_ascii_identifier instead of is_valid_identifier

### DIFF
--- a/classes/class_object.rst
+++ b/classes/class_object.rst
@@ -1196,7 +1196,7 @@ Returns the object's unique instance ID. This ID can be saved in :ref:`EncodedOb
 
 Returns the object's metadata value for the given entry ``name``. If the entry does not exist, returns ``default``. If ``default`` is ``null``, an error is also generated.
 
-\ **Note:** A metadata's name must be a valid identifier as per :ref:`StringName.is_valid_identifier()<class_StringName_method_is_valid_identifier>` method.
+\ **Note:** A metadata's name must be a valid identifier as per :ref:`StringName.is_valid_ascii_identifier()<class_StringName_method_is_valid_ascii_identifier>` method.
 
 \ **Note:** Metadata that has a name starting with an underscore (``_``) is considered editor-only. Editor-only metadata is not displayed in the Inspector and should not be edited, although it can still be found by this method.
 
@@ -1360,7 +1360,7 @@ Returns ``true`` if any connection exists on the given ``signal`` name.
 
 Returns ``true`` if a metadata entry is found with the given ``name``. See also :ref:`get_meta()<class_Object_method_get_meta>`, :ref:`set_meta()<class_Object_method_set_meta>` and :ref:`remove_meta()<class_Object_method_remove_meta>`.
 
-\ **Note:** A metadata's name must be a valid identifier as per :ref:`StringName.is_valid_identifier()<class_StringName_method_is_valid_identifier>` method.
+\ **Note:** A metadata's name must be a valid identifier as per :ref:`StringName.is_valid_ascii_identifier()<class_StringName_method_is_valid_ascii_identifier>` method.
 
 \ **Note:** Metadata that has a name starting with an underscore (``_``) is considered editor-only. Editor-only metadata is not displayed in the Inspector and should not be edited, although it can still be found by this method.
 


### PR DESCRIPTION
Resolves #11870 

has_meta and get_meta now link to StringName.is_valid_ascii_identifier(), as StringName.is_valid_identifier() is deprecated.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
