### PR TITLE
Adding a sample mesh so demo code works 'out of the box'.

### DIFF
--- a/tutorials/performance/using_multimesh.rst
+++ b/tutorials/performance/using_multimesh.rst
@@ -62,6 +62,8 @@ efficient for millions of objects, but for a few thousands, GDScript should be f
         multimesh = MultiMesh.new()
         # Set the format first.
         multimesh.transform_format = MultiMesh.TRANSFORM_3D
+        # Set the mesh that will be duplicated
+        multimesh.mesh = BoxMesh.new()
         # Then resize (otherwise, changing the format is not allowed).
         multimesh.instance_count = 10000
         # Maybe not all of them should be visible at first.

--- a/tutorials/performance/using_multimesh.rst
+++ b/tutorials/performance/using_multimesh.rst
@@ -62,7 +62,7 @@ efficient for millions of objects, but for a few thousands, GDScript should be f
         multimesh = MultiMesh.new()
         # Set the format first.
         multimesh.transform_format = MultiMesh.TRANSFORM_3D
-        # Set the mesh that will be duplicated
+        # Set the mesh that will be duplicated.
         multimesh.mesh = BoxMesh.new()
         # Then resize (otherwise, changing the format is not allowed).
         multimesh.instance_count = 10000


### PR DESCRIPTION
If the gdscript example is put into a scene as is and executed it throws the error "_multimesh_re_create_aabb: Condition "multimesh->mesh.is_null()" is true." 

This patch adds a boxmesh as a placeholder. Tested and working in 4.6.2stable.

Not a hard bug to track down as-is, but it caused me to scratch my head for a minute when I started messing with multimesh so I thought it might be useful.

