### PR TITLE
Ungroup shortcut needs shift to be held

### DIFF
--- a/tutorials/2d/introduction_to_2d.rst
+++ b/tutorials/2d/introduction_to_2d.rst
@@ -157,8 +157,8 @@ Use the three-dot menu for this:
   They can easily be identified by a padlock next to their node names in the scene tree. 
   Clicking on this padlock also unlocks the nodes.
 - **Group selected nodes** (:kbd:`Ctrl + G`). This allows selection of the root node if any 
-  of the children are selected. Using :kbd:`Ctrl + G` ungroups them. Additionally, clicking 
-  the ungroup button in the scene tree performs the same action.
+  of the children are selected. Using :kbd:`Ctrl + Shift + G` ungroups them. Additionally,
+  clicking the ungroup button in the scene tree performs the same action.
 - **Skeleton Options**: Provides options to work with Skeleton2D and Bone2D.
 
   - Show Bones: Toggles the visibility of bones for the selected node.


### PR DESCRIPTION
I am trying to press <kbd>Ctrl+G</kbd> after a group is made and nothing happens. However <kbd>Ctrl+Shift+G</kbd> correctly ungroups, and that's what the UI shows as well (v4.7.stable.official \[5b4e0cb0f\]):
<img width="746" height="110" alt="image" src="https://github.com/user-attachments/assets/86da4dfa-ee97-4b5d-909c-0b3d1e2bfedf" />
So I think the documentation is wrong / outdated.