### PR TITLE
Fix logo license link in Frequently asked questions

### DIFF
--- a/about/faq.rst
+++ b/about/faq.rst
@@ -31,7 +31,7 @@ different licenses.
 
 For full details, look at the `COPYRIGHT.txt <https://github.com/godotengine/godot/blob/master/COPYRIGHT.txt>`_
 as well as the `LICENSE.txt <https://github.com/godotengine/godot/blob/master/LICENSE.txt>`_
-and `LOGO_LICENSE.txt <https://github.com/godotengine/godot/blob/master/LOGO_LICENSE.txt>`_ files
+and `logo LICENSE.txt <https://github.com/godotengine/godot/blob/master/misc/logo/LICENSE.txt>`_ files
 in the Godot repository.
 
 Also, see `the license page on the Godot website <https://godotengine.org/license>`_.


### PR DESCRIPTION
* Follow-up to https://github.com/godotengine/godot-website/pull/1322.

