### PR TITLE
Replace mentions of the default `icon.png` with `icon.svg`

### DIFF
--- a/tutorials/2d/2d_movement.rst
+++ b/tutorials/2d/2d_movement.rst
@@ -19,7 +19,7 @@ Setup
 -----
 
 Each example below uses the same scene setup. Start with a ``CharacterBody2D`` with two
-children: ``Sprite2D`` and ``CollisionShape2D``. You can use the Godot icon ("icon.png")
+children: ``Sprite2D`` and ``CollisionShape2D``. You can use the Godot icon (``icon.svg``)
 for the Sprite2D's texture or use any other 2D image you have.
 
 Open ``Project -> Project Settings`` and select the "Input Map" tab. Add the following

--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -164,7 +164,7 @@ clicked. For that, we'll need a script that extends from
 
         # Icons are optional.
         # Alternatively, you may use the UID of the icon or the absolute path.
-        @icon("icon.png")
+        @icon("icon.svg")
 
         # Automatically register the node in the Create New Node dialog
         # and make it available for use with other scripts.
@@ -188,7 +188,7 @@ clicked. For that, we'll need a script that extends from
 
         // Icons are optional.
         // Alternatively, you may use the UID of the icon or the absolute path.
-        [Icon("icon.png")]
+        [Icon("icon.svg")]
 
         // Automatically register the node in the Create New Node dialog
         // and make it available for use with other scripts.
@@ -209,7 +209,7 @@ clicked. For that, we'll need a script that extends from
 That's it for our basic button. You can save this as ``my_button.gd`` inside the
 plugin folder. You may have a 16×16 icon to show in the scene tree. If you
 don't have one, you can grab the default one from the engine and save it in your
-`addons/my_custom_node` folder as `icon.png`, or use the default Godot logo
+`addons/my_custom_node` folder as `icon.svg`, or use the default Godot logo
 (`preload("res://icon.svg")`).
 
 .. tip::

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1701,7 +1701,7 @@ Here are some examples of expressions:
     do_something() # Function call.
     [1, 2, 3] # Array definition.
     {A = 1, B = 2} # Dictionary definition.
-    preload("res://icon.png") # Preload builtin function.
+    preload("res://icon.svg") # Preload builtin function.
     self # Reference to current instance.
 
 Identifiers, attributes, and subscripts are valid assignment targets. Other expressions cannot be on the left side of

--- a/tutorials/ui/size_and_anchors.rst
+++ b/tutorials/ui/size_and_anchors.rst
@@ -9,9 +9,9 @@ resolution, positioning controls would be a simple matter of setting the
 position and size of each one of them. Unfortunately, that is rarely the
 case.
 
-While some configurations may be more common than others, devices like 
-phones, tablets and portable gaming consoles can vary greatly. Therefore, 
-we often have to account for different aspect ratios, resolutions and user 
+While some configurations may be more common than others, devices like
+phones, tablets and portable gaming consoles can vary greatly. Therefore,
+we often have to account for different aspect ratios, resolutions and user
 scaling.
 
 There are several ways to account for this, but for now, let's just imagine
@@ -22,7 +22,7 @@ the top of the screen, or maybe the right or left margins.
 .. image:: img/anchors.png
 
 This is done by editing the *anchor offsets* of controls, which behave similar
-to a margin. To access these settings, you will first need to select the *Custom* 
+to a margin. To access these settings, you will first need to select the *Custom*
 anchor preset.
 
 Each control has four anchor offsets: left, right, bottom, and top, which correspond
@@ -72,7 +72,7 @@ a TextureRect can be centered in its parent:
  .. code-tab:: gdscript GDScript
 
     var rect = TextureRect.new()
-    rect.texture = load("res://icon.png")
+    rect.texture = load("res://icon.svg")
     rect.anchor_left = 0.5
     rect.anchor_right = 0.5
     rect.anchor_top = 0.5
@@ -88,7 +88,7 @@ a TextureRect can be centered in its parent:
 
     var rect = new TextureRect();
 
-    rect.Texture = ResourceLoader.Load<Texture>("res://icon.png");
+    rect.Texture = ResourceLoader.Load<Texture>("res://icon.svg");
     rect.AnchorLeft = 0.5f;
     rect.AnchorRight = 0.5f;
     rect.AnchorTop = 0.5f;


### PR DESCRIPTION
Godot 4.0 and later creates `icon.svg` instead of `icon.png` in new projects.

- This supersedes https://github.com/godotengine/godot-docs/pull/11935.
