### PR TITLE
First3dGame - Change randi_range to randf_range to match source, use explicit floats for min and max speed

### DIFF
--- a/getting_started/first_3d_game/04.mob_scene.rst
+++ b/getting_started/first_3d_game/04.mob_scene.rst
@@ -125,10 +125,10 @@ and ``max_speed``, to define a random speed range, which we will later use to de
 
         // Minimum speed of the mob in meters per second
         [Export]
-        public float MinSpeed { get; set; } = 10.0;
+        public float MinSpeed { get; set; } = 10.0f;
         // Maximum speed of the mob in meters per second
         [Export]
-        public float MaxSpeed { get; set; } = 18.0;
+        public float MaxSpeed { get; set; } = 18.0f;
 
         public override void _PhysicsProcess(double delta)
         {
@@ -290,10 +290,10 @@ Here is the complete ``mob.gd`` script for reference.
     {
         // Minimum speed of the mob in meters per second.
         [Export]
-        public float MinSpeed { get; set; } = 10.0;
+        public float MinSpeed { get; set; } = 10.0f;
         // Maximum speed of the mob in meters per second.
         [Export]
-        public float MaxSpeed { get; set; } = 18.0;
+        public float MaxSpeed { get; set; } = 18.0f;
 
         public override void _PhysicsProcess(double delta)
         {

--- a/getting_started/first_3d_game/04.mob_scene.rst
+++ b/getting_started/first_3d_game/04.mob_scene.rst
@@ -107,9 +107,9 @@ and ``max_speed``, to define a random speed range, which we will later use to de
     extends CharacterBody3D
 
     # Minimum speed of the mob in meters per second.
-    @export var min_speed = 10
+    @export var min_speed = 10.0
     # Maximum speed of the mob in meters per second.
-    @export var max_speed = 18
+    @export var max_speed = 18.0
 
 
     func _physics_process(_delta):
@@ -125,10 +125,10 @@ and ``max_speed``, to define a random speed range, which we will later use to de
 
         // Minimum speed of the mob in meters per second
         [Export]
-        public int MinSpeed { get; set; } = 10;
+        public float MinSpeed { get; set; } = 10.0;
         // Maximum speed of the mob in meters per second
         [Export]
-        public int MaxSpeed { get; set; } = 18;
+        public float MaxSpeed { get; set; } = 18.0;
 
         public override void _PhysicsProcess(double delta)
         {
@@ -178,8 +178,8 @@ between ``-PI / 4`` radians and ``PI / 4`` radians.
         RotateY((float)GD.RandRange(-Mathf.Pi / 4.0, Mathf.Pi / 4.0));
     }
 
-We got a random position, now we need a ``random_speed``. ``randi_range()`` will be useful as it gives random int values, and we will use ``min_speed`` and ``max_speed``.
-``random_speed`` is just an integer, and we just use it to multiply our ``CharacterBody3D.velocity``. After ``random_speed`` is applied, we rotate ``CharacterBody3D.velocity`` Vector3 towards the player.
+We got a random position, now we need a ``random_speed``. ``randf_range()`` will be useful as it gives random float values, and we will use ``min_speed`` and ``max_speed``.
+``random_speed`` is just an float, and we just use it to multiply our ``CharacterBody3D.velocity``. After ``random_speed`` is applied, we rotate ``CharacterBody3D.velocity`` Vector3 towards the player.
 
 .. tabs::
  .. code-tab:: gdscript GDScript
@@ -187,8 +187,8 @@ We got a random position, now we need a ``random_speed``. ``randi_range()`` will
    func initialize(start_position, player_position):
        # ...
 
-       # We calculate a random speed (integer)
-       var random_speed = randi_range(min_speed, max_speed)
+       # We calculate a random speed (float)
+       var random_speed = randf_range(min_speed, max_speed)
        # We calculate a forward velocity that represents the speed.
        velocity = Vector3.FORWARD * random_speed
        # We then rotate the velocity vector based on the mob's Y rotation
@@ -201,8 +201,8 @@ We got a random position, now we need a ``random_speed``. ``randi_range()`` will
     {
         // ...
 
-        // We calculate a random speed (integer).
-        int randomSpeed = GD.RandRange(MinSpeed, MaxSpeed);
+        // We calculate a random speed (float).
+        float randomSpeed = GD.RandRange(MinSpeed, MaxSpeed);
         // We calculate a forward velocity that represents the speed.
         Velocity = Vector3.Forward * randomSpeed;
         // We then rotate the velocity vector based on the mob's Y rotation
@@ -255,9 +255,9 @@ Here is the complete ``mob.gd`` script for reference.
     extends CharacterBody3D
 
     # Minimum speed of the mob in meters per second.
-    @export var min_speed = 10
+    @export var min_speed = 10.0
     # Maximum speed of the mob in meters per second.
-    @export var max_speed = 18
+    @export var max_speed = 18.0
 
     func _physics_process(_delta):
         move_and_slide()
@@ -271,8 +271,8 @@ Here is the complete ``mob.gd`` script for reference.
         # so that it doesn't move directly towards the player.
         rotate_y(randf_range(-PI / 4, PI / 4))
 
-        # We calculate a random speed (integer)
-        var random_speed = randi_range(min_speed, max_speed)
+        # We calculate a random speed (float)
+        var random_speed = randf_range(min_speed, max_speed)
         # We calculate a forward velocity that represents the speed.
         velocity = Vector3.FORWARD * random_speed
         # We then rotate the velocity vector based on the mob's Y rotation
@@ -290,10 +290,10 @@ Here is the complete ``mob.gd`` script for reference.
     {
         // Minimum speed of the mob in meters per second.
         [Export]
-        public int MinSpeed { get; set; } = 10;
+        public float MinSpeed { get; set; } = 10.0;
         // Maximum speed of the mob in meters per second.
         [Export]
-        public int MaxSpeed { get; set; } = 18;
+        public float MaxSpeed { get; set; } = 18.0;
 
         public override void _PhysicsProcess(double delta)
         {
@@ -310,8 +310,8 @@ Here is the complete ``mob.gd`` script for reference.
             // so that it doesn't move directly towards the player.
             RotateY((float)GD.RandRange(-Mathf.Pi / 4.0, Mathf.Pi / 4.0));
 
-            // We calculate a random speed (integer).
-            int randomSpeed = GD.RandRange(MinSpeed, MaxSpeed);
+            // We calculate a random speed (float).
+            float randomSpeed = GD.RandRange(MinSpeed, MaxSpeed);
             // We calculate a forward velocity that represents the speed.
             Velocity = Vector3.Forward * randomSpeed;
             // We then rotate the velocity vector based on the mob's Y rotation

--- a/getting_started/first_3d_game/07.killing_player.rst
+++ b/getting_started/first_3d_game/07.killing_player.rst
@@ -267,10 +267,10 @@ Next is ``mob.gd``.
 
         // Minimum speed of the mob in meters per second
         [Export]
-        public float MinSpeed { get; set; } = 10.0;
+        public float MinSpeed { get; set; } = 10.0f;
         // Maximum speed of the mob in meters per second
         [Export]
-        public float MaxSpeed { get; set; } = 18.0;
+        public float MaxSpeed { get; set; } = 18.0f;
 
         public override void _PhysicsProcess(double delta)
         {

--- a/getting_started/first_3d_game/07.killing_player.rst
+++ b/getting_started/first_3d_game/07.killing_player.rst
@@ -221,9 +221,9 @@ Next is ``mob.gd``.
     extends CharacterBody3D
 
     # Minimum speed of the mob in meters per second.
-    @export var min_speed = 10
+    @export var min_speed = 10.0
     # Maximum speed of the mob in meters per second.
-    @export var max_speed = 18
+    @export var max_speed = 18.0
 
     # Emitted when the player jumped on the mob
     signal squashed
@@ -240,8 +240,8 @@ Next is ``mob.gd``.
         # so that it doesn't move directly towards the player.
         rotate_y(randf_range(-PI / 4, PI / 4))
 
-        # We calculate a random speed (integer)
-        var random_speed = randi_range(min_speed, max_speed)
+        # We calculate a random speed (float)
+        var random_speed = randf_range(min_speed, max_speed)
         # We calculate a forward velocity that represents the speed.
         velocity = Vector3.FORWARD * random_speed
         # We then rotate the velocity vector based on the mob's Y rotation
@@ -267,10 +267,10 @@ Next is ``mob.gd``.
 
         // Minimum speed of the mob in meters per second
         [Export]
-        public int MinSpeed { get; set; } = 10;
+        public float MinSpeed { get; set; } = 10.0;
         // Maximum speed of the mob in meters per second
         [Export]
-        public int MaxSpeed { get; set; } = 18;
+        public float MaxSpeed { get; set; } = 18.0;
 
         public override void _PhysicsProcess(double delta)
         {
@@ -287,8 +287,8 @@ Next is ``mob.gd``.
             // so that it doesn't move directly towards the player.
             RotateY((float)GD.RandRange(-Mathf.Pi / 4.0, Mathf.Pi / 4.0));
 
-            // We calculate a random speed (integer)
-            int randomSpeed = GD.RandRange(MinSpeed, MaxSpeed);
+            // We calculate a random speed (float)
+            float randomSpeed = GD.RandRange(MinSpeed, MaxSpeed);
             // We calculate a forward velocity that represents the speed.
             Velocity = Vector3.Forward * randomSpeed;
             // We then rotate the velocity vector based on the mob's Y rotation

--- a/getting_started/first_3d_game/09.adding_animations.rst
+++ b/getting_started/first_3d_game/09.adding_animations.rst
@@ -522,9 +522,9 @@ And the *Mob*'s script.
     extends CharacterBody3D
 
     # Minimum speed of the mob in meters per second.
-    @export var min_speed = 10
+    @export var min_speed = 10.0
     # Maximum speed of the mob in meters per second.
-    @export var max_speed = 18
+    @export var max_speed = 18.0
 
     # Emitted when the player jumped on the mob
     signal squashed
@@ -541,8 +541,8 @@ And the *Mob*'s script.
         # so that it doesn't move directly towards the player.
         rotate_y(randf_range(-PI / 4, PI / 4))
 
-        # We calculate a random speed (integer)
-        var random_speed = randi_range(min_speed, max_speed)
+        # We calculate a random speed (float)
+        var random_speed = randf_range(min_speed, max_speed)
         # We calculate a forward velocity that represents the speed.
         velocity = Vector3.FORWARD * random_speed
         # We then rotate the velocity vector based on the mob's Y rotation
@@ -570,10 +570,10 @@ And the *Mob*'s script.
 
         // Minimum speed of the mob in meters per second
         [Export]
-        public int MinSpeed { get; set; } = 10;
+        public float MinSpeed { get; set; } = 10.0;
         // Maximum speed of the mob in meters per second
         [Export]
-        public int MaxSpeed { get; set; } = 18;
+        public float MaxSpeed { get; set; } = 18.0;
 
         public override void _PhysicsProcess(double delta)
         {
@@ -590,8 +590,8 @@ And the *Mob*'s script.
             // so that it doesn't move directly towards the player.
             RotateY((float)GD.RandRange(-Mathf.Pi / 4.0, Mathf.Pi / 4.0));
 
-            // We calculate a random speed (integer).
-            int randomSpeed = GD.RandRange(MinSpeed, MaxSpeed);
+            // We calculate a random speed (float).
+            float randomSpeed = GD.RandRange(MinSpeed, MaxSpeed);
             // We calculate a forward velocity that represents the speed.
             Velocity = Vector3.Forward * randomSpeed;
             // We then rotate the velocity vector based on the mob's Y rotation

--- a/getting_started/first_3d_game/09.adding_animations.rst
+++ b/getting_started/first_3d_game/09.adding_animations.rst
@@ -570,10 +570,10 @@ And the *Mob*'s script.
 
         // Minimum speed of the mob in meters per second
         [Export]
-        public float MinSpeed { get; set; } = 10.0;
+        public float MinSpeed { get; set; } = 10.0f;
         // Maximum speed of the mob in meters per second
         [Export]
-        public float MaxSpeed { get; set; } = 18.0;
+        public float MaxSpeed { get; set; } = 18.0f;
 
         public override void _PhysicsProcess(double delta)
         {


### PR DESCRIPTION
Issue #9770
The docs used randi_range and integers for random_speed which does not match the source in https://github.com/godotengine/godot-demo-projects/tree/master/3d/squash_the_creeps and would cause an integer division bug when scaling the animation speed.

Additionally, min and max speed have been changed to floats for clarity. https://github.com/godotengine/godot-demo-projects/pull/1329




