### PR TITLE
Change primitive type from TRIANGLES to TRIANGLE_STRIP in example of Using ArrayMesh

### DIFF
--- a/tutorials/3d/procedural_geometry/arraymesh.rst
+++ b/tutorials/3d/procedural_geometry/arraymesh.rst
@@ -140,7 +140,7 @@ by adding each array to ``surface_array`` and then committing to the mesh.
     surface_array[Mesh.ARRAY_INDEX] = indices
 
     # No blendshapes, lods, or compression used.
-    mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, surface_array)
+    mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLE_STRIP, surface_array)
 
  .. code-tab:: csharp C#
 
@@ -153,10 +153,10 @@ by adding each array to ``surface_array`` and then committing to the mesh.
     if (arrMesh != null)
     {
         // No blendshapes, lods, or compression used.
-        arrMesh.AddSurfaceFromArrays(Mesh.PrimitiveType.Triangles, surfaceArray); 
+        arrMesh.AddSurfaceFromArrays(Mesh.PrimitiveType.TriangleStrip, surfaceArray); 
     }
 
-.. note:: In this example, we used ``Mesh.PRIMITIVE_TRIANGLES``, but you can use any primitive type
+.. note:: In this example, we used ``Mesh.PRIMITIVE_TRIANGLE_STRIP``, but you can use any primitive type
           available from mesh.
 
 Put together, the full code looks like:
@@ -188,7 +188,7 @@ Put together, the full code looks like:
 
         # Create mesh surface from mesh array.
         # No blendshapes, lods, or compression used.
-        mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, surface_array)
+        mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLE_STRIP, surface_array)
 
  .. code-tab:: csharp C#
 
@@ -220,7 +220,7 @@ Put together, the full code looks like:
             {
                 // Create mesh surface from mesh array
                 // No blendshapes, lods, or compression used.
-                arrMesh.AddSurfaceFromArrays(Mesh.PrimitiveType.Triangles, surfaceArray);
+                arrMesh.AddSurfaceFromArrays(Mesh.PrimitiveType.TriangleStrip, surfaceArray);
             }
         }
     }
@@ -232,7 +232,7 @@ example code for generating shapes, starting with a rectangle.
 Generating a rectangle
 ----------------------
 
-Since we are using ``Mesh.PRIMITIVE_TRIANGLES`` to render, we will construct a rectangle
+Since we are using ``Mesh.PRIMITIVE_TRIANGLE_STRIP`` to render, we will construct a rectangle
 with triangles.
 
 A rectangle is formed by two triangles sharing four vertices. For our example, we will create


### PR DESCRIPTION
The original example in the [Using ArrayMesh](https://docs.godotengine.org/en/4.7/tutorials/3d/procedural_geometry/arraymesh.html) documentation uses primitive type TRIANGLES, which requires all triangles to be defined separately (number of vertices should be a multiple of 3), whereas the rectangle in the example is constructed with 4 vertices, which is possible only with TRIANGLE_STRIP primitive type.

The example code without this change results in an error during runtime:
```
E 0:00:01:195   draw_list_draw: Vertex amount (4) must be a multiple of the amount of vertices required by the render primitive (3).
  <C++ Error>   Condition "(to_draw % draw_list.validation.pipeline_primitive_divisor) != 0" is true.
  <C++ Source>  servers/rendering/rendering_device.cpp:6154 @ draw_list_draw()
```

This PR fixes this error by changing the primitive type to TRIANGLE_STRIP.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
