### PR TITLE
Specify `light()` only runs for pixels affected by light

### DIFF
--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -547,6 +547,9 @@ the ``unshaded`` render mode. If no light function is written, Godot will use th
 written to in the ``fragment()`` function to calculate the lighting for you (subject to the render mode).
 
 The ``light()`` function is called for every light in every pixel. It is called within a loop for each light type.
+Keep in mind the ``light()`` function only runs for pixels that are affected by at least one light source, and is
+completely skipped for pixels that are not hit by any light and shadow. You can use this to create different behavior for
+lit and unlit pixels in your shader.
 
 Below is an example of a custom ``light()`` function using a Lambertian lighting model:
 


### PR DESCRIPTION
- Added a small section to specify that the `light()` function is only ran when the pixel is actually affected by at least one light.

### Notes
> The light() function is called for every light in every pixel. It is called within a loop for each light type.

I think these original two lines could be merged with my new additions, but since I am not fully confident about the potential implications of changing those lines or how to better explain them, I left them as is.

### Reason for change
I added this because, even after reading the documentation, I did not realise that simply calling `ALPHA = 0.0` in the `fragment()`, followed by a `ALPHA = 1.0` in the light() would make the pixels only be shown if they are lit. I presumed the `light()` function would **always** be called if it was overwritten, even when the pixel was 'unlit'. In my mind this would simply add a light value of 0,0, which means any hardcoded overwrite such as `ALPHA = 1.0` would apply to everything. In hindsight it makes sense, but since it was not specified, I thought I'd avoid future readers the trouble.

I personally used this for a shader for particles, making the particles only visible in light.

### Open questions
I originally added the following example, but I have removed it:
> for example setting ``ALPHA = 0.0`` in the ``light()`` function will cause lit
pixels to become transparent, while unlit pixels remain opaque.

But lit/unlit are ambiguous terms, and user will likely read in-light/in-shadow instead, which is incorrect. It also requires the `fragment()` to have emission on, to properly show this, and without `ATTENUATION` it doesn't show as per-pixel, but creates chunks which are either affected or not.

<img width="1393" height="933" alt="image" src="https://github.com/user-attachments/assets/cf33241a-944e-4e14-8689-b8a1035a52c6" />

So while I think an example of how this could be used could be helpful for making sure readers understand the implications, it would become too specific and too involved.

One thing I'm not fully sure on how to properly convey, and frankly I was **very** surprised by, is that light() also runs on pixels that are outside the light's range, but use the same Viewport/Screen pixel. Presumably this is because the model is going through the transparency pass, but I don't see why that would require it to compute light() onto the model itself, if the light source is far behind the model.

<img width="850" height="584" alt="image" src="https://github.com/user-attachments/assets/f749f7ae-66b3-40c1-b155-615ae6fd46b9" />
 

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
