### PR TITLE
Mention shader type in Introduction to shaders

### DIFF
--- a/tutorials/shaders/introduction_to_shaders.rst
+++ b/tutorials/shaders/introduction_to_shaders.rst
@@ -36,6 +36,8 @@ look like this.
 
 .. code-block:: glsl
 
+    shader_type canvas_item;
+
     void fragment() {
         COLOR = some_color;
     }


### PR DESCRIPTION
The first shader example is a valid `canvas_item` shader, but not a valid `spatial` shader as `COLOR` is read-only in `spatial`'s `fragment()` (it reads the vertex color).
