### PR TITLE
Add `AreaLight3D` references to tutorials

### DIFF
--- a/tutorials/3d/global_illumination/reflection_probes.rst
+++ b/tutorials/3d/global_illumination/reflection_probes.rst
@@ -181,7 +181,7 @@ When using the Forward+ renderer, Godot uses a *clustering* approach for
 reflection probe rendering. As many reflection probes as desired can be added (as long as
 performance allows). However, there's still a default limit of 512 *clustered
 elements* that can be present in the current camera view. A clustered element is
-an omni light, a spot light, a :ref:`decal <doc_using_decals>` or a
+an omni light, a spot light, an area light, a :ref:`decal <doc_using_decals>`, or a
 :ref:`reflection probe <doc_reflection_probes>`. This limit can be increased by adjusting
 :ref:`Max Clustered Elements<class_ProjectSettings_property_rendering/limits/cluster_builder/max_clustered_elements>`
 in **Project Settings > Rendering > Limits > Cluster Builder**.

--- a/tutorials/3d/global_illumination/using_voxel_gi.rst
+++ b/tutorials/3d/global_illumination/using_voxel_gi.rst
@@ -139,7 +139,7 @@ There are 3 global illumination modes available for meshes:
     - **Emission > On UV2**
 
 Additionally, there are 3 bake modes available for lights
-(DirectionalLight3D, OmniLight3D and SpotLight3D):
+(DirectionalLight3D, OmniLight3D, SpotLight3D, and AreaLight3D):
 
 - **Disabled:** The light won't be taken into account for VoxelGI baking.
   The light won't contribute indirect lighting to the scene.

--- a/tutorials/3d/lights_and_shadows.rst
+++ b/tutorials/3d/lights_and_shadows.rst
@@ -11,7 +11,7 @@ result. Light can come from several types of sources in a scene:
 
 - From the material itself, in the form of the emission color (though it does
   not affect nearby objects unless baked or screen-space indirect lighting is enabled).
