### PR TITLE
Fix issue with labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,7 +4,7 @@
 
 area:about:
 - changed-files:
-  - any-glob-to-any-files: area/**
+  - any-glob-to-any-files: about/**
 
 area:community:
 - changed-files:


### PR DESCRIPTION
named one of the folders wrong originally. I'm hoping this is why the labeler isn't running, unfortunately the failed workflows don't tell you what line in a file is having an issue.