### PR TITLE
Document oversampling in Multiple resolutions

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -159,6 +159,13 @@ See :ref:`doc_renderers` for a detailed comparison of the rendering methods.
      requiring re-rasterization. Multi-channel usage makes SDF fonts scale down
      to lower sizes better compared to monochrome SDF fonts.
 
+- :ref:`Oversampling <doc_multiple_resolutions_font_and_image_oversampling>` for SVG images
+  using the :ref:`class_DPITexture` import type. This allows for sharper results when scaling
+  up the texture by re-rasterizing the SVG source image to a new resolution at run-time.
+
+  - Oversampling can optionally take individual :ref:`class_CanvasItem` scales into
+    account for crisper rendering when scaling nodes.
+
 - GPU-based :ref:`particles <doc_particle_systems_2d>` with support for
   :ref:`custom particle shaders <doc_particle_shader>`.
 - CPU-based particles.

--- a/tutorials/assets_pipeline/importing_images.rst
+++ b/tutorials/assets_pipeline/importing_images.rst
@@ -8,36 +8,51 @@ Supported image formats
 
 Godot can import the following image formats:
 
-- BMP (``.bmp``)
-  - No support for 16-bit per pixel images. Only 1-bit, 4-bit, 8-bit, 24-bit, and 32-bit per pixel images are supported.
-- DirectDraw Surface (``.dds``)
-  - If mipmaps are present in the texture, they will be loaded directly.
-  This can be used to achieve effects using custom mipmaps.
-- Khronos Texture (``.ktx``)
-  - Decoding is done using `libktx <https://github.com/KhronosGroup/KTX-Software>`__.
-  Only supports 2D images. Cubemaps, texture arrays and de-padding are not supported.
-- OpenEXR (``.exr``)
-  - Supports HDR (highly recommended for panorama skies).
-- Radiance HDR (``.hdr``)
-  - Supports HDR (highly recommended for panorama skies).
-- JPEG (``.jpg``, ``.jpeg``)
-  - Doesn't support transparency per the format's limitations.
-- PNG (``.png``)
-  - Precision is limited to 8 bits per channel upon importing (no HDR images).
+**Raster:**
+
+- BMP (``.bmp``) - All pixel formats are supported, but :abbr:`RLE (Run-Length Encoding)`
+  compression is not supported.
+
+- DirectDraw Surface (``.dds``) - If mipmaps are present in the texture, they will be
+  loaded directly. This can be used to achieve effects using custom mipmaps.
+
+- Khronos Texture (``.ktx``) - Decoding is done using
+  `libktx <https://github.com/KhronosGroup/KTX-Software>`__. Only supports 2D images.
+  Cubemaps, texture arrays, and de-padding are not supported.
+
+- OpenEXR (``.exr``) - Supports HDR (highly recommended for panorama skies).
+
+- Radiance HDR (``.hdr``) - Supports HDR (highly recommended for panorama skies).
+
+- JPEG (``.jpg``, ``.jpeg``) - Doesn't support transparency per the format's limitations.
+
+- PNG (``.png``) - Precision is limited to 8 bits per channel upon importing (no HDR images).
+
 - Truevision Targa (``.tga``)
-- SVG (``.svg``)
-  - SVGs are rasterized using `ThorVG <https://www.thorvg.org/>`__
-  when importing them. `Support is limited <https://www.thorvg.org/about#:~:text=certain%20features%20remain%20unsupported%20within%20the%20current%20framework>`__;
-  complex vectors may not render correctly. :ref:`Text must be converted to paths <doc_importing_images_svg_text>`;
-  otherwise, it won't appear in the rasterized image.
-  You can check whether ThorVG can render a certain vector correctly using its
-  `web-based viewer <https://www.thorvg.org/viewer>`__.
-  For complex vectors, rendering them to PNGs using `Inkscape <https://inkscape.org/>`__
-  is often a better solution. This can be automated thanks to its
-  `command-line interface <https://wiki.inkscape.org/wiki/index.php/Using_the_Command_Line#Export_files>`__.
-- WebP (``.webp``)
-  - WebP files support transparency and can be compressed lossily or losslessly.
+
+- WebP (``.webp``) - WebP files support transparency and can be compressed lossily or losslessly.
   The precision is limited to 8 bits per channel.
