### PR TITLE
Remove pulse from custom effect example

### DIFF
--- a/tutorials/ui/bbcode_in_richtextlabel.rst
+++ b/tutorials/ui/bbcode_in_richtextlabel.rst
@@ -1251,6 +1251,32 @@ the user fixes whatever error cropped up in their custom effect logic.
 
 Here are some examples of custom effects:
 
+Pulse
+~~~~~
+
+::
+   @tool
+   extends RichTextEffect
+   class_name RichTextPulse
+
+   # Syntax: [pulse color=#00FFAA height=0.0 freq=2.0][/pulse]
+
+   # Define the tag name.
+   var bbcode = "pulse"
+
+   func _process_custom_fx(char_fx):
+        # Get parameters, or use the provided default value if missing.
+        var color = char_fx.env.get("color", char_fx.color)
+        var height = char_fx.env.get("height", 0.0)
+        var freq = char_fx.env.get("freq", 2.0)
+
+        var sined_time = (sin(char_fx.elapsed_time * freq) + 1.0) / 2.0
+        var y_off = sined_time * height
+        color.a = 1.0
+        char_fx.color = char_fx.color.linear_interpolate(color, sined_time)
+        char_fx.offset = Vector2(0, -1) * y_off
+        return true
+
 Ghost
 ~~~~~
 

--- a/tutorials/ui/bbcode_in_richtextlabel.rst
+++ b/tutorials/ui/bbcode_in_richtextlabel.rst
@@ -1251,32 +1251,6 @@ the user fixes whatever error cropped up in their custom effect logic.
 
 Here are some examples of custom effects:
 
-Pulse
-~~~~~
-
-::
-   @tool
-   extends RichTextEffect
-   class_name RichTextPulse
-
-   # Syntax: [pulse color=#00FFAA height=0.0 freq=2.0][/pulse]
-
-   # Define the tag name.
-   var bbcode = "pulse"
-
-   func _process_custom_fx(char_fx):
-        # Get parameters, or use the provided default value if missing.
-        var color = char_fx.env.get("color", char_fx.color)
-        var height = char_fx.env.get("height", 0.0)
-        var freq = char_fx.env.get("freq", 2.0)
-
-        var sined_time = (sin(char_fx.elapsed_time * freq) + 1.0) / 2.0
-        var y_off = sined_time * height
-        color.a = 1.0
-        char_fx.color = char_fx.color.linear_interpolate(color, sined_time)
-        char_fx.offset = Vector2(0, -1) * y_off
-        return true
-
 Ghost
 ~~~~~
 
@@ -1343,5 +1317,4 @@ This will add a few new BBCode commands, which can be used like so:
 
 .. code-block:: none
 
-    [center][ghost]This is a custom [matrix]effect[/matrix][/ghost] made in
-    [pulse freq=5.0 height=2.0][pulse color=#00FFAA freq=2.0]GDScript[/pulse][/pulse].[/center]
+    [center][ghost]This is a custom effect[/ghost] made in [matrix]GDScript[/matrix][/center]


### PR DESCRIPTION
Seems to have disappeared at some point between now and the v3.2 docs, though it's still referenced in the example below the GDScripts. This just adds back in the script ( and changes `tool` to `@tool` ).

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
