### PR TITLE
Fix broken table cell (XR) in the Overall comparison section of the renderers overview

### DIFF
--- a/tutorials/rendering/renderers.rst
+++ b/tutorials/rendering/renderers.rst
@@ -152,7 +152,7 @@ Overall comparison
 |                     |                          |                          | optimized. Use Mobile or |
 |                     |                          |                          | Compatibility instead.   |
 +---------------------+--------------------------+--------------------------+--------------------------+
-| XR                  | ⚠️ Supported, but not    | ✔️ Yes. Recommended for | ⚠️ Supported, but poorly  |
+| XR                  | ⚠️ Supported, but not    | ✔️ Yes. Recommended for  | ⚠️ Supported, but poorly |
 |                     | recommended. Use Mobile  | desktop and standalone   | optimized. Use Mobile or |
 |                     | instead.                 | headsets.                | Compatibility instead.   |
 +---------------------+--------------------------+--------------------------+--------------------------+


### PR DESCRIPTION
A table cell was broken due to misaligned '|' characters.
They are now aligned properly and the cells separate cleanly.

Before:
<img width="806" height="132" alt="before" src="https://github.com/user-attachments/assets/4e1469cd-f176-41aa-b8c5-e0eec4dbc385" />

After:
<img width="793" height="193" alt="after" src="https://github.com/user-attachments/assets/735da2ca-5e89-483f-8e20-fec0b98c98bd" />

Official docs link: https://docs.godotengine.org/en/stable/tutorials/rendering/renderers.html#overall-comparison
Local files link (assuming you started the live server from git root at port 8080): http://127.0.0.1:8080/_build/html/tutorials/rendering/renderers.html#overall-comparison