### PR TITLE
Update the list of modules that can be excluded from build

### DIFF
--- a/engine_details/development/compiling/optimizing_for_size.rst
+++ b/engine_details/development/compiling/optimizing_for_size.rst
@@ -270,11 +270,11 @@ a lot of them:
 
 ::
 
-    scons target=template_release module_astcenc_enabled=no module_basis_universal_enabled=no module_bcdec_enabled=no module_bmp_enabled=no module_camera_enabled=no module_csg_enabled=no module_dds_enabled=no module_enet_enabled=no module_etcpak_enabled=no module_fbx_enabled=no module_gltf_enabled=no module_gridmap_enabled=no module_hdr_enabled=no module_interactive_music_enabled=no module_jsonrpc_enabled=no module_ktx_enabled=no module_mbedtls_enabled=no module_meshoptimizer_enabled=no module_mp3_enabled=no module_mobile_vr_enabled=no module_msdfgen_enabled=no module_multiplayer_enabled=no module_noise_enabled=no module_navigation_2d_enabled=no module_navigation_3d_enabled=no module_ogg_enabled=no module_openxr_enabled=no module_raycast_enabled=no module_regex_enabled=no module_svg_enabled=no module_tga_enabled=no module_theora_enabled=no module_tinyexr_enabled=no module_upnp_enabled=no module_vhacd_enabled=no module_vorbis_enabled=no module_webrtc_enabled=no module_websocket_enabled=no module_webxr_enabled=no module_zip_enabled=no
+    scons target=template_release module_astcenc_enabled=no module_basis_universal_enabled=no module_bcdec_enabled=no module_bmp_enabled=no module_camera_enabled=no module_csg_enabled=no module_dds_enabled=no module_enet_enabled=no module_etcpak_enabled=no module_fbx_enabled=no module_gltf_enabled=no module_gridmap_enabled=no module_hdr_enabled=no module_interactive_music_enabled=no module_jsonrpc_enabled=no module_ktx_enabled=no module_mbedtls_enabled=no module_meshoptimizer_enabled=no module_mp3_enabled=no module_mobile_vr_enabled=no module_msdfgen_enabled=no module_multiplayer_enabled=no module_noise_enabled=no module_navigation_2d_enabled=no module_navigation_3d_enabled=no module_ogg_enabled=no module_openxr_enabled=no module_raycast_enabled=no module_svg_enabled=no module_tga_enabled=no module_theora_enabled=no module_tilemap_enabled=no module_tinyexr_enabled=no module_upnp_enabled=no module_vhacd_enabled=no module_vorbis_enabled=no module_webrtc_enabled=no module_websocket_enabled=no module_webxr_enabled=no module_zip_enabled=no
 
 If this proves not to work for your use case, you should review the list of
 modules and see which ones you actually still need for your game (e.g. you might
-want to keep networking-related modules, regex support,
+want to keep networking-related modules, tilemaps for 2D levels,
 ``mp3``/``ogg``/``vorbis`` to play music, or ``theora`` to play videos).
 
 Alternatively, you can supply a list of disabled modules by creating
@@ -312,10 +312,10 @@ following:
     module_ogg_enabled = "no"
     module_openxr_enabled = "no"
     module_raycast_enabled = "no"
-    module_regex_enabled = "no"
     module_svg_enabled = "no"
     module_tga_enabled = "no"
     module_theora_enabled = "no"
+    module_tilemap_enabled = "no"
     module_tinyexr_enabled = "no"
     module_upnp_enabled = "no"
     module_vhacd_enabled = "no"

--- a/engine_details/development/compiling/optimizing_for_size.rst
+++ b/engine_details/development/compiling/optimizing_for_size.rst
@@ -270,11 +270,11 @@ a lot of them:
 
 ::
 
