### PR TITLE
docs: fix duplicated words in shader tutorial docs

### DIFF
--- a/tutorials/shaders/shader_reference/shader_functions.rst
+++ b/tutorials/shaders/shader_reference/shader_functions.rst
@@ -643,7 +643,7 @@ Exponential and math function descriptions
 
     |componentwise|
 
-    Raises ``e`` to the power of ``x``, or the the natural exponentiation.
+    Raises ``e`` to the power of ``x``, or the natural exponentiation.
 
     Equivalent to ``pow(e, x)``.
 

--- a/tutorials/shaders/using_viewport_as_texture.rst
+++ b/tutorials/shaders/using_viewport_as_texture.rst
@@ -34,7 +34,7 @@ Create a new scene and add the following nodes exactly as shown below.
 
 .. image:: img/viewport_texture_node_tree.webp
 
-Go into the the MeshInstance3D and make the mesh a SphereMesh
+Go into the MeshInstance3D and make the mesh a SphereMesh
 
 Setting up the SubViewport
 --------------------------


### PR DESCRIPTION
Two one-line typo fixes for duplicated words in shader docs:
- `tutorials/shaders/shader_reference/shader_functions.rst` — "or the the natural exponentiation" → "or the natural exponentiation"
- `tutorials/shaders/using_viewport_as_texture.rst` — "Go into the the MeshInstance3D" → "Go into the MeshInstance3D"

No content/structure change.