### PR TITLE
Remove note on editor window persistence

### DIFF
--- a/tutorials/editor/customizing_editor.rst
+++ b/tutorials/editor/customizing_editor.rst
@@ -96,11 +96,6 @@ following changes are persisted to the saved layout:
 - FileSystem dock properties: split mode, display mode, sorting order, file list
   display mode, selected paths and unfolded paths.
 
-.. note::
-
-    Splitting the script or shader editor to its own window is *not* persisted
-    as part of a layout.
-
 After making changes, open the **Editor** menu at the top of the editor then
 choose **Editor Layouts > Save**. Enter a name for the layout, then click
 **Save**. If you've already saved an editor layout, you can choose to override


### PR DESCRIPTION
Removed note about script or shader editor window persistence since in current Godot versions both script and shader script window positions are persisted when floated

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
