### PR TITLE
Fix 'subemitters' to 'sub-emitters' for consistency with the particle…

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -384,7 +384,7 @@ Godot 4 includes three renderers:
 
 **Particles:**
 
-- GPU-based particles with support for subemitters (2D + 3D), trails (2D + 3D),
+- GPU-based particles with support for sub-emitters (2D + 3D), trails (2D + 3D),
   attractors (3D only) and collision (2D + 3D).
 
   - 3D particle attractor shapes supported: box, sphere and 3D vector fields.


### PR DESCRIPTION
… sub-emitters tutorial page

The docs use "subemitters" (no hyphen) in list_of_features.rst:
https://github.com/godotengine/godot-docs/blob/master/about/list_of_features.rst

But the dedicated tutorial page consistently uses "sub-emitters" (hyphenated) 
throughout its body text:
https://docs.godotengine.org/en/stable/tutorials/3d/particles/subemitters.html

This PR makes the spelling consistent with the tutorial page.
