### PR TITLE
Fix controller mapping docs

### DIFF
--- a/tutorials/inputs/controllers_gamepads_joysticks.rst
+++ b/tutorials/inputs/controllers_gamepads_joysticks.rst
@@ -333,11 +333,11 @@ or creating an issue in the `SDL repository <https://github.com/libsdl-org/SDL/i
 
 .. note::
 
-   Note that there are "generic" controllers on the market (usually their
-   ``Input.get_joy_info(device)["raw_name"]`` property contains ``"USB Gamepad"`` string),
-   and different generic controllers may use the same chipset, but they would have a different button placement,
-   so creating a mapping for one of those controllers will most likely conflict with other ones,
-   because the engine has no way of differentiating between controllers with the same chipset.
+    Note that there are "generic" controllers on the market (usually their
+    ``Input.get_joy_info(device)["raw_name"]`` property contains ``"USB Gamepad"`` string),
+    and different generic controllers may use the same chipset, but they would have a different button placement,
+    so creating a mapping for one of those controllers will most likely conflict with other ones,
+    because the engine has no way of differentiating between controllers with the same chipset.
 
 My controller works on a given platform, but not on another platform.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tutorials/inputs/controllers_gamepads_joysticks.rst
+++ b/tutorials/inputs/controllers_gamepads_joysticks.rst
@@ -283,8 +283,19 @@ the SDL game controller database used by Godot or the
 `Godot game controller database <https://github.com/godotengine/godot/blob/master/core/input/godotcontrollerdb.txt>`__.
 In this case, you will need to create a custom mapping for your controller.
 
-There are many ways to create mappings. One option is to use the mapping wizard
-in the `official Joypads demo <https://godotengine.org/asset-library/asset/2785>`__.
+.. Nintorch: Currently Godot's Input.add_joy_mapping() is broken, it will add a new mapping
+   on top of an already existing mapping from SDL (if it exists), so I'm not sure it
+   should be used as an example at the moment. See GH-118606 in Godot's main repository
+   for more information.
+
+   One option is to use the mapping wizard
+   in the `official Joypads demo <https://godotengine.org/asset-library/asset/2785>`__.
+
+There are many ways to create mappings.
+One option is to start Steam in Big Picture mode, configure the controller and then look in ``config/config.vdf``
+in the Steam installation directory for the ``SDL_GamepadBind`` entry.
+Another option is to use `SDL's testcontroller application <https://www.libsdl.org/tmp/testcontroller.zip>`__
+(the link only provides a Windows executable).
 Once you have a working mapping for your controller, you can test it by defining
 the ``SDL_GAMECONTROLLERCONFIG`` environment variable before running Godot:
 
@@ -304,14 +315,29 @@ the ``SDL_GAMECONTROLLERCONFIG`` environment variable before running Godot:
     $env:SDL_GAMECONTROLLERCONFIG="your:mapping:here"
     path\to\godot.exe
 
-To test mappings on non-desktop platforms or to distribute your project with
-additional controller mappings, you can add them by calling
-:ref:`Input.add_joy_mapping() <class_Input_method_add_joy_mapping>`
-as early as possible in a script's ``_ready()`` function.
+.. Nintorch: See the comment above on why this is commented out.
+   To test mappings on non-desktop platforms or to distribute your project with
+   additional controller mappings, you can add them by calling
+   :ref:`Input.add_joy_mapping() <class_Input_method_add_joy_mapping>`
+   as early as possible in a script's ``_ready()`` function.
 
 Once you are satisfied with the custom mapping, you can contribute it for
 the next Godot version by opening a pull request on the
-`Godot game controller database <https://github.com/godotengine/godot/blob/master/core/input/godotcontrollerdb.txt>`__.
+`Godot game controller database <https://github.com/godotengine/godot/blob/master/core/input/godotcontrollerdb.txt>`__,
+or creating an issue in the `Godot repository <https://github.com/godotengine/godot/issues>`__.
+
+Since Godot uses SDL 3 for controller input, please consider contributing
+the mapping for the SDL library as well by opening a pull request on the
+`official SDL gamepad database <https://github.com/libsdl-org/SDL/blob/main/src/joystick/SDL_gamepad_db.h>`__,
+or creating an issue in the `SDL repository <https://github.com/libsdl-org/SDL/issues>`__.
+
+.. note::
+
+   Note that there are "generic" controllers on the market (usually their
+   ``Input.get_joy_info(device)["raw_name"]`` property contains ``"USB Gamepad"`` string),
+   and different generic controllers may use the same chipset, but they would have a different button placement,
+   so creating a mapping for one of those controllers will most likely conflict with other ones,
+   because the engine has no way of differentiating between controllers with the same chipset.
 
 My controller works on a given platform, but not on another platform.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Currently (more specifically, since Godot 4.5 when we integrated SDL) Godot's `Input.add_joy_mapping()` is broken, it will add a new mapping on top of an already existing mapping from SDL (if it exists), so I'm not sure it should be used as an example at the moment. See https://github.com/godotengine/godot/pull/118606 for more information.
If the mapping doesn't exist, then it (hopefully) should work fine since that way the mapping process is basically the same as before Godot 4.5: raw data from the OS passes to SDL, SDL passes it (hopefully?) without modification to Godot, Godot uses its own mapping system. I haven't tested this possibility yet though.

This PR also adds 2 new methods to create a new mapping that were originally described in the official SDL gamepad database file. The link for the testcontroller application was taken from [here](https://github.com/libsdl-org/SDL/issues/9265#issuecomment-2002565224).

This PR also suggests the users to contribute their mappings (that were created with the methods described by the SDL developers) to the SDL repository.

After https://github.com/godotengine/godot/pull/118606 is merged, we should be able to restore the references to `Input.add_joy_mapping()` on this page.