### PR TITLE
fix typo: "Visual Studio" being labeled as "Visaul Studio"

### DIFF
--- a/engine_details/development/compiling/compiling_for_windows.rst
+++ b/engine_details/development/compiling/compiling_for_windows.rst
@@ -23,15 +23,15 @@ For compiling under Windows, the following is required:
 
       .. tabs::
 
-          .. tab:: Visaul Studio 2019
+          .. tab:: Visual Studio 2019
               - **MSVC v142 - VS 2019 C++ {arch} build tools (Latest)** for the target architectures.
               - **Windows 11 SDK (10.0.22621.0)** (exact version).
 
-          .. tab:: Visaul Studio 2022
+          .. tab:: Visual Studio 2022
               - **MSVC v143 - VS 2022 C++ {arch} build tools (Latest)** for the target architectures.
               - **Windows 11 SDK (10.0.22621.0)** or newer.
 
-          .. tab:: Visaul Studio 2026
+          .. tab:: Visual Studio 2026
               - **MSVC Build Tools for {arch} (Latest)** for the target architectures.
               - **Windows 11 SDK (10.0.22621.0)** or newer.
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
fixed Visual Studio being written as Visaul Studio in https://docs.godotengine.org/en/stable/engine_details/development/compiling/compiling_for_windows.html#doc-compiling-for-windows
<img width="1022" height="488" alt="Captura de pantalla 2026-06-21 145445" src="https://github.com/user-attachments/assets/ab1bd617-2fcd-453c-b309-4dcc6158760c" />
