### PR TITLE
clarify that debugger/profiler_target_fps editor setting controls target frametime value.

### DIFF
--- a/tutorials/scripting/debug/debugger_panel.rst
+++ b/tutorials/scripting/debug/debugger_panel.rst
@@ -164,8 +164,8 @@ specific frame number and highlight the selected data type in the result
 categories on the left.
 
 You can switch the result display between a time value (in milliseconds per
-frame) or a percentage of the target frametime. ``debugger/profiler_target_fps``
-editor setting controls target frametime value (clamped between 1 and 1000
+frame) or a percentage of the target frametime. The :ref:`debugger/profiler_target_fps <class_EditorSettings_property_debugger/profiler_target_fps>`
+editor setting controls the target frametime value (clamped between 1 and 1000
 FPS).
 
 If framerate spikes occur during profiling, this can cause the graph to be

--- a/tutorials/scripting/debug/debugger_panel.rst
+++ b/tutorials/scripting/debug/debugger_panel.rst
@@ -164,9 +164,9 @@ specific frame number and highlight the selected data type in the result
 categories on the left.
 
 You can switch the result display between a time value (in milliseconds per
-frame) or a percentage of the target frametime. The :ref:`debugger/profiler_target_fps <class_EditorSettings_property_debugger/profiler_target_fps>`
-editor setting controls the target frametime value (clamped between 1 and 1000
-FPS).
+frame) or a percentage of the target frametime. The
+:ref:`debugger/profiler_target_fps <class_EditorSettings_property_debugger/profiler_target_fps>`
+editor setting controls the target frametime value according to the specified FPS.
 
 If framerate spikes occur during profiling, this can cause the graph to be
 poorly scaled. Disable **Fit to Frame** so that the graph will zoom onto the 60

--- a/tutorials/scripting/debug/debugger_panel.rst
+++ b/tutorials/scripting/debug/debugger_panel.rst
@@ -164,8 +164,9 @@ specific frame number and highlight the selected data type in the result
 categories on the left.
 
 You can switch the result display between a time value (in milliseconds per
-frame) or a percentage of the target frametime (which is currently hardcoded to
-16.67 milliseconds, or 60 FPS).
+frame) or a percentage of the target frametime. ``debugger/profiler_target_fps``
+editor setting controls target frametime value (clamped between 1 and 1000
+FPS).
 
 If framerate spikes occur during profiling, this can cause the graph to be
 poorly scaled. Disable **Fit to Frame** so that the graph will zoom onto the 60


### PR DESCRIPTION
Fixes #11908 

The current statement in the documentation is wrong. Updated it according to the current reality. 

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