-- Light nodes: DirectionalLight3D, OmniLight3D and SpotLight3D.
+- Light nodes: DirectionalLight3D, OmniLight3D, SpotLight3D, and AreaLight3D.
 - Ambient light in the :ref:`Environment <class_Environment>` or
   :ref:`doc_reflection_probes`.
 - Global illumination (:ref:`LightmapGI <doc_using_lightmap_gi>`,
@@ -28,8 +28,8 @@ in the :ref:`doc_standard_material_3d` tutorial.
 Light nodes
 -----------
 
-There are three types of light nodes: :ref:`class_DirectionalLight3D`,
-:ref:`class_OmniLight3D` and :ref:`class_SpotLight3D`. Let's take a look at the common
+There are four types of light nodes: :ref:`class_DirectionalLight3D`,
+:ref:`class_OmniLight3D`, :ref:`class_SpotLight3D`, and :ref:`class_AreaLight3D`. Let's take a look at the common
 parameters for lights:
 
 .. image:: img/light_params.png
@@ -60,7 +60,7 @@ When using the Forward+ renderer, Godot uses a *clustering* approach for
 real-time lighting. As many lights as desired can be added (as long as
 performance allows). However, there's still a default limit of 512 *clustered
 elements* that can be present in the current camera view. A clustered element is
-an omni light, a spot light, a :ref:`decal <doc_using_decals>` or a
+an omni light, a spot light, an area light, a :ref:`decal <doc_using_decals>`, or a
 :ref:`reflection probe <doc_reflection_probes>`. This limit can be increased by adjusting
 :ref:`Max Clustered Elements<class_ProjectSettings_property_rendering/limits/cluster_builder/max_clustered_elements>`
 in **Project Settings > Rendering > Limits > Cluster Builder**.
@@ -486,7 +486,7 @@ smoothly.
 Shadow atlas
 ------------
 
-Unlike Directional lights, which have their own shadow texture, omni and spot
+Unlike Directional lights, which have their own shadow texture, omni, spot, and area
 lights are assigned to slots of a shadow atlas. This atlas can be configured in
 the advanced Project Settings (**Rendering > Lights And Shadows > Positional Shadow**).
 
@@ -543,7 +543,7 @@ to make the right choices here to avoid creating bottlenecks.
 Directional shadow quality settings can be changed at runtime by calling the
 appropriate :ref:`class_RenderingServer` methods.
 
-Positional (omni/spot) shadow quality settings can be changed at runtime on the
+Positional (omni/spot/area) shadow quality settings can be changed at runtime on the
 root :ref:`class_Viewport`.
 
 Shadow map size
@@ -596,7 +596,7 @@ significant performance cost.
 Light/shadow distance fade
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-OmniLight3D and SpotLight3D offer several properties to hide distant lights.
+OmniLight3D, SpotLight3D, and AreaLight3D offer several properties to hide distant lights.
 This can improve performance significantly in large scenes with dozens of lights
 or more.
 

--- a/tutorials/3d/physical_light_and_camera_units.rst
+++ b/tutorials/3d/physical_light_and_camera_units.rst
@@ -166,12 +166,12 @@ After enabling physical light units, 2 new properties become available in Light3
 
 - **Intensity:** The light's intensity in `lux
   <https://en.wikipedia.org/wiki/Lux>`__ (DirectionalLight3D) or
-  `lumens <https://en.wikipedia.org/wiki/Lumen_(unit)>`__ (OmniLight3D/SpotLight3D).
+  `lumens <https://en.wikipedia.org/wiki/Lumen_(unit)>`__ (OmniLight3D/SpotLight3D/AreaLight3D).
   If a custom **Energy** is set, this energy is multiplied by the intensity.
 - **Temperature:** The light's *color temperature* defined in Kelvin.
   If a custom **Color** is set, this color is multiplied by the color temperature.
 
-**OmniLight3D/SpotLight3D intensity**
+**OmniLight3D/SpotLight3D/AreaLight3D intensity**
 
 Lumens are a measure of luminous flux, which is the total amount of visible
 light emitted by a light source per unit of time.

--- a/tutorials/3d/using_decals.rst
+++ b/tutorials/3d/using_decals.rst
@@ -262,7 +262,7 @@ When using the Forward+ renderer, Godot uses a *clustering* approach for
 decal rendering. As many decals as desired can be added (as long as
 performance allows). However, there's still a default limit of 512 *clustered
 elements* that can be present in the current camera view. A clustered element is
-an omni light, a spot light, a :ref:`decal <doc_using_decals>` or a
+an omni light, a spot light, an area light, a :ref:`decal <doc_using_decals>`, or a
 :ref:`reflection probe <doc_reflection_probes>`. This limit can be increased by adjusting
 :ref:`Max Clustered Elements<class_ProjectSettings_property_rendering/limits/cluster_builder/max_clustered_elements>`
 in **Project Settings > Rendering > Limits > Cluster Builder**.


### PR DESCRIPTION
Added `AreaLight3D` as a reference across the tutorial documentation, where ever it was missing.

- Added AreaLight3D as a clustered element across multiple pages
- Added AreaLight3D as one of the four lights that is referenced throughout the [Lights and Shadows tutorial](https://docs.godotengine.org/en/stable/tutorials/3d/lights_and_shadows.html)
- Added AreaLight3D as a light that uses Lumens in the [Physical light tutorial](https://docs.godotengine.org/en/latest/tutorials/3d/physical_light_and_camera_units.html)


### Requires Confirmation:
While I can confirm they use lumens and have basic light settings, **I am not 100% sure that Arealights are part of the same *clustered elements* approach as omnilight and spotlights.** The[ AreaLight3D documentation](https://docs.godotengine.org/en/latest/classes/class_arealight3d.html#description) seems to hint at that with:

> **Performance:** Area lights are more demanding on the GPU compared to omni and spot lights. In Forward+, there is an additional GPU cost on all rendered objects as soon as one area light is present in the view frustum (due to the nature of **clustered lighting**). 

but perhaps that refers to something else. **This should be double-checked.**


Similarly, **whether AreaLight3D's shadow settings can be set on runtime** and **whether they have their own shadow texture**, like Omni- and Spotlights is something I **presumed** due to the AreaLight working similarly to those positional lights, and thusfar the **DirectionalLight3D** seems to be the only exception. Someone with more in-depth knowledge than me should at least confirm whether that's likely true.

### Other notes
Keep in mind the page for [SDFGI](https://docs.godotengine.org/en/stable/tutorials/3d/global_illumination/using_sdfgi.html) already has an AreaLight3D reference added in PR https://github.com/godotengine/godot-docs/pull/12175, which I made earlier today.

I switched between formatting it as  `AreaLight3D` or `area light` depending on the context and how other lights were referenced. But this seems extremely inconsistent throughout the documentation.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
