### PR TITLE
Change mentions of "member" to "property" where appropriate

### DIFF
--- a/about/release_policy.rst
+++ b/about/release_policy.rst
@@ -261,7 +261,7 @@ The following changes are acceptable in minor releases, but not patch releases:
 - Significant new features.
 - Renaming a method parameter. In C#, method parameters can be passed by name
   (but not in GDScript). As a result, this can break some projects that use C#.
-- Deprecating a method, member variable, or class. This is done by adding a
+- Deprecating a method, property, or class. This is done by adding a
   deprecated flag to its class reference, which will show up in the editor. When
   a method is marked as deprecated, it's slated to be removed in the next
   *major* release.
@@ -275,7 +275,7 @@ The following changes are acceptable in minor releases, but not patch releases:
 The following changes are considered **compatibility-breaking** and can only be
 performed in a new major release:
 
-- Renaming or removing a method, member variable, or class.
+- Renaming or removing a method, property, or class.
 - Modifying a node's inheritance tree by making it inherit from a different class.
 - Changing the default value of a project setting value in a way that affects existing
   projects. To only affect new projects, the project manager should write a

--- a/engine_details/class_reference/index.rst
+++ b/engine_details/class_reference/index.rst
@@ -64,8 +64,8 @@ The reference for each class is contained in an XML file like the one below:
 
 It starts with brief and long descriptions. In the generated docs, the brief
 description is always at the top of the page, while the long description lies
-below the list of methods, variables, and constants. You can find methods,
-member variables, constants, and signals in separate XML nodes.
+below the list of methods, properties, and constants. You can find methods,
+properties, constants, and signals in separate XML nodes.
 
 For each, you want to learn how they work in Godot's source code. Then, fill
 their documentation by completing or improving the text in these tags:
@@ -150,7 +150,7 @@ For links to the same class, the class name is optional and can be omitted.
 | | Link to enum                 |                                         |                                                              |
 +--------------------------------+-----------------------------------------+--------------------------------------------------------------+
 | | ``[member Class.name]``      | ``Get [member Node2D.scale].``          | Get :ref:`Node2D.scale <class_Node2D_property_scale>`.       |
-| | Link to member               |                                         |                                                              |
+| | Link to property             |                                         |                                                              |
 +--------------------------------+-----------------------------------------+--------------------------------------------------------------+
 | | ``[method Class.name]``      | ``Call [method Node3D.hide].``          | Call :ref:`Node3D.hide() <class_Node3D_method_hide>`.        |
 | | Link to method               |                                         |                                                              |

--- a/engine_details/engine_api/vendor_runtime_module.rst
+++ b/engine_details/engine_api/vendor_runtime_module.rst
@@ -67,7 +67,7 @@ Using our base editor plugin template code above, an example implementation look
     @tool
     extends EditorPlugin
 
-    # A class member to hold the editor export plugin during its lifecycle.
+    # A property to hold the editor export plugin during its lifecycle.
     var export_plugin: VRMExportPlugin
 
     func _enter_tree():

--- a/getting_started/first_2d_game/03.coding_the_player.rst
+++ b/getting_started/first_2d_game/03.coding_the_player.rst
@@ -23,7 +23,7 @@ click "Create":
 .. note:: If this is your first time encountering GDScript, please read
           :ref:`doc_scripting` before continuing.
 
-Start by declaring the member variables this object will need:
+Start by declaring the properties this object will need:
 
 .. tabs::
  .. code-tab:: gdscript GDScript

--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -177,7 +177,7 @@ Turning around
 --------------
 
 It's time to make our node move and rotate. To do so, we're going to add two
-member variables to our script: the movement speed in pixels per second and the
+properties to our script: the movement speed in pixels per second and the
 angular speed in radians per second. Add the following after the ``extends Sprite2D`` line.
 
 .. tabs::
@@ -191,7 +191,7 @@ angular speed in radians per second. Add the following after the ``extends Sprit
     private int _speed = 400;
     private float _angularSpeed = Mathf.Pi;
 
