### PR TITLE
Fix: Replace fake constructor with _Ready() initialization

### DIFF
--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -148,7 +148,7 @@ Add the following code to your script:
 
  .. code-tab:: csharp C#
 
-    public MySprite2D()
+    public override void _Ready()
     {
         GD.Print("Hello, world!");
     }


### PR DESCRIPTION
fix: replace void constructor with _Ready() override

MySprite2D() was declared as a void method, making it a no-op that Godot never calls. Replaced with _Ready() so initialization logic (GD.Print) actually executes on node load.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
