### PR TITLE
Fix variable declaration for sprite2d in _ready()

### DIFF
--- a/tutorials/scripting/nodes_and_scene_instances.rst
+++ b/tutorials/scripting/nodes_and_scene_instances.rst
@@ -132,7 +132,7 @@ script.
     var sprite2d
 
     func _ready():
-        var sprite2d = Sprite2D.new() # Create a new Sprite2D.
+        sprite2d = Sprite2D.new() # Create a new Sprite2D.
         add_child(sprite2d) # Add it as a child of this node.
 
  .. code-tab:: csharp


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
