### PR TITLE
Add note about translation contexts in PO files

### DIFF
--- a/tutorials/i18n/internationalizing_games.rst
+++ b/tutorials/i18n/internationalizing_games.rst
@@ -201,6 +201,10 @@ identical:
     // "Close", as in a distance (opposite of "far").
     GetNode<Label>("Distance").Text = Tr("Close", "Distance");
 
+To add a translation context, it must correspond to the ``msgctxt`` field 
+in a PO file. CSV files do not support translation contexts, therefore PO 
+files must be used if the project requires context.
+
 .. _doc_internationalizing_games_pluralization:
 
 Pluralization


### PR DESCRIPTION
The translation contexts section previously documented how to use contexts in code, but did not explain how to add them to translation files. This adds a brief note description on contexts corresponding to `msgctxt`, and that CSV files do not support contexts.