### PR TITLE
Fix MyRefCounted example

### DIFF
--- a/engine_details/architecture/object_class.rst
+++ b/engine_details/architecture/object_class.rst
@@ -304,7 +304,7 @@ dropped, the object automatically self-destructs.
 .. code-block:: cpp
 
     class MyRefCounted: public RefCounted {
-        GDCLASS(MyReference, RefCounted);
+        GDCLASS(MyRefCounted, RefCounted);
     };
 
     Ref<MyRefCounted> my_ref = memnew(MyRefCounted);


### PR DESCRIPTION
The example for making a class `MyRefCounted` did not pass the same class to the `GDCLASS` macro despite that appearing to be required based on the first example shown. I am new to C++ and just started learning how to contribute, so it is possible that I am missing something.

First example - passes `CustomObject` (same class) to `GDCLASS`
> ```
> class CustomObject : public Object {
> 	GDCLASS(CustomObject, Object); // This is required to inherit from Object.
> };
> ```
> https://docs.godotengine.org/en/latest/engine_details/architecture/object_class.html#general-definition

Example in question - passes `MyReference` (different class) instead of `MyRefCounted` to `GDCLASS`
> ```
> class MyRefCounted: public RefCounted {
>	GDCLASS(MyReference, RefCounted);
> };
> ```
> https://docs.godotengine.org/en/latest/engine_details/architecture/object_class.html#refcounted-memory-management