### PR TITLE
Document translation template generation

### DIFF
--- a/tutorials/i18n/index.rst
+++ b/tutorials/i18n/index.rst
@@ -8,6 +8,7 @@ Internationalization
    :name: toc-learn-features-i18n
 
    internationalizing_games
+   translation_template_generation
    localization_using_spreadsheets
    localization_using_gettext
    locales

--- a/tutorials/i18n/localization_using_gettext.rst
+++ b/tutorials/i18n/localization_using_gettext.rst
@@ -74,6 +74,9 @@ specified scene and GDScript files. This POT generation also supports translatio
 contexts and pluralization if used in a script, with the optional second
 argument of ``tr()`` and the ``tr_n()`` method.
 
+For configuration, extraction behavior, and customizing generated strings, see
+:ref:`generating translation templates <doc_translation_template_generation>`.
+
 Open :menu:`Project > Project Settings > Localization > Template Generation`, then use the
 :button:`Add…` button to specify the path to your project's scenes and scripts that
 contain localizable strings:

--- a/tutorials/i18n/translation_template_generation.rst
+++ b/tutorials/i18n/translation_template_generation.rst
@@ -1,0 +1,47 @@
+.. _doc_translation_template_generation:
+
+Generating translation templates
+================================
+
+Translation templates collect a project's source strings before translation.
+Godot's template generator can create GNU gettext ``.pot`` files and CSV
+templates from scenes and scripts. Regenerate a template whenever localizable
+content changes so translators work from the current project.
+
+Configuring the generator
+-------------------------
+
+Open :menu:`Project > Project Settings > Localization > Template Generation`.
+Use :button:`Add...` to include scenes and scripts that contain source strings,
+then click :button:`Generate` and choose an output path. Use a ``.pot``
+extension for gettext or ``.csv`` for spreadsheet-based translations. The
+generator is also available from the Command Palette for quick updates while
+you are editing localizable content.
+
+What the generator extracts
+---------------------------
+
+The generator collects strings from supported scene properties and from
+:ref:`tr() <class_Object_method_tr>` and
+:ref:`tr_n() <class_Object_method_tr_n>` calls in scripts. For example, it can
+find UI control text. This list is not exhaustive because Godot can add new
+localizable properties over time.
+
+Nodes whose **Auto Translate Mode** is disabled do not contribute their
+translatable scene strings. Use this for identifiers or content supplied by a
+service. Translation contexts are included in templates. For Controls, set
+**Translation Context** when an otherwise identical source string has a
+different meaning in one part of the interface. See
+:ref:`translation contexts <doc_internationalizing_games_translation_contexts>`.
+
+Customizing extracted strings
+-----------------------------
+
+Use :ref:`EditorTranslationParserPlugin <class_EditorTranslationParserPlugin>`
+for custom file formats or to adjust extracted strings. Its
+``_customize_strings()`` method can add, remove, or modify entries before Godot
+writes the template. For example, a project can remove placeholder text from
+scenes while retaining automatic translation for the rest of a node.
+
+For script-specific extraction details, including comments for translators,
+see :ref:`localization using gettext <doc_localization_using_gettext_gdscript>`.


### PR DESCRIPTION
Adds a dedicated guide for the translation template generator and links it from the gettext workflow.

It covers configuring PO and CSV output, Command Palette access, the kinds of strings that are extracted, Auto Translate Mode, translation contexts, and `EditorTranslationParserPlugin._customize_strings()` for custom processing.

Closes #12219.

Validation:

- `codespell` passed on the three edited files.
- `git diff --check` passed.
- A complete local Sphinx build was started after installing the documented dependencies, but did not complete within the available command time. CI can run the full documentation build.