-Member variables sit near the top of the script, after any "extends" lines,
+Properties sit near the top of the script, after any "extends" lines,
 but before functions. Every node
 instance with this script attached to it will have its own copy of the ``speed``
 and ``angular_speed`` properties.

--- a/tutorials/3d/introduction_to_3d.rst
+++ b/tutorials/3d/introduction_to_3d.rst
@@ -297,7 +297,7 @@ Node3Ds have a local transform, which is relative to the parent
 node (as long as the parent node is also of **or inherits from** the type
 Node3D). This transform can be accessed as a 3×4
 :ref:`Transform3D <class_Transform3D>`, or as 3 :ref:`Vector3 <class_Vector3>`
-members representing location, Euler rotation (X, Y and Z angles) and
+properties representing location, Euler rotation (X, Y, and Z angles) and
 scale.
 
 .. image:: img/tuto_3d2.webp

--- a/tutorials/3d/using_gridmaps.rst
+++ b/tutorials/3d/using_gridmaps.rst
@@ -220,4 +220,4 @@ on a GridMap, relative to the camera position (in meters).
 Using GridMap in code
 ---------------------
 
-See :ref:`class_GridMap` for details on the node's methods and member variables.
+See :ref:`class_GridMap` for details on the node's methods and properties.

--- a/tutorials/performance/using_servers.rst
+++ b/tutorials/performance/using_servers.rst
@@ -256,7 +256,7 @@ and moves a :ref:`class_CanvasItem` when the body moves.
     func _body_moved(state, index):
         # Created your own canvas item; use it here.
         # `ci_rid` from the sprite example above needs to be moved to a
-        # member variable (instead of within `_ready()`) so it can be referenced here.
+        # property (instead of within `_ready()`) so it can be referenced here.
         RenderingServer.canvas_item_set_transform(ci_rid, state.transform)
 
 
@@ -295,7 +295,7 @@ and moves a :ref:`class_CanvasItem` when the body moves.
         {
             // Created your own canvas item; use it here.
             // `ciRid` from the sprite example above needs to be moved to a
-            // member variable (instead of within `_Ready()`) so it can be referenced here.
+            // property (instead of within `_Ready()`) so it can be referenced here.
             RenderingServer.CanvasItemSetTransform(_canvasItem, state.Transform);
         }
 

--- a/tutorials/physics/ray-casting.rst
+++ b/tutorials/physics/ray-casting.rst
@@ -242,7 +242,7 @@ this case, it is much more efficient to use the collision layer/mask system.
 
 The ``intersect_ray()`` parameters object can also be supplied a collision mask.
 For example, to use the same mask as the parent body, use the ``collision_mask``
-member variable. The array of exceptions can be supplied as the last argument as well:
+property. The array of exceptions can be supplied as the last argument as well:
 
 .. tabs::
  .. code-tab:: gdscript GDScript

--- a/tutorials/platform/android/android_plugin.rst
+++ b/tutorials/platform/android/android_plugin.rst
@@ -165,7 +165,7 @@ As mentioned, a v2 Android plugin is now provided to the Godot Editor as an ``Ed
         @tool
         extends EditorPlugin
 
-        # A class member to hold the editor export plugin during its lifecycle.
+        # A property to hold the editor export plugin during its lifecycle.
         var export_plugin : AndroidExportPlugin
 
         func _enter_tree():

