### PR TITLE
Replace most leftover "instance" verbs with "instantiate"

### DIFF
--- a/getting_started/first_2d_game/04.creating_the_enemy.rst
+++ b/getting_started/first_2d_game/04.creating_the_enemy.rst
@@ -7,7 +7,7 @@ Now it's time to make the enemies our player will have to dodge. Their behavior
 will not be very complex: mobs will spawn randomly at the edges of the screen,
 choose a random direction, and move in a straight line.
 
-We'll create a ``Mob`` scene, which we can then *instance* to create any number
+We'll create a ``Mob`` scene, which we can then *instantiate* to create any number
 of independent mobs in the game.
 
 Node setup

--- a/getting_started/first_2d_game/05.the_main_game_scene.rst
+++ b/getting_started/first_2d_game/05.the_main_game_scene.rst
@@ -9,7 +9,7 @@ Create a new scene and add a :ref:`Node <class_Node>` named ``Main``.
 (The reason we are using Node instead of Node2D is because this node will
 be a container for handling game logic. It does not require 2D functionality itself.)
 
-Click the **Instance** button (represented by a chain link icon) and select your saved
+Click the **Instantiate** button (represented by a chain link icon) and select your saved
 ``player.tscn``.
 
 .. image:: img/instance_scene.webp
@@ -74,7 +74,7 @@ Main script
 
 Add a script to ``Main``. At the top of the script, we use
 ``@export var mob_scene: PackedScene`` to allow us to choose the Mob scene we want
-to instance.
+to instantiate.
 
 .. tabs::
  .. code-tab:: gdscript GDScript

--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -211,7 +211,7 @@ signal of ``MessageTimer`` to the ``HUD`` node, and add the following code to th
 Connecting HUD to Main
 ----------------------
 
-Now that we're done creating the ``HUD`` scene, go back to ``Main``. Instance
+Now that we're done creating the ``HUD`` scene, go back to ``Main``. Instantiate
 the ``HUD`` scene in ``Main`` like you did the ``Player`` scene. The scene tree
 should look like this, so make sure you didn't miss anything:
 

--- a/getting_started/first_3d_game/04.mob_scene.rst
+++ b/getting_started/first_3d_game/04.mob_scene.rst
@@ -65,7 +65,7 @@ Godot has a node that detects when objects leave the screen,
 
 .. note::
 
-    When you keep instancing an object, there's a technique you can
+    When you keep instantiating an object, there's a technique you can
     use to avoid the cost of creating and destroying instances all the time
     called pooling. It consists of pre-creating an array of objects and reusing
     them over and over.

--- a/getting_started/first_3d_game/index.rst
+++ b/getting_started/first_3d_game/index.rst
@@ -22,7 +22,7 @@ You will learn to:
 - Use kinematic bodies to move 3D characters and detect when and how they
   collide.
 - Use physics layers and a group to detect interactions with specific entities.
-- Code basic procedural gameplay by instancing monsters at regular time
+- Code basic procedural gameplay by instantiating monsters at regular time
   intervals.
 - Design a movement animation and change its speed at runtime.
 - Draw a user interface on a 3D game.

--- a/getting_started/step_by_step/instancing.rst
+++ b/getting_started/step_by_step/instancing.rst
@@ -5,10 +5,10 @@ Creating instances
 
 .. note::
 
-   This tutorial refers to instancing scenes in the editor. To learn how
-   to instance scenes from code, see :ref:`doc_nodes_and_scene_instances`.
+   This tutorial refers to instantiating scenes in the editor. To learn how
+   to instantiate scenes from code, see :ref:`doc_nodes_and_scene_instances`.
 
-   Godot's approach to *instancing* described below should not be confused with
+   Godot's approach to *instantiation* described below should not be confused with
    hardware instancing that can be used to render large amounts of similar
    objects quickly. See :ref:`doc_using_multimesh` instead.
 
@@ -31,12 +31,12 @@ and bounce on walls, a :ref:`Sprite2D <class_Sprite2D>` node, and a
 
 Once you have saved a scene, it works as a blueprint: you can reproduce it in other
 scenes as many times as you'd like. Replicating an object from a template like
