### PR TITLE
Update Windows and macOS build instructions.

### DIFF
--- a/engine_details/development/compiling/compiling_for_macos.rst
+++ b/engine_details/development/compiling/compiling_for_macos.rst
@@ -89,22 +89,12 @@ Compiling with AccessKit support
 
 AccessKit provides support for screen readers.
 
-By default, Godot is built with AccessKit dynamically linked. You can use it by placing
-``accesskit.dylib`` alongside the standalone executable or in the app bundle's ``Frameworks`` folder.
+Compiling with AccessKit requires additional dependencies to be installed.
+If you wish to skip this step, you can use the ``accesskit=no`` SCons option.
 
-.. note:: You can use dynamically linked AccessKit with export templates as well, rename
-          the DYLIB to ``accesskit.{architecture}.dylib``
-          and place them inside the export template app bundle ``Frameworks`` folder, and the
-          libraries will be automatically copied during the export process.
-
-To compile Godot with statically linked AccessKit:
-
-- Download the pre-built static libraries from `godot-accesskit-c-static library <https://github.com/godotengine/godot-accesskit-c-static/releases>`_, and unzip them.
-- When building Godot, add ``accesskit_sdk_path={path}`` to tell SCons where to look for the AccessKit libraries:
-
-    ::
-
-        scons platform=macos accesskit_sdk_path=<...>
+You can install the required dependencies by running
+``python misc/scripts/install_accesskit.py``
+in the Godot source repository. After running this script, compile Godot as usual.
 
 .. note:: You can optionally build the godot-angle-static libraries yourself with
           the following steps:
@@ -122,6 +112,52 @@ To compile Godot with statically linked AccessKit:
 
           The AccessKit static library should be built using the same compiler you are
           using for building Godot.
+
+          To compile Godot with a custom build of AccessKit, add ``accesskit_sdk_path={path}`` to
+          tell SCons where to look for the AccessKit libraries:
+
+          ::
+
+              scons platform=macos accesskit_sdk_path=<...>
+
+Compiling with ANGLE support
+----------------------------
+
+ANGLE provides a translation layer from OpenGL ES 3.x to Metal and can be used
+to improve support for the Compatibility renderer on some older GPUs with outdated
+OpenGL drivers.
+
+Compiling with ANGLE requires additional dependencies to be installed.
+If you wish to skip this step, you can use the ``angle=no`` SCons option.
+
+You can install the required dependencies by running
+``python misc/scripts/install_angle.py``
+in the Godot source repository. After running this script, compile Godot as usual.
+
+.. note:: You can optionally build the godot-angle-static libraries yourself with
+          the following steps:
+
+          1. Clone the `godot-angle-static <https://github.com/godotengine/godot-angle-static>`_
+             directory and navigate to it.
+          2. Run the following command:
+
+          ::
+
+              git submodule update --init
+              ./update_angle.sh
+              scons
+
+          You can also specify the build architecture using ``arch={architecture}``.
+
+          The ANGLE static library should be built using the same compiler you are
+          using for building Godot.
+
+          To compile Godot with a custom build of ANGLE, add ``angle_libs={path}`` to
+          tell SCons where to look for the ANGLE libraries:
+
+          ::
+
+              scons platform=macos angle_libs=<...>
 
 Automatic ``.app`` bundle creation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/engine_details/development/compiling/compiling_for_windows.rst
+++ b/engine_details/development/compiling/compiling_for_windows.rst
@@ -298,24 +298,14 @@ Compiling with AccessKit support
 
 AccessKit provides support for screen readers.
 
-By default, Godot is built with AccessKit dynamically linked. You can use it by placing
-``accesskit.dll`` alongside the executable.
+Compiling with AccessKit requires additional dependencies to be installed.
+If you wish to skip this step, you can use the ``accesskit=no`` SCons option.
 
-.. note:: You can use dynamically linked AccessKit with export templates as well, rename
-          the DLL to ``accesskit.{architecture}.dll``
-          and place them alongside the export template executables, and the libraries will
-          be automatically copied during the export process.
+You can install the required dependencies by running
+``python misc/scripts/install_accesskit.py``
+in the Godot source repository. After running this script, compile Godot as usual.
 
