### PR TITLE
docs: fix duplicated "is" in Vector2 class and GDScript advanced notes

### DIFF
--- a/classes/class_vector2.rst
+++ b/classes/class_vector2.rst
@@ -679,7 +679,7 @@ Creates a **Vector2** rotated to the given ``angle`` in radians. This is equival
     print(Vector2(1, 0).angle()) # Prints 0.0, which is the angle used above.
     print(Vector2.from_angle(PI / 2)) # Prints (0.0, 1.0)
 
-\ **Note:** The length of the returned **Vector2** is *approximately* ``1.0``, but is is not guaranteed to be exactly ``1.0`` due to floating-point precision issues. Call :ref:`normalized()<class_Vector2_method_normalized>` on the returned **Vector2** if you require a unit vector.
+\ **Note:** The length of the returned **Vector2** is *approximately* ``1.0``, but is not guaranteed to be exactly ``1.0`` due to floating-point precision issues. Call :ref:`normalized()<class_Vector2_method_normalized>` on the returned **Vector2** if you require a unit vector.
 
 .. rst-class:: classref-item-separator
 

--- a/tutorials/scripting/gdscript/gdscript_advanced.rst
+++ b/tutorials/scripting/gdscript/gdscript_advanced.rst
@@ -462,7 +462,7 @@ It is possible but discouraged to store the state in a member variable.
 Multiple states are necessary in cases such as nested loops where the same
 iterator instance is used simultaneously. The ``iter`` parameter in 
 ``_iter_init()`` and ``_iter_next()`` is a single-element array so that updates
-can persist. Whereas in ``_iter_get()``, the state is is not wrapped because it
+can persist. Whereas in ``_iter_get()``, the state is not wrapped because it
 is supposed to be read-only.
 
 Returning ``true`` from ``_iter_init()`` and ``_iter_next()`` indicates that the


### PR DESCRIPTION
Two one-line typo fixes for duplicated "is":
- `classes/class_vector2.rst` — "but is is not guaranteed" → "but is not guaranteed"
- `tutorials/scripting/gdscript/gdscript_advanced.rst` — "the state is is not wrapped" → "the state is not wrapped"

No content/structure change.