-this is called **instancing**.
+this is called **instantiation**.
 
 .. image:: img/instancing_ball_instances_example.webp
 
-As we mentioned in the previous part, instanced scenes behave like a node: the
-editor hides their content by default. When you instance the Ball, you only see
+As we mentioned in the previous part, instantiated scenes behave like a node: the
+editor hides their content by default. When you instantiate the Ball, you only see
 the Ball node. Notice also how each duplicate has a unique name.
 
 Every instance of the Ball scene starts with the same structure and properties
@@ -47,7 +47,7 @@ scene.
 In practice
 -----------
 
-Let's use instancing in practice to see how it works in Godot. We invite
+Let's use instantiation in practice to see how it works in Godot. We invite
 you to download the ball's sample project we prepared for you:
 `instancing_starter.zip <https://github.com/godotengine/godot-docs-project-starters/releases/download/latest-4.x/instancing_starter.zip>`_.
 
@@ -85,7 +85,7 @@ you to add an instance of a scene as a child of the currently selected node.
 
 .. image:: img/instancing_scene_link_button.webp
 
-Double-click the ball scene to instance it.
+Double-click the ball scene to instantiate it.
 
 .. image:: img/instancing_instance_child_window.webp
 
@@ -150,7 +150,7 @@ on the corresponding tab above the viewport.
 
 .. image:: img/instancing_scene_tabs.webp
 
-Select one of the instanced Ball nodes and, in the :ui:`Inspector`, set its
+Select one of the instantiated Ball nodes and, in the :ui:`Inspector`, set its
 :inspector:`Gravity Scale` value to ``10``.
 
 .. image:: img/instancing_property_gravity_scale.webp
@@ -199,7 +199,7 @@ rectangle represents an entity that's visible in the game from the player's
 perspective. The arrows point towards the instantiator of each scene.
 
 Once you have a diagram, we recommend creating a scene for each element listed
-in it to develop your game. You'll use instancing, either by code or directly in
+in it to develop your game. You'll use instantiation, either by code or directly in
 the editor, to build your tree of scenes.
 
 Programmers tend to spend a lot of time designing abstract architectures and
@@ -216,8 +216,8 @@ and nested elements:
 Imagine we started by creating the room. We could make a couple of different
 room scenes, with unique arrangements of furniture in them. Later, we could make
 a house scene that uses multiple room instances for the interior. We would
-create a citadel out of many instanced houses and a large terrain on which we
-would place the citadel. Each of these would be a scene instancing one or more sub-scenes.
+create a citadel out of many instantiated houses and a large terrain on which we
+would place the citadel. Each of these would be a scene instantiating one or more sub-scenes.
 
 Later, we could create scenes representing guards and add them to the citadel.
 They would be indirectly added to the overall game world.
@@ -231,7 +231,7 @@ all working with the Godot editor.
 Summary
 -------
 
-Instancing, the process of producing an object from a blueprint, has many handy
+Instantiation, the process of producing an object from a blueprint, has many handy
 uses. With scenes, it gives you:
 
 - The ability to divide your game into reusable components.

--- a/tutorials/2d/using_tilesets.rst
+++ b/tutorials/2d/using_tilesets.rst
@@ -166,7 +166,7 @@ sounds), particle effects, and more.
 .. warning::
 
    Scene tiles come with a greater performance overhead compared to atlases, as
-   every scene is instanced individually for every placed tile.
+   every scene is instantiated individually for every placed tile.
 
    It's recommended to only use scene tiles when necessary. To draw sprites in a
    tile without any kind of advanced manipulation,

--- a/tutorials/3d/global_illumination/using_lightmap_gi.rst
+++ b/tutorials/3d/global_illumination/using_lightmap_gi.rst
@@ -234,11 +234,11 @@ Setting up the scene
 
 Before anything is done, a **LightmapGI** node needs to be added to a scene.
 This will enable light baking on all nodes (and sub-nodes) in that scene, even
-on instanced scenes.
+on instantiated scenes.
 
 .. image:: img/lightmap_gi_scene.webp
 
