### PR TITLE
Restructure our XR pages and introduce additional information

### DIFF
--- a/tutorials/xr/arcore_intro.rst
+++ b/tutorials/xr/arcore_intro.rst
@@ -1,0 +1,14 @@
+.. _doc_arcire_intro:
+
+ARCore
+======
+
+ARCore is an Android API that allows phone based AR applications to work on the device. 
+Support for this API is offered through the `Godot ARCore plugin. <https://github.com/godotvr/godot_arcore>`__
+
+For more information, please consult the documentation provided with the plugin.
+
+.. note::
+
+    This plugin is **not** maintained by the Godot Foundation.
+    The plugin currently lies dormant and is not under active development.

--- a/tutorials/xr/index.rst
+++ b/tutorials/xr/index.rst
@@ -12,35 +12,57 @@ Virtual Reality and Augmented Reality).
 
    xr_terminology
    
-Basic Tutorial
---------------
+Getting Started
+---------------
 
 .. toctree::
    :maxdepth: 1
    :name: xr-basic-tutorial
 
    setting_up_xr
-   deploying_to_android
-   a_better_xr_start_script
    ar_passthrough
    xr_next_steps
 
-Advanced topics
----------------
+XR Interfaces
+-------------
+
+OpenXR
+~~~~~~
 
 .. toctree::
    :maxdepth: 1
-   :name: openxr-advanced-topics
+   :name: openxr-topics
 
+   a_better_xr_start_script
+   deploying_to_android
    openxr_settings
    xr_action_map
-   xr_room_scale
-   xr_full_screen_effects
    openxr_composition_layers
    openxr_hand_tracking
    openxr_body_tracking
    openxr_render_models
    openxr_spatial_entities
+
+WebXR
+~~~~~
+
+.. toctree::
+   :maxdepth: 1
+   :name: webxr-topics
+
+   webxr_intro
+
+Others
+~~~~~~
+
+.. toctree::
+   :maxdepth: 1
+   :name: other-interfaces-topics
+
+   mobilevr_intro
+   arcore_intro
+   openvr_intro
+   tiltfive_intro
 
 Godot XR Tools
 --------------
@@ -51,3 +73,13 @@ Godot XR Tools
 
    introducing_xr_tools
    basic_xr_locomotion
+
+Advanced Topics
+---------------
+
+.. toctree::
+   :maxdepth: 1
+   :name: openxr-advanced-topics
+
+   xr_room_scale
+   xr_full_screen_effects

--- a/tutorials/xr/mobilevr_intro.rst
+++ b/tutorials/xr/mobilevr_intro.rst
@@ -1,0 +1,65 @@
+.. _doc_mobilevr_intro:
+
+Mobile VR
+=========
+
+Godot has a mobile VR implementation that is meant to be used with phones placed inside of a VR holder.
+It is implemented through the :ref:`MobileVRInterface <class_mobilevrinterface>`.
+This is a bare bones implementation that outputs a side by side stereoscopic image.
+It supports basic 3DOF tracking on phones that provide gyroscope and accelerometer data.
+
+.. warning::
+
+    This implementation is not actively maintained. As it allows maintainers and reviewers the ability
+    to test stereoscopic rendering without the need for expensive XR hardware,
+    this XR interface is mostly used for diagnostic purposes.
+
+
+.. tabs::
+  .. code-tab:: gdscript GDScript
+
+    extends Node3D
+
+    var xr_interface: XRInterface
+
+    func _ready() -> void:
+        xr_interface = XRServer.find_interface("Native mobile")
+        if xr_interface and xr_interface.initialize():
+            print("Mobile VR initialized successfully")
+
+            # Change our main viewport to output to the HMD.
+            get_viewport().use_xr = true
+        else:
+            print("Mobile VR not initialized, please check if your headset is connected")
+
+  .. code-tab:: csharp
+
+    using Godot;
+
+    public partial class MyNode3D : Node3D
+    {
+        private XRInterface _xrInterface;
+
+        public override void _Ready()
+        {
+            _xrInterface = XRServer.FindInterface("Native mobile");
+            if(_xrInterface != null && _xrInterface.Initialize())
+            {
+                GD.Print("Mobile VR initialized successfully");
+
+                // Change our main viewport to output to the HMD.
+                GetViewport().UseXR = true;
+            }
+            else
+            {
+                GD.Print("Mobile VR not initialized, please check if your headset is connected");
+            }
+        }
+    }
+
+The mobile VR interface has various settings that control the output provided to screen.
+The most important two are the ``k1`` and ``k2`` constants that affect the amount of barrel distortion
+that is applied to counter the lens distortion of the VR phone holder used.
+Many have a QR code you can scan that provides this information.
+
+It is also important to provide the correct dimensions of the device and the phone's display, these metrics are stored in centimeters.

