### PR TITLE
Update signals.rst to change main scene from Sprite2D to Node_2D

### DIFF
--- a/getting_started/step_by_step/signals.rst
+++ b/getting_started/step_by_step/signals.rst
@@ -105,6 +105,7 @@ Save your newly created scene as ``node_2d.tscn``, if you haven't already.
 You can then run it with :kbd:`F6` (:kbd:`Cmd + R` on macOS).
 At the moment, the button will be visible, but nothing will happen if you
 press it.
+If you can not find the button, you may need to open Project → Project Settings → General → Application → Run → Main Scene, replace the Sprite2D.tscn with node_2d.tscn.
 
 Connecting a signal in the editor
 ---------------------------------


### PR DESCRIPTION
I followed the step by step from chapter 1 to chapter signal. But the button is not visible before title "Connecting a signal in the editor". Finally I found the main scene should be updated to show node_2d

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
