### PR TITLE
Added information about an easy pitfall with rand_weighted()

### DIFF
--- a/classes/class_randomnumbergenerator.rst
+++ b/classes/class_randomnumbergenerator.rst
@@ -155,7 +155,7 @@ Method Descriptions
 
 :ref:`int<class_int>` **rand_weighted**\ (\ weights\: :ref:`PackedFloat32Array<class_PackedFloat32Array>`\ ) :ref:`🔗<class_RandomNumberGenerator_method_rand_weighted>`
 
-Returns a random integer between ``0`` and the size of the array that is passed as a parameter. Each value in the array should be a floating-point number that represents the relative likelihood that it will be returned as an index. A higher value means the value is more likely to be returned as an index, while a value of ``0`` means it will never be returned as an index.
+Returns a random integer between ``0`` and the size of the array that is passed as a parameter. Each value in the array should be a floating-point number that represents the relative likelihood that it will be returned as an index. A higher value means the value is more likely to be returned as an index, while a value of ``0`` means it will never be returned as an index. A negative value weight may cause unintended results. If the negative number's absolute value is greater than the sum of the remaining weights, the method will always return ``0``.  
 
 For example, if ``[0.5, 1, 1, 2]`` is passed as a parameter, then the method is twice as likely to return ``3`` (the index of the value ``2``) and twice as unlikely to return ``0`` (the index of the value ``0.5``) compared to the indices ``1`` and ``2``.
 


### PR DESCRIPTION
This part of the `rand_weighted()` method under the hood causes negative number weights to produce likely-unexpected results.

```cpp
for (int64_t i = 0; i < weights_size; ++i) {
	weights_sum += weights[i];
}
```

Added a brief mention of this fact under the `rand_weighted()` method.

To reproduce what I'm talking about, this code will only ever print the number 1 because the `-6.0` weight is added to the weights_sum canceling out all other values. 

```gdscript
func _ready() -> void:
	var my_array: Array[int] = [1,2,3,4]
	var my_weights: Array[float] = [1.0, 2.0, 3.0, -6.0]
	var rng: RandomNumberGenerator = RandomNumberGenerator.new()
	for i: int in 1000:
		print(my_array[rng.rand_weighted(my_weights)])

```

I'm doubtful this is a bug, but it's definitely an easy pitfall.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