--- a/tutorials/xr/openvr_intro.rst
+++ b/tutorials/xr/openvr_intro.rst
@@ -1,0 +1,17 @@
+.. _doc_openvr_intro:
+
+OpenVR
+======
+
+OpenVR is the original API Valve created to interface with SteamVR.
+Support for this API is offered through the `Godot OpenVR plugin. <https://github.com/godotvr/godot_openvr>`__
+
+For any new XR project we highly recommend using Godot's built-in OpenXR support.
+The OpenVR plugin can be applicable for some niche use cases such as creating OpenVR Overlays.
+
+For more information, please consult the documentation provided with the plugin.
+
+.. note::
+
+    This plugin is **not** maintained by the Godot Foundation.
+    A few intrepid contributors ensure occasional maintenance releases of the plugin as needed.

--- a/tutorials/xr/setting_up_xr.rst
+++ b/tutorials/xr/setting_up_xr.rst
@@ -45,7 +45,8 @@ compared to the other two.
 OpenXR
 ------
 
-OpenXR is a new industry standard that allows different XR platforms to present themselves through a standardized API to XR applications. This standard is an open standard maintained by the Khronos Group and thus aligns very well with Godot's interests.
+OpenXR is the industry standard API that allows different XR platforms to interact with XR applications. This standard is an open standard maintained by the Khronos Group and thus aligns very well with Godot's interests.
+We are thus using this as the example in this introduction. Check the respective chapters for differences in other APIs.
 
 The Vulkan implementation of OpenXR is closely integrated with Vulkan, taking over part of the Vulkan system. This requires tight integration of certain core graphics features in the Vulkan renderer which are needed before the XR system is setup. This was one of the main deciding factors to include OpenXR as a core interface.
 
@@ -101,10 +102,7 @@ Next we need to add a script to our root node. Add the following code into this 
         if xr_interface and xr_interface.is_initialized():
             print("OpenXR initialized successfully")
 
-            # Turn off v-sync!
-            DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_DISABLED)
-
-            # Change our main viewport to output to the HMD
+            # Change our main viewport to output to the HMD.
             get_viewport().use_xr = true
         else:
             print("OpenXR not initialized, please check if your headset is connected")
@@ -124,10 +122,7 @@ Next we need to add a script to our root node. Add the following code into this 
             {
                 GD.Print("OpenXR initialized successfully");
 
-                // Turn off v-sync!
-                DisplayServer.WindowSetVsyncMode(DisplayServer.VSyncMode.Disabled);
-
-                // Change our main viewport to output to the HMD
+                // Change our main viewport to output to the HMD.
                 GetViewport().UseXR = true;
             }
             else
@@ -137,18 +132,25 @@ Next we need to add a script to our root node. Add the following code into this 
         }
     }
 
-This code fragment assumes we are using OpenXR, if you wish to use any of the other interfaces you can change the ``find_interface`` call.
+
+.. note::
+
+    There is no restriction to where this code is executed from. It is common to add this script to the :ref:`XROrigin3D <class_xrorigin3d>` node or as a :ref:`Node3D <class_node3d>` child of the root node.
+
+    The OpenXR interface is unique in that we have to start it before the project loads, hence ``is_initialized`` is checked here. Most interfaces require a call to their ``initialize`` function instead.
+
+    If you wish to support multiple XR interfaces, say release a game both targeting OpenXR hardware and deploy over WebXR, you can check one after the other until a functioning interface is found.
+
 
 .. warning::
 
-    As you can see in the code snippet above, we turn off v-sync.
-    When using OpenXR you are outputting the rendering results to an HMD that often requires us to run at 90Hz or higher.
-    If your monitor is a 60hz monitor and v-sync is turned on, you will limit the output to 60 frames per second.
+    As OpenXR outputs the rendering result to an HMD, which often runs at a higher framerate than the monitor, Godot's V-Sync settings are ignored and V-sync will always be disabled.
 