-    scons target=template_release module_astcenc_enabled=no module_basis_universal_enabled=no module_bcdec_enabled=no module_bmp_enabled=no module_camera_enabled=no module_csg_enabled=no module_dds_enabled=no module_enet_enabled=no module_etcpak_enabled=no module_fbx_enabled=no module_gltf_enabled=no module_gridmap_enabled=no module_hdr_enabled=no module_interactive_music_enabled=no module_jsonrpc_enabled=no module_ktx_enabled=no module_mbedtls_enabled=no module_meshoptimizer_enabled=no module_mp3_enabled=no module_mobile_vr_enabled=no module_msdfgen_enabled=no module_multiplayer_enabled=no module_noise_enabled=no module_navigation_2d_enabled=no module_navigation_3d_enabled=no module_ogg_enabled=no module_openxr_enabled=no module_raycast_enabled=no module_regex_enabled=no module_svg_enabled=no module_tga_enabled=no module_theora_enabled=no module_tinyexr_enabled=no module_upnp_enabled=no module_vhacd_enabled=no module_vorbis_enabled=no module_webrtc_enabled=no module_websocket_enabled=no module_webxr_enabled=no module_zip_enabled=no
+    scons target=template_release module_astcenc_enabled=no module_basis_universal_enabled=no module_bcdec_enabled=no module_bmp_enabled=no module_camera_enabled=no module_csg_enabled=no module_dds_enabled=no module_enet_enabled=no module_etcpak_enabled=no module_fbx_enabled=no module_gltf_enabled=no module_gridmap_enabled=no module_hdr_enabled=no module_interactive_music_enabled=no module_jsonrpc_enabled=no module_ktx_enabled=no module_mbedtls_enabled=no module_meshoptimizer_enabled=no module_mp3_enabled=no module_mobile_vr_enabled=no module_msdfgen_enabled=no module_multiplayer_enabled=no module_noise_enabled=no module_navigation_2d_enabled=no module_navigation_3d_enabled=no module_ogg_enabled=no module_openxr_enabled=no module_raycast_enabled=no module_svg_enabled=no module_tga_enabled=no module_theora_enabled=no module_tilemap_enabled=no module_tinyexr_enabled=no module_upnp_enabled=no module_vhacd_enabled=no module_vorbis_enabled=no module_webrtc_enabled=no module_websocket_enabled=no module_webxr_enabled=no module_zip_enabled=no
 
 If this proves not to work for your use case, you should review the list of
 modules and see which ones you actually still need for your game (e.g. you might
-want to keep networking-related modules, regex support,
+want to keep networking-related modules, ``tilemap`` for 2D levels/maps,
 ``mp3``/``ogg``/``vorbis`` to play music, or ``theora`` to play videos).
 
 Alternatively, you can supply a list of disabled modules by creating
@@ -312,10 +312,10 @@ following:
     module_ogg_enabled = "no"
     module_openxr_enabled = "no"
     module_raycast_enabled = "no"
-    module_regex_enabled = "no"
     module_svg_enabled = "no"
     module_tga_enabled = "no"
     module_theora_enabled = "no"
+    module_tilemap_enabled = "no"
     module_tinyexr_enabled = "no"
     module_upnp_enabled = "no"
     module_vhacd_enabled = "no"


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
After godotengine/godot#121548 and godotengine/godot#115474's core-shattering changes, the `Disabling unwanted modules` section of the `engine_details/development/compiling/optimizing_for_size.rst` page needed to be updated. `regex` is now core, so that can't be disabled, whereas `tilemap` can now be because it's a module.

Also swapped the `e.g.` "regex support" part with a mention of ``tilemap`` instead, since `TileMapLayer`s are still very common in 2D games just like `MP3`s/`OGG`s are common, so I think it's of particular mention. (Especially since I wouldn't want people blindly copy-pasting the command into their command-line and wondering why their game broke, especially those who haven't learned that it's a module now. It's what I would do by accident :P ) If it's okay to not replace "regex support" with anything or something else is better there, though, please suggest so.

Also please update me if there's another module/core shift in the works so I can update this PR accordingly. :) Also please tell me if any other doc page mentions specific modules. I quickly searched and I don't see any other pages that reference `TileMapLayer` or `RegEx` as being part of a module/core/etc.