### PR TITLE
TYPO? ”Node tab” -> ”signals tab”

### DIFF
--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -220,7 +220,7 @@ should look like this, so make sure you didn't miss anything:
 Now we need to connect the ``HUD`` functionality to our ``Main`` script. This
 requires a few additions to the ``Main`` scene:
 
-In the Node tab, connect the HUD's ``start_game`` signal to the ``new_game()``
+In the Signals tab, connect the HUD's ``start_game`` signal to the ``new_game()``
 function of the Main node by clicking the "Pick" button in the "Connect a Signal"
 window and selecting the ``new_game()`` method or type "new_game" below "Receiver Method"
 in the window. Verify that the green connection icon now appears next to


### PR DESCRIPTION
In the current version (4.6), this is now the “Signals” tab, so I think this line might be leftover from an older version. Beginners don’t know the old terminology, so it can be confusing — I got quite lost myself.

https://github.com/godotengine/godot-docs/issues/11909

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
