### PR TITLE
Replace remaining links to the contributing section

### DIFF
--- a/.github/workflows/build_offline_docs.yml
+++ b/.github/workflows/build_offline_docs.yml
@@ -71,8 +71,8 @@ jobs:
           # Convert WebP images to PNG and replace references, so that ePub readers can display those images.
           # The ePub 3.0 specification has WebP support, but it's not widely supported by apps and e-readers yet.
           shopt -s globstar nullglob
-          parallel --will-cite convert {} {.}.png ::: {about,community,contributing,getting_started,img,tutorials}/**/*.webp
-          parallel --will-cite sed -i "s/\\.webp$/\\.png/g" ::: {about,community,contributing,getting_started,tutorials}/**/*.rst
+          parallel --will-cite convert {} {.}.png ::: {about,community,engine_details,getting_started,img,tutorials}/**/*.webp
+          parallel --will-cite sed -i "s/\\.webp$/\\.png/g" ::: {about,community,engine_details,getting_started,tutorials}/**/*.rst
 
           # Remove banners at the top of each page when building `latest`.
           sed -i 's/"godot_is_latest": True/"godot_is_latest": False/' conf.py

--- a/_tools/check-rst.sh
+++ b/_tools/check-rst.sh
@@ -2,7 +2,7 @@
 
 set -uo pipefail
 
-output=$(grep -r -P '^(?!\s*\.\.).*\S::$' --include='*.rst' --exclude='docs_writing_guidelines.rst' .)
+output=$(grep -r -P '^(?!\s*\.\.).*\S::$' --include='*.rst' .)
 if [[ -n $output ]]; then
   echo 'The shorthand codeblock syntax (trailing `::`) is not allowed.'
   echo "$output"


### PR DESCRIPTION
1. The `contributing` section has been moved to a separate site. And a new, smaller `engine_details` section has appeared in the main documentation.
2. The `docs_writing_guidelines.rst` page has been moved to the contributing documentation ([link](https://contributing.godotengine.org/en/latest/documentation/guidelines/docs_writing_guidelines.html)).