### PR TITLE
Compiling for iOS Docs: Add note on building iOS export templates with generate_bundle

### DIFF
--- a/engine_details/development/compiling/compiling_for_ios.rst
+++ b/engine_details/development/compiling/compiling_for_ios.rst
@@ -68,9 +68,17 @@ template located in ``misc/dist/apple_embedded_xcode``. The release and debug li
 should be placed in ``libgodot.ios.debug.xcframework`` and
 ``libgodot.ios.release.xcframework`` respectively. Camera module libraries
 should be placed in ``libgodot_camera.ios.debug.xcframework`` and 
-``libgodot_camera.ios.release.xcframework``. This process can be automated
-by using the ``generate_bundle=yes`` option on the *last* SCons command used to
-build export templates (so that all binaries can be included).
+``libgodot_camera.ios.release.xcframework``. 
+
+.. note::
+
+    This process can be automated by using the ``generate_bundle=yes`` option on the *last* SCons command used to build export templates (so that all binaries can be included).
+
+    Additionally, you can collect ``godot_ios.zip`` in the ``bin/`` folder, rename it to ``ios.zip``, and use it as an export template by moving it to the system export templates directory for your Godot version:
+
+    * **Windows:** ``%APPDATA%\Godot\export_templates\<version>\``
+    * **Linux:** ``$HOME/.local/share/godot/export_templates/<version>/``
+    * **macOS:** ``$HOME/Library/Application Support/Godot/export_templates/<version>/``
 
 The MoltenVK static ``.xcframework`` folder must also be placed in the
 ``apple_embedded_xcode`` folder once it has been created. MoltenVK is always statically


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->

Adds a note directive to the iOS export template documentation clarifying how to automate binary packaging using the generate_bundle=yes SCons flag, along with the correct path where godot_ios.zip should be placed for system-wide export templates.

AI is used in this PR for language grammar improvement 