### PR TITLE
Clarify that some built-ins are effective when written on any branch in Spatial shader

### DIFF
--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -296,8 +296,8 @@ shader, this value can be used as desired.
 | inout vec3 **BINORMAL**                | Binormal in model space.                               |
 |                                        | In world space if ``world_vertex_coords`` is used.     |
 +----------------------------------------+--------------------------------------------------------+
-| out vec4 **POSITION**                  | If written to, overrides final vertex position in clip |
-|                                        | space.                                                 |
+| out vec4 **POSITION**                  | If written to on any branch, overrides final vertex    |
+|                                        | position in clip space.                                |
 +----------------------------------------+--------------------------------------------------------+
 | inout vec2 **UV**                      | UV main channel.                                       |
 +----------------------------------------+--------------------------------------------------------+
@@ -341,8 +341,8 @@ shader, this value can be used as desired.
 +----------------------------------------+--------------------------------------------------------+
 | in vec4 **CUSTOM3**                    | Custom value from vertex primitive.                    |
 +----------------------------------------+--------------------------------------------------------+
-| out float **Z_CLIP_SCALE**             | If written to, scales the vertex towards the camera to |
-|                                        | avoid clipping into things like walls.                 |
+| out float **Z_CLIP_SCALE**             | If written to on any branch, scales the vertex towards |
+|                                        | the camera to avoid clipping into things like walls.   |
 |                                        | Lighting and shadows will continue to work correctly   |
 |                                        | when this is written to, but screen-space effects like |
 |                                        | SSAO and SSR may break with lower scales. Try to keep  |
@@ -466,7 +466,7 @@ these properties, and if you don't write to them, Godot will optimize away the c
 | out float **ALPHA**                    | Alpha (range ``[0.0, 1.0]``). If read from or written to, the material will go to the            |
 |                                        | transparent pipeline.                                                                            |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
-| out float **ALPHA_SCISSOR_THRESHOLD**  | If written to, values below a certain amount of alpha are discarded.                             |
+| out float **ALPHA_SCISSOR_THRESHOLD**  | If written to on any branch, values below a certain amount of alpha are discarded.               |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
 | out float **ALPHA_HASH_SCALE**         | Alpha hash scale when using the alpha hash transparency mode. Defaults to ``1.0``.               |
 |                                        | Higher values result in more visible pixels in the dithering pattern.                            |
@@ -523,11 +523,12 @@ these properties, and if you don't write to them, Godot will optimize away the c
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
 | out vec3 **EMISSION**                  | Emission color (can go over ``(1.0, 1.0, 1.0)`` for HDR).                                        |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
-| out vec4 **FOG**                       | If written to, blends final pixel color with ``FOG.rgb`` based on ``FOG.a``.                     |
+| out vec4 **FOG**                       | If written to on any branch, blends final pixel color with ``FOG.rgb`` based on ``FOG.a``.       |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
-| out vec4 **RADIANCE**                  | If written to, blends environment map radiance with ``RADIANCE.rgb`` based on ``RADIANCE.a``.    |
+| out vec4 **RADIANCE**                  | If written to on any branch, blends environment map radiance with ``RADIANCE.rgb`` based on      |
+|                                        | ``RADIANCE.a``.                                                                                  |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
-| out vec4 **IRRADIANCE**                | If written to, blends environment map irradiance with ``IRRADIANCE.rgb`` based on                |
+| out vec4 **IRRADIANCE**                | If written to on any branch, blends environment map irradiance with ``IRRADIANCE.rgb`` based on  |
 |                                        | ``IRRADIANCE.a``.                                                                                |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
 
@@ -629,8 +630,8 @@ If you want the lights to add together, add the light contribution to ``DIFFUSE_
 +-----------------------------------+------------------------------------------------------------------------+
 | out vec3 **SPECULAR_LIGHT**       | Specular light result.                                                 |
 +-----------------------------------+------------------------------------------------------------------------+
-| out float **ALPHA**               | Alpha (range ``[0.0, 1.0]``). If written to, the material will go to   |
-|                                   | the transparent pipeline.                                              |
+| out float **ALPHA**               | Alpha (range ``[0.0, 1.0]``). If written to on any branch, the         |
+|                                   | material will go through the transparent pipeline.                     |
 +-----------------------------------+------------------------------------------------------------------------+
 
 .. note::


### PR DESCRIPTION
In other words, the built-ins will have an effect even if the branch never evaluates to `true` (e.g. when placed within an `if (false)` block).

- This closes https://github.com/godotengine/godot/issues/119552.
