### PR TITLE
Mention `RWLock` is similar to `shared_mutex` instead of timed variant

### DIFF
--- a/engine_details/architecture/core_types.rst
+++ b/engine_details/architecture/core_types.rst
@@ -188,7 +188,7 @@ efficiency reasons.
 +-----------------------+------------------------------+---------------------------------------------------------------------------------------+
 | |binary_mutex|        | ``std::mutex``               | Non-recursive mutex type. Use ``MutexLock lock(mutex)`` to lock it.                   |
 +-----------------------+------------------------------+---------------------------------------------------------------------------------------+
-| |rw_lock|             | ``std::shared_timed_mutex``  | Read-write aware mutex type. Use ``RWLockRead lock(mutex)`` or                        |
+| |rw_lock|             | ``std::shared_mutex``        | Read-write aware mutex type. Use ``RWLockRead lock(mutex)`` or                        |
 |                       |                              | ``RWLockWrite lock(mutex)`` to lock it.                                               |
 +-----------------------+------------------------------+---------------------------------------------------------------------------------------+
 | |safe_binary_mutex|   | ``std::mutex``               | Recursive mutex type that can be used with ``ConditionVariable``.                     |


### PR DESCRIPTION
Technically a follow-up of https://github.com/godotengine/godot/pull/117801/

`RWLock` doesn't use any of the timed features, so it's better to mention the closest STL data type is `shared_mutex` instead of its timed variant.

Also, `RWLock` did in fact use `shared_timed_mutex` internally before https://github.com/godotengine/godot/pull/117801/ changed it to a plain `shared_mutex`.