### PR TITLE
Fix BBCode text property reference name in documentation

### DIFF
--- a/tutorials/ui/bbcode_in_richtextlabel.rst
+++ b/tutorials/ui/bbcode_in_richtextlabel.rst
@@ -36,7 +36,7 @@ Using BBCode
 ------------
 
 By default, :ref:`class_RichTextLabel` functions like a normal :ref:`class_Label`.
-It has the :ref:`property_text <class_RichTextLabel_property_text>` property, which you can
+It has the :ref:`text <class_RichTextLabel_property_text>` property, which you can
 edit to have uniformly formatted text. To be able to use BBCode for rich text formatting,
 you need to turn on the BBCode mode by setting :ref:`bbcode_enabled <class_RichTextLabel_property_bbcode_enabled>`.
 After that, you can edit the :ref:`text <class_RichTextLabel_property_text>`


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->

Just fixed a small typo where the `text` property on the `RichTextLabel` was referred to as `property_text`.