--- a/tutorials/plugins/editor/import_plugins.rst
+++ b/tutorials/plugins/editor/import_plugins.rst
@@ -69,7 +69,7 @@ when needed:
 When this plugin is activated, it will create a new instance of the import
 plugin (which we'll soon make) and add it to the editor using the
 :ref:`add_import_plugin() <class_EditorPlugin_method_add_import_plugin>` method. We store
-a reference to it in a class member ``import_plugin`` so we can refer to it
+a reference to it in a ``import_plugin`` property so we can refer to it
 later when removing it. The
 :ref:`remove_import_plugin() <class_EditorPlugin_method_remove_import_plugin>` method is
 called when the plugin is deactivated to clean up the memory and let the editor

--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -338,7 +338,7 @@ The script could look like this:
     extends EditorPlugin
 
 
-    # A class member to hold the dock during the plugin life cycle.
+    # A property to hold the dock during the plugin life cycle.
     var dock
 
 

--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -112,8 +112,8 @@ Important information
 
 The general rule is that **any other GDScript that your tool script uses must
 *also* be a tool**. The editor is not able to construct instances from GDScript
-files without ``@tool``, which means you cannot call methods or reference member
-variables from them otherwise. However, since static methods, constants and
+files without ``@tool``, which means you cannot call methods or reference properties
+from them otherwise. However, since static methods, constants, and
 enums can be used without creating an instance, it is possible to call them or
 reference them from a ``@tool`` script onto other non-tool scripts. One exception to
 this are :ref:`static variables <doc_gdscript_basics_static_variables>`.

--- a/tutorials/scripting/c_sharp/c_sharp_differences.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_differences.rst
@@ -321,7 +321,7 @@ See also: :ref:`doc_c_sharp_signals`.
 `@onready` annotation
 ---------------------
 
-GDScript has the ability to defer the initialization of a member variable until the ready function
+GDScript has the ability to defer the initialization of a property until the ready function
 is called with `@onready` (cf. :ref:`doc_gdscript_onready_annotation`).
 For example:
 

--- a/tutorials/scripting/c_sharp/c_sharp_exports.rst
+++ b/tutorials/scripting/c_sharp/c_sharp_exports.rst
@@ -3,9 +3,9 @@
 C# exported properties
 ======================
 
-In Godot, class members can be exported. This means their value gets saved along
+In Godot, member variables can be exported. This means their value gets saved along
 with the resource (such as the :ref:`scene <class_PackedScene>`) they're
-attached to. They will also be available for editing in the property editor.
+attached to. They will also be available for editing in the Inspector.
 Exporting is done by using the ``[Export]`` attribute.
 
 .. code-block:: csharp
@@ -19,7 +19,7 @@ Exporting is done by using the ``[Export]`` attribute.
     }
 
 In that example the value ``5`` will be saved, and after building the current project
-it will be visible in the property editor.
+it will be visible in the Inspector.
 
 One of the fundamental benefits of exporting member variables is to have
 them visible and editable in the editor. This way, artists and game designers
@@ -46,7 +46,7 @@ Exporting works with fields and properties. They can have any access modifier.
     [Export]
     public int Number { get; set; }
 
-Exported members can specify a default value; otherwise, the `default value of the type <https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/default-values>`_ is used instead.
+Exported member variables can specify a default value; otherwise, the `default value of the type <https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/default-values>`_ is used instead.
 
 An ``int`` like ``Number`` defaults to ``0``. ``Text`` defaults to null because
 ``string`` is a reference type.
@@ -368,12 +368,12 @@ in conjunction with a :ref:`script in "tool" mode <doc_gdscript_tool_mode>`.
 Exporting bit flags
 -------------------
 
-Members whose type is an enum with the ``[Flags]`` attribute can be exported and
+Member variables whose type is an enum with the ``[Flags]`` attribute can be exported and
 their values are limited to the members of the enum type.
 The editor will create a widget in the Inspector, allowing to select none, one,
 or multiple of the enum members. The value will be stored as an integer.
 
-A flags enum uses powers of 2 for the values of the enum members. Members that
+A flags enum uses powers of 2 for the values of the enum members. Member variables that
 combine multiple flags using logical OR (``|``) are also possible.
 
 .. code-block:: csharp
@@ -441,7 +441,7 @@ If in doubt, use boolean variables instead.
 Exporting enums
 ---------------
 
-Members whose type is an enum can be exported and their values are limited to the members
+Member variables whose type is an enum can be exported and their values are limited to the members
 of the enum type. The editor will create a widget in the Inspector, enumerating the
 following as "Thing 1", "Thing 2", "Another Thing". The value will be stored as an integer.
 
@@ -457,7 +457,7 @@ following as "Thing 1", "Thing 2", "Another Thing". The value will be stored as 
     [Export]
     public MyEnum MyEnumCurrent { get; set; }
 
