### PR TITLE
Fix incorrect probe count limit in Forward+ in Reflection probes

### DIFF
--- a/tutorials/3d/global_illumination/reflection_probes.rst
+++ b/tutorials/3d/global_illumination/reflection_probes.rst
@@ -178,11 +178,11 @@ Limitations
 -----------
 
 When using the Forward+ renderer, Godot uses a *clustering* approach for
-reflection probe rendering. As many reflection probes as desired can be added (as long as
-performance allows). However, there's still a default limit of 512 *clustered
-elements* that can be present in the current camera view. A clustered element is
-an omni light, a spot light, a :ref:`decal <doc_using_decals>` or a
-:ref:`reflection probe <doc_reflection_probes>`. This limit can be increased by adjusting
+reflection probe rendering. Up to 256 reflection probes can be visible at a time.
+However, there's still a default limit of 512 *clustered elements* that can be present
+in the current camera view. A clustered element is an omni light, a spot light,
+a :ref:`decal <doc_using_decals>` or a :ref:`reflection probe <doc_reflection_probes>`.
+This limit can be increased by adjusting
 :ref:`Max Clustered Elements<class_ProjectSettings_property_rendering/limits/cluster_builder/max_clustered_elements>`
 in **Project Settings > Rendering > Limits > Cluster Builder**.
 

--- a/tutorials/3d/global_illumination/reflection_probes.rst
+++ b/tutorials/3d/global_illumination/reflection_probes.rst
@@ -178,10 +178,14 @@ Limitations
 -----------
 
 When using the Forward+ renderer, Godot uses a *clustering* approach for
-reflection probe rendering. As many reflection probes as desired can be added (as long as
-performance allows). However, there's still a default limit of 512 *clustered
-elements* that can be present in the current camera view. A clustered element is
-an omni light, a spot light, an area light, a :ref:`decal <doc_using_decals>`, or a
+reflection probe rendering. By default, up to 64 reflection probes can be present
+in the scene tree and visible at a time. This limit can be changed up to 256 by adjusting
+:ref:`Reflection Count <class_ProjectSettings_property_rendering/reflections/reflection_atlas/reflection_count>`
+in **Project Settings > Rendering > Reflections > Reflection Atlas**.
+
+However, there's still a default limit of 512 *clustered elements* that can be present
+in the current camera view. A clustered element is an omni light, a spot light,
+an area light, a :ref:`decal <doc_using_decals>` or a
 :ref:`reflection probe <doc_reflection_probes>`. This limit can be increased by adjusting
 :ref:`Max Clustered Elements<class_ProjectSettings_property_rendering/limits/cluster_builder/max_clustered_elements>`
 in **Project Settings > Rendering > Limits > Cluster Builder**.

--- a/tutorials/rendering/renderers.rst
+++ b/tutorials/rendering/renderers.rst
@@ -226,28 +226,28 @@ Global Illumination
 
 See :ref:`doc_introduction_to_global_illumination` for more information.
 
-+-------------------------+--------------------------+--------------------------+--------------------------+
-| Feature                 | Compatibility            | Mobile                   | Forward+                 |
-+=========================+==========================+==========================+==========================+
-| ReflectionProbe         | ✔️ Supported, 2 per      | ✔️ Supported, 8 per      | ✔️ Supported, unlimited. |
-|                         | mesh.                    | mesh.                    |                          |
-+-------------------------+--------------------------+--------------------------+--------------------------+
-| LightmapGI              | ⚠️ Rendering of baked    | ✔️ Supported.            | ✔️ Supported.            |
-|                         | lightmaps is supported.  |                          |                          |
-|                         | Baking requires hardware |                          |                          |
-|                         | with RenderingDevice     |                          |                          |
-|                         | support.                 |                          |                          |
-+-------------------------+--------------------------+--------------------------+--------------------------+
-| VoxelGI                 | ❌ Not supported.        | ❌ Not supported.        | ✔️ Supported.            |
-|                         |                          |                          |                          |
-+-------------------------+--------------------------+--------------------------+--------------------------+
-| Screen-Space            | ❌ Not supported.        | ❌ Not supported.        | ✔️ Supported.            |
-| Indirect Lighting (SSIL)|                          |                          |                          |
-+-------------------------+--------------------------+--------------------------+--------------------------+
-| Signed Distance Field   | ❌ Not supported.        | ❌ Not supported.        | ✔️ Supported.            |
-| Global Illumination     |                          |                          |                          |
-| (SDFGI)                 |                          |                          |                          |
-+-------------------------+--------------------------+--------------------------+--------------------------+
++-------------------------+--------------------------+--------------------------+-----------------------------+
+| Feature                 | Compatibility            | Mobile                   | Forward+                    |
++=========================+==========================+==========================+=============================+
+| ReflectionProbe         | ✔️ Supported, 2 per      | ✔️ Supported, 8 per      | ✔️ Supported, up to 256     |
+|                         | mesh.                    | mesh.                    | in scene (64 by default).   |
++-------------------------+--------------------------+--------------------------+-----------------------------+
+| LightmapGI              | ⚠️ Rendering of baked    | ✔️ Supported.            | ✔️ Supported.               |
+|                         | lightmaps is supported.  |                          |                             |
+|                         | Baking requires hardware |                          |                             |
+|                         | with RenderingDevice     |                          |                             |
+|                         | support.                 |                          |                             |
++-------------------------+--------------------------+--------------------------+-----------------------------+
+| VoxelGI                 | ❌ Not supported.        | ❌ Not supported.        | ✔️ Supported.               |
+|                         |                          |                          |                             |
++-------------------------+--------------------------+--------------------------+-----------------------------+
+| Screen-Space            | ❌ Not supported.        | ❌ Not supported.        | ✔️ Supported.               |
+| Indirect Lighting (SSIL)|                          |                          |                             |
++-------------------------+--------------------------+--------------------------+-----------------------------+
+| Signed Distance Field   | ❌ Not supported.        | ❌ Not supported.        | ✔️ Supported.               |
+| Global Illumination     |                          |                          |                             |
+| (SDFGI)                 |                          |                          |                             |
++-------------------------+--------------------------+--------------------------+-----------------------------+
 
 Environment and post-processing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The number of reflection probes that can be rendered at once is actually limited to 256 in Forward+.

[Godot Contributors Chat discussion](https://chat.godotengine.org/channel/rendering?msg=o3qBcSMuf84ofZFmy)
