### PR TITLE
Update AnimationTree tutorial for new observer classes

### DIFF
--- a/tutorials/animation/animation_tree.rst
+++ b/tutorials/animation/animation_tree.rst
@@ -494,3 +494,26 @@ Then you can set or read them:
 
 .. note:: Advance Expressions from a StateMachine will not be found under the parameters. This is because they are held in another script rather than the
          AnimationTree itself. Advance `Conditions` will be found under parameters.
+
+Signals and Animation Node Observers
+------------------------------------
+
+Certain animation node types support an :ref:`AnimationNodeObserver <class_AnimationNodeObserver>` parameter which relays animation events through signals.
+For example, :ref:`AnimationNodeTransition <class_AnimationNodeTransition>` can be configured with an :ref:`AnimationNodeObserverTransition <class_AnimationNodeObserverTransition>`
+which emits signals when a transition state starts and finishes:
+
+.. tabs::
+ .. code-tab:: gdscript GDScript
+
+    var observer := tree.get("parameters/Transition/observer") as AnimationNodeObserverTransition
+    if observer:
+        observer.state_started.connect(on_state_started)
+        observer.state_finished.connect(on_state_finished)
+
+ .. code-tab:: csharp
+
+    if (tree.Get("parameters/Transition/observer").Obj is AnimationNodeObserverTransition observer)
+    {
+        observer.StateStarted += OnStateStarted;
+        observer.StateFinished += OnStateFinished;
+    }

--- a/tutorials/animation/animation_tree.rst
+++ b/tutorials/animation/animation_tree.rst
@@ -505,3 +505,26 @@ Then you can set or read them:
    Advance Expressions from a StateMachine will not be found under the parameters.
    This is because they are held in another script rather than the AnimationTree itself.
    Advance :ui:`Conditions` will be found under parameters.
+
+Signals and Animation Node Observers
+------------------------------------
+
+Certain animation node types support an :ref:`AnimationNodeObserver <class_AnimationNodeObserver>` parameter which relays animation events through signals.
+For example, :ref:`AnimationNodeTransition <class_AnimationNodeTransition>` can be configured with an :ref:`AnimationNodeObserverTransition <class_AnimationNodeObserverTransition>`
+which emits signals when a transition state starts and finishes:
+
+.. tabs::
+ .. code-tab:: gdscript GDScript
+
+    var observer := tree.get("parameters/Transition/observer") as AnimationNodeObserverTransition
+    if observer:
+        observer.state_started.connect(on_state_started)
+        observer.state_finished.connect(on_state_finished)
+
+ .. code-tab:: csharp
+
+    if (tree.Get("parameters/Transition/observer").Obj is AnimationNodeObserverTransition observer)
+    {
+        observer.StateStarted += OnStateStarted;
+        observer.StateFinished += OnStateFinished;
+    }


### PR DESCRIPTION
This is paired with https://github.com/godotengine/godot/pull/118789 and shouldn't be merged until after that is merged (so after 4.7 has its stable release).

I intentionally left the new section on the shorter side as I wanted it to be discoverable when searching "signal" or "event" without it being an exhaustive list of observer signals that would go out of date if new observers are added, but I can change this to be more in depth if desired.