-A sub-scene can be instanced several times, as this is supported by the baker.
+A sub-scene can be instantiated several times, as this is supported by the baker.
 Each instance will be assigned a lightmap of its own. To avoid issues with
 inconsistent lightmap texel scaling, make sure to respect the rule about mesh
 scaling mentioned before.

--- a/tutorials/3d/particles/subemitters.rst
+++ b/tutorials/3d/particles/subemitters.rst
@@ -32,10 +32,10 @@ parent and one will be set as the child. Find the ``Sub Emitter`` property on th
 and click the box next to it to assign the sub-emitter. You will see a list of available particle
 systems in the scene. Select one and click the confirmation button.
 
-Particle systems from instanced scenes can be set as sub-emitters too, as long as the
-``Editable Children`` property is enabled on the instanced scene. This also works the other
-way around: You can assign a sub-emitter to a particle system in an instanced scene,
-even one coming from a different instanced scene.
+Particle systems from instantiated scenes can be set as sub-emitters too, as long as the
+``Editable Children`` property is enabled on the instantiated scene. This also works the other
+way around: You can assign a sub-emitter to a particle system in an instantiated scene,
+even one coming from a different instantiated scene.
 
 .. note::
 

--- a/tutorials/animation/animation_track_types.rst
+++ b/tutorials/animation/animation_track_types.rst
@@ -213,7 +213,7 @@ key you just created to select an animation in the inspector dock.
 If an animation is already playing and you want to stop it early, you can create
 a key and have it set to `[STOP]` in the inspector.
 
-.. note:: If you instanced a scene that contains an animation player into your
+.. note:: If you instantiate a scene that contains an animation player into your
           scene, you need to enable "Editable Children" in the scene tree to
           access its animation player. Also, an animation player cannot
           reference itself.

