### PR TITLE
Adjust license text according to main repository

### DIFF
--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -48,7 +48,7 @@ This text reads as follows:
 
     This game uses Godot Engine, available under the following license:
 
-    Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md).
+    Copyright (c) 2014-present Godot Engine contributors (see <https://github.com/godotengine/godot/blob/master/AUTHORS.md>).
     Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.
 
     Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -48,7 +48,7 @@ This text reads as follows:
 
     This game uses Godot Engine, available under the following license:
 
-    Copyright (c) 2014-present Godot Engine contributors.
+    Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md).
     Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.
 
     Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
It should be identical to https://github.com/godotengine/godot/blob/master/LICENSE.txt again now