### PR TITLE
Add keyboard shortcut for grouping on macOS on first 2d game creating the enemy page

### DIFF
--- a/getting_started/first_2d_game/04.creating_the_enemy.rst
+++ b/getting_started/first_2d_game/04.creating_the_enemy.rst
@@ -24,7 +24,7 @@ Click Scene -> New Scene from the top menu and add the following nodes:
 Don't forget to set the children so they can't be selected, like you did with
 the Player scene. This is done by selecting the parent node (``RigidBody2D``) in the
 Scene tree dock, then using the :button:`Group` button at the top of the 2D editor
-(or pressing :kbd:`Ctrl + G`).
+(pressing :kbd:`Ctrl + G` on Windows/Linux or :kbd:`Cmd + G` on macOS).
 
 Select the ``Mob`` node and set its ``Gravity Scale``
 property in the :ref:`RigidBody2D <class_RigidBody2D>`

--- a/getting_started/first_2d_game/04.creating_the_enemy.rst
+++ b/getting_started/first_2d_game/04.creating_the_enemy.rst
@@ -24,7 +24,7 @@ Click Scene -> New Scene from the top menu and add the following nodes:
 Don't forget to set the children so they can't be selected, like you did with
 the Player scene. This is done by selecting the parent node (``RigidBody2D``) in the
 Scene tree dock, then using the :button:`Group` button at the top of the 2D editor
-(pressing :kbd:`Ctrl + G` on Windows/Linux or :kbd:`Cmd + G` on macOS).
+(:kbd:`Ctrl + G` or :kbd:`Cmd + G` on macOS).
 
 Select the ``Mob`` node and set its ``Gravity Scale``
 property in the :ref:`RigidBody2D <class_RigidBody2D>`


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->

This change adds the macOS keyboard shortcut for grouping to the first 2d game's creating and enemy page.
