### PR TITLE
fix @icon example in "Making plugins"

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -210,7 +210,7 @@ That's it for our basic button. You can save this as ``my_button.gd`` inside the
 plugin folder. You may have a 16×16 icon to show in the scene tree. If you
 don't have one, you can grab the default one from the engine and save it in your
 `addons/my_custom_node` folder as `icon.svg`, or use the default Godot logo
-(`preload("res://icon.svg")`).
+(`@icon("res://icon.svg")`).
 
 .. tip::
 


### PR DESCRIPTION
preload returns a resource which is not possible for @icon. The change shows the exact line that has to be used to make it work.
