### PR TITLE
Fix Transform2D matrix dimensions

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -783,7 +783,7 @@ in a 3D grid.
 :ref:`Transform2D <class_Transform2D>`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-3×2 matrix used for 2D transforms.
+2×3 matrix used for 2D transforms.
 
 :ref:`Plane <class_Plane>`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->

Fixes #12185.

Corrects the Transform2D built-in type description from a 3×2 matrix to a 2×3 matrix, matching the Transform2D class reference.

Tests:
- `uvx pre-commit run --files tutorials/scripting/gdscript/gdscript_basics.rst`
- `make SPHINXBUILD=.venv/bin/sphinx-build SPHINXOPTS='--color -j 4 -W' dummy`
