### PR TITLE
Document environment variable for export in Compiling with PCK encryption key

### DIFF
--- a/engine_details/development/compiling/compiling_with_script_encryption_key.rst
+++ b/engine_details/development/compiling/compiling_with_script_encryption_key.rst
@@ -77,6 +77,11 @@ Step by step
 
    .. image:: img/encryption_key.png
 
+   If performing an export from the :ref:`command line <doc_command_line_tutorial>`,
+   before exporting, set the ``GODOT_SCRIPT_ENCRYPTION_KEY`` environment variable
+   to the same value as the one used to compile the export templates
+   (``SCRIPT_AES256_ENCRYPTION_KEY``).
+
 5. Add filters for the files/folders to encrypt. **By default**, include filters
    are empty and **nothing will be encrypted**.
 


### PR DESCRIPTION
This environment variable is also documented on individual platforms' export pages, but it's different from the one used at compile-time. Therefore, it's important to make this more explicit on the page that describes compiling export templates with a PCK encryption key.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/770#discussioncomment-17681073.