### PR TITLE
Add specific icons to admonitions

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1208,16 +1208,51 @@ code,
     margin-right: 9px;
 }
 
+.rst-content .admonition.note .admonition-title::before,
+.rst-content .admonition.warning .admonition-title::before,
+.rst-content .admonition.tip .admonition-title::before,
+.rst-content .admonition.important .admonition-title::before {
+    content: "";
+    top: 0.1rem;
+    display: inline;
+    height: 1rem;
+    width: 1rem;
+    padding-right: 1rem;
+    mask-repeat: no-repeat;
+}
+
+.rst-content .admonition.note .admonition-title::before {
+    mask-image: var(--admonition-note-icon);
+    background-color: var(--admonition-note-title-color);
+}
+
+.rst-content .admonition.warning .admonition-title::before {
+    mask-image: var(--admonition-danger-icon);
+    background-color: var(--admonition-attention-title-color);
+}
+
+.rst-content .admonition.tip .admonition-title::before {
+    mask-image: var(--admonition-tip-icon);
+    background-color: var(--admonition-tip-title-color);
+}
+
+.rst-content .admonition.important .admonition-title::before {
+    mask-image: var(--admonition-attention-icon);
+    background-color: var(--admonition-attention-title-color);
+}
+
 .rst-content .admonition.attention,
 .rst-content .admonition.caution,
-.rst-content .admonition.warning {
+.rst-content .admonition.warning,
+.rst-content .admonition.important {
     background-color: var(--admonition-attention-background-color);
     color: var(--admonition-attention-color);
 }
 
 .rst-content .admonition.attention .admonition-title,
 .rst-content .admonition.caution .admonition-title,
-.rst-content .admonition.warning .admonition-title {
+.rst-content .admonition.warning .admonition-title,
+.rst-content .admonition.important .admonition-title {
     background-color: var(--admonition-attention-title-background-color);
     color: var(--admonition-attention-title-color);
 }
@@ -1232,14 +1267,12 @@ code,
     color: var(--admonition-danger-title-color);
 }
 
-.rst-content .admonition.tip,
-.rst-content .admonition.important {
+.rst-content .admonition.tip {
     background-color: var(--admonition-tip-background-color);
     color: var(--admonition-tip-color);
 }
 
-.rst-content .admonition.tip .admonition-title,
-.rst-content .admonition.important .admonition-title {
+.rst-content .admonition.tip .admonition-title {
     background-color: var(--admonition-tip-title-background-color);
     color: var(--admonition-tip-title-color);
 }

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1220,16 +1220,51 @@ code,
     margin-right: 9px;
 }
 
+.rst-content .admonition.note .admonition-title::before,
+.rst-content .admonition.warning .admonition-title::before,
+.rst-content .admonition.tip .admonition-title::before,
+.rst-content .admonition.important .admonition-title::before {
+    content: "";
+    top: 0.1rem;
+    display: inline;
+    height: 1rem;
+    width: 1rem;
+    padding-right: 1rem;
+    mask-repeat: no-repeat;
+}
+
+.rst-content .admonition.note .admonition-title::before {
+    mask-image: var(--admonition-note-icon);
+    background-color: var(--admonition-note-title-color);
+}
+
+.rst-content .admonition.warning .admonition-title::before {
+    mask-image: var(--admonition-danger-icon);
+    background-color: var(--admonition-attention-title-color);
+}
+
+.rst-content .admonition.tip .admonition-title::before {
+    mask-image: var(--admonition-tip-icon);
+    background-color: var(--admonition-tip-title-color);
+}
+
+.rst-content .admonition.important .admonition-title::before {
+    mask-image: var(--admonition-attention-icon);
+    background-color: var(--admonition-attention-title-color);
+}
+
 .rst-content .admonition.attention,
 .rst-content .admonition.caution,
-.rst-content .admonition.warning {
+.rst-content .admonition.warning,
+.rst-content .admonition.important {
     background-color: var(--admonition-attention-background-color);
     color: var(--admonition-attention-color);
 }
 
 .rst-content .admonition.attention .admonition-title,
 .rst-content .admonition.caution .admonition-title,
-.rst-content .admonition.warning .admonition-title {
+.rst-content .admonition.warning .admonition-title,
+.rst-content .admonition.important .admonition-title {
     background-color: var(--admonition-attention-title-background-color);
     color: var(--admonition-attention-title-color);
 }
@@ -1244,14 +1279,12 @@ code,
     color: var(--admonition-danger-title-color);
 }
 
-.rst-content .admonition.tip,
-.rst-content .admonition.important {
+.rst-content .admonition.tip {
     background-color: var(--admonition-tip-background-color);
     color: var(--admonition-tip-color);
 }
 
-.rst-content .admonition.tip .admonition-title,
-.rst-content .admonition.important .admonition-title {
+.rst-content .admonition.tip .admonition-title {
     background-color: var(--admonition-tip-title-background-color);
     color: var(--admonition-tip-title-color);
 }


### PR DESCRIPTION
Since #12017 adds icons to the proposed "class reference admonitions", this PR reuses the same icons and applies them to Note, Warning, Tip, and Important admonitions. All other admonitions (Danger, See also, Here be dragons, and anything else I missed) are left untouched.

This also changes the Important color from green (same as Tip) to yellow (same as Warning/Attention), for consistency in the icon color.

| Master | This PR |
| ------ | ------- |
| <img width="820" height="420" alt="image" src="https://github.com/user-attachments/assets/6db6aa00-a3fa-4b84-a3ef-4475505e0d0f" /> | <img width="820" height="420" alt="image" src="https://github.com/user-attachments/assets/1fac20fc-1caf-41b7-b9ea-2a52d9b47263" /> |

<details>
<summary>More images</summary>
In the following image, only the Important admonition is affected, the other two are identical to the master branch:
<img width="830" height="600" alt="image" src="https://github.com/user-attachments/assets/a44e4014-6e39-43ed-b1cb-60f52d1a7dbf" />

More examples:
<img width="820" height="350" alt="image" src="https://github.com/user-attachments/assets/bed4f51c-127c-4b88-8d82-35e565b40fa9" />
<img width="820" height="280" alt="image" src="https://github.com/user-attachments/assets/0f414a9c-82ac-4826-8f6c-ba9b8d560b80" />
</details>

Depends on #12017.