### PR TITLE
Remove dead community tutorial link

### DIFF
--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -32,7 +32,6 @@ Text tutorials
 - `Catlike Coding by Jasper Flick <https://catlikecoding.com/godot/>`__
 - `GDScript website by Andrew Wilkes <https://gdscript.com>`__
 - `Godot Recipes by KidsCanCode <https://kidscancode.org/godot_recipes/4.x/>`__
-- `Godot Tutorials by SomethingLikeGames <https://www.somethinglikegames.de/en/tags/godot-engine/>`__
 - `GameDev Academy by Zenva <https://gamedevacademy.org/category/godot-tutorials/godot-4/>`__
 - `Game Dev Artisan website <https://gamedevartisan.com/>`__
 


### PR DESCRIPTION
Everything on the Something Like Games website has been taken down becauase the website owner doesn't want their tutorials possibly being used to train AI (Post on that is [here](https://www.somethinglikegames.de/en/blog/2026/offline/)).

Closes #12027