### PR TITLE
Fix variable name from _dock_scene to dock_scene

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -346,7 +346,7 @@ The script could look like this:
 
         public override void _EnterTree()
         {
-            var _dock_scene = GD.Load<PackedScene>("res://addons/MyCustomDock/MyDock.tscn").Instantiate<Control>();
+            var dock_scene = GD.Load<PackedScene>("res://addons/MyCustomDock/MyDock.tscn").Instantiate<Control>();
 
             // Create the dock and add the loaded scene to it.
             _dock = new EditorDock();

--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -310,11 +310,11 @@ The script could look like this:
     func _enter_tree():
         # Initialization of the plugin goes here.
         # Load the dock scene and instantiate it.
-        var dockScene = preload("res://addons/my_custom_dock/my_dock.tscn").instantiate()
+        var dock_scene = preload("res://addons/my_custom_dock/my_dock.tscn").instantiate()
 
         # Create the dock and add the loaded scene to it.
         dock = EditorDock.new()
-        dock.add_child(dockScene)
+        dock.add_child(dock_scene)
 
         dock.title = "My Dock"
 

--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -346,11 +346,11 @@ The script could look like this:
 
         public override void _EnterTree()
         {
-            var dock_scene = GD.Load<PackedScene>("res://addons/MyCustomDock/MyDock.tscn").Instantiate<Control>();
+            var dockScene = GD.Load<PackedScene>("res://addons/MyCustomDock/MyDock.tscn").Instantiate<Control>();
 
             // Create the dock and add the loaded scene to it.
             _dock = new EditorDock();
-            _dock.AddChild(dock_scene);
+            _dock.AddChild(dockScene);
 
             _dock.Title = "My Dock";
 

--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -310,11 +310,11 @@ The script could look like this:
     func _enter_tree():
         # Initialization of the plugin goes here.
         # Load the dock scene and instantiate it.
-        var dock_scene = preload("res://addons/my_custom_dock/my_dock.tscn").instantiate()
+        var dockScene = preload("res://addons/my_custom_dock/my_dock.tscn").instantiate()
 
         # Create the dock and add the loaded scene to it.
         dock = EditorDock.new()
-        dock.add_child(dock_scene)
+        dock.add_child(dockScene)
 
         dock.title = "My Dock"
 


### PR DESCRIPTION
The example C# code to attach the dock scene wouldn't compile because the variable was declared as `_dock_scene` but later used as `dock_scene`. I removed the leading underscore to go with the style of locally-scoped variables rather than a private class member.
