### PR TITLE
Document changes to AnimationNodeBlendSpace `sync` in Upgrading to Godot 4.7

### DIFF
--- a/tutorials/migrating/upgrading_to_godot_4.7.rst
+++ b/tutorials/migrating/upgrading_to_godot_4.7.rst
@@ -178,6 +178,21 @@ Method ``_commit`` adds new ``amend`` parameter                                 
 Behavior changes
 ----------------
 
+Animation
+~~~~~~~~~
+
+.. note::
+
+    AnimationNodeBlendSpace1D and AnimationNodeBlendSpace2D have a new SyncMode
+    enum that replaces the previous boolean ``sync`` property. If you are using
+    an AnimationTree and your animations aren't transitioning correctly after
+    upgrading, you may need to set that value in each of your blend spaces to
+    get the desired behavior back.
+
+    The new sync modes are documented in
+    :ref:`AnimationNodeBlendSpace1D.sync_mode <class_AnimationNodeBlendSpace1D_property_sync_mode>`
+    and :ref:`AnimationNodeBlendSpace2D.sync_mode <class_AnimationNodeBlendSpace2D_property_sync_mode>`.
+
 Rendering
 ~~~~~~~~~
 


### PR DESCRIPTION
- See https://github.com/godotengine/godot-docs-user-notes/discussions/738#discussioncomment-17448768
and https://github.com/godotengine/godot/pull/117275.
