### PR TITLE
Add warning for using array pattern with packed arrays

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -2005,6 +2005,12 @@ The following pattern types are available:
             [42, ..]:
                 print("Open ended array")
 
+    .. warning::
+
+        Array patterns do not match packed arrays (such as ``PackedStringArray``).
+        Call ``Array(packed_array)`` to convert them into arrays before matching with array patterns.
+
+
 - Dictionary pattern
     Works in the same way as the array pattern. Every key has to be a constant pattern.
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->

I've recently encountered a "papercut" when using pattern matching after `String.split`: the split result is a `PackedStringArray` that does not work with array patterns. While there is a warning in the pattern matching about the type strictness above, it might also help to add an additional warning in the "Array pattern" section as it's pretty far down in the docs, a couple screens of scroll from the warning above.

I wonder if it's also worth a proposal to add matching packed arrays with array pattern too, as they are quite similar to arrays in many ways, and definitely more comparable to `StringName` vs. `String` than `float` vs. `int`.