### PR TITLE
An Update to the player input scripting instructions

### DIFF
--- a/getting_started/step_by_step/scripting_player_input.rst
+++ b/getting_started/step_by_step/scripting_player_input.rst
@@ -105,7 +105,7 @@ Moving when pressing "up"
 -------------------------
 
 To only move when pressing a key, we need to modify the code that calculates the
-velocity. Uncomment the code and replace the line starting with ``var velocity`` with the code below.
+velocity. To modify, add the code starting with ``var velocity`` seen in the code below.
 
 .. tabs::
  .. code-tab:: gdscript GDScript
@@ -114,6 +114,8 @@ velocity. Uncomment the code and replace the line starting with ``var velocity``
     if Input.is_action_pressed("ui_up"):
         velocity = Vector2.UP.rotated(rotation) * speed
 
+ position += velocity * delta
+
  .. code-tab:: csharp C#
 
     var velocity = Vector2.Zero;
@@ -121,6 +123,8 @@ velocity. Uncomment the code and replace the line starting with ``var velocity``
     {
         velocity = Vector2.Up.Rotated(Rotation) * _speed;
     }
+
+    Position += velocity * (float)delta;
 
 We initialize the ``velocity`` with a value of ``Vector2.ZERO``, another
 constant of the built-in ``Vector`` type representing a 2D vector of length 0.


### PR DESCRIPTION
Clarified instructions for modifying velocity calculation when pressing the 'up' key. It is my first pull, but I saw a misuse of commenting. hope that helps :-)

Instead of uncommenting the code again, why not leave it as a wrong example. commenting then uncommenting it's like holding a cup without its handle.

unchanged code:
var velocity = Vector2.Zero;
if (Input.IsActionPressed("ui_up"))
{
velocity = Vector2.Up.Rotated(Rotation) * _speed;
}
After this code sniplet this should be added = "Position += velocity * (float)delta;"

The full code should look like:
var velocity = Vector2.Zero;
if (Input.IsActionPressed("ui_up"))
{
velocity = Vector2.Up.Rotated(Rotation) * _speed;
}

Position += velocity * (float)delta;
And for GDScript it should look like this:
var velocity = Vector2.ZERO
if Input.is_action_pressed("ui_up"):
velocity = Vector2.UP.rotated(rotation) * speed

position += velocity * delta

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