-Integer and string members can also be limited to a specific list of values using the
+Integer and string member variables can also be limited to a specific list of values using the
 ``[Export]`` annotation with the ``PropertyHint.Enum`` hint.
 The editor will create a widget in the Inspector, enumerating the following as Warrior,
 Magician, Thief. The value will be stored as an integer, corresponding to the index

--- a/tutorials/scripting/evaluating_expressions.rst
+++ b/tutorials/scripting/evaluating_expressions.rst
@@ -135,13 +135,13 @@ instance such as ``self``, another script instance or even a singleton:
 Associating a base instance allows doing the following:
 
 - Reference the instance's constants (``const``) in the expression.
-- Reference the instance's member variables (``var``) in the expression.
+- Reference the instance's properties (``var``) in the expression.
 - Call methods defined in the instance and use their return values in the expression.
 
 .. warning::
 
     Setting a base instance to a value other than ``null`` allows referencing
-    constants, member variables, and calling all methods defined in the script
+    constants, properties, and calling all methods defined in the script
     attached to the instance. Allowing users to enter expressions may allow
     cheating in your game, or may even introduce security vulnerabilities if you
     allow arbitrary clients to run expressions on other players' devices.

--- a/tutorials/scripting/gdscript/gdscript_advanced.rst
+++ b/tutorials/scripting/gdscript/gdscript_advanced.rst
@@ -458,7 +458,7 @@ And it can be used like any other iterator:
     for i in itr:
         print(i) # Will print 0, 2, and 4.
 
-It is possible but discouraged to store the state in a member variable.
+It is possible but discouraged to store the state in a property.
 Multiple states are necessary in cases such as nested loops where the same
 iterator instance is used simultaneously. The ``iter`` parameter in
 ``_iter_init()`` and ``_iter_next()`` is a single-element array so that updates
@@ -511,7 +511,7 @@ and that's it. No need to consider inheritance, base classes, etc.
 And that's it. If the object that hit the big rock has a smash() method,
 it will be called. No need for inheritance or polymorphism. Dynamically
 typed languages only care about the instance having the desired method
-or member, not what it inherits or the class type. The definition of
+or property, not what it inherits or the class type. The definition of
 Duck Typing should make this clearer:
 
 *"When I see a bird that walks like a duck and swims like a duck and

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -43,7 +43,7 @@ here's an example of how GDScript looks.
     extends BaseClass
 
 
-    # Member variables.
+    # Properties.
     var a = 5
     var s = "Hello"
     var arr = [1, 2, 3]
@@ -188,7 +188,7 @@ in case you want to take a look under the hood.
 +------------+---------------------------------------------------------------------------------------------------------------------------------------------------+
 | func       | Defines a function.  See `Functions`_.                                                                                                            |
 +------------+---------------------------------------------------------------------------------------------------------------------------------------------------+
-| static     | Defines a static function or a static member variable.                                                                                            |
+| static     | Defines a static function or a static variable.                                                                                                   |
 +------------+---------------------------------------------------------------------------------------------------------------------------------------------------+
 | const      | Defines a constant. See `Constants`_.                                                                                                             |
 +------------+---------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -510,7 +510,7 @@ be obtained when a call to ``Node._ready()`` is made.
 
 This can get a little cumbersome, especially when nodes and external
 references pile up. For this, GDScript has the ``@onready`` annotation, that
-defers initialization of a member variable until ``_ready()`` is called. It
+defers initialization of a property until ``_ready()`` is called. It
 can replace the above code with a single line:
 
 ::
