### PR TITLE
Explain the ctrl-scroll can be used to change Grid Floor

### DIFF
--- a/tutorials/3d/using_gridmaps.rst
+++ b/tutorials/3d/using_gridmaps.rst
@@ -204,7 +204,7 @@ From left to right in the toolbar:
   that will be painted on the Z-axis. This will also rotate selected areas if they
   are being moved.
 - **Change Grid Floor**: Adjusts what floor is currently being worked on, can be
-  changed with the arrows or typing
+  changed with the arrows or typing or with ctrl-scroll
 - **Filter Meshes**: Used to search for a specific mesh in the bottom panel.
 - **Zoom**: Controls the zoom level on meshes in the bottom panel.
 - **Layout toggles**: These two buttons toggle between different layouts for meshes


### PR DESCRIPTION
Using gridmaps I was finding it rather painful to move up and down gridfloor levels, and thought "there has to be a shortcut for this." It's not documented, but it does exist and I had to figure out on my own. So here's a minor change so it's references where I would expect it to be. Hopefully it will help someone else find it.