### PR TITLE
[4.8] Add note to unit testing page about enabling static typing warnings for GDScript tests

### DIFF
--- a/engine_details/architecture/unit_testing.rst
+++ b/engine_details/architecture/unit_testing.rst
@@ -451,3 +451,12 @@ If no errors are printed and everything goes well, you're done!
     function present inside the script file,
     you can disable the runtime section of the test by naming the script file so that it matches the pattern ``*.notest.gd``.
     For example, "test_empty_file.notest.gd".
+
+.. note::
+
+    By default, GDScript tests suppress the ``UNTYPED_DECLARATION`` and ``INFERRED_DECLARATION``
+    warnings. Add the comments ``# enable UNTYPED_DECLARATION`` or ``# enable INFERRED_DECLARATION``
+    to the GDScript test file to enable the corresponding warning for that test.
+
+    In general, GDScript tests should not use statically typed variables.
+    Only enable static typing warnings if you are specifically testing them.

--- a/engine_details/architecture/unit_testing.rst
+++ b/engine_details/architecture/unit_testing.rst
@@ -458,5 +458,5 @@ If no errors are printed and everything goes well, you're done!
     warnings. Add the comments ``# enable UNTYPED_DECLARATION`` or ``# enable INFERRED_DECLARATION``
     to the GDScript test file to enable the corresponding warning for that test.
 
-    In general, GDScript tests should not use statically typed variables.
+    In general, GDScript tests should not use statically-typed variables.
     Only enable static typing warnings if you are specifically testing them.


### PR DESCRIPTION
Since https://github.com/godotengine/godot/pull/121839 , the `UNTYPED_DECLARATION` and `INFERRED_DECLARATION` warnings can be enabled for an individual GDScript test by including a comment in the test file.

This PR documents the behavior, but also notes that most GDScript tests should _not_ be made statically typed, and that the only ones that use these warnings should be ones specifically testing their functionality.