### PR TITLE
Improve the discoverability of print_debug()

### DIFF
--- a/tutorials/scripting/debug/output_panel.rst
+++ b/tutorials/scripting/debug/output_panel.rst
@@ -80,6 +80,9 @@ For more complex use cases, these can be used:
   that does **not** print to the editor Output panel.
   It prints to the standard output stream *only*, which means it's still included
   in file logging.
+- :ref:`print_debug() <class_@GDScript_method_print_debug>`: Same as ``print()``,
+  but adds the current stack frame on a new line at the end. Only supported when
+  running from the editor, or when the project is exported in debug mode.
 - :ref:`print_stack() <class_@GDScript_method_print_stack>`: Print a stack trace
   from the current location. Only supported when running from the editor,
   or when the project is exported in debug mode.


### PR DESCRIPTION
As the title says, the goal of this PR is to improve the discoverability of print_debug(). It tries to achieve that by putting a reference to it on the main Output panel doc page. I personally found this method very useful, and I think this would help other people to discover it quicker. 
