### PR TITLE
Removed unnecessary semicolon

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -1491,7 +1491,7 @@ callable. This can be used to pass functions as arguments.
         return result
 
     func add1(value: int) -> int:
-        return value + 1;
+        return value + 1
 
     func _ready() -> void:
         var my_array = [1, 2, 3]


### PR DESCRIPTION
I was confused when reading this line as a beginner, since at that point I didn't know that semicolons in GDScript are a thing yet. They are introduced as optional a bit below that, in "Statements and control flow" section - but I don't think this particular line was meant to showcase it.