--- a/tutorials/assets_pipeline/importing_3d_scenes/advanced_import_settings.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/advanced_import_settings.rst
@@ -116,7 +116,7 @@ The options are as follows:
 
 - **Save to File:** Saves the :ref:`class_Mesh` *resource* to an external file
   (this isn't a scene file). You generally don't need to use this for placing
-  the mesh in a 3D scene – instead, you should instance the 3D scene directly.
+  the mesh in a 3D scene – instead, you should instantiate the 3D scene directly.
   However, having direct access to the Mesh resource is useful for specific
   nodes, such as :ref:`class_MeshInstance3D`, :ref:`class_MultiMeshInstance3D`,
   :ref:`class_GPUParticles3D` or :ref:`class_CPUParticles3D`.

--- a/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.rst
+++ b/tutorials/assets_pipeline/importing_3d_scenes/import_configuration.rst
@@ -63,7 +63,7 @@ scene in the FileSystem dock:
   inherit from Node3D is recommended. Otherwise, you'll lose the ability to
   position the node directly in the 3D editor.
 - **Root Name:** The name of the root node in the imported scene. This is
-  generally not noticeable when instancing the scene in the editor (or
+  generally not noticeable when instantiating the scene in the editor (or
   drag-and-dropping from the FileSystem dock), as the root node is renamed to
   match the filename in this case.
 - **Apply Root Scale:** If enabled, **Root Scale** will be *applied* on the

--- a/tutorials/best_practices/godot_interfaces.rst
+++ b/tutorials/best_practices/godot_interfaces.rst
@@ -76,7 +76,7 @@ access.
     [Tool]
     public MyType
     {
-        // Property initializations load during Script instancing, i.e. .new().
+        // Property initializations load during Script instantiation, i.e. .new().
         // No "preload" loads during scene load exists in C#.
 
         // Initialize with a value. Editable at runtime.

--- a/tutorials/io/saving_games.rst
+++ b/tutorials/io/saving_games.rst
@@ -60,7 +60,7 @@ Serializing
 
 The next step is to serialize the data. This makes it much easier to
 read from and store to disk. In this case, we're assuming each member of
-group Persist is an instanced node and thus has a path. GDScript
+group Persist is an instantiated node and thus has a path. GDScript
 has the helper class :ref:`JSON<class_json>` to convert between dictionary and string.
 Our node needs to contain a save function that returns this data.
 The save function will look like this:
@@ -144,9 +144,9 @@ way to pull the data out of the file as well.
         var save_file = FileAccess.open("user://savegame.save", FileAccess.WRITE)
         var save_nodes = get_tree().get_nodes_in_group("Persist")
         for node in save_nodes:
-            # Check the node is an instanced scene so it can be instanced again during load.
+            # Check the node is an instantiated scene so it can be instantiated again during load.
             if node.scene_file_path.is_empty():
-                print("persistent node '%s' is not an instanced scene, skipped" % node.name)
+                print("persistent node '%s' is not an instantiated scene, skipped" % node.name)
                 continue
 
             # Check the node has a save function.
@@ -176,10 +176,10 @@ way to pull the data out of the file as well.
         var saveNodes = GetTree().GetNodesInGroup("Persist");
         foreach (Node saveNode in saveNodes)
         {
-            // Check the node is an instanced scene so it can be instanced again during load.
+            // Check the node is an instantiated scene so it can be instantiated again during load.
             if (string.IsNullOrEmpty(saveNode.SceneFilePath))
             {
-                GD.Print($"persistent node '{saveNode.Name}' is not an instanced scene, skipped");
+                GD.Print($"persistent node '{saveNode.Name}' is not an instantiated scene, skipped");
                 continue;
             }
 

--- a/tutorials/performance/thread_safe_apis.rst
+++ b/tutorials/performance/thread_safe_apis.rst
@@ -81,7 +81,7 @@ set in multiple ones. Otherwise, you are safer just using the servers API
 Rendering
 ---------
 
-Instancing nodes that render anything in 2D or 3D (such as :ref:`class_Sprite2D`
+Instantiating nodes that render anything in 2D or 3D (such as :ref:`class_Sprite2D`
 or :ref:`class_MeshInstance3D`) is *not* thread-safe by default. To run the
 rendering driver on a separate thread, set the
 :ref:`Rendering > Driver > Thread Model <class_ProjectSettings_property_rendering/driver/threads/thread_model>`

--- a/tutorials/physics/kinematic_character_2d.rst
+++ b/tutorials/physics/kinematic_character_2d.rst
@@ -101,7 +101,7 @@ shape scale.**
 Now, create a script for the character, the one used as an example
 above should work as a base.
 
-Finally, instance that character scene in the tilemap, and make the
+Finally, instantiate that character scene in the tilemap, and make the
 map scene the main one, so it runs when pressing play.
 
 .. image:: img/kbinstance.webp

--- a/tutorials/physics/using_character_body_2d.rst
+++ b/tutorials/physics/using_character_body_2d.rst
@@ -301,7 +301,7 @@ in the sample project), we have a character shooting bullets and we want the bul
 bounce off the walls.
 
 This example uses three scenes. The main scene contains the Player and Walls.
-The Bullet and Wall are separate scenes so that they can be instanced.
+The Bullet and Wall are separate scenes so that they can be instantiated.
 
 The Player is controlled by the ``w`` and ``s`` keys for forward and back. Aiming
 uses the mouse pointer. Here is the code for the Player, using ``move_and_slide()``:

--- a/tutorials/plugins/editor/making_main_screen_plugins.rst
+++ b/tutorials/plugins/editor/making_main_screen_plugins.rst
@@ -148,7 +148,7 @@ Update the plugin script
 ------------------------
 
 We need to update the ``main_screen_plugin.gd`` script so the plugin
-instances our main panel scene and places it where it needs to be.
+instantiates our main panel scene and places it where it needs to be.
 Here is the full plugin script:
 
 .. tabs::
@@ -248,10 +248,10 @@ Here is the full plugin script:
     #endif
 
 A couple of specific lines were added. ``MainPanel`` is a constant that holds
-a reference to the scene, and we instance it into `main_panel_instance`.
+a reference to the scene, and we instantiate it into `main_panel_instance`.
 
 The ``_enter_tree()`` function is called before ``_ready()``. This is where
-we instance the main panel scene, and add them as children of specific parts
+we instantiate the main panel scene, and add them as children of specific parts
 of the editor. We use ``EditorInterface.get_editor_main_screen()`` to
 obtain the main editor screen and add our main panel instance as a child to it.
 We call the ``_make_visible(false)`` function to hide the main panel so

--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -148,7 +148,7 @@ A custom node
 -------------
 
 Sometimes you want a certain behavior in many nodes, such as a custom scene
-or control that can be reused. Instancing is helpful in a lot of cases, but
+or control that can be reused. Instantiation is helpful in a lot of cases, but
 sometimes it can be cumbersome, especially if you're using it in many
 projects. A good solution to this is to make a plugin that adds a node with a
 custom behavior.

--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -662,11 +662,11 @@ doubles the range of all OmniLight3D nodes:
 
         func _run():
             for node in EditorInterface.get_edited_scene_root().find_children("", "OmniLight3D"):
-                # Don't operate on instanced subscene children, as changes are lost
+                # Don't operate on instantiated subscene children, as changes are lost
                 # when reloading the scene.
-                # See the "Instancing scenes" section below for a description of `owner`.
-                var is_instanced_subscene_child = node != get_scene() and node.owner != get_scene()
-                if not is_instanced_subscene_child:
+                # See the "Instantiating scenes" section below for a description of `owner`.
+                var is_instantiated_subscene_child = node != get_scene() and node.owner != get_scene()
+                if not is_instantiated_subscene_child:
                     node.omni_range *= 2.0
                     EditorInterface.mark_scene_as_unsaved()
 
@@ -685,11 +685,11 @@ doubles the range of all OmniLight3D nodes:
             
                 foreach (OmniLight3D node in sceneNode.FindChildren("", "OmniLight3D"))
                 {
-                    // Don't operate on instanced subscene children, as changes are lost
+                    // Don't operate on instantiated subscene children, as changes are lost
                     // when reloading the scene.
-                    // See the "Instancing scenes" section below for a description of `owner`.
-                    var isInstancedSubsceneChild = node != sceneNode && node.Owner != sceneNode;
-                    if (!isInstancedSubsceneChild)
+                    // See the "Instantiating scenes" section below for a description of `owner`.
+                    var isInstantiatedSubsceneChild = node != sceneNode && node.Owner != sceneNode;
+                    if (!isInstantiatedSubsceneChild)
                     {
                         node.OmniRange *= 2.0f;
                         EditorInterface.Singleton.MarkSceneAsUnsaved();
@@ -712,8 +712,8 @@ you also get a confirmation when trying to close the scene with unsaved changes.
     so make sure you've selected the scene you intend to iterate upon before
     running the script.
 
-Instancing scenes
------------------
+Instantiating scenes
+--------------------
 
 You can instantiate packed scenes normally and add them to the scene currently
 opened in the editor. By default, nodes or scenes added with

--- a/tutorials/rendering/multiple_resolutions.rst
+++ b/tutorials/rendering/multiple_resolutions.rst
@@ -110,7 +110,7 @@ in turn have different pixel density and resolutions. Handling all of
 them can be a lot of work, so Godot tries to make the developer's life a
 little easier. The :ref:`Viewport <class_Viewport>`
 node has several functions to handle resizing, and the root node of the
-scene tree is always a viewport (scenes loaded are instanced as a child
+scene tree is always a viewport (scenes loaded are instantiated as a child
 of it, and it can always be accessed by calling
 ``get_tree().root`` or ``get_node("/root")``).
 

--- a/tutorials/rendering/viewports.rst
+++ b/tutorials/rendering/viewports.rst
@@ -133,7 +133,7 @@ the game (like in StarCraft).
 As a helper for situations where you want to create :ref:`Viewports <class_Viewport>` that
 display single objects and don't want to create a :ref:`World3D <class_World3D>`, Viewport has
 the option to use its :ref:`Own World3D <class_Viewport_property_own_world_3d>`. This is useful when you want to
-instance 3D characters or objects in :ref:`World2D <class_World2D>`.
+instantiate 3D characters or objects in :ref:`World2D <class_World2D>`.
 
 For 2D, each :ref:`Viewport <class_Viewport>` always contains its own :ref:`World2D <class_World2D>`.
 This suffices in most cases, but in case sharing them may be desired, it

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -2432,7 +2432,7 @@ Inner classes
 ~~~~~~~~~~~~~
 
 A class file can contain inner classes. Inner classes are defined using the
-``class`` keyword. They are instanced using the ``ClassName.new()``
+``class`` keyword. They are instantiated using the ``ClassName.new()``
 function.
 
 ::
@@ -2460,7 +2460,7 @@ Classes as resources
 
 Classes stored as files are treated as :ref:`GDScripts <class_GDScript>`. They
 must be loaded from disk to access them in other classes. This is done using
-either the ``load`` or ``preload`` functions (see below). Instancing of a loaded
+either the ``load`` or ``preload`` functions (see below). Instantiation of a loaded
 class resource is done by calling the ``new`` function on the class object:
 
 ::

--- a/tutorials/scripting/instancing_with_signals.rst
+++ b/tutorials/scripting/instancing_with_signals.rst
@@ -3,14 +3,14 @@
 
 .. _doc_instancing_with_signals:
 
-Instancing with signals
-=======================
+Instantiation with signals
+==========================
 
 Signals provide a way to decouple game objects, allowing you to avoid forcing a
 fixed arrangement of nodes. One sign that a signal might be called for is when
 you find yourself using ``get_parent()``. Referring directly to a node's parent
 means that you can't easily move that node to another location in the scene tree.
-This can be especially problematic when you are instancing objects at runtime
+This can be especially problematic when you are instantiating objects at runtime
 and may want to place them in an arbitrary location in the running scene tree.
 
 Below we'll consider an example of such a situation: firing bullets.

--- a/tutorials/scripting/nodes_and_scene_instances.rst
+++ b/tutorials/scripting/nodes_and_scene_instances.rst
@@ -8,7 +8,7 @@ instantiate scenes from code.
 
 .. seealso::
 
-    Check the :ref:`doc_instancing` tutorial to learn about Godot's approach to scene instancing.
+    Check the :ref:`doc_instancing` tutorial to learn about Godot's approach to scene instantiation.
 
 Getting nodes
 -------------
@@ -178,11 +178,11 @@ When you free a node, it also frees all its children. Thanks to this, to delete
 an entire branch of the scene tree, you only have to free the topmost parent
 node.
 
-Instancing scenes
------------------
+Instantiating scenes
+--------------------
 
 Scenes are templates from which you can create as many reproductions as you'd
-like. This operation is called instancing, and doing it from code happens in two
+like. This operation is called instantiation, and doing it from code happens in two
 steps:
 
 1. Loading the scene from the local drive.
@@ -224,5 +224,5 @@ as a child of your current node.
     AddChild(instance);
 
 The advantage of this two-step process is you can keep a packed scene loaded and
-create new instances on the fly. For example, to quickly instance several
+create new instances on the fly. For example, to quickly instantiate several
 enemies or bullets.

--- a/tutorials/scripting/resources.rst
+++ b/tutorials/scripting/resources.rst
@@ -67,7 +67,7 @@ save, Godot will save the image inside the ``.tscn`` scene file.
 
 .. note::
 
-    Even if you save a built-in resource, when you instance a scene multiple
+    Even if you save a built-in resource, when you instantiate a scene multiple
     times, the engine will only load one copy of it.
 
 Loading resources from code

--- a/tutorials/scripting/scene_tree.rst
+++ b/tutorials/scripting/scene_tree.rst
@@ -40,7 +40,7 @@ and servers are the low-level API.
 
 The scene system provides its own main loop to OS,
 :ref:`SceneTree <class_SceneTree>`.
-This is automatically instanced and set when running a scene, no need
+This is automatically instantiated and set when running a scene, no need
 to do any extra work.
 
 It's important to know that this class exists because it has a few

--- a/tutorials/scripting/scene_unique_nodes.rst
+++ b/tutorials/scripting/scene_unique_nodes.rst
@@ -53,7 +53,7 @@ Same-scene limitation
 
 A scene unique node can only be retrieved by a node inside the same scene. To
 demonstrate this limitation, consider this example **Player** scene that
-instances a **Sword** scene:
+instantiates a **Sword** scene:
 
 .. image:: img/unique_name_scene_instance_example.webp
 

--- a/tutorials/scripting/singletons_autoload.rst
+++ b/tutorials/scripting/singletons_autoload.rst
@@ -38,7 +38,7 @@ Autoloading nodes and scripts can give us these characteristics.
 .. note::
 
     Godot won't make an Autoload a "true" singleton as per the singleton design
-    pattern. It may still be instanced more than once by the user if desired.
+    pattern. It may still be instantiated more than once by the user if desired.
 
 .. tip::
 
@@ -219,7 +219,7 @@ current scene and replace it with the requested one.
         # Load the new scene.
         var s = ResourceLoader.load(path)
 
-        # Instance the new scene.
+        # Instantiate the new scene.
         current_scene = s.instantiate()
 
         # Add it to the active scene, as child of root.
@@ -252,7 +252,7 @@ current scene and replace it with the requested one.
         // Load a new scene.
         var nextScene = GD.Load<PackedScene>(path);
 
-        // Instance the new scene.
+        // Instantiate the new scene.
         CurrentScene = nextScene.Instantiate();
 
         // Add it to the active scene, as child of root.

--- a/tutorials/shaders/screen-reading_shaders.rst
+++ b/tutorials/shaders/screen-reading_shaders.rst
@@ -112,7 +112,7 @@ With correct back-buffer copying, the two spheres blend correctly:
 
     In 3D, materials that use ``hint_screen_texture`` are considered transparent themselves and
     will not appear in the resulting screen texture of other materials.
-    If you plan to instance a scene that uses a material with ``hint_screen_texture``,
+    If you plan to instantiate a scene that uses a material with ``hint_screen_texture``,
     you will need to use a BackBufferCopy node.
 
 In 3D, there is less flexibility to solve this particular issue because the

--- a/tutorials/shaders/shader_reference/shading_language.rst
+++ b/tutorials/shaders/shader_reference/shading_language.rst
@@ -455,7 +455,7 @@ Or use struct constructor for same purpose:
 
     PointLight light = PointLight(vec3(0.0), vec3(1.0, 0.0, 0.0), 0.5);
 
-Structs may contain other struct or array, you can also instance them as global
+Structs may contain other struct or array, you can also instantiate them as global
 constant:
 
 .. code-block:: glsl

--- a/tutorials/xr/openxr_spatial_entities.rst
+++ b/tutorials/xr/openxr_spatial_entities.rst
@@ -83,7 +83,7 @@ object is instantiated and registered with the :ref:`XRServer<class_XRServer>`.
 Each type of spatial entity will implement its own subclass and we can thus react differently to
 each type of entity.
 
-Generally speaking we will instance different subscenes for each type of entity.
+Generally speaking we will instantiate different subscenes for each type of entity.
 As the tracker objects can be used with :ref:`XRAnchor3D<class_XRAnchor3D>` nodes, these subscenes
 should have such a node as their root node.
 
@@ -212,7 +212,7 @@ Below is the basis of the script that implements our manager logic:
     # A tracked managed by XRServer was changed.
     func _on_tracker_updated(_tracker_name: StringName, _type: int):
         # For now we ignore this, there aren't any changes here we need to react
-        # to and the instanced scene can react to this itself if needed.
+        # to and the instantiated scene can react to this itself if needed.
         pass
 
 


### PR DESCRIPTION
In Godot `4.0`, in a moment of lucidity, PackedScene's `instance()` function was renamed to `instantiate()` and the surrounding documentation followed suite. Despite this, there's some leftover text, or even new text, that didn't quite get the memo.

This PR replaces every occurrence of "instance" being used as a verb with "instantiate".
Similarly, "instancing" has been replaced with "instantiation" where appropriate.
File names are not changed in this PR.

Keep **very strongly** in mind the following:
- **Instantiation** is the whole creation process.
- **Instancing** is a real term in graphics rendering. It refers to the grouping of similar objects to render them all in one swoop. It's not the same concept as instantiation.
	- Similarly, an object is said to be **instanced** when it is, or can be, part of this batch, but this meaning very rare in the docs.