-    XR interfaces like OpenXR perform their own sync.
+    Instead, OpenXR perform its own frame timing to ensure a consistent framerate.
 
     Also note that by default the physics engine runs at 60Hz as well and this can result in choppy physics.
     You should set ``Engine.physics_ticks_per_second`` to a higher value.
+
 
 If you run your project at this point in time, everything will work but you will be in a dark world. So to finish off our starting point add a :ref:`DirectionalLight3D <class_directionallight3d>` and a :ref:`WorldEnvironment <class_worldenvironment>` node to your scene.
 You may wish to also add a mesh instance as a child to each controller node just to temporarily visualise them.

--- a/tutorials/xr/tiltfive_intro.rst
+++ b/tutorials/xr/tiltfive_intro.rst
@@ -1,0 +1,14 @@
+.. _doc_tiltfive_intro:
+
+TiltFive
+========
+
+TiltFive is a PC based, multiplayer AR device specializing in table top gaming.
+Support for this platform is offered through the `TiltFive Godot plugin. <https://github.com/GodotVR/TiltFiveGodot4>`__
+
+For more information, please consult the documentation provided with the plugin.
+
+.. note::
+
+    This plugin is **not** maintained by the Godot Foundation.
+    A few intrepid contributors ensure development of the plugin as needed.

--- a/tutorials/xr/webxr_intro.rst
+++ b/tutorials/xr/webxr_intro.rst
@@ -1,0 +1,172 @@
+.. _doc_webxr_intro:
+
+WebXR
+=====
+
+WebXR is a web standard for delivering XR experiences right from a web browser,
+without the user needing to install anything. Godot has built-in support for WebXR.
+
+.. note::
+
+    As this uses the HTML export WebXR requires the use of the compatibility renderer.
+    Godot currently requires multiview support for stereo rendering which is not available on all WebXR capable devices.
+
+Setup
+-----
+
+Setting up WebXR is a little different because your application always starts as a normal non-XR webpage.
+We thus define a 2D UI on our main page that includes a button that will switch to XR.
+
+We will need the following code to make things work:
+
+.. tabs::
+  .. code-tab:: gdscript GDScript
+
+    extends Node3D
+
+    @onready var start_xr_button: Button = $EnterWebXR
+
+    # Our WebXR interface.
+    var xr_interface: WebXRInterface
+
+    # Is a WebXR is_session_supported query running
+    var webxr_session_query: bool = false
+
+    # Set this to true if we wish to have an AR session
+    var require_ar: bool = false
+
+    # Set this to true if we wish to have hand tracking
+    var enable_hand_tracking: bool = false
+
+    # Handle the Enter VR button on the WebXR browser
+    func _on_enter_webxr_button_pressed() -> void:
+        # Configure the WebXR interface
+        xr_interface.session_mode = "immersive-ar" if require_ar else "immersive-vr"
+        xr_interface.requested_reference_space_types = "local-floor, local"
+        xr_interface.required_features = "local-floor"
+        xr_interface.optional_features = ""
+
+        # Add hand-tracking if needed
+        if enable_hand_tracking:
+            xr_interface.optional_features += ", hand-tracking"
+
+        # Initialize the interface. This should trigger either _on_webxr_session_started
+        # or _on_webxr_session_failed
+        if not xr_interface.initialize():
+            OS.alert("Failed to initialize WebXR")
+
+
+    # Called when we're ready
+    func _ready() -> void:
+        xr_interface = XRServer.find_interface("WebXR")
+        if xr_interface:
+            # Connect our signals
+            xr_interface.session_supported.connect(_on_webxr_session_supported)
+            xr_interface.session_started.connect(_on_webxr_session_started)
+            xr_interface.session_ended.connect(_on_webxr_session_ended)
+            xr_interface.session_failed.connect(_on_webxr_session_failed)
+
+           	webxr_session_query = true
+        	xr_interface.is_session_supported("immersive-ar" if require_ar else "immersive-vr")
+        else:
+            print("WebXR is not available")
+
+
+    # Handle WebXR session supported check
+    func _on_webxr_session_supported(session_mode: String, supported: bool) -> void:
+        # Skip if not running session-query
+        if not webxr_session_query:
+            return
+
+        # Clear the query flag
+        webxr_session_query = false
+
+        # Report if not supported
+        if not supported:
+            OS.alert("Your web browser doesn't support " + session_mode + ". Sorry!")
+            return
+
+        # WebXR supported - show canvas on web browser to enter WebVR
+        start_xr_button.visible = true
+
+
+    # Called when the WebXR session has started successfully
+    func _on_webxr_session_started() -> void:
+        # Hide the canvas and switch the viewport to XR
+        start_xr_button.visible = false
+
+        get_viewport().transparent_bg = require_ar
+        get_viewport().use_xr = true
+
+
+    # Called when the user ends the immersive VR session
+    func _on_webxr_session_ended() -> void:
+        # Show the canvas and switch the viewport to non-XR
+        start_xr_button.visible = true
+
+        get_viewport().transparent_bg = false
+        get_viewport().use_xr = false
+
+
+    # Called when the immersive VR session fails to start
+    func _on_webxr_session_failed(message: String) -> void:
+        OS.alert("Unable to enter VR: " + message)
+        start_xr_button.visible = true
+
+
+Make sure the "Enable WebXR" button's ``button_pressed`` signal calls the ``_on_enter_webxr_button_pressed`` method.
+
+.. note::
+
+    In the code above we attempt to use the ``local-floor`` reference spaces.
+    This reference spaces assumes gameplay where we need to know the player's height from the floor.
+
+    For games where the player is seated inside of a vehicle, such as flight sims or racing games, the reference space ``local`` may be more appropriate.
+
+
+Controller input
+----------------
+
+The input system in WebXR works against a fixed set of inputs that obfuscate the actual hardware being used. In order to allow for code to be portable between a WebXR and OpenXR application these inputs are mapped to actions that overlap with the default action map used by our OpenXR interface.
+
+There are small differences such as WebXR separating touchpad and thumbsticks as separate inputs, instead of the primary and secondary input setup found in our default OpenXR action map.
+
+The core inputs are available for WebXR:
+
+
+.. table::
+   :widths: auto
+
+   +-----------------------------+-----------+---------------------------------------------------------+
+   |  Name                       | Type      | Description                                             |
+   +-----------------------------+-----------+---------------------------------------------------------+
+   |  trigger_click              | Boolean   | ``true`` if the trigger is pressed                      |
+   +-----------------------------+-----------+---------------------------------------------------------+
+   |  trigger                    | Float     | Trigger value between 0.0 and 1.0                       |
+   +-----------------------------+-----------+---------------------------------------------------------+
+   |  grip_click                 | Boolean   | ``true`` if the grip button is pressed                  |
+   +-----------------------------+-----------+---------------------------------------------------------+
+   |  grip                       | Float     | Grip value between 0.0 and 1.0                          |
+   +-----------------------------+-----------+---------------------------------------------------------+
+   |  touchpad_click             | Boolean   | ``true`` if the touchpad is pressed                     |
+   +-----------------------------+-----------+---------------------------------------------------------+
+   |  thumbstick_click           | Boolean   | ``true`` if the thumbstick is pressed                   |
+   +-----------------------------+-----------+---------------------------------------------------------+
+   |  ax_button                  | Boolean   | ``true`` if the A or X button is pressed                |
+   +-----------------------------+-----------+---------------------------------------------------------+
+   |  by_button                  | Boolean   | ``true`` if the B or Y button is pressed                |
+   +-----------------------------+-----------+---------------------------------------------------------+
+   |  touchpad_x                 | Float     | Finger movement on the touchpad in the X direction      |
+   +-----------------------------+-----------+---------------------------------------------------------+
+   |  touchpad_y                 | Float     | Finger movement on the touchpad in the Y direction      |
+   +-----------------------------+-----------+---------------------------------------------------------+
+   |  touchpad                   | Vector2   | Touchpad input as a Vector2                             |
+   +-----------------------------+-----------+---------------------------------------------------------+
+   |  thumbstick_x               | Float     | Thumbstick movement in the X direction                  |
+   +-----------------------------+-----------+---------------------------------------------------------+
+   |  thumbstick_y               | Float     | Thumbstick movement in the Y direction                  |
+   +-----------------------------+-----------+---------------------------------------------------------+
+   |  thumbstick                 | Vector2   | Thumbstick input as a Vector2                           |
+   +-----------------------------+-----------+---------------------------------------------------------+
+
+WebXR also exposes ``aim`` and ``grip`` poses that respectively identify a forward facing location at the tip of the controller and a position on the controller grip.


### PR DESCRIPTION
This PR restructures the XR manual pages somewhat to create a specific section for OpenXR topics and adding sections for mobile VR and webXR and lays the groundwork for future sections of a similar type.