+
+**Vector:**
+
+- SVG (``.svg``)
+
+  - By default, SVGs are rasterized at import-time.
+
+  - SVG is the only image format that can be imported as DPITexture, which allows
+    for run-time rasterization to match the current oversampling factor.
+    See :ref:`doc_importing_images_changing_import_type` for details.
+
+  - Godot uses the `ThorVG <https://www.thorvg.org/>`__ library for SVG rendering.
+    `SVG feature support is limited <https://www.thorvg.org/about#:~:text=certain%20features%20remain%20unsupported%20within%20the%20current%20framework>`__;
+    complex vectors may not render correctly. :ref:`Text must be converted to paths <doc_importing_images_svg_text>`;
+    otherwise, it won't appear in the rasterized image. For complex vectors, rendering them
+    to PNGs using `Inkscape <https://inkscape.org/>`__ is often a better solution.
+    This can be automated thanks to its
+    `command-line interface <https://wiki.inkscape.org/wiki/index.php/Using_the_Command_Line#Export_files>`__.
+
+  - You can check whether ThorVG can render a certain vector correctly using its
+    `web-based viewer <https://www.thorvg.org/viewer>`__.
 
 .. note::
 
@@ -81,6 +96,10 @@ It is possible to choose other types of imported resources in the Import dock:
   which can be sampled in custom shaders. This resource type can only be
   displayed when using the Forward+ or Mobile renderers, not the Compatibility
   renderer.
+- **DPITexture:** Only available for SVG images. Similar to Texture2D, but can be
+  re-rasterized at different scales in the editor and at runtime without needing
+  to be reimported.
+  See :ref:`doc_multiple_resolutions_font_and_image_oversampling` for details.
 - **Font Data (Monospace Image Font):** Import the image as a bitmap font where
   all characters have the same width. See :ref:`doc_gui_using_fonts`.
 - **Image:** Import the image as-is. This resource type cannot be displayed

--- a/tutorials/rendering/multiple_resolutions.rst
+++ b/tutorials/rendering/multiple_resolutions.rst
@@ -549,6 +549,50 @@ on all other platforms.
     from the editor will only be DPI-aware if **Allow hiDPI** is enabled in the
     Project Settings.
 
+.. _doc_multiple_resolutions_font_and_image_oversampling:
+
+Font and image oversampling
+---------------------------
+
+Godot supports a process called *oversampling*, which refers to automatically
+re-rendering textures from their original vector source when the viewport scale
+factor changes. This ensures font and image textures remain crisp at any
+resolution.
+
+Font oversampling is enabled by default, but it can be disabled by unchecking
+**GUI > Fonts > Dynamic Fonts > Use Oversampling** in the Project Settings.
+
+Image oversampling is disabled by default, and can be enabled for specific
+images in SVG format by changing their import type to :ref:`class_DPITexture` in
+the Import dock. Other image formats do not support oversampling, as they store
+bitmap data instead of vectors.
+
+The editor automatically performs oversampling when zooming in the 2D editor,
+which allows you to preview how oversampling will look at specific scale
+factors. This can be disabled by unchecking **View > Auto Resample CanvasItems**
+at the top of the 2D editor viewport.
+
+Oversampling can also be applied according to the Node2D or Control's Scale
+property. This *scale-based oversampling* behavior is disabled by default,
+but it can be enabled by setting **Oversampling with Scale** in the inspector
+to **Enabled** on the desired node. This is useful for nodes that may have
+their scale changed at runtime, such as custom scale factors for certain UI
+elements like crosshairs. However, keep in mind this can be demanding on the
+CPU if the scale changes frequently, as the texture has to be re-rendered each time.
+
+For best results, the node should use uniform scaling. Non-uniform scaling will
+work, but may result in aliasing on the shorter axis as oversampling is always
+applied uniformly.
+
+.. note::
+
+    Control's :ref:`offset_transform_enabled <class_Control_property_offset_transform_enabled>`
+    property is taken into account by scale-based oversampling, but only if
+    :ref:`offset_transform_visual_only <class_Control_property_offset_transform_visual_only>` is *disabled*.
+    When :ref:`offset_transform_visual_only <class_Control_property_offset_transform_visual_only>` is enabled,
+    it does not affect the node's actual scale (as used for input coordinates),
+    but only its visual representation. Therefore, it is ignored by oversampling.
+
 .. _doc_multiple_resolutions_reducing_aliasing_on_downsampling:
 
 Reducing aliasing on downsampling
@@ -560,6 +604,10 @@ appear when downsampling to something considerably lower like 1280×720.
 To resolve this, you can :ref:`enable mipmaps <doc_importing_images_mipmaps>` on
 all your 2D textures. However, enabling mipmaps will increase memory usage which
 can be an issue on low-end mobile devices.
+
+For SVG images, you can also change their import type to :ref:`class_DPITexture` in the Import dock
+to benefit from automatic oversampling as described above. This avoids aliasing by re-rasterizing
+the texture when the scale factor changes.
 
 Handling aspect ratios
 ----------------------


### PR DESCRIPTION
- Mention DPITexture in Importing images.
- Document RLE-compressed BMP importing not being currently supported.
  - On the other hand, RLE-compressesd TGA is already supported. Perhaps the existing code could be ported over to the BMP loader.
- Update information in Importing images for 4.7.
