### PR TITLE
Add documentation on DrawableTexture2D and texture blit shaders

### DIFF
--- a/tutorials/rendering/drawable_textures.rst
+++ b/tutorials/rendering/drawable_textures.rst
@@ -1,0 +1,207 @@
+.. _doc_drawable_textures:
+
+Using DrawableTextures
+======================
+
+DrawableTextures are a type of Texture2D with additional functions for modifying
+the texture via the GPU. This can be used for procedural texturing, real-time effects,
+and much more.
+
+Basic rectangle blitting
+------------------------
+
+The most basic operation on a drawable texture is
+:ref:`blit_rect() <class_DrawableTexture2D_method_blit_rect>`.
+Blitting (copying) the whole of one texture into the given rectangle on the ``DrawableTexture``.
+
+.. code-block:: gdscript
+
+    texture.blit_rect(Rect2(20, 50, 60, 60), preload("res://circle.svg"))
+    texture.blit_rect(Rect2(20, 50, 60, 60), preload("res://circle.svg"), Color.WHITE, 0)
+
+The code above blits the circle texture into the rectangle ``(20, 50, 60, 60)``
+on the ``DrawableTexture``. ``(20, 50)`` is the top left corner of the rectangle
+being drawn to, and ``(60, 60)`` is its size. If you wanted to draw over the
+whole texture, simply match the ``rect`` parameter to the ``DrawableTexture``'s
+size.
+
+The third parameter in ``blit_rect()`` is an optional parameter, ``modulate``.
+This is a color that the output is multiplied by (in the default behavior). This
+can be used to recolor, or even mask the drawn output of ``blit_rect()``. For
+example, using a modulate of ``Color(0, 0, 1, 0)`` will only draw to and update
+the blue values of each pixel on the ``DrawableTexture``.
+
+``blit_rect()``'s fourth parameter, ``mipmap``, can specify a mipmap level to
+draw to. You only need to use this if you want fine control over each mipmap
+layer. Keep in mind, you do not need to adjust the rectangle size; it is
+converted to a portion of the texture's whole size. If you just want to update
+all the mipmap layers, you should draw to the texture, then call
+``generate_mipmaps()`` on it.
+
+Blend modes and texture blit shaders
+------------------------------------
+
+The drawing process for ``blit_rect()`` and DrawableTextures is governed by a
+:ref:`texture blit shader <doc_texture_blit_shader>`. Even when the user does
+not supply one, the engine has a default texture blit shader it uses.
+
+.. code-block:: glsl
+
+    // Default texture blit shader.
+
+    shader_type texture_blit;
+    render_mode blend_mix;
+
+    uniform sampler2D source_texture0 : hint_blit_source0;
+    uniform sampler2D source_texture1 : hint_blit_source1;
+    uniform sampler2D source_texture2 : hint_blit_source2;
+    uniform sampler2D source_texture3 : hint_blit_source3;
+
+    void blit() {
+        // Copies from each whole source texture to a rect on each output texture.
+        COLOR0 = texture(source_texture0, UV) * MODULATE;
+        COLOR1 = texture(source_texture1, UV) * MODULATE;
+        COLOR2 = texture(source_texture2, UV) * MODULATE;
+        COLOR3 = texture(source_texture3, UV) * MODULATE;
+    }
+
+The blend mode specified in ``render_mode`` defines how the output color value
+is blended with the current color of the pixel on the DrawableTexture. The
+engine defaults to ``blend_mix`` if no blend mode is specified in
+``render_mode``. Texture blit shaders also support ``blend_add`` (additive),
+``blend_sub`` (subtractive), ``blend_mul`` (multiply), and ``blend_disabled``
+(alpha does not act as transparency and is written as-is).
+The premultiplied alpha blend mode is *not* supported here.
+
+It is also possible to use a different blend mode than the one specified in the shader.
+To do so, you can instantiate and pass in a new :ref:`class_BlitMaterial`
+in the script.
+
+.. code-block:: gdscript
+
+    var blit_material = BlitMaterial.new()
+    blit_material.blend_mode = BlitMaterial.BLEND_MODE_DISABLED
+    texture.blit_rect(Rect2(0, 0, 200, 200), load("res://icon.svg"), Color.WHITE, 0, blit_material)
+
+If you want more complex behavior, you can write your own texture blit shader.
+Create a new shader with the ``texture_blit`` shader type, write your shader
+code, and load it into a material to pass to the function.
+
+.. note::
+
+    The material is passed as a function parameter, rather than bound to the
+    resource. This makes it easier to perform multiple types of draws to the
+    same texture.
+
+Using multiple blits in a single texture
+----------------------------------------
+
+DrawableTextures also have a :ref:`blit_rect_multi() <class_DrawableTexture2D_method_blit_rect_multi>`
+method, which allows for up to 4 inputs and outputs in the same step.
+
+.. code-block:: gdscript
+
+    texture.blit_rect_multi(
+            Rect2(0, 0, 200, 200),
+            [preload("res://icon.svg"), preload("res://circle.svg")],
+            [other_drawable_texture]
+        )
+
+The default behavior of this is to just match each input and output in order.
+For example, this can be useful for drawing to an albedo, normal, and height
+texture simultaneously.
+
+Of course, this behavior can also be customized via the texture blit shader.
+In the shader, the extra outputs are written to via ``COLOR1``, ``COLOR2``,
+and ``COLOR3`` (with ``COLOR0`` being the primary output). The extra inputs
+can be read as uniforms with ``hint_blit_source1``, ``hint_blit_source2``,
+and ``hint_blit_source3``.
+
+.. _doc_drawable_textures_example_1:
+
+Example 1: Simple painting
+--------------------------
+
+One of the most intuitive uses for DrawableTextures is for, well, drawing!
+For this example, we're going to start a new project, and create
+a new UI scene with a Control node at its root.
+
+Next, you'll need to create a :ref:`class_TextureRect` node, which is going to
+be our user's canvas. Size it appropriately for your screen, and then attach a
+new script to it. The start of this script should initialize the TextureRect's
+texture to a new DrawableTexture.
+
+.. code-block:: gdscript
+
+    extends TextureRect
+
+    func _ready():
+        texture = DrawableTexture2D.new()
+        # Be careful; if the dimensions of the node are not equal to the size set here,
+        # our draw call later will seem to happen at the wrong spot.
+        texture.setup(500, 500, DrawableTexture2D.DRAWABLE_FORMAT_RGBA8, false)
+
+Next, we need the TextureRect to respond to the player clicking and dragging as
+if they are painting. To do this, we can override the ``_on_gui_input()`` method
+from the TextureRect in our script, and parse InputMouseButton and
+InputMouseMotion events:
+
+.. code-block:: gdscript
+
+    var drawing = false
+
+    func _on_gui_input(event):
+        if event is InputEventMouseButton:
+            # Mouse click/unclick - start/stop drawing.
+            drawing = not drawing
+        if event is InputEventMouseMotion and drawing:
+            # Calculate rect to center our drawn rectangle on mouse position
+            # instead of mouse at top left.
+            var rect = Rect2(event.position.x - 10, event.position.y - 10, 20, 20)
+            texture.blit_rect(rect, null)
+
+This should now draw black squares as you click and drag around the TextureRect.
+For more natural drawing, we probably want to be drawing a circle shape, and
+actually coloring it.
+
+We can adjust what's being drawn by using a Texture to copy from, and the
+modulate parameter. We will use this :download:`plain white circle texture <img/circle.svg>`,
+which we load as the ``texture`` parameter in ``blit_rect()``,
+and use a red color as the ``modulate`` parameter.
+
+.. code-block:: gdscript
+
+    if event is InputEventMouseMotion and drawing:
+        # Calculate rect to center our drawn rectangle on mouse position
+        # instead of mouse at top left.
+        var rect = Rect2(event.position.x - 10, event.position.y - 10, 20, 20)
+        texture.blit_rect(rect, preload("res://circle.svg"), Color.RED)
+
+The drawing now looks much more natural and colorful. To further customize this,
+you could connect a :ref:`class_ColorPickerButton` node to the script to store
+the user's color choice for the ``modulate`` parameter of ``blit_rect()``. You
+could also store a brush size variable, give the user a way to adjust it, and
+incorporate it into the rectangle calculation so the user can draw larger or
+smaller strokes.
+
+.. code-block:: gdscript
+
+    var drawing = false
+    var my_color = Color.RED
+    var my_size = 20.0
+
+    func _on_gui_input(event):
+        if event is InputEventMouseButton:
+            # Mouse click/unclick - start/stop drawing.
+            drawing = not drawing
+        if event is InputEventMouseMotion and drawing:
+            # Calculate rect to center our drawn rectangle on mouse position
+            # instead of mouse at top left.
+            var rect = Rect2(event.position.x - my_size / 2, event.position.y - my_size / 2, my_size, my_size)
+            texture.blit_rect(rect, preload("res://circle.svg"), my_color)
+
+    func _on_color_picker_button_color_changed(color):
+        my_color = color
+
+    func _on_h_slider_value_changed(value):
+        my_size = value

