### PR TITLE
Replace references to the asset library

### DIFF
--- a/about/introduction.rst
+++ b/about/introduction.rst
@@ -82,7 +82,7 @@ This documentation is organized into several sections:
   or developing C++ modules.
 - **Community** is dedicated to the life of Godot's community and contains a list of
   recommended third-party tutorials and materials outside of this documentation.
-  It also provides details on the Asset Library. It also used to list Godot
+  It also provides details on the Asset Store. It also used to list Godot
   communities, which are now listed on the `Godot website <https://godotengine.org/community/>`_.
 - Finally, the **Class reference** documents the full Godot API,
   also available directly within the engine's script editor.

--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -115,10 +115,10 @@ Editor
 **Plugins:**
 
 - Editor plugins can be downloaded from the
-  :ref:`asset library <doc_what_is_assetlib>` to extend editor functionality.
+  :ref:`Asset Store <doc_what_is_asset_store>` to extend editor functionality.
 - :ref:`Create your own plugins <doc_making_plugins>` using GDScript to add new
   features or speed up your workflow.
-- :ref:`Download projects from the asset library <doc_using_assetlib_editor>`
+- :ref:`Download projects from the Asset Store <doc_using_asset_store_editor>`
   in the Project Manager and import them directly.
 
 Rendering

--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -5,7 +5,7 @@ Tutorials and resources
 
 This is a list of third-party tutorials and resources created by the Godot
 community. For resources, remember that there is the official
-`Godot Asset Library <https://godotengine.org/asset-library/asset>`_ full of
+`Godot Asset Store <https://store.godotengine.org/>`_ full of
 official and community resources too!
 
 Think there is something missing here? Feel free to submit a `Pull Request <https://github.com/godotengine/godot-docs/blob/master/community/tutorials.rst>`_ as always.
@@ -39,5 +39,5 @@ Resources
 ---------
 
 - `awesome-godot: A curated list of free/libre plugins, scripts and add-ons <https://github.com/godotengine/awesome-godot>`_
-- `Godot Asset Library <https://godotengine.org/asset-library/asset>`_
+- `Godot Asset Store <https://store.godotengine.org/>`_
 - `Godot Shaders: A community-driven shader library <https://godotshaders.com/>`_

--- a/tutorials/scripting/cpp/about_godot_cpp.rst
+++ b/tutorials/scripting/cpp/about_godot_cpp.rst
@@ -30,7 +30,7 @@ compiling the engine's source code, making it easier to distribute your work.
 It gives you access to most of the API available to GDScript and C#, allowing
 you to code game logic with full control regarding performance. It's ideal if
 you need high-performance code you'd like to distribute as an add-on in the
-:ref:`asset library <doc_what_is_assetlib>`.
+:ref:`Asset Store <doc_what_is_asset_store>`.
 
 Also:
 

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -13,7 +13,7 @@ If you decide to work with it, here's what to expect your workflow to look like:
 * Develop your code with your :ref:`favorite IDE <toc-devel-configuring_an_ide>` locally.
 * Build and test your code with the earliest compatible Godot version.
 * Create builds for all platforms you want to support (e.g. using `GitHub Actions <https://github.com/godotengine/godot-cpp-template/blob/main/.github/workflows/make_build.yml>`__).
-* Optional: Publish on the `Godot Asset Library <https://godotengine.org/asset-library/asset>`__.
+* Optional: Publish on the `Godot Asset Store <https://store.godotengine.org/>`__.
 
 Example project
 ---------------

--- a/tutorials/xr/introducing_xr_tools.rst
+++ b/tutorials/xr/introducing_xr_tools.rst
@@ -20,9 +20,8 @@ Installing XR Tools
 
 Continuing on from our project we started in :ref:`doc_setting_up_xr` we want to add in the Godot XR Tools library.
 This can be downloaded from the `Godot XR Tools releases page <https://github.com/GodotVR/godot-xr-tools/releases>`_.
-Find the latest release for Godot 4, and under **Assets**, download the
-``godot-xr-tools.zip`` file. You can also find it in the asset library with the
-title "Godot XR Tools for Godot 4".
+Find the latest release, and under **Assets**, download the ``godot-xr-tools.zip``
+file. You can also find it in the Asset Store with the title "Godot XR Tools".
 
 If you're using the zip file, once it's downloaded unzip it.
 You will notice the files are held within a ``godot-xr-tools`` subfolder.


### PR DESCRIPTION
Does what the title says. Keep in mind this isn't everything in the docs. Some pages are pointing to demo projects that aren't on the asset store yet. And some pages will need more in depth changes (image updates and or text changes)