### PR TITLE
Update advice on using physics process for kinematic bodies

### DIFF
--- a/tutorials/physics/kinematic_character_2d.rst
+++ b/tutorials/physics/kinematic_character_2d.rst
@@ -47,7 +47,7 @@ Physics process
 ~~~~~~~~~~~~~~~
 
 To manage the logic of a kinematic body or character, it is always
-advised to use physics process, because it's called before physics step and its execution is
+advised to use :ref:`physics process <doc_idle_and_physics_processing>`, because it's called before physics step and its execution is
 in sync with physics server, also it is called the same amount of times
 per second, always. This makes physics and motion calculation work in a
 more predictable way than using regular process, which might have spikes

--- a/tutorials/physics/kinematic_character_2d.rst
+++ b/tutorials/physics/kinematic_character_2d.rst
@@ -47,7 +47,8 @@ Physics process
 ~~~~~~~~~~~~~~~
 
 To manage the logic of a kinematic body or character, it is always
-advised to use :ref:`physics process <doc_idle_and_physics_processing>`, because it's called before physics step and its execution is
+advised to use :ref:`physics process <doc_idle_and_physics_processing>`,
+because it's called before physics step and its execution is
 in sync with physics server, also it is called the same amount of times
 per second, always. This makes physics and motion calculation work in a
 more predictable way than using regular process, which might have spikes


### PR DESCRIPTION
The Physics Process section in the Kinematic Character 2D documentation could benefit from an additional reference to clarify the delta parameter. Currently, delta is used in _physics_process(delta) without a direct explanation in that section, which may be unclear for newer users.

Documentation page : https://docs.godotengine.org/en/stable/tutorials/physics/kinematic_character_2d.html#physics-process