--- a/tutorials/rendering/img/circle.svg
+++ b/tutorials/rendering/img/circle.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 5.292 5.292"><circle cx="2.646" cy="2.646" r="2.381" style="fill:#fff"/></svg>

--- a/tutorials/rendering/index.rst
+++ b/tutorials/rendering/index.rst
@@ -17,4 +17,5 @@ Rendering
    multiple_resolutions
    jitter_stutter
    compositor
+   drawable_textures
    hdr_output

--- a/tutorials/shaders/introduction_to_shaders.rst
+++ b/tutorials/shaders/introduction_to_shaders.rst
@@ -118,7 +118,8 @@ Here are the available types:
 * :ref:`canvas_item <doc_canvas_item_shader>` for 2D rendering.
 * :ref:`particles <doc_particle_shader>` for particle systems.
 * :ref:`sky <doc_sky_shader>` to render :ref:`Skies <class_Sky>`.
-* :ref:`fog <doc_fog_shader>` to render :ref:`FogVolumes <class_FogVolume>`
+* :ref:`fog <doc_fog_shader>` to render :ref:`FogVolumes <class_FogVolume>`.
+* :ref:`texture_blit <doc_texture_blit_shader>` to render :ref:`DrawableTexture2Ds <class_DrawableTexture2D>`.
 
 Render modes
 ------------

