### PR TITLE
Refactor collision handling for mob squashing in Godot 4.6

### DIFF
--- a/getting_started/first_3d_game/06.jump_and_squash.rst
+++ b/getting_started/first_3d_game/06.jump_and_squash.rst
@@ -250,19 +250,17 @@ With this code, if no collisions occurred on a given frame, the loop won't run.
             # get_collider will return null, leading to a null pointer when calling 
             # collision.get_collider().is_in_group("mob").
             # This block of code prevents processing duplicate collisions.
-            if collision.get_collider() == null:
-                continue
-
-            # If the collider is with a mob
-            if collision.get_collider().is_in_group("mob"):
-                var mob = collision.get_collider()
-                # we check that we are hitting it from above.
-                if Vector3.UP.dot(collision.get_normal()) > 0.1:
-                    # If so, we squash it and bounce.
-                    mob.squash()
-                    target_velocity.y = bounce_impulse
-                    # Prevent further duplicate calls.
-                    break
+            if collision.get_collider() is Node:
+                # If the collider is with a mob
+                if collision.get_collider().is_in_group("mob"):
+                    var mob = collision.get_collider()
+                    # we check that we are hitting it from above.
+                    if Vector3.UP.dot(collision.get_normal()) > 0.1:
+                        # If so, we squash it and bounce.
+                        mob.squash()
+                        target_velocity.y = bounce_impulse
+                        # Prevent further duplicate calls.
+                        break
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
`KinematicCollision3D.get_collider()` now returns `Object` instead of `Node`, leading to an error if the tutorial is followed without question.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
