### PR TITLE
Add documentation for Vendor Runtime Modules

### DIFF
--- a/engine_details/engine_api/custom_modules_in_cpp.rst
+++ b/engine_details/engine_api/custom_modules_in_cpp.rst
@@ -41,6 +41,8 @@ instead. Adding C++ modules can be useful in the following scenarios:
     C++ modules are mainly needed when GDExtension doesn't suffice and deeper engine
     integration is required.
 
+.. _doc_creating_custom_modules_in_cpp:
+
 Creating a new module
 ---------------------
 

--- a/engine_details/engine_api/index.rst
+++ b/engine_details/engine_api/index.rst
@@ -12,7 +12,7 @@ a subselection of common and useful ways to do it.
 
 Alternatively, some of the functions presented here are also available through the
 :ref:`GDExtension <doc_what_is_gdextension>` API.
-You can use them in C++ by using creating a :ref:`godot-cpp <doc_about_godot_cpp>` based GDExtension,
+You can use them in C++ by creating a :ref:`godot-cpp <doc_about_godot_cpp>` based GDExtension,
 or with any of the :ref:`community-created GDExtension implementations <doc_scripting_languages>`. Note though
 that some aspects of the code or directory structures may be different in GDExtension compared to the module APIs.
 
@@ -21,6 +21,7 @@ that some aspects of the code or directory structures may be different in GDExte
    :name: toc-devel-cpp-source-advanced
 
    custom_modules_in_cpp
+   vendor_runtime_module
    gdextension/index
    binding_to_external_libraries
    custom_godot_servers

--- a/engine_details/engine_api/vendor_runtime_module.rst
+++ b/engine_details/engine_api/vendor_runtime_module.rst
@@ -1,0 +1,118 @@
+.. _doc_vendor_runtime_module:
+
+Vendor Runtime Module
+=====================
+
+A Vendor Runtime Module is a :ref:`Godot module <doc_custom_modules_in_cpp>`
+which is only applicable at runtime in a running project.
+It is created like a regular :ref:`custom C++ module <doc_custom_modules_in_cpp>`, but is
+packaged using an :ref:`editor plugin <doc_making_plugins>` to make the functionality
+it provides easily accessible and usable within a *stock* Godot project.
+
+What for?
+---------
+
+Vendor runtime modules provide developers with access to vendor-specific optimizations, features,
+and/or platforms for their running projects. 
+
+This provides benefits to vendors who are able to expose their technologies to all developers,
+and improve and refine them in a rapid, iterative, and frictionless manner.
+This also provides benefits to developers and users who are able to access and use a diverse range of vendor 
+technologies to improve their games.
+
+Creating a vendor runtime module
+--------------------------------
+
+Generating export templates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Make sure to follow the :ref:`instructions for creating a custom C++ module <doc_creating_custom_modules_in_cpp>`.
+
+Since this is a runtime module whose functionality is meant to only be accessed from the running project, you must
+generate an export template for every platform you plan to support.
+See the :ref:`Compiling <toc-devel-compiling>` pages for more information.
+
+Creating the wrapper editor plugin
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once the export templates are generated, you must create an editor plugin to package them and make them easily
+accessible to end users via the `Godot Asset Store <https://store.godotengine.org/>`_.
+
+Follow :ref:`these instructions <doc_making_plugins_template>` to start creating the plugin. Your base plugin script should look like the following:
+
+.. code-block:: gdscript
+
+    @tool
+    extends EditorPlugin
+
+
+    func _enter_tree():
+        # Initialization of the plugin goes here.
+        pass
+
+
+    func _exit_tree():
+        # Clean-up of the plugin goes here.
+        pass
+
+
+The next step is to define and instantiate an :ref:`EditorExportPlugin<class_EditorExportPlugin>` instance. 
+The :ref:`EditorExportPlugin<class_EditorExportPlugin>` instance is used to hook into the export flow and
+replace the default export templates with the ones generated from the vendor runtime module.
+
+Using our base editor plugin template code above, an example implementation looks like this:
+
+.. code-block:: gdscript
+
+    @tool
+    extends EditorPlugin
+
+    # A class member to hold the editor export plugin during its lifecycle.
+    var export_plugin: VRMExportPlugin
+
+    func _enter_tree():
+        # Initialization of the plugin goes here.
+        export_plugin = VRMExportPlugin.new()
+        add_export_plugin(export_plugin)
+
+
+    func _exit_tree():
+        # Clean-up of the plugin goes here.
+        remove_export_plugin(export_plugin)
+        export_plugin = null
+
+
+    class VRMExportPlugin extends EditorExportPlugin:
+        var _path_to_debug_export_template = ""
+        var _path_to_release_export_template = ""
+
+        # Return true for all supported platforms.
+        func _supports_platform(platform):
+            return platform is EditorExportPlatformAndroid
+
+        # Overrides the default export templates.
+        func _get_export_options_overrides(platform):
+            var overrides = {}
+            if not _supports_platform(platform):
+                return overrides
+            
+            # Overrides Android export preset's "custom_template" options.
+            overrides["custom_template/debug"] = _path_to_debug_export_template
+            overrides["custom_template/release"] = _path_to_release_export_template
+
+            return overrides
+
+        # Optional: specify additional export preset options to customize the export template.
+        func _get_export_options(platform):
+            pass
+        
+        func _get_name():
+            return "VRM Plugin"
+
+
+.. tip::
+
+    This section covers the basics to wrap and expose a vendor runtime module via an editor plugin, but
+    editor plugins have a lot more functionality that can be used to customize the editor further. 
+    Feel free to :ref:`explore and leverage those functionalities <toc-tutorials-plugins>` to improve the
+    user experience for your vendor runtime module.

--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -18,6 +18,8 @@ you can understand how they work and be able to develop your own. The first
 is a custom node that you can add to any scene in the project, and the
 other is a custom dock added to the editor.
 
+.. _doc_making_plugins_template:
+
 Creating a plugin
 -----------------
 


### PR DESCRIPTION
This PR introduces and defines `Vendor Runtime Modules`, a mean for vendors to provide added functionality via custom modules that can be easily integrate into stock Godot projects.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
