### PR TITLE
GDScript reference: Fix inconsistency in an abstract class example

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -2233,14 +2233,14 @@ abstract class:
     class_name AbstractClass
     extends Node
 
-    @abstract class AbstractSubClass:
+    @abstract class AbstractInnerClass:
         func _ready():
             pass
 
-    # This is an example of a concrete subclass of AbstractSubClass.
-    # This class can be instantiated using `AbstractClass.ConcreteSubclass.new()`
+    # This is an example of a concrete subclass of `AbstractInnerClass`.
+    # This class can be instantiated using `AbstractClass.ConcreteInnerClass.new()`
     # in other scripts, even though it's part of an abstract `class_name` script.
-    class ConcreteClass extends AbstractSubClass:
+    class ConcreteInnerClass extends AbstractInnerClass:
         func _ready():
             print("Concrete class ready.")
 


### PR DESCRIPTION
The example comment had `ConcreteSubclass` while the example code was `ConcreteClass` so match them up and make them consistent with the other names by changing them both to `ConcreteSubClass`.