--- a/tutorials/shaders/shader_reference/index.rst
+++ b/tutorials/shaders/shader_reference/index.rst
@@ -17,3 +17,4 @@ Shading reference
    particle_shader
    sky_shader
    fog_shader
+   texture_blit_shader

--- a/tutorials/shaders/shader_reference/texture_blit_shader.rst
+++ b/tutorials/shaders/shader_reference/texture_blit_shader.rst
@@ -1,0 +1,108 @@
+.. _doc_texture_blit_shader:
+
+Texture blit shaders
+====================
+
+Texture blit shaders are used to define the behavior of blit calls on a
+:ref:`DrawableTexture2D <doc_drawable_textures>`.
+
+Texture blit shaders only have one processing function, the ``blit()`` function,
+which runs for every pixel of the source texture inside the rect given to
+``blit_rect()``.
+
+.. seealso::
+
+    See :ref:`doc_drawable_textures` for more information on how to use texture
+    blit shaders as part of a DrawableTexture.
+
+Render modes
+------------
+
++---------------------------------+----------------------------------------------------------------------+
+| Render mode                     | Description                                                          |
++=================================+======================================================================+
+| **blend_mix**                   | Mix blend mode (alpha is transparency), default.                     |
++---------------------------------+----------------------------------------------------------------------+
+| **blend_add**                   | Additive blend mode.                                                 |
++---------------------------------+----------------------------------------------------------------------+
+| **blend_sub**                   | Subtractive blend mode.                                              |
++---------------------------------+----------------------------------------------------------------------+
+| **blend_mul**                   | Multiplicative blend mode.                                           |
++---------------------------------+----------------------------------------------------------------------+
+| **blend_disabled**              | Disable blending, values (including alpha) are written as-is.        |
++---------------------------------+----------------------------------------------------------------------+
+
+.. note::
+
+    There is no premultiplied alpha blend mode for Texture blit shaders.
+
+Built-ins
+---------
+
+Values marked as ``in`` are read-only. Values marked as ``out`` can optionally be written to and will
+not necessarily contain sensible values. Values marked as ``inout`` provide a sensible default
+value, and can optionally be written to. Samplers cannot be written to so they are not marked.
+
+Global built-ins
+----------------
+
+Global built-ins are available everywhere, including custom functions.
+
++-------------------+------------------------------------------------------------------------------------------+
+| Built-in          | Description                                                                              |
++===================+==========================================================================================+
+| in float **TIME** | Global time since the engine has started, in seconds. It repeats after every ``3,600``   |
+|                   | seconds (which can be changed with the                                                   |
+|                   | :ref:`rollover<class_ProjectSettings_property_rendering/limits/time/time_rollover_secs>` |
+|                   | setting). It's affected by                                                               |
+|                   | :ref:`time_scale<class_Engine_property_time_scale>` but not by pausing. If you need a    |
+|                   | ``TIME`` variable that is not affected by time scale, add your own                       |
+|                   | :ref:`global shader uniform<doc_shading_language_global_uniforms>` and update it each    |
+|                   | frame.                                                                                   |
++-------------------+------------------------------------------------------------------------------------------+
+| in float **PI**   | A ``PI`` constant (``3.141592``).                                                        |
+|                   | The ratio of a circle's circumference to its diameter and the number of radians in a     |
+|                   | half turn.                                                                               |
++-------------------+------------------------------------------------------------------------------------------+
+| in float **TAU**  | A ``TAU`` constant (``6.283185``).                                                       |
+|                   | An equivalent of ``PI * 2`` and amount of radians in full turn.                          |
++-------------------+------------------------------------------------------------------------------------------+
+| in float **E**    | An ``E`` constant (``2.718281``).                                                        |
+|                   | Euler's number and a base of the natural logarithm.                                      |
++-------------------+------------------------------------------------------------------------------------------+
+
+
+Blit built-ins
+--------------
+
+Source textures
+~~~~~~~~~~~~~~~
+
+Texture blit shaders have up to 4 source textures bound as inputs. These can be
+accessed with a ``sampler2D`` using ``hint_blit_source0``,
+``hint_blit_source1``, ``hint_blit_source2``, and ``hint_blit_source3``.
+
++---------------------------------------------+---------------------------------------------------------------+
+| Built-in                                    | Description                                                   |
++=============================================+===============================================================+
+| in vec4 **FRAGCOORD**                       | Coordinate of pixel center. In screen space. ``xy`` specifies |
+|                                             | position in viewport. Upper-left of the viewport is the       |
+|                                             | origin, ``(0.0, 0.0)``.                                       |
++---------------------------------------------+---------------------------------------------------------------+
+| in vec2 **UV**                              | UV from the ``vertex()`` function.                            |
+|                                             | This is set to sample all of a source texture.                |
++---------------------------------------------+---------------------------------------------------------------+
+| in vec4 **MODULATE**                        | ``MODULATE`` color passed in by RenderingServer API.          |
++---------------------------------------------+---------------------------------------------------------------+
+| out vec4 **COLOR0**                         | Output color to blended with the DrawableTexture target.      |
+|                                             | Initialized to ``(0.0, 0.0, 0.0, 0.0)``.                      |
++---------------------------------------------+---------------------------------------------------------------+
+| out vec4 **COLOR1**                         | Output color to blended with an extra DrawableTexture target. |
+|                                             | Initialized to ``(0.0, 0.0, 0.0, 0.0)``.                      |
++---------------------------------------------+---------------------------------------------------------------+
+| out vec4 **COLOR2**                         | Output color to blended with an extra DrawableTexture target. |
+|                                             | Initialized to ``(0.0, 0.0, 0.0, 0.0)``.                      |
++---------------------------------------------+---------------------------------------------------------------+
+| out vec4 **COLOR3**                         | Output color to blended with an extra DrawableTexture target. |
+|                                             | Initialized to ``(0.0, 0.0, 0.0, 0.0)``.                      |
++---------------------------------------------+---------------------------------------------------------------+


### PR DESCRIPTION
This salvages https://github.com/godotengine/godot-docs/pull/11296 with all suggestions applied, plus some additional changse such as linking the two new pages together.

Thanks @ColinSORourke for writing the original pages :slightly_smiling_face: 