### PR TITLE
Add top-down 2D shooter proof-of-concept game

### DIFF
--- a/game/project.godot
+++ b/game/project.godot
@@ -1,0 +1,43 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the properties have a precise format.
+config_version=5
+
+[application]
+
+config/name="TopDown Shooter POC"
+run/main_scene="res://scenes/main.tscn"
+config/features=PackedStringArray("4.2", "Forward Plus")
+
+[display]
+
+window/size/viewport_width=800
+window/size/viewport_height=600
+
+[input]
+
+move_up={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"echo":false,"script":null)
+]
+}
+move_down={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"echo":false,"script":null)
+]
+}
+move_left={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"echo":false,"script":null)
+]
+}
+move_right={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"echo":false,"script":null)
+]
+}
+shoot={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"echo":false,"script":null)
+]
+}

--- a/game/scenes/bullet.tscn
+++ b/game/scenes/bullet.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=3 format=3 uid="uid://bullet001"]
+
+[ext_resource type="Script" path="res://scripts/bullet.gd" id="1_bullet"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_bullet"]
+size = Vector2(16, 6)
+
+[node name="Bullet" type="Area2D"]
+script = ExtResource("1_bullet")
+
+[node name="Body" type="Polygon2D" parent="."]
+polygon = PackedVector2Array(-8, -3, 8, -3, 8, 3, -8, 3)
+color = Color(1, 0.5, 0.1, 1)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("RectangleShape2D_bullet")

--- a/game/scenes/enemy.tscn
+++ b/game/scenes/enemy.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=3 format=3 uid="uid://enemy001"]
+
+[ext_resource type="Script" path="res://scripts/enemy.gd" id="1_enemy"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_enemy"]
+size = Vector2(32, 32)
+
+[node name="Enemy" type="Area2D"]
+script = ExtResource("1_enemy")
+
+[node name="Body" type="Polygon2D" parent="."]
+polygon = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+color = Color(0.85, 0.1, 0.1, 1)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("RectangleShape2D_enemy")

--- a/game/scenes/main.tscn
+++ b/game/scenes/main.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=3 format=3 uid="uid://main001"]
+
+[ext_resource type="Script" path="res://scripts/main.gd" id="1_main"]
+[ext_resource type="PackedScene" uid="uid://player001" path="res://scenes/player.tscn" id="2_player"]
+
+[node name="Main" type="Node2D"]
+script = ExtResource("1_main")
+
+[node name="Player" parent="." instance=ExtResource("2_player")]
+position = Vector2(400, 300)

