### PR TITLE
Update changing application icons instructions for Windows

### DIFF
--- a/tutorials/export/changing_application_icon_for_windows.rst
+++ b/tutorials/export/changing_application_icon_for_windows.rst
@@ -28,9 +28,9 @@ using this `ImageMagick <https://www.imagemagick.org/>`_ command:
 
 .. code-block:: none
 
-    magick convert icon.png -define icon:auto-resize=256,128,64,48,32,16 icon.ico
+    magick icon.png -define icon:auto-resize=256,128,64,48,32,16 icon.ico
 
-Depending on which version of ImageMagick you installed, you might need to leave out the ``magick`` and run this command instead:
+Depending on which version of ImageMagick you installed, you might need to use this command instead:
 
 .. code-block:: none
 


### PR DESCRIPTION
I have changed the ImageMagick command to use ``magick`` instead of ``magick convert``. Using ``magick convert``, as directed by this article, gave me a depreciation message which read:

```
WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"
```

I looked around, and using ``magick convert`` used to have the behavior of running this command with backwards compatibility for the IMv6 way of formatting. The formatting for this command didn't change, so it would be more correct to just use ``magick``. Additionally, this backwards compatibility was removed at some point and ``magick convert`` no longer executes and instead just gives the warning detailed above.

- *Bugsquad edit: This closes https://github.com/godotengine/godot-docs/issues/12149.*
