### PR TITLE
[iOS] Fix outdated simulator notes.

### DIFF
--- a/engine_details/development/compiling/compiling_for_ios.rst
+++ b/engine_details/development/compiling/compiling_for_ios.rst
@@ -76,11 +76,10 @@ linked on iOS; there is no dynamic linking option available, unlike macOS.
 
 .. warning::
 
-    Compiling for the iOS simulator is currently not supported as per
-    `GH-102149 <https://github.com/godotengine/godot/issues/102149>`__.
+    The iOS simulator only supports the ``Compatibility`` renderer.
 
     Apple Silicon Macs can run iOS apps natively, so you can run exported iOS projects
-    directly on an Apple Silicon Mac without needing the iOS simulator.
+    directly on an Apple Silicon Mac without iOS simulator limitations.
 
 Run
 ---

--- a/tutorials/export/exporting_for_ios.rst
+++ b/tutorials/export/exporting_for_ios.rst
@@ -66,11 +66,10 @@ When the export completes, the output folder should look like this:
 
 .. warning::
 
-    Exporting for the iOS simulator is currently not supported as per
-    `GH-102149 <https://github.com/godotengine/godot/issues/102149>`__.
+    The iOS simulator only supports the ``Compatibility`` renderer.
 
     Apple Silicon Macs can run iOS apps natively, so you can run exported iOS projects
-    directly on an Apple Silicon Mac without needing the iOS simulator.
+    directly on an Apple Silicon Mac without iOS simulator limitations.
 
 Opening **exported_xcode_project_name.xcodeproj** lets you build and deploy
 like any other iOS app.


### PR DESCRIPTION
Building simulator binaries were fixed in https://github.com/godotengine/godot/pull/102179

This PR replaces outdated compiling it with more relevant simulator limitation note.