--- a/game/scenes/player.tscn
+++ b/game/scenes/player.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=3 format=3 uid="uid://player001"]
+
+[ext_resource type="Script" path="res://scripts/player.gd" id="1_player"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_player"]
+size = Vector2(32, 32)
+
+[node name="Player" type="CharacterBody2D"]
+script = ExtResource("1_player")
+
+[node name="Body" type="Polygon2D" parent="."]
+polygon = PackedVector2Array(-16, -16, 16, -16, 16, 16, -16, 16)
+color = Color(0.1, 0.3, 1, 1)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("RectangleShape2D_player")

--- a/game/scripts/bullet.gd
+++ b/game/scripts/bullet.gd
@@ -1,0 +1,30 @@
+extends Area2D
+
+# Docs ref: tutorials/scripting/instancing_with_signals.rst - bullet pattern
+# Docs ref: tutorials/physics/using_area_2d.rst - body_entered / area_entered signals
+
+const SPEED = 600.0
+const ROOM_BOUNDS = Rect2(0, 0, 800, 600)
+
+var velocity: Vector2 = Vector2.ZERO
+
+func setup(direction: Vector2) -> void:
+	velocity = direction * SPEED
+	rotation = direction.angle()
+
+func _ready() -> void:
+	body_entered.connect(_on_body_entered)
+	area_entered.connect(_on_area_entered)
+
+func _physics_process(delta: float) -> void:
+	position += velocity * delta
+	if not ROOM_BOUNDS.has_point(position):
+		queue_free()
+
+func _on_body_entered(_body: Node2D) -> void:
+	queue_free()
+
+func _on_area_entered(area: Area2D) -> void:
+	if area.is_in_group("enemies"):
+		area.queue_free()
+	queue_free()

--- a/game/scripts/enemy.gd
+++ b/game/scripts/enemy.gd
@@ -1,0 +1,4 @@
+extends Area2D
+
+func _ready() -> void:
+	add_to_group("enemies")

--- a/game/scripts/main.gd
+++ b/game/scripts/main.gd
@@ -1,0 +1,63 @@
+extends Node2D
+
+# Docs ref: tutorials/scripting/instancing_with_signals.rst - spawning bullets via signal
+# Docs ref: tutorials/physics/physics_introduction.rst - StaticBody2D for walls
+
+const ROOM_W = 800
+const ROOM_H = 600
+const WALL_T = 20
+
+@onready var player: CharacterBody2D = $Player
+
+var _bullet_scene: PackedScene = preload("res://scenes/bullet.tscn")
+var _enemy_scene: PackedScene = preload("res://scenes/enemy.tscn")
+
+func _ready() -> void:
+	player.shoot.connect(_on_player_shoot)
+	_create_walls()
+	_spawn_enemies()
+
+func _on_player_shoot(direction: Vector2, from_pos: Vector2) -> void:
+	var bullet = _bullet_scene.instantiate()
+	add_child(bullet)
+	bullet.global_position = from_pos
+	bullet.setup(direction)
+
+func _create_walls() -> void:
+	# top, bottom, left, right
+	_make_wall(ROOM_W / 2.0, WALL_T / 2.0,          ROOM_W,  WALL_T)
+	_make_wall(ROOM_W / 2.0, ROOM_H - WALL_T / 2.0, ROOM_W,  WALL_T)
+	_make_wall(WALL_T / 2.0, ROOM_H / 2.0,          WALL_T,  ROOM_H)
+	_make_wall(ROOM_W - WALL_T / 2.0, ROOM_H / 2.0, WALL_T,  ROOM_H)
+
+func _make_wall(cx: float, cy: float, w: float, h: float) -> void:
+	var wall := StaticBody2D.new()
+	add_child(wall)
+	wall.global_position = Vector2(cx, cy)
+
+	var col := CollisionShape2D.new()
+	var shape := RectangleShape2D.new()
+	shape.size = Vector2(w, h)
+	col.shape = shape
+	wall.add_child(col)
+
+	var vis := Polygon2D.new()
+	var hw := w / 2.0
+	var hh := h / 2.0
+	vis.polygon = PackedVector2Array([
+		Vector2(-hw, -hh), Vector2(hw, -hh),
+		Vector2(hw,  hh),  Vector2(-hw, hh)
+	])
+	vis.color = Color(0.45, 0.45, 0.45)
+	wall.add_child(vis)
+
+func _spawn_enemies() -> void:
+	var positions := [
+		Vector2(200, 150), Vector2(400, 150), Vector2(600, 150),
+		Vector2(150, 350), Vector2(650, 350),
+		Vector2(300, 450), Vector2(500, 450),
+	]
+	for pos in positions:
+		var enemy = _enemy_scene.instantiate()
+		add_child(enemy)
+		enemy.global_position = pos

--- a/game/scripts/player.gd
+++ b/game/scripts/player.gd
@@ -1,0 +1,19 @@
+extends CharacterBody2D
+
+# Docs ref: tutorials/2d/2d_movement.rst - 8-way movement pattern
+# Docs ref: tutorials/inputs/input_examples.rst - event vs polling input
+
+const SPEED = 300.0
+
+signal shoot(direction: Vector2, from_position: Vector2)
+
+func _physics_process(_delta: float) -> void:
+	var input_dir = Input.get_vector("move_left", "move_right", "move_up", "move_down")
+	velocity = input_dir * SPEED
+	move_and_slide()
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("shoot"):
+		var mouse_pos = get_global_mouse_position()
+		var direction = (mouse_pos - global_position).normalized()
+		shoot.emit(direction, global_position)


### PR DESCRIPTION
Demonstrates building a Godot 4 game from the docs in this repo. Patterns sourced from: tutorials/2d/2d_movement.rst (8-way WASD), tutorials/scripting/instancing_with_signals.rst (bullet spawning), tutorials/physics/using_area_2d.rst (hit detection), and tutorials/inputs/input_examples.rst (keyboard/mouse input).

Game features:
- Blue square player moves with WASD, aims at mouse cursor
- Spacebar fires orange rectangle bullets toward the cursor
- 7 red square enemies destroyed on bullet contact
- 4 gray walls bounding the play area
- Walls and enemies created programmatically in main.gd

https://claude.ai/code/session_0148izPqrvhTZqnnYZZ3hP2W

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
