### PR TITLE
Fix missing include in Custom modules in C++

### DIFF
--- a/engine_details/engine_api/custom_modules_in_cpp.rst
+++ b/engine_details/engine_api/custom_modules_in_cpp.rst
@@ -86,6 +86,8 @@ And then the cpp file.
 
     #include "summator.h"
 
+    #include "core/object/class_db.h"
+
     void Summator::add(int p_value) {
         count += p_value;
     }


### PR DESCRIPTION
- See https://github.com/godotengine/godot-docs-user-notes/discussions/727#discussioncomment-17314092.
