### PR TITLE
Update AR to MR in passthrough documentation

### DIFF
--- a/tutorials/xr/mr_passthrough.rst
+++ b/tutorials/xr/mr_passthrough.rst
@@ -1,9 +1,9 @@
 .. _doc_openxr_passthrough:
 
-AR / Passthrough
+MR / Passthrough
 ================
 
-Augmented Reality is supported through various methods depending on the capabilities of the hardware.
+Mixed Reality is supported through various methods depending on the capabilities of the hardware.
 
 Headsets such as the Magic Leap and glasses such as TiltFive show the rendered result on
 `see-through displays <https://en.wikipedia.org/wiki/See-through_display>`__ allowing the user


### PR DESCRIPTION
I think it is a bit misleading.

Augmented Reality is often depicting the usage of a smartphone or tablet to see virtual objects in the real world.
While the same is happening here, for VR Headsets this is more reflected as Mixed Reality.
To avoid this confusion, I suggest renaming it to Mixed Reality.
