### PR TITLE
Add class_name to documentation comments examples

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_documentation_comments.rst
+++ b/tutorials/scripting/gdscript/gdscript_documentation_comments.rst
@@ -49,6 +49,7 @@ For example:
 
 ::
 
+    class_name MyClass
     extends Node2D
     ## A brief description of the class's role and functionality.
     ##
@@ -140,6 +141,7 @@ Complete script example
 
 ::
 
+    class_name MyClass
     extends Node2D
     ## A brief description of the class's role and functionality.
     ##


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-docs/issues/12079

This PR defines a class_name at the top of GDScript examples showcasing documentation comments for classes to help show users that they could add descriptions using documentation comments (##) to their class:
```gdscript
class_name MyClass
```
