### PR TITLE
Resolve outdated/incorrect information in SDFGI tutorial

### DIFF
--- a/tutorials/3d/global_illumination/using_sdfgi.rst
+++ b/tutorials/3d/global_illumination/using_sdfgi.rst
@@ -137,18 +137,18 @@ There are 3 global illumination modes available for meshes:
 - **Dynamic (not supported with SDFGI):** The mesh won't be taken into account in SDFGI generation.
   The mesh will receive indirect lighting from the scene, but it will not
   contribute indirect lighting to the scene.
-  *This acts identical to the **Disabled** bake mode when using SDFGI.*
+  This acts identical to the **Disabled** bake mode when using SDFGI.
 
 Additionally, there are 3 bake modes available for lights
-(DirectionalLight3D, OmniLight3D and SpotLight3D):
+(DirectionalLight3D, OmniLight3D, SpotLight3D, and AreaLight3D):
 
 - **Disabled:** The light won't be taken into account for SDFGI baking.
   The light won't contribute indirect lighting to the scene.
 - **Static:** The light will be taken into account for SDFGI baking. The light
   will contribute indirect lighting to the scene. If the light is changed in any
   way after baking, indirect lighting will look incorrect until the camera moves
-  away from the light and back (which causes SDFGI to be baked again). will look
-  incorrect. If in doubt, use this mode for level lighting.
+  away from the light and back (which causes SDFGI to be baked again).
+  If in doubt, use this mode for level lighting.
 - **Dynamic (default):** The light won't be taken into account for SDFGI baking,
   but it will still contribute indirect lighting to the scene in real-time.
   This option is slower compared to **Static**. Only use the **Dynamic** global
@@ -216,7 +216,7 @@ This can be fixed in two ways:
   to be moved at a high speed, then enabling SDFGI once the camera speed slows down.
 
 When SDFGI is enabled, it will also take some time for global illumination
-to be fully converged (25 frames by default). This can create a noticeable transition
+to be fully converged (30 frames by default). This can create a noticeable transition
 effect while GI is still converging. To hide this, you can use a ColorRect node
 that spans the whole viewport and fade it out when switching scenes using an
 AnimationPlayer node.


### PR DESCRIPTION
- Added AreaLight3D to the references for Light Sources
- Resolved bold-italic formatting incorrectly being parsed in .rst, due to it not being supported, by no longer making the sentence italic.
- Removed an incorrect, left-over half sentence.
- Adjusted the default SDF fully converged frames to 30.


Perhaps the Lights should be actual links to their documentation, but I left it as-is for now.


<img width="1206" height="740" alt="image" src="https://github.com/user-attachments/assets/5c5d3eeb-299d-4cca-9f6d-017b428fcdb0" />

_In a new project, the default SDF 'frames to converge' setting is 30 frames._

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
