### PR TITLE
Fix links for CMake and SCons documentation

### DIFF
--- a/tutorials/scripting/cpp/build_system/cmake.rst
+++ b/tutorials/scripting/cpp/build_system/cmake.rst
@@ -17,8 +17,8 @@ SCons build system. This means it may lack some features that are available to
 projects using SCons.
 
 .. _CMakeLists.txt: https://github.com/godotengine/godot-cpp/blob/master/CMakeLists.txt
-.. _CMake: http://scons.org
-.. _Scons: http://cmake.org
+.. _CMake: http://cmake.org
+.. _Scons: http://scons.org
 
 Introduction
 ------------


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