-To compile Godot with statically linked AccessKit:
-
-- Download the pre-built static libraries from `godot-accesskit-c-static library <https://github.com/godotengine/godot-accesskit-c-static/releases>`_, and unzip them.
-- When building Godot, add ``accesskit_sdk_path={path}`` to tell SCons where to look for the AccessKit libraries:
-
-    ::
-
-        scons platform=windows accesskit_sdk_path=<...>
-
-.. note:: You can optionally build the godot-angle-static libraries yourself with
+.. note:: You can optionally build the AccessKit libraries yourself with
           the following steps:
 
           1. Clone the `godot-accesskit-c-static <https://github.com/godotengine/godot-accesskit-c-static/>`_
@@ -333,6 +323,46 @@ To compile Godot with statically linked AccessKit:
           same CRT (if you are building with MinGW) you are using for building
           Godot.
 
+          To compile Godot with a custom build of AccessKit, add ``accesskit_sdk_path={path}`` to
+          tell SCons where to look for the AccessKit libraries:
+
+          ::
+
+              scons platform=windows accesskit_sdk_path=<...>
+
+Compiling with WinRT support
+----------------------------
+
+WinRT provides support for OneCore TTS (accessing Windows 10+ voices), and Emoji Picker.
+
+If you are building with MinGW, compiling with WinRT requires additional dependencies to be installed.
+If you wish to skip this step, you can use the ``winrt=no`` SCons option.
+
+You can install the required dependencies by running
+``python misc/scripts/install_winrt.py``
+in the Godot source repository. After running this script, compile Godot as usual.
+
+.. note:: You can optionally build the WinRT headers yourself with
+          the following steps:
+
+          1. Clone the `winrt-mingw <https://github.com/godotengine/winrt-mingw>`_
+             directory and navigate to it.
+          2. Run the following command:
+
+          ::
+
+              cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCPPWINRT_BUILD_VERSION=2.0.250303.1 -DBUILD_TESTING=OFF cppwinrt/
+              echo "" > build/app.manifest.rc
+              cmake --build build
+              ./build/cppwinrt.exe -input windows-rs/crates/libs/bindgen/default/ -output include/
+
+          To compile Godot with a custom build of WinRT, add ``winrt_path={path}`` to
+          tell SCons where to look for the AccessKit headers:
+
+          ::
+
+              scons platform=windows winrt_path=<...>
+
 Compiling with ANGLE support
 ----------------------------
 
@@ -340,22 +370,12 @@ ANGLE provides a translation layer from OpenGL ES 3.x to Direct3D 11 and can be 
 to improve support for the Compatibility renderer on some older GPUs with outdated
 OpenGL drivers and on Windows for ARM.
 
-By default, Godot is built with dynamically linked ANGLE, you can use it by placing
-``libEGL.dll`` and ``libGLESv2.dll`` alongside the executable.
+Compiling with ANGLE requires additional dependencies to be installed.
+If you wish to skip this step, you can use the ``angle=no`` SCons option.
 
-.. note:: You can use dynamically linked ANGLE with export templates as well, rename
-          the DLLs to ``libEGL.{architecture}.dll`` and ``libGLESv2.{architecture}.dll``
-          and place them alongside the export template executables, and the libraries will
-          be automatically copied during the export process.
-
-To compile Godot with statically linked ANGLE:
-
-- Download the pre-built static libraries from `godot-angle-static library <https://github.com/godotengine/godot-angle-static/releases>`_, and unzip them.
-- When building Godot, add ``angle_libs={path}`` to tell SCons where to look for the ANGLE libraries:
-
-    ::
-
-        scons platform=windows angle_libs=<...>
+You can install the required dependencies by running
+``python misc/scripts/install_angle.py``
+in the Godot source repository. After running this script, compile Godot as usual.
 
 .. note:: You can optionally build the godot-angle-static libraries yourself with
           the following steps:
@@ -382,6 +402,13 @@ To compile Godot with statically linked ANGLE:
           The ANGLE static library should be built using the same compiler and the
           same CRT (if you are building with MinGW) you are using for building
           Godot.
+
+          To compile Godot with a custom build of ANGLE, add ``angle_libs={path}`` to
+          tell SCons where to look for the ANGLE libraries:
+
+          ::
+
+              scons platform=windows angle_libs=<...>
 
 Development in Visual Studio
 ----------------------------


### PR DESCRIPTION
- Removes mentions of dynamic linking.
- Adds WinRT (for Windows) and ANGLE (for macOS) instructions.
- Updates instructions to mention install scripts for dependencies.