@@ -580,7 +580,7 @@ considered a comment.
 Use two hash symbols (``##``) instead of one (``#``) to add a *documentation
 comment*, which will appear in the script documentation and in the inspector
 description of an exported variable. Documentation comments must be placed
-directly *above* a documentable item (such as a member variable), or at the top
+directly *above* a documentable member (such as a property), or at the top
 of a file. Dedicated formatting options are also available. See
 :ref:`doc_gdscript_documentation_comments` for details.
 
@@ -1038,7 +1038,7 @@ Signals are better used by getting them from actual objects, e.g. ``$Button.butt
 Contains an object and a function, which is useful for passing functions as
 values (e.g. when connecting to signals).
 
-Getting a method as a member returns a callable. ``var x = $Sprite2D.rotate``
+Getting a method as a variable returns a callable. ``var x = $Sprite2D.rotate``
 will set the value of ``x`` to a callable with ``$Sprite2D`` as the object and
 ``rotate`` as the method.
 
@@ -1047,7 +1047,7 @@ You can call it using the ``call`` method: ``x.call(PI)``.
 Variables
 ---------
 
-Variables can exist as class members or local to functions. They are
+Variables can exist as members of a class or local to functions. They are
 created with the ``var`` keyword and may, optionally, be assigned a
 value upon initialization.
 
@@ -1103,7 +1103,7 @@ Valid types are:
 Initialization order
 ~~~~~~~~~~~~~~~~~~~~
 
-Member variables are initialized in the following order:
+Properties are initialized in the following order:
 
 1. Depending on the variable's static type, the variable is either ``null``
    (untyped variables and objects) or has a default value of the type
@@ -1155,7 +1155,7 @@ Member variables are initialized in the following order:
 Static variables
 ~~~~~~~~~~~~~~~~
 
-A class member variable can be declared static:
+A member variable can be declared static:
 
 ::
 
@@ -1401,7 +1401,7 @@ Functions
 
 Functions always belong to a `class <Classes_>`_. The scope priority for
 variable look-up is: local → class member → global. The ``self`` variable is
-always available and is provided as an option for accessing class members
+always available and is provided as an option for accessing member variables
 (see `self`_), but is not always required (and should *not* be sent as the
 function's first argument, unlike Python).
 
@@ -1598,7 +1598,7 @@ Lambda functions capture the local environment:
 Static functions
 ~~~~~~~~~~~~~~~~
 
-A function can be declared static. When a function is static, it has no access to the instance member variables or ``self``.
+A function can be declared static. When a function is static, it has no access to the instance's member variables or ``self``.
 A static function has access to static variables. Also static functions are useful to make libraries of helper functions:
 
 ::
@@ -2358,7 +2358,7 @@ Class constructor
 The class constructor, called on class instantiation, is named ``_init``. If you
 want to call the base class constructor, you can also use the ``super`` syntax.
 Note that every class has an implicit constructor that is always called
-(defining the default values of class variables). ``super`` is used to call the
+(defining the default values of member variables). ``super`` is used to call the
 explicit constructor:
 
 ::
@@ -2489,7 +2489,7 @@ Exports
 Properties (setters and getters)
 --------------------------------
 
-Sometimes, you want a class' member variable to do more than just hold data and actually perform
+Sometimes, you want a class's member variable to do more than just hold data and actually perform
 some validation or computation whenever its value changes. It may also be desired to
 encapsulate its access in some way.
 
@@ -2518,7 +2518,7 @@ Example:
 Alternative syntax
 ~~~~~~~~~~~~~~~~~~
 
-Also there is another notation to use existing class functions if you want to split the code from the variable declaration
+Also there is another notation to use existing class functions if you want to split the code from the property declaration
 or you need to reuse the code across multiple properties (but you can't distinguish which property the setter/getter is being called for):
 
 ::
@@ -2532,22 +2532,22 @@ This can also be done in the same line:
 
     var my_prop: get = get_my_prop, set = set_my_prop
 
-The setter and getter must use the same notation, mixing styles for the same variable is not allowed.
+The setter and getter must use the same notation, mixing styles for the same property is not allowed.
 
 .. note::
 
     You cannot specify type hints for *inline* setters and getters. This is done on purpose to reduce the boilerplate.
-    If the variable is typed, then the setter's argument is automatically of the same type, and the getter's return value must match it.
-    Separated setter/getter functions can have type hints, and the type must match the variable's type or be a wider type.
+    If the property is typed, then the setter's argument is automatically of the same type, and the getter's return value must match it.
+    Separated setter/getter functions can have type hints, and the type must match the property's type or be a wider type.
 
 When setter/getter is not called
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When a variable is initialized, the value of the initializer will be written directly to the variable.
-This occurs even if the ``@onready`` or ``@export`` annotation is applied to the variable.
+When a property is initialized, the value of the initializer will be written directly to the property.
+This occurs even if the ``@onready`` or ``@export`` annotation is applied to the property.
 
-Using the variable's name to set it inside its own setter or to get it inside its own getter will directly access the underlying member.
-This prevents infinite recursion and saves you from explicitly declaring another variable:
+When accessing a property in its own setter/getter, the underlying variable will be accessed directly.
+This prevents infinite recursion and saves you from explicitly declaring another property:
 
 ::
 

--- a/tutorials/scripting/gdscript/gdscript_documentation_comments.rst
+++ b/tutorials/scripting/gdscript/gdscript_documentation_comments.rst
@@ -7,7 +7,7 @@ In GDScript, comments can be used to document your code and add descriptions to 
 members of a script. There are two differences between a normal comment and a documentation
 comment. Firstly, a documentation comment should start with double hash symbols
 ``##``. Secondly, it must immediately precede a script member, or for script descriptions,
-be placed at the top of the script. If an exported variable is documented,
+be placed at the top of the script. If an exported property is documented,
 its description is used as a tooltip in the editor. This documentation can be
 generated as XML files by the editor.
 
@@ -204,11 +204,11 @@ Complete script example
     ## @experimental
     class Inner:
 
-        ## Inner class variable v4.
+        ## Variable of inner class named "v4".
         var v4
 
 
-        ## Inner class function fn.
+        ## Function of inner class named "fn".
         func fn(): pass
 
 ``@deprecated`` and ``@experimental`` tags
@@ -261,7 +261,7 @@ Here's the list of available tags:
 | | Link to enum                 |                                              |                                                              |
 +--------------------------------+----------------------------------------------+--------------------------------------------------------------+
 | | ``[member Class.name]``      | ``Get [member Node2D.scale].``               | Get :ref:`Node2D.scale <class_Node2D_property_scale>`.       |
-| | Link to member (property)    |                                              |                                                              |
+| | Link to property             |                                              |                                                              |
 +--------------------------------+----------------------------------------------+--------------------------------------------------------------+
 | | ``[method Class.name]``      | ``Call [method Node3D.hide].``               | Call :ref:`Node3D.hide() <class_Node3D_method_hide>`.        |
 | | Link to method               |                                              |                                                              |

--- a/tutorials/scripting/gdscript/gdscript_exports.rst
+++ b/tutorials/scripting/gdscript/gdscript_exports.rst
@@ -3,23 +3,23 @@
 GDScript exported properties
 ============================
 
-In Godot, class members can be exported. This means their value gets saved along
+In Godot, properties can be exported. This means their value gets saved along
 with the resource (such as the :ref:`scene <class_PackedScene>`) they're
 attached to, and get transferred over when using :ref:`RPCs <doc_high_level_multiplayer_rpcs>`.
-They will also be available for editing in the property editor. Exporting is done by using
+They will also be available for editing in the Inspector. Exporting is done by using
 the ``@export`` annotation.
 
 ::
 
     @export var number: int = 5
 
-In that example the value ``5`` will be saved and visible in the property editor.
+In that example the value ``5`` will be saved and visible in the Inspector.
 
-An exported variable must be initialized to a constant expression or have a type specifier
-in the variable. Some of the export annotations have a specific type and don't need the variable to be typed (see the
+An exported property must be initialized to a constant expression or have a type specifier
+in the property. Some of the export annotations have a specific type and don't need the property to be typed (see the
 *Examples* section below).
 
-One of the fundamental benefits of exporting member variables is to have
+One of the fundamental benefits of exporting properties is to have
 them visible and editable in the editor. This way, artists and game designers
 can modify values that later influence how the program runs. For this, a
 special export syntax is provided. Additionally, :ref:`documentation comments <doc_gdscript_documentation_comments>` can be

--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -874,14 +874,14 @@ For inner classes, use single-line declarations:
 Signals and properties
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Write signal declarations, followed by properties, that is to say, member
-variables, after the docstring.
+Write signal declarations, followed by properties (also known as member
+variables), after the docstring.
 
 Enums should come after signals, as you can use them as export hints for other
 properties.
 
-Then, write constants, exported variables, public, private, and onready
-variables, in that order.
+Then, write constants, exported properties, public, private, and onready
+properties, in that order.
 
 ::
 

--- a/tutorials/scripting/nodes_and_scene_instances.rst
+++ b/tutorials/scripting/nodes_and_scene_instances.rst
@@ -101,7 +101,7 @@ Syntactic sugar
 ~~~~~~~~~~~~~~~
 
 You can use two shorthands to shorten your code in GDScript. Firstly, putting the
-``@onready`` annotation before a member variable makes it initialize right before
+``@onready`` annotation before a property makes it initialize right before
 the ``_ready()`` callback.
 
 .. code-block:: gdscript

--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -169,11 +169,11 @@ unsigned:
     uint a = 2; // invalid
     uint a = uint(2); // valid
 
-Members
-~~~~~~~
+Components
+~~~~~~~~~~
 
-Individual scalar members of vector types are accessed via the "x", "y", "z" and
-"w" members. Alternatively, using "r", "g", "b" and "a" also works and is
+Individual scalar components of vector types are accessed via the "x", "y", "z", and
+"w" components. Alternatively, using "r", "g", "b", and "a" also works and is
 equivalent. Use whatever fits best for your needs.
 
 For matrices, use the ``m[column][row]`` indexing syntax to access each scalar,

--- a/tutorials/shaders/shaders_style_guide.rst
+++ b/tutorials/shaders/shaders_style_guide.rst
@@ -290,10 +290,10 @@ distinguishing numbers greater than 1 from those lower than 1.
         ALBEDO.rgb = vec3(5., .1, .2);
     }
 
-Accessing vector members
-------------------------
+Accessing vector components
+---------------------------
 
-Use ``r``, ``g``, ``b``, and ``a`` when accessing a vector's members if it
+Use ``r``, ``g``, ``b``, and ``a`` when accessing a vector's components if it
 contains a color. If the vector contains anything else than a color, use ``x``,
 ``y``, ``z``, and ``w``. This allows those reading your code to better
 understand what the underlying data represents.

--- a/tutorials/ui/bbcode_in_richtextlabel.rst
+++ b/tutorials/ui/bbcode_in_richtextlabel.rst
@@ -1217,9 +1217,9 @@ the Inspector by adding it to the **Markup > Custom Effects** array, or in code 
     tag will be left as-is.
 
 There is only one function that you need to extend: ``_process_custom_fx(char_fx)``.
-Optionally, you can also provide a custom BBCode identifier by adding a member
-name ``bbcode``. The code will check the ``bbcode`` property automatically or will
-use the name of the file to determine what the BBCode tag should be.
+Optionally, you can also provide a custom BBCode identifier by adding a property
+named ``bbcode``. The code will either check the ``bbcode`` property or fall back to
+the name of the file to determine what the BBCode tag should be.
 
 ``_process_custom_fx``
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/tutorials/xr/openxr_spatial_entities.rst
+++ b/tutorials/xr/openxr_spatial_entities.rst
@@ -1299,7 +1299,7 @@ Plane tracking gives access to two components that are guaranteed to be supporte
      - Provides us with a type identification of each plane
 
 Our plane tracking configuration object already enables all supported components, but we'll need to interrogate
-it so we'll store our instance in a member variable.
+it so we'll store our instance in a property.
 We can use our :ref:`OpenXRPlaneTracker<class_OpenXRPlaneTracker>` tracker object to store our component data.
 
 .. code-block:: gdscript


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/121793 and [RocketChat discussion](https://chat.godotengine.org/channel/documentation/thread/tPE9nBS6iKFaX2WJm)

~~I will explore and think about this more.
Unlike the class reference, the manual seems particularly keen on distinguishing between "member variable" and "property".~~