### PR TITLE
Add warning for back-buffer reading performance

### DIFF
--- a/tutorials/shaders/screen-reading_shaders.rst
+++ b/tutorials/shaders/screen-reading_shaders.rst
@@ -17,6 +17,12 @@ The workaround is to make a copy of the screen, or a part of the screen,
 to a back-buffer and then read from it while drawing. Godot provides a
 few tools that make this process easy.
 
+.. warning::
+
+    Reading from the back-buffer disrupts the render pipeline and
+    can be performance intensive. For shaders that don't require access
+    to the depth buffer, consider a :ref:`Viewport <doc_viewports>` instead.
+
 Screen texture
 --------------
 


### PR DESCRIPTION
Added a warning about performance impact when reading from the back-buffer in shaders.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->

This edit's primary purpose is to warn novice users of accidentally causing shaders to have a higher performance impact then intended. This is NOT a bug in Godot, it's just how reading from back buffers work. See [this issue](https://github.com/godotengine/godot/issues/108935#issuecomment-3115851485) for reference.