### PR TITLE
Add physics interpolation warning to class ref method reparent

### DIFF
--- a/classes/class_node.rst
+++ b/classes/class_node.rst
@@ -2904,11 +2904,11 @@ Removes the node from the given ``group``. Does nothing if the node is not in th
 
 |void| **reparent**\ (\ new_parent\: :ref:`Node<class_Node>`, keep_global_transform\: :ref:`bool<class_bool>` = true\ ) :ref:`🔗<class_Node_method_reparent>`
 
-Changes the parent of this **Node** to the ``new_parent``. The node needs to already have a parent. The node's :ref:`owner<class_Node_property_owner>` is preserved if its owner is still reachable from the new location (i.e., the node is still a descendant of the new parent after the operation).
+Changes this **Node**'s parent to ``new_parent``. The node must already have a parent. The node's :ref:`owner<class_Node_property_owner>` is preserved if it remains reachable from the new location (that is, if the node is still a descendant of the new parent after the operation).
 
-If ``keep_global_transform`` is ``true``, the node's global transform will be preserved if supported. :ref:`Node2D<class_Node2D>`, :ref:`Node3D<class_Node3D>` and :ref:`Control<class_Control>` support this argument (but :ref:`Control<class_Control>` keeps only position).
+If ``keep_global_transform`` is ``true``, the node's global transform will be preserved if supported. :ref:`Node2D<class_Node2D>`, :ref:`Node3D<class_Node3D>` and :ref:`Control<class_Control>` support this argument, but :ref:`Control<class_Control>` preserves only its position.
 
-\ **Warning:** If you're using :ref:`ProjectSettings.physics/common/physics_interpolation<class_ProjectSettings_property_physics/common/physics_interpolation>` and the result of the reparenting is a radically different global transform, this can result in a visible glitch as the object is rendered moving from the old to new position over the physics tick. To prevent that glitch, call :ref:`reset_physics_interpolation()<class_Node_method_reset_physics_interpolation>` after reparenting.
+\ **Warning:** If :ref:`ProjectSettings.physics/common/physics_interpolation<class_ProjectSettings_property_physics/common/physics_interpolation>` is enabled and reparenting causes a large change in global transform, the object may appear to move from its old position to its new one over the next physics tick. To avoid this, call :ref:`reset_physics_interpolation()<class_Node_method_reset_physics_interpolation>` after reparenting.
 
 .. rst-class:: classref-item-separator
 

--- a/classes/class_node.rst
+++ b/classes/class_node.rst
@@ -2908,6 +2908,8 @@ Changes the parent of this **Node** to the ``new_parent``. The node needs to alr
 
 If ``keep_global_transform`` is ``true``, the node's global transform will be preserved if supported. :ref:`Node2D<class_Node2D>`, :ref:`Node3D<class_Node3D>` and :ref:`Control<class_Control>` support this argument (but :ref:`Control<class_Control>` keeps only position).
 
+\ **Warning:** If you're using :ref:`ProjectSettings.physics/common/physics_interpolation<class_ProjectSettings_property_physics/common/physics_interpolation>` and the result of the reparenting is a radically different global transform, this can result in a visible glitch as the object is rendered moving from the old to new position over the physics tick. To prevent that glitch, call :ref:`reset_physics_interpolation()<class_Node_method_reset_physics_interpolation>` after reparenting.
+
 .. rst-class:: classref-item-separator
 
 ----


### PR DESCRIPTION
I noticed that the `reparent()` method can cause visible artifacts when physics interpolation is enabled and the node is moved to a very different transform.

This adds a warning to the method reference so users are reminded to call `reset_physics_interpolation()` after reparenting when appropriate.