### PR TITLE
Update documentation changelog for 4.7

### DIFF
--- a/about/docs_changelog.rst
+++ b/about/docs_changelog.rst
@@ -15,6 +15,43 @@ added since version 3.0.
     This document only contains new pages, so not all changes are reflected.
     Many pages have been substantially updated but are not reflected in this document.
 
+New pages since version 4.6
+---------------------------
+
+Editor
+~~~~~~
+
+- :ref:`doc_game_embedding`
+
+User Interface (UI)
+~~~~~~~~~~~~~~~~~~~
+
+- :ref:`doc_creating_applications`
+
+New pages since version 4.5
+---------------------------
+
+Input
+~~~~~
+
+- :ref:`doc_controller_features`
+
+Migrating
+~~~~~~~~~
+
+- :ref:`doc_upgrading_to_godot_4.6`
+
+Platform-specific
+~~~~~~~~~~~~~~~~~
+
+- :ref:`doc_resolving_crashes_on_android`
+- :ref:`doc_wayland_x11`
+
+Scripting
+~~~~~~~~~
+
+- :ref:`doc_godot_cpp_core_types`
+
 New pages since version 4.4
 ---------------------------
 


### PR DESCRIPTION
This also adds a section for new pages in 4.6 that can be cherry-picked later on. The 4.7 migration guide isn't listed yet as it's not written yet.