### PR TITLE
clarification attempt

### DIFF
--- a/tutorials/scripting/change_scenes_manually.rst
+++ b/tutorials/scripting/change_scenes_manually.rst
@@ -74,7 +74,7 @@ access and integrity.
 2. **Hide the existing scene.** By changing the visibility or collision
    detection of the nodes, you can hide the entire node sub-tree from the
    player's perspective. Use
-   :ref:`CanvasItem.hide() <class_CanvasItem_method_hide>` to hide a scene and
+   :ref:`CanvasItem.hide() <class_CanvasItem_method_hide>` to hide a scene (does not alter collision detection) and
    :ref:`CanvasItem.show() <class_CanvasItem_method_show>` to show it again.
 
     - Memory still exists.
@@ -83,7 +83,7 @@ access and integrity.
 
         - Pro: There's no need to move any more nodes around to save data.
 
-        - Con: More data is being kept in memory, which will be become a problem
+        - Con: More data is being kept in memory, which will become a problem
           on memory-sensitive platforms like web or mobile.
 
     - Processing continues.
@@ -122,16 +122,16 @@ access and integrity.
 
 There are also cases where you may wish to have many scenes present at the same
 time, such as adding your own singleton at runtime, or preserving
-a scene's data between scene changes (adding the scene to the root node).
+a scene's data between scene changes (adding the scene's data to the root node).
 
 .. tabs::
  .. code-tab:: gdscript GDScript
 
-        get_tree().root.add_child(scene)
+        get_tree().root.add_child(scene_data)
 
  .. code-tab:: csharp
 
-        GetTree().Root.AddChild(scene);
+        GetTree().Root.AddChild(scene_data);
 
 Another case may be displaying multiple scenes at the same time using
 :ref:`SubViewportContainers <class_SubViewportContainer>`. This is optimal for


### PR DESCRIPTION
## Note on my changes

Line 74 leads the reader to expect collision detection to be relevant at line 77.

Line 125 "adding the scene to the root node" felt confusing since the scene is supposedly already in the root node.

---

## Unrelated note: a beginner's perspective

- The [end of the 3D game tutorial](https://docs.godotengine.org/en/stable/getting_started/first_3d_game/going_further.html) directed me to read the "Core features" chapter containing this "Change scenes manually" page
- but this "Change scenes manually" page felt like it requires much deeper knowledge of how Godot works than I had
- I just spent a long time with an LLM especially to understand what the page means by "current scene" (e.g. in the first paragraph of the page), and I think I get the page now, but there probably should be a link to a page of the doc detailing the notion of "current scene"
- I synthesized the LLM's explanations below: you may consider checking and adding some of it to a relevant page of the doc.

---

## Explanations of LLM related to the page

### 1. What is the "Current Scene" (`current_scene`)?

In Godot, the **SceneTree** has a specific property called `current_scene`. It is not "the first child of root" picked arbitrarily — it is an **internal variable** that points to a precise node.

* When you define a "Main Scene" in your project settings, Godot loads it at startup, adds it as a child of `root`, and stores its reference in the `current_scene` variable.
* When you call `change_scene_to_file("Level2.tscn")`, Godot does exactly the following:
  1. It looks up which node is stored in `get_tree().current_scene`.
  2. It calls `free()` on that node (destroying it along with all its children).
  3. It loads the new file.
  4. It adds it as a child of `root`.
  5. **It updates the `current_scene` variable so it points to this new node.**

---

### 2. How does `root` manage its children?

`root` is a node like any other — it can have 10 or 20 children at the same time. But from Godot's perspective, not all of them have the same status:

* **The "Special" child:** The one pointed to by `current_scene`. It is the only one Godot will automatically remove during a scene change.
* **The "Protected" children:** All other nodes that **you** have manually added to `root` via `add_child()`, or **Autoloads** (Singletons). Godot will never touch these during a `change_scene_to_file` call.

---

### Effects of assigning the `current_scene` variable

Regarding the assignment of `current_scene` (`get_tree().current_scene = new_node`), here are the concrete effects:

#### 1. The target of the next cleanup

The most important effect is telling Godot **which node should be discarded** on the next call to `change_scene_to_file()` or `change_scene_to_packed()`.

* Godot does not try to figure out which level is "logically" the right one. It simply looks at the node stored in this variable and calls `free()` on it.

#### 2. The anchor point for reloading

When you call `get_tree().reload_current_scene()`, Godot uses the file path of the node stored in `current_scene` to reload the level. If `current_scene` points to the wrong node, you will reload the wrong part of your game.

#### 3. No effect on the hierarchy (Gotcha!)

This is the most counter-intuitive point: **assigning `current_scene` does not move the node within the scene tree.**

* If you create a node and do `get_tree().current_scene = my_node` but forget to call `get_tree().root.add_child(my_node)`, your node is still an orphan.
* Conversely, adding a node to `root` does not automatically assign it to `current_scene`.

#### 4. The order of operations (The clean manual approach)

If you change scenes manually, you must follow this exact order to keep everything consistent:

```gdscript
# 1. Load and instantiate the new level
var new_level = load("res://Level2.tscn").instantiate()

# 2. Add it to the scene tree (under root)
get_tree().root.add_child(new_level)

# 3. Delete the old level (the current one)
get_tree().current_scene.queue_free()

# 4. Update the variable for future scene changes
get_tree().current_scene = new_level
```
