### PR TITLE
Document stretch mode/aspect change for new projects in Upgrading to Godot 4.7

### DIFF
--- a/tutorials/migrating/upgrading_to_godot_4.7.rst
+++ b/tutorials/migrating/upgrading_to_godot_4.7.rst
@@ -264,6 +264,14 @@ The following default values have been changed. If your project uses any of thes
 with their default value, you can achieve a similar behavior to the previous version by manually
 setting the values to match the old defaults.
 
+
+.. note::
+
+    The default stretch mode and stretch aspect for **newly created** projects
+    is now ``canvas_items`` and ``expand`` respectively (previously ``disabled``
+    and ``keep``). This can be changed in the Project Settings under
+    ``display/window/stretch/mode`` and ``display/window/stretch/aspect``.
+
 Animation
 ~~~~~~~~~
 


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot-docs/pull/11959.

Existing projects are not automatically affected by this change, as the setting is written for newly created projects only (like Jolt or Direct3D 12).

- See https://github.com/godotengine/godot/pull/118815.
