### PR TITLE
Fix duplicate word typo in shader functions reference

### DIFF
--- a/tutorials/shaders/shader_reference/shader_functions.rst
+++ b/tutorials/shaders/shader_reference/shader_functions.rst
@@ -643,7 +643,7 @@ Exponential and math function descriptions
 
     |componentwise|
 
-    Raises ``e`` to the power of ``x``, or the the natural exponentiation.
+    Raises ``e`` to the power of ``x``, or the natural exponentiation.
 
     Equivalent to ``pow(e, x)``.
 


### PR DESCRIPTION
> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

## What

Fix duplicate-word typo in `tutorials/shaders/shader_reference/shader_functions.rst` (`or the the natural exponentiation` → `or the natural exponentiation`), in the description of the `exp(x)` shader function.

## Why

Trivial doc copy-edit.

## How verified

Pure RST text change inside an existing definition list item; no surrounding markup touched.

## Maintainer note

Feel free to close if agent-authored typo fixes aren't welcome here — completely understand.
