### PR TITLE
Add list of required MSVC components, update GCC/clang versions.

### DIFF
--- a/engine_details/development/compiling/compiling_for_windows.rst
+++ b/engine_details/development/compiling/compiling_for_windows.rst
@@ -19,17 +19,32 @@ For compiling under Windows, the following is required:
 
     - `Visual Studio Community <https://www.visualstudio.com/vs/community/>`_,
       version 2019 or later. Visual Studio 2022 is recommended.
-      **Make sure to enable C++ in the list of workflows to install.**
-      **Make sure to enable Windows SDK 10.0.22621 (for Visual Studio 2019) or more recent version (for Visual Studio 2022+).**
-      If you've already installed Visual Studio without C++ support, run the installer
-      again; it should present you a **Modify** button.
+      **During installation make sure to select C++ in the list of workflows, and select the following individual components:**
+
+      .. tabs::
+
+          .. tab:: Visaul Studio 2019
+              - **MSVC v142 - VS 2019 C++ {arch} build tools (Latest)** for the target architectures.
+              - **Windows 11 SDK (10.0.22621.0)** (exact version).
+
+          .. tab:: Visaul Studio 2022
+              - **MSVC v143 - VS 2022 C++ {arch} build tools (Latest)** for the target architectures.
+              - **Windows 11 SDK (10.0.22621.0)** or newer.
+
+          .. tab:: Visaul Studio 2026
+              - **MSVC Build Tools for {arch} (Latest)** for the target architectures.
+              - **Windows 11 SDK (10.0.22621.0)** or newer.
+
+      If you've already installed Visual Studio without C++ support for the target architecture,
+      or without the Windows SDK, run the installer again; it should present you a **Modify** button.
       Supports ``x86_64``, ``x86_32``, and ``arm64``.
     - `MinGW-w64 <https://mingw-w64.org/>`_ with GCC can be used as an alternative to
       Visual Studio. Be sure to install/configure it to use the ``posix`` thread model.
-      **Important:** When using MinGW to compile the ``master`` branch, you need GCC 9 or later.
+      **Important:** When using MinGW to compile the ``master`` branch, you need GCC 12 or later.
       Supports ``x86_64`` and ``x86_32`` only.
     - `MinGW-LLVM <https://github.com/mstorsjo/llvm-mingw/releases>`_ with clang can be used as
       an alternative to Visual Studio and MinGW-w64.
+      **Important:** When using MinGW to compile the ``master`` branch, you need clang 14 or later.
       Supports ``x86_64``, ``x86_32``, and ``arm64``.
 - `Python 3.9+ <https://www.python.org/downloads/windows/>`_.
   **Make sure to enable the option to add Python to the** ``PATH`` **in the installer.**


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot-docs/issues/11955
- Makes Window SDK version note more readable (as part of components list instead of single line note).
- Updates GCC/clang version (WinRT components require C++20 capable compiler).

<img width="806" height="372" alt="Screenshot 2026-05-27 at 12 27 53" src="https://github.com/user-attachments/assets/ce3d9e80-dae9-4d3a-a2f3-66da4acd5159" />
