### PR TITLE
Clarify statement about pooling

### DIFF
--- a/getting_started/first_3d_game/04.mob_scene.rst
+++ b/getting_started/first_3d_game/04.mob_scene.rst
@@ -70,7 +70,7 @@ Godot has a node that detects when objects leave the screen,
     called pooling. It consists of pre-creating an array of objects and reusing
     them over and over.
 
-    When working with GDScript, you don't need to worry about this. The main
+    When working with GDScript, this usually isn't needed. The main
     reason to use pools is to avoid freezes with garbage-collected languages
     like C# or Lua. GDScript uses a different technique to manage memory,
     reference counting, which doesn't have that caveat. You can learn more


### PR DESCRIPTION
Small change for the note about pooling seen [here](https://docs.godotengine.org/en/stable/getting_started/first_3d_game/04.mob_scene.html#removing-monsters-off-screen)

Right after the explanation of what pooling is, the current text says "When working with GDScript, you don't need to worry about this." To me this doesn't leave room for acknowledging any reason to use pooling other than avoiding freezes in GC languages.

You could argue that the current text is correct because it says "you don't **_need_** to", which leaves room for cases where the developer **_wants_** to use pooling. But if a game's performance is bottlenecked on instantiating and destroying lots of the same type of object, then pooling may actually become a **_need_**. Happy to have this rejected if pooling is truly useless in GDScript