### PR TITLE
Use official casing for the macOS platform name

### DIFF
--- a/tutorials/platform/linux/wayland_x11.rst
+++ b/tutorials/platform/linux/wayland_x11.rst
@@ -7,7 +7,7 @@ Overview
 --------
 
 One of the important components of any operating system is its display server.
-Windows and MacOS only provide one option, Linux however has two, X11 and Wayland.
+Windows and macOS only provide one option, Linux however has two, X11 and Wayland.
 
 X11 is an older standard and is currently being gradually phased out by the majority
 of linux distributions in favor of supporting Wayland, which has been developed as a

--- a/tutorials/scripting/c_sharp/index.rst
+++ b/tutorials/scripting/c_sharp/index.rst
@@ -65,7 +65,7 @@ iOS support is currently experimental and has a few limitations.
 
 - The official export templates for the iOS simulator only supports the ``x64`` architecture.
 
-- Exporting to iOS can only be done from a MacOS device.
+- Exporting to iOS can only be done from a macOS device.
 
 Currently, projects written in C# cannot be exported to the web platform. To use C#
 on that platform, consider Godot 3 instead.


### PR DESCRIPTION
I noticed this while looking at https://github.com/godotengine/godot-docs/pull/11675 for https://github.com/godotengine/godot-docs/pull/11896.
