### PR TITLE
Fix Lychee URL checking on CI

### DIFF
--- a/.github/workflows/check_urls.yml
+++ b/.github/workflows/check_urls.yml
@@ -24,13 +24,14 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: >
-            --base .
+            --root-dir .
             --no-progress
             --cache
             --max-cache-age 1d
+            --exclude-path _build/
             --exclude-path _templates/
             --exclude-path classes/
-            "**/*.md" "**/*.html" "**/*.rst"
+            "**/*.md" "**/*.rst"
 
       - name: Fail if there were link errors
         run: exit ${{ steps.lc.outputs.exit_code }}

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ tmp-unused-images-history
 
 # Jetbrains IDE files
 /.idea/
+
+# Lychee URL checking cache
+.lycheecache

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -10,18 +10,27 @@ tcp:\/\/.*
 # Security checks prevent checking the URLs of these websites automatically,
 # typically returning 403 errors.
 .*asecuritysite\.com.*
+.*computerhope\.com*
+.*developer\.arm\.com.*
+.*guru3d\.com.*
+.*inkscape\.org.*
 .*intel\.com.*
+.*itch\.io.*
+.*khronos\.org.*
+.*medium\.com.*
 .*reddit\.com.*
-.*inkscape.org.*
-.*computerhope.com*
+.*shadertoy\.com.*
 
 # Don't check URLs from these websites due to frequent rate limits (error 429) or timeouts.
 .*adobe\.com.*
+.*developer\.apple\.com.*
+.*flathub\.org.*
 .*gamedevartisan\.com.*
 .*github\.com.*
 .*gnu\.org.*
 .*loopit\.dk.*
 .*meta\.com.*
+.*nightly\.link.*
 .*sourceforge\.io.*
 
 # Not a valid URL with the GET method, which lychee always sends.

--- a/engine_details/architecture/core_types.rst
+++ b/engine_details/architecture/core_types.rst
@@ -117,7 +117,7 @@ scripting API.
 |                       |                          | otherwise.                                                                            |
 +-----------------------+--------------------------+---------------------------------------------------------------------------------------+
 | |rb_map|              | ``std::map``             | Map type that uses a                                                                  |
-|                       |                          | `red-black tree <https://en.wikipedia.org/wiki/Red-black-tree>`__ to find keys.       |
+|                       |                          | `red-black tree <https://en.wikipedia.org/wiki/Red-black_tree>`__ to find keys.       |
 |                       |                          | The performance benefits of ``RBMap`` aren't established, so prefer using other types.|
 +-----------------------+--------------------------+---------------------------------------------------------------------------------------+
 | |dictionary| 📜       | ``std::unordered_map``   | Keys and values can be of any Variant type. No static typing is imposed.              |

--- a/engine_details/engine_api/custom_modules_in_cpp.rst
+++ b/engine_details/engine_api/custom_modules_in_cpp.rst
@@ -466,7 +466,7 @@ Now if you go to the ``godot/modules/summator/doc_classes`` folder, you will see
 that it contains a ``Summator.xml`` file, or any other classes, that you referenced
 in your ``get_doc_classes`` function.
 
-Edit the file(s) following the `class reference primer <https://contributing.godotengine.org/en/latest/documentation/class_reference/class_reference_primer.html>`__ and recompile the engine.
+Edit the file(s) following the `class reference primer <https://docs.godotengine.org/en/latest/engine_details/class_reference/index.html>`__ and recompile the engine.
 
 Once the compilation process is finished, the docs will become accessible within
 the engine's built-in documentation system.

--- a/tutorials/animation/creating_movies.rst
+++ b/tutorials/animation/creating_movies.rst
@@ -482,7 +482,7 @@ only 5.2 seconds of video after that point:
     ffmpeg -i input.avi -ss 00:00:12.10 -t 00:00:05.20 -crf 15 output.mp4
 
 Cutting videos can also be done with the GUI tool
-`LosslessCut <https://mifi.github.io/lossless-cut/>`__.
+`LosslessCut <https://losslesscut.app/>`__.
 
 Resizing video
 ~~~~~~~~~~~~~~

--- a/tutorials/animation/playing_videos.rst
+++ b/tutorials/animation/playing_videos.rst
@@ -208,9 +208,9 @@ below with almost any input video format (AVI, MOV, WebM, …).
 .. this warning can be removed. That will likely be FFmpeg 7.2 or 8.0, and will
 .. likely happen during the Godot 4.5 or 4.6 release cycle.
 .. Commits fixing the issues:
-.. - https://github.org/FFmpeg/FFmpeg@22aa71d4da37a4ad2b0d28deeace64b57aa2ef50
-.. - https://github.org/FFmpeg/FFmpeg@84d85e7ad4ace228265af0c8c5caccc0730042fd
-.. - https://github.org/FFmpeg/FFmpeg@6e26f57f672b05e7b8b052007a83aef99dc81ccb
+.. - https://github.com/FFmpeg/FFmpeg/commit/22aa71d4da37a4ad2b0d28deeace64b57aa2ef50
+.. - https://github.com/FFmpeg/FFmpeg/commit/84d85e7ad4ace228265af0c8c5caccc0730042fd
+.. - https://github.com/FFmpeg/FFmpeg/commit/6e26f57f672b05e7b8b052007a83aef99dc81ccb
 
 Balancing quality and file size
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -103,7 +103,7 @@ Launcher icons are used by Android launcher apps to represent your application t
 There are three types of icons:
 
 - **Main Icon:** The "classic" icon. This will be used on all Android versions up to Android 8 (Oreo), exclusive. Must be at least 192×192 px.
-- **Adaptive Icons:** Starting from Android 8 (inclusive), `Adaptive Icons <https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive>`_ were introduced. Applications will need to include separate background and foreground icons to have a native look. The user's launcher application will control the icon's animation and masking. Must be at least 432×432 px.
+- **Adaptive Icons:** Starting from Android 8 (inclusive), `Adaptive Icons <https://developer.android.com/develop/ui/compose/system/icon_design_adaptive>`_ were introduced. Applications will need to include separate background and foreground icons to have a native look. The user's launcher application will control the icon's animation and masking. Must be at least 432×432 px.
 - **Themed Icons (optional):** Starting from Android 13 (inclusive), Themed Icons were introduced. Applications will need to include a monochrome icon to enable this feature. The user's launcher application will control the icon's theme. Must be at least 432×432 px.
 
 .. seealso:: It's important to adhere to some rules when designing adaptive icons. `Google Design has provided a nice article <https://medium.com/google-design/designing-adaptive-icons-515af294c783>`_ that helps to understand those rules and some of the capabilities of adaptive icons.


### PR DESCRIPTION
This also adds the cache file to `.gitignore` in case you run Lychee locally with the same options as CI.

There is still one error I'm trying to fix:

```
Issues found in 1 input. Find details below.

[engine_details/architecture/object_class.rst]:
 [ERROR] error: (at 397:3) | Cannot parse 'res://someresource.res::1' into a URL: invalid port number
```

Adding `res://someresource.res::1` to `.lycheeignore` or passing `--exclude res://someresource.res::1` didn't help.
