### PR TITLE
Document valid values for --rendering-method

### DIFF
--- a/tutorials/editor/command_line_tutorial.rst
+++ b/tutorials/editor/command_line_tutorial.rst
@@ -106,7 +106,7 @@ given build type.
 | ``--audio-output-latency <ms>``          | |release| Override audio output latency in milliseconds (default is 15 ms). Lower values make sound playback more reactive but increase CPU usage, and may   |
 |                                          | result in audio cracking if the CPU can't keep up.                                                                                                           |
 +------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| ``--rendering-method <renderer>``        | |release| Renderer name. Valid values are ``forward_plus``, ``mobile``, and ``gl_compatibility``. Requires driver support.                                                                                                        |
+| ``--rendering-method <renderer>``        | |release| Renderer name. Valid values are ``forward_plus``, ``mobile``, and ``gl_compatibility``. Requires driver support.                                   |
 +------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | ``--rendering-driver <driver>``          | |release| Rendering driver (depends on display driver). Use ``--help`` first to display the list of available drivers.                                       |
 +------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/tutorials/editor/command_line_tutorial.rst
+++ b/tutorials/editor/command_line_tutorial.rst
@@ -106,7 +106,7 @@ given build type.
 | ``--audio-output-latency <ms>``          | |release| Override audio output latency in milliseconds (default is 15 ms). Lower values make sound playback more reactive but increase CPU usage, and may   |
 |                                          | result in audio cracking if the CPU can't keep up.                                                                                                           |
 +------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| ``--rendering-method <renderer>``        | |release| Renderer name. Requires driver support.                                                                                                            |
+| ``--rendering-method <renderer>``        | |release| Renderer name. Valid values are ``forward_plus``, ``mobile``, and ``gl_compatibility``. Requires driver support.                                                                                                        |
 +------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | ``--rendering-driver <driver>``          | |release| Rendering driver (depends on display driver). Use ``--help`` first to display the list of available drivers.                                       |
 +------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Adds the list of valid values for the `--rendering-method` command line option to the command line tutorial. Previously the entry only said "Renderer name. Requires driver support." with no indication of what to pass after the flag.

Valid values cross-checked against tutorials/rendering/renderers.rst and the rendering method naming convention from #10139.

Fixes #11928.

Disclosure: Used AI assistance to identify the issue and locate the relevant file. The edit itself is a one-line addition I wrote and verified.
