### PR TITLE
link to paralax2D class in feature list

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -150,7 +150,7 @@ Godot 4 includes three renderers:
      :ref:`class_Polygon2D` and :ref:`class_Line2D`, with support for texturing.
 
 - AnimatedSprite2D as a helper for creating animated sprites.
-- Parallax layers.
+- :ref:`class_Parallax2D` layers.
 
    - Pseudo-3D support including preview in the editor.
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->

i have never contributed here, so hopefully i did this correctly.

alternative:
link to https://docs.godotengine.org/en/stable/tutorials/2d/2d_parallax.html tutorial page instead of class
