### PR TITLE
Fix timer grammar in first 2D game tutorial

### DIFF
--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -159,7 +159,7 @@ signal connection dialog. The default settings in this dialog should be fine, so
 select **Connect** to create a new signal connection.
 
 Once all three timers have this set up, you should be able to see each timer
-have a Signal connection for their respective ``timeout()`` signal, showing in
+has a Signal connection for their respective ``timeout()`` signal, showing in
 green, within their respective Signals tabs:
 
 - (For MobTimer): ``_on_mob_timer_timeout()``


### PR DESCRIPTION
This updates the “Your First 2D Game” tutorial to correct the sentence “each timer have” to “each timer has.”
Fixes #12135