### PR TITLE
Fix BSD compile instructions

### DIFF
--- a/engine_details/development/compiling/compiling_for_linuxbsd.rst
+++ b/engine_details/development/compiling/compiling_for_linuxbsd.rst
@@ -117,7 +117,7 @@ Distro-specific one-liners
 
         ::
 
-            pkg install \
+            pkg install -y \
               devel/scons \
               pkgconf \
               xorg-libraries \
@@ -169,22 +169,21 @@ Distro-specific one-liners
 
         ::
 
-            pkgin install \
+            pkg_add pkgin
+            pkgin -y install \
               pkg-config \
-              py313-scons
-
-        .. hint::
-
-            For audio support, you can optionally install ``pulseaudio``.
+              py313-scons \
+              wayland \
+              pulseaudio
 
     .. tab:: OpenBSD
 
         ::
 
-            pkg_add \
-              python \
+            pkg_add -I \
               scons \
-              llvm
+              wayland \
+              pulseaudio
 
     .. tab:: openKylin
 


### PR DESCRIPTION
Some more adjustments based on experience fixing compilation on the bsds.

- `-y` for `pkg install` and `-I` for `pkgin install` skips user confirmation which is already present in the instructions for the other platforms.
- NetBSD requires you to install `pkgin` with `pkg_add` before using it, even though it is the suggested tool for installing packages.
- The note about pulseaudio being optional on NetBSD specifically doesn't make sense, it should be optional on all platforms.
- OpenBSD ships with `clang` as the default toolchain, no reason to install `llvm`.
- Wayland headers should be installed on OpenBSD and NetBSD for wayland support.