### PR TITLE
Remove duplicated sentence in exporting_projects.rst

### DIFF
--- a/tutorials/export/exporting_projects.rst
+++ b/tutorials/export/exporting_projects.rst
@@ -133,11 +133,8 @@ If you click the button in the upper right of the window, you can install templa
 from a TPZ file (essentially a ZIP archive). You can download a TPZ file of all
 export templates from the `download page of the website <https://www.godotengine.org/download>`_.
 
-There is no inherent advantage to using the TPZ file for all platforms,
-functionality is identical, and it will take up more space compared to only
-There is no inherent advantage to using the TPZ file for all platforms. It is functionally identical, and it will take up more space compared to only
-selecting what you need.
-
+There is no inherent advantage to using the TPZ file for all platforms. It is functionally
+identical, and it will take up more space compared to only selecting what you need.
 
 .. _doc_exporting_projects_export_mode:
 


### PR DESCRIPTION
While going through the guide, I noticed a paragraph that has two copies of the same content. I removed the incomplete copy and reflowed the paragraph to fit the apparent text width.

---

I made it here from the "Your first 2D game" tutorial, so I wanted to say thanks! I feel well equipped to start making my second game now :slightly_smiling_face: 