### PR TITLE
Correct default shortcut for 3D select mode

### DIFF
--- a/tutorials/3d/introduction_to_3d.rst
+++ b/tutorials/3d/introduction_to_3d.rst
@@ -58,7 +58,7 @@ left to right:
 - **Scale Mode** (:kbd:`R`): Enables scaling and displays scaling gizmos in different 
   axes for the selected nodes. See :ref:`doc_introduction_to_3d_space_and_manipulation` 
   for more details.
-- **Select Mode** (:kbd:`Q`): Allows selection of nodes in the viewport. Left clicking
+- **Select Mode** (:kbd:`V`): Allows selection of nodes in the viewport. Left clicking
   on a node to select one. Left clicking and dragging a rectangle selects all 
   nodes within the rectangle's boundaries, once released.
   Holding :kbd:`Shift` while selecting adds more nodes to the selection.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
In the change for the new 3D toolbar, the select mode shortcut wasn't updated