### PR TITLE
handles() is called _handles() in EditorPlugin

### DIFF
--- a/tutorials/plugins/editor/making_main_screen_plugins.rst
+++ b/tutorials/plugins/editor/making_main_screen_plugins.rst
@@ -268,7 +268,7 @@ user clicks on the main viewport buttons at the top of the editor.
 The ``_get_plugin_name()`` and ``_get_plugin_icon()`` functions control
 the displayed name and icon for the plugin's main viewport button.
 
-Another function you can add is the ``handles()`` function, which
+Another function you can add is the ``_handles()`` function, which
 allows you to handle a node type, automatically focusing the main
 screen when the type is selected. This is similar to how clicking
 on a 3D node will automatically switch to the 3D viewport.


### PR DESCRIPTION
Changed "handles()" to refer to the correct EditorPlugin function _handles()

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
