### PR TITLE
Add CI check for trailing whitespace

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+# This file contains a list of Git commit hashes that should be hidden from the
+# regular Git history. Typically, this includes commits involving mass auto-formatting
+# or other normalizations. Commit hashes *must* use the full 40-character notation.
+# To apply the ignore list in your local Git client, you must run:
+#
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# This file is automatically used by GitHub.com's blame view.
+
+# Remove trailing whitespace
+ecf7d701a0431c5b587fb698733e2ad6f8d90846

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,8 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
+      - id: trailing-whitespace
+        exclude: '^classes'
       - id: fix-byte-order-marker
       - id: mixed-line-ending
         args: ['--fix=lf']

--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -757,7 +757,7 @@ XR support (AR and VR)
 
 - Support for :ref:`Android-based headsets <doc_deploying_to_android>` using OpenXR.
   Including support for the following standalone headsets:
-  
+
    - Meta Quest 1/2/3 and Pro
    - Pico 4/4 Ultra
    - Magic Leap 2

--- a/community/asset_library/submitting_to_assetlib.rst
+++ b/community/asset_library/submitting_to_assetlib.rst
@@ -60,8 +60,8 @@ if you follow these recommendations, you can help make the asset
 library a better place for all users.
 
 * When creating non-project assets, it is common practice to place your files
-  inside of an **addons/asset_name/** folder. Do this to avoid having your files 
-  clash with other assets, or with the files of users installing your asset. 
+  inside of an **addons/asset_name/** folder. Do this to avoid having your files
+  clash with other assets, or with the files of users installing your asset.
   This folder will **not** be automatically generated when a user installs your asset.
 
 * Fix or suppress all script **warnings**. The warning system is there to

--- a/community/asset_store/submitting_to_asset_store.rst
+++ b/community/asset_store/submitting_to_asset_store.rst
@@ -60,8 +60,8 @@ if you follow these recommendations, you can help make the asset
 store a better place for all users.
 
 * When creating non-project assets, it is common practice to place your files
-  inside of an **addons/asset_name/** folder. Do this to avoid having your files 
-  clash with other assets, or with the files of users installing your asset. 
+  inside of an **addons/asset_name/** folder. Do this to avoid having your files
+  clash with other assets, or with the files of users installing your asset.
   This folder will **not** be automatically generated when a user installs your asset.
 
 * Fix or suppress all script **warnings**. The warning system is there to
@@ -201,7 +201,7 @@ Pricing
 While paid assets can't be uploaded yet, there are some settings relevant to free
 assets. You can link to another website where you accept donations, such as Patreon
 or Ko-Fi. You can also disable reviews if you want (in the future paid assets will
-**not** have this option). 
+**not** have this option).
 
 Submitting for review
 ---------------------

--- a/engine_details/development/compiling/compiling_for_ios.rst
+++ b/engine_details/development/compiling/compiling_for_ios.rst
@@ -67,7 +67,7 @@ To create an Xcode project like in the official builds, you need to use the
 template located in ``misc/dist/apple_embedded_xcode``. The release and debug libraries
 should be placed in ``libgodot.ios.debug.xcframework`` and
 ``libgodot.ios.release.xcframework`` respectively. Camera module libraries
-should be placed in ``libgodot_camera.ios.debug.xcframework`` and 
+should be placed in ``libgodot_camera.ios.debug.xcframework`` and
 ``libgodot_camera.ios.release.xcframework``. This process can be automated
 by using the ``generate_bundle=yes`` option on the *last* SCons command used to
 build export templates (so that all binaries can be included).

--- a/engine_details/development/configuring_an_ide/clion.rst
+++ b/engine_details/development/configuring_an_ide/clion.rst
@@ -32,7 +32,7 @@ build the project and only exists for loading the project in JetBrains IDEs.
       - CLion will attempt to detect your Visual Studio installation. If it is unsuccessful, use the file icon to the right of ``Toolset:`` to select the directory with your Visual Studio installation.
 
       You may exit and reload CLion and it will reload ``compile_commands.json``
-  
+
 .. figure:: img/clion_visual_studio_toolchain.webp
    :align: center
 

--- a/engine_details/development/handling_compatibility_breakages.rst
+++ b/engine_details/development/handling_compatibility_breakages.rst
@@ -122,7 +122,7 @@ then run it with the ``--dump-extension-api`` flag:
     git switch master
     scons
     godot --dump-extension-api
-    
+
 This will create a file named ``extension_api.json`` in your current directory. Switch to your feature branch, recompile Godot,
 and then run it with the ``--validate-extension-api`` flag followed by the path to the ``extension_api.json`` file you just generated:
 

--- a/engine_details/development/profiling/index.rst
+++ b/engine_details/development/profiling/index.rst
@@ -92,7 +92,7 @@ Godot currently supports three tracing profilers:
 .. note::
 
     Perfetto is the default tracing system for Android, so pre-built export templates
-    with Perfetto built-in and enabled are provided from 
+    with Perfetto built-in and enabled are provided from
     the `GitHub Releases page <https://github.com/godotengine/godot-builds/releases>`__.
 
 In order to use either of them, you'll need to build the engine from source.

--- a/engine_details/development/profiling/perfetto.rst
+++ b/engine_details/development/profiling/perfetto.rst
@@ -11,26 +11,26 @@ service has been built into the platform since Android 9.
 Using official Perfetto templates
 ---------------------------------
 
-Starting with Godot 4.7, Perfetto export templates are provided for every stable Godot release and can be 
+Starting with Godot 4.7, Perfetto export templates are provided for every stable Godot release and can be
 downloaded from the `GitHub Releases page <https://github.com/godotengine/godot/releases/>`_.
 
 Using the Gradle build template
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Navigate to the release page and download the ``Godot_v<godot_version>_android_source.perfetto.zip`` 
+- Navigate to the release page and download the ``Godot_v<godot_version>_android_source.perfetto.zip``
   release artifact where ``godot_version`` corresponds to the version of the engine being used.
 - In the **Project > Export** dialog, **Advanced Options** and **Use Gradle Build** must be enabled.
 - Point **Android Source Template** to the downloaded export template.
 
 .. image:: img/cpp_profiler_perfetto_gradle_build_config.webp
 
-Follow the instructions in the :ref:`Configuration section <doc_profiler_perfetto_configuration>` to 
+Follow the instructions in the :ref:`Configuration section <doc_profiler_perfetto_configuration>` to
 learn how to configure and create a trace.
 
 Using non-gradle build templates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Navigate to the release page and download the following release artifacts 
+- Navigate to the release page and download the following release artifacts
   where ``godot_version`` corresponds to the version of the engine being used:
 
   - ``Godot_v<godot_version>_android_debug.perfetto.apk`` (for debug builds)
@@ -45,13 +45,13 @@ Using non-gradle build templates
 
 .. image:: img/cpp_profiler_perfetto_non_gradle_build_config.webp
 
-Follow the instructions in the :ref:`Configuration section <doc_profiler_perfetto_configuration>` to 
+Follow the instructions in the :ref:`Configuration section <doc_profiler_perfetto_configuration>` to
 learn how to configure and create a trace.
 
 Custom Godot builds with Perfetto support
 -----------------------------------------
 
-From the ``godot`` root directory, run the following python script to install 
+From the ``godot`` root directory, run the following python script to install
 the latest version of the Perfetto SDK under ``thirdparty/perfetto``:
 
 .. code-block:: shell
@@ -113,12 +113,12 @@ Create a file called ``godot.config`` with this content:
 
     Godot records two categories of track events:
 
-    - **godot**: Used to record Godot engine events. This is used for performance analysis. 
-      Event tracing overhead should not significantly impact performance. 
+    - **godot**: Used to record Godot engine events. This is used for performance analysis.
+      Event tracing overhead should not significantly impact performance.
       This should be the typical tracing mode for most developers.
-    - **godot_scripting**: Used to record Godot scripting events. 
-      This is a slow category as it profiles the entire game scripting logic. 
-      This is used for code understanding / debugging / finding what caused a frame hitch. 
+    - **godot_scripting**: Used to record Godot scripting events.
+      This is a slow category as it profiles the entire game scripting logic.
+      This is used for code understanding / debugging / finding what caused a frame hitch.
       Performance is much slower, but it helps to find that one problematic function call that was otherwise hidden.
 
 Record a trace
@@ -128,7 +128,7 @@ Finally, launch your game on an Android device using the export templates you
 built earlier.
 
 When you're ready to record a trace (for example, when you've hit the part of
-your game that is exhibiting performance issues), you can 
+your game that is exhibiting performance issues), you can
 use `this script from the Perfetto GitHub repository <https://github.com/google/perfetto/blob/main/tools/record_android_trace>`_.
 
 .. code-block:: shell

--- a/engine_details/engine_api/vendor_runtime_module.rst
+++ b/engine_details/engine_api/vendor_runtime_module.rst
@@ -13,11 +13,11 @@ What for?
 ---------
 
 Vendor runtime modules provide developers with access to vendor-specific optimizations, features,
-and/or platforms for their running projects. 
+and/or platforms for their running projects.
 
 This provides benefits to vendors who are able to expose their technologies to all developers,
 and improve and refine them in a rapid, iterative, and frictionless manner.
-This also provides benefits to developers and users who are able to access and use a diverse range of vendor 
+This also provides benefits to developers and users who are able to access and use a diverse range of vendor
 technologies to improve their games.
 
 Creating a vendor runtime module
@@ -56,7 +56,7 @@ Follow :ref:`these instructions <doc_making_plugins_template>` to start creating
         pass
 
 
-The next step is to define and instantiate an :ref:`EditorExportPlugin<class_EditorExportPlugin>` instance. 
+The next step is to define and instantiate an :ref:`EditorExportPlugin<class_EditorExportPlugin>` instance.
 The :ref:`EditorExportPlugin<class_EditorExportPlugin>` instance is used to hook into the export flow and
 replace the default export templates with the ones generated from the vendor runtime module.
 
@@ -95,7 +95,7 @@ Using our base editor plugin template code above, an example implementation look
             var overrides = {}
             if not _supports_platform(platform):
                 return overrides
-            
+
             # Overrides Android export preset's "custom_template" options.
             overrides["custom_template/debug"] = _path_to_debug_export_template
             overrides["custom_template/release"] = _path_to_release_export_template
@@ -105,7 +105,7 @@ Using our base editor plugin template code above, an example implementation look
         # Optional: specify additional export preset options to customize the export template.
         func _get_export_options(platform):
             pass
-        
+
         func _get_name():
             return "VRM Plugin"
 
@@ -113,6 +113,6 @@ Using our base editor plugin template code above, an example implementation look
 .. tip::
 
     This section covers the basics to wrap and expose a vendor runtime module via an editor plugin, but
-    editor plugins have a lot more functionality that can be used to customize the editor further. 
+    editor plugins have a lot more functionality that can be used to customize the editor further.
     Feel free to :ref:`explore and leverage those functionalities <toc-tutorials-plugins>` to improve the
     user experience for your vendor runtime module.

--- a/getting_started/first_2d_game/01.project_setup.rst
+++ b/getting_started/first_2d_game/01.project_setup.rst
@@ -41,7 +41,7 @@ Your project folder should look like this.
 This game is designed for portrait mode, so we need to adjust the size of the
 game window. Click on *Project -> Project Settings* to open the project settings
 window, in the left column open the *Display -> Window* tab. There, set
-"Viewport Width" to ``480`` and "Viewport Height" to ``720``. You can see the 
+"Viewport Width" to ``480`` and "Viewport Height" to ``720``. You can see the
 "Project" menu on the upper left corner.
 
 .. image:: img/setting-project-width-and-height.webp

--- a/getting_started/first_2d_game/02.player_scene.rst
+++ b/getting_started/first_2d_game/02.player_scene.rst
@@ -20,10 +20,10 @@ what the object *is*. In the upper-left corner, in the "Scene" tab, click the
 
 .. note::
 
-    Godot also provides the :ref:`CharacterBody2D <class_CharacterBody2D>` node, 
-    specifically designed for 2D characters, which includes built-in support for some 
-    of the processes explained in this tutorial. In many real world projects, CharacterBody2D 
-    would be a better choice for players and enemies. However, this tutorial focuses on 
+    Godot also provides the :ref:`CharacterBody2D <class_CharacterBody2D>` node,
+    specifically designed for 2D characters, which includes built-in support for some
+    of the processes explained in this tutorial. In many real world projects, CharacterBody2D
+    would be a better choice for players and enemies. However, this tutorial focuses on
     core concepts that apply to a wider range of nodes and use cases.
 
 .. image:: img/add_node.webp

--- a/getting_started/first_2d_game/06.heads_up_display.rst
+++ b/getting_started/first_2d_game/06.heads_up_display.rst
@@ -40,7 +40,7 @@ Under "Theme Overrides > Fonts", choose "Load" and select the "Xolonium-Regular.
 
 .. image:: img/custom_font_load_font.webp
 
-The font size is still too small, increase it to ``64`` under "Theme Overrides > Font Sizes". 
+The font size is still too small, increase it to ``64`` under "Theme Overrides > Font Sizes".
 Once you've done this with the ``ScoreLabel``, repeat the changes for the ``Message`` and ``StartButton`` nodes.
 
 .. image:: img/custom_font_size.webp

--- a/getting_started/first_3d_game/06.jump_and_squash.rst
+++ b/getting_started/first_3d_game/06.jump_and_squash.rst
@@ -246,8 +246,8 @@ With this code, if no collisions occurred on a given frame, the loop won't run.
             var collision = get_slide_collision(index)
 
             # If there are duplicate collisions with a mob in a single frame
-            # the mob will be deleted after the first collision, and a second call to 
-            # get_collider will return null, leading to a null pointer when calling 
+            # the mob will be deleted after the first collision, and a second call to
+            # get_collider will return null, leading to a null pointer when calling
             # collision.get_collider().is_in_group("mob").
             # This block of code prevents processing duplicate collisions.
             if collision.get_collider() == null:

--- a/getting_started/introduction/first_look_at_the_editor.rst
+++ b/getting_started/introduction/first_look_at_the_editor.rst
@@ -38,7 +38,7 @@ The Project Manager's settings can be opened using the **Settings** menu:
 
 .. image:: img/editor_intro_settings.webp
 
-From here, you can change the editor's language (default is the system language), interface theme, display 
+From here, you can change the editor's language (default is the system language), interface theme, display
 scale, network mode, and also the directory naming convention.
 
 .. seealso:: To learn the Project Manager's ins and outs, read
@@ -53,7 +53,7 @@ Let's look at its main areas:
 
 .. image:: img/editor_intro_editor_empty.webp
 
-By default, along the window's top edge, it features **main menu** on the left, **workspace** switching 
+By default, along the window's top edge, it features **main menu** on the left, **workspace** switching
 buttons in the center (active workspace is highlighted), and **playtest** buttons and the
 **Movie Maker Mode** toggle on the right:
 
@@ -61,7 +61,7 @@ buttons in the center (active workspace is highlighted), and **playtest** button
 
 Just below the workspace buttons, the opened :ref:`scenes <doc_key_concepts_overview_scenes>`
 as tabs are seen. The plus (+) button right next to the tabs will add a new scene to the project.
-With the button on the far right, distraction-free mode can be toggled, which maximizes or restores 
+With the button on the far right, distraction-free mode can be toggled, which maximizes or restores
 the **viewport**'s size by hiding **docks** in the interface:
 
 .. image:: img/editor_intro_scene_selector.webp
@@ -113,7 +113,7 @@ When you click on one, it expands vertically. Below, you can see the animation e
 
 .. image:: img/editor_intro_bottom_panel_animation.webp
 
-Bottom panels can also be shown or hidden using the shortcuts defined in 
+Bottom panels can also be shown or hidden using the shortcuts defined in
 **Editor Settings > Shortcuts**, under the **Bottom Panels** category.
 
 .. _doc_intro_to_the_editor_interface_five_screens:
@@ -167,11 +167,11 @@ Godot comes with a built-in class reference.
 You can search for information about a class, method, property, constant, or
 signal by any one of the following methods:
 
-* Pressing :kbd:`F1` (or :kbd:`Opt + Space` on macOS, or :kbd:`Fn + F1` for laptops 
+* Pressing :kbd:`F1` (or :kbd:`Opt + Space` on macOS, or :kbd:`Fn + F1` for laptops
   with a :kbd:`Fn` key) anywhere in the editor.
 * Clicking the "Search Help" button in the top-right of the Script main screen.
 * Clicking on the Help menu and Search Help.
-* :kbd:`Ctrl + Click` (:kbd:`Cmd + Click` on macOS) on a class name, function name, 
+* :kbd:`Ctrl + Click` (:kbd:`Cmd + Click` on macOS) on a class name, function name,
   or built-in variable in the script editor.
 
 .. image:: img/editor_intro_search_help_button.webp

--- a/getting_started/step_by_step/scripting_first_script.rst
+++ b/getting_started/step_by_step/scripting_first_script.rst
@@ -21,7 +21,7 @@ Creating your first script
 In this lesson, you will code your first script to make the Godot icon turn in
 circles. As we mentioned :ref:`in the introduction
 <doc_introduction_learning_programming>`, we assume you have programming
-foundations. 
+foundations.
 
 This tutorial is written for GDScript, and the equivalent C# code is included in
 another tab of each codeblock for convenience.
@@ -105,7 +105,7 @@ the following line of code:
 
     using Godot;
     using System;
-    
+
     public partial class MySprite2D : Sprite2D
     {
     }
@@ -333,7 +333,7 @@ Here is the complete ``sprite_2d.gd`` file for reference.
 
     using Godot;
     using System;
-    
+
     public partial class MySprite2D : Sprite2D
     {
         private int _speed = 400;

--- a/tutorials/2d/2d_lights_and_shadows.rst
+++ b/tutorials/2d/2d_lights_and_shadows.rst
@@ -250,7 +250,7 @@ The following properties can be adjusted on 2D lights that have shadows enabled:
     this effect. Nearest filtering affects only how the engine samples textures — it
     does not change how the engine renders lighting and shadows.
 
-    To achieve pixelated lighting and shadows, use a custom shader to modify 
+    To achieve pixelated lighting and shadows, use a custom shader to modify
     ``LIGHT_VERTEX`` and ``SHADOW_VERTEX`` to snap light sampling to a pixel grid.
     The following shader snaps lighting to a grid using the ``floor()`` function:
 

--- a/tutorials/2d/2d_parallax.rst
+++ b/tutorials/2d/2d_parallax.rst
@@ -91,7 +91,7 @@ do?
 Make the viewport smaller
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The simplest answer is to make the viewport the same size or smaller than your textures. 
+The simplest answer is to make the viewport the same size or smaller than your textures.
 In **Project Settings > Display > Window**, change the
 :ref:`Viewport Width<class_ProjectSettings_property_display/window/size/viewport_width>`
 and :ref:`Viewport Height<class_ProjectSettings_property_display/window/size/viewport_height>`
@@ -187,7 +187,7 @@ Repeat times
 ------------
 
 Ideally, following this guide, your parallax textures are large enough to cover the screen even when zoomed out.
-Until now, we have had a perfectly fitting 288x208 texture inside of a 288x208 viewport. However, problems 
+Until now, we have had a perfectly fitting 288x208 texture inside of a 288x208 viewport. However, problems
 occur when we zoom out by setting the :ref:`Camera2D.zoom<class_camera2d_property_zoom>` to ``(0.5, 0.5)``:
 
 .. image:: img/2d_parallax_zoom_single.webp

--- a/tutorials/2d/custom_drawing_in_2d.rst
+++ b/tutorials/2d/custom_drawing_in_2d.rst
@@ -1008,7 +1008,7 @@ Calculating this arc will be more complex than in the case of the line:
         # Average points to get center.
         var center : Vector2 = Vector2((_point2.x + point1.x) / 2,
                                        (_point2.y + point1.y) / 2)
-        # Calculate the rest of the arc parameters. 
+        # Calculate the rest of the arc parameters.
         var radius : float = point1.distance_to(_point2) / 2
         var start_angle : float = (_point2 - point1).angle()
         var end_angle : float = (point1 - _point2).angle()
@@ -1026,7 +1026,7 @@ Calculating this arc will be more complex than in the case of the line:
         // Average points to get center.
         Vector2 center = new Vector2((_point2.X + Point1.X) / 2.0f,
                                         (_point2.Y + Point1.Y) / 2.0f);
-        // Calculate the rest of the arc parameters. 
+        // Calculate the rest of the arc parameters.
         float radius = Point1.DistanceTo(_point2) / 2.0f;
         float startAngle = (_point2 - Point1).Angle();
         float endAngle = (Point1 - _point2).Angle();

--- a/tutorials/2d/introduction_to_2d.rst
+++ b/tutorials/2d/introduction_to_2d.rst
@@ -3,16 +3,16 @@
 Introduction to 2D
 ==================
 
-Godot's 2D game development tools include a dedicated 2D rendering engine, physics system, 
-and features tailored specifically for creating 2D experiences. You can efficiently design 
-levels with the TileMap system, animate characters with 2D sprite or Cutout animation, 
-and leverage 2D lighting for dynamic scene illumination. The built-in 2D particle system 
-allows you to create complex visual effects, and Godot also supports custom shaders to 
-enhance your graphics. These features, combined with Godot's accessibility and 
+Godot's 2D game development tools include a dedicated 2D rendering engine, physics system,
+and features tailored specifically for creating 2D experiences. You can efficiently design
+levels with the TileMap system, animate characters with 2D sprite or Cutout animation,
+and leverage 2D lighting for dynamic scene illumination. The built-in 2D particle system
+allows you to create complex visual effects, and Godot also supports custom shaders to
+enhance your graphics. These features, combined with Godot's accessibility and
 flexibility, provide a solid foundation for creating engaging 2D games.
 
 .. figure:: img/2d_platformer_demo.webp
-   
+
    2D Platformer Demo available on the Asset Library.
 
 This page will show you the 2D workspace and how you can get to know it.
@@ -22,27 +22,27 @@ This page will show you the 2D workspace and how you can get to know it.
 2D workspace
 ------------
 
-You will use the 2D workspace to work with 2D scenes, design levels, or create user 
+You will use the 2D workspace to work with 2D scenes, design levels, or create user
 interfaces.
-To switch to the 2D workspace, you can either select a 2D node from the scene tree, 
+To switch to the 2D workspace, you can either select a 2D node from the scene tree,
 or use the workspace selector located at the top edge of the editor:
 
 .. image:: img/2d_editor_viewport.webp
 
-Similar to 3D, you can use the tabs below the workspace selector to change between currently 
-opened scenes or create a new one using the plus (+) button. The left and right docks should 
+Similar to 3D, you can use the tabs below the workspace selector to change between currently
+opened scenes or create a new one using the plus (+) button. The left and right docks should
 be familiar from :ref:`editor introduction <toc-editor-interface>`.
 
 Below the scene selector is the main toolbar, and beneath the main toolbar
 is the 2D viewport.
 
-You can drag and drop compatible nodes from the FileSystem dock to add them to the 
+You can drag and drop compatible nodes from the FileSystem dock to add them to the
 viewport as nodes.
-Dragging and dropping adds the dragged node as a sibling of the selected node 
+Dragging and dropping adds the dragged node as a sibling of the selected node
 (if the root node is selected, adds as a child).
 Keeping :kbd:`Shift` pressed when dropping adds the node as a child of the selected node.
 Holding :kbd:`Alt` when dropping adds the node as a child of the root node.
-If :kbd:`Alt + Shift` is held when dropping, the node type can be selected if 
+If :kbd:`Alt + Shift` is held when dropping, the node type can be selected if
 applicable.
 
 
@@ -50,60 +50,60 @@ Main toolbar
 ~~~~~~~~~~~~
 
 Some buttons in the main toolbar are the same as those in the 3D workspace. A brief explanation
-is given with the shortcut if the mouse cursor is hovered over a button for one second. 
-Some buttons may have additional functionality if another keypress is performed. 
-A recap of main functionality of each button with its default shortcut is provided below 
+is given with the shortcut if the mouse cursor is hovered over a button for one second.
+Some buttons may have additional functionality if another keypress is performed.
+A recap of main functionality of each button with its default shortcut is provided below
 from left to right:
 
 .. image:: img/2d_toolbar.webp
 
-- **Select Mode** (:kbd:`Q`): Allows selection of nodes in the viewport. Left clicking on a node 
+- **Select Mode** (:kbd:`Q`): Allows selection of nodes in the viewport. Left clicking on a node
   in the viewport selects it.
   Left clicking and dragging a rectangle selects all nodes within the rectangle's boundaries,
   once released.
   Holding :kbd:`Shift` while selecting adds more nodes to the selection.
   Clicking on a selected node while holding :kbd:`Shift` deselects the node.
-  In this mode, you can drag the selected node(s) to move, press :kbd:`Ctrl` to switch to the 
-  rotation mode temporarily, or use the red circles to scale it. If multiple nodes are 
-  selected, only movement and rotation are possible. In this mode, rotation and scaling 
+  In this mode, you can drag the selected node(s) to move, press :kbd:`Ctrl` to switch to the
+  rotation mode temporarily, or use the red circles to scale it. If multiple nodes are
+  selected, only movement and rotation are possible. In this mode, rotation and scaling
   will not use the snapping options if snapping is enabled.
-- **Move Mode** (:kbd:`W`): Enables move (or translate) mode for the selected nodes. See 
+- **Move Mode** (:kbd:`W`): Enables move (or translate) mode for the selected nodes. See
   :ref:`doc_introduction_to_2d_the_viewport` for more details.
-- **Rotate Mode** (:kbd:`E`): Enables rotation mode for the selected nodes. See 
+- **Rotate Mode** (:kbd:`E`): Enables rotation mode for the selected nodes. See
   :ref:`doc_introduction_to_2d_the_viewport` for more details.
-- **Scale Mode** (:kbd:`S`): Enables scaling and displays scaling gizmos in both 
+- **Scale Mode** (:kbd:`S`): Enables scaling and displays scaling gizmos in both
   axes for the selected node(s). See :ref:`doc_introduction_to_2d_the_viewport` for more details.
-- **Show list of selectable nodes at position clicked**: As the description suggests, 
-  this provides a list of selectable nodes at the clicked position as a context menu, if 
+- **Show list of selectable nodes at position clicked**: As the description suggests,
+  this provides a list of selectable nodes at the clicked position as a context menu, if
   there is more than one node in the clicked area.
 - **Rotation pivot**: Sets the rotation pivot to rotate node(s) around.
   An added node has its rotation pivot at ``x: 0``, ``y: 0``, by default, with
-  exceptions. For example, the default pivot for a :ref:`Sprite2D <class_Sprite2D>` is its 
-  center if the ``centered`` property is set to ``true``. If you would like to change the 
-  rotation pivot of a node, click this button and choose a new location by left clicking. 
-  The node rotates considering this point. If you have multiple nodes selected, this icon 
-  will add a temporary pivot to be used commonly by all selected nodes. Pressing :kbd:`Shift` 
-  and clicking this button will create the pivot at the center of selected nodes. If any of 
+  exceptions. For example, the default pivot for a :ref:`Sprite2D <class_Sprite2D>` is its
+  center if the ``centered`` property is set to ``true``. If you would like to change the
+  rotation pivot of a node, click this button and choose a new location by left clicking.
+  The node rotates considering this point. If you have multiple nodes selected, this icon
+  will add a temporary pivot to be used commonly by all selected nodes. Pressing :kbd:`Shift`
+  and clicking this button will create the pivot at the center of selected nodes. If any of
   the snap options are enabled, the pivot will also snap to them when dragged.
 - **Pan Mode** (:kbd:`G`): Allows you to navigate in the viewport without accidentally selecting any nodes.
   In other modes, you can also hold :kbd:`Space` and drag with the left mouse button to do the same.
-- **Ruler Mode**: After enabling, click on the viewport to display the current global 
+- **Ruler Mode**: After enabling, click on the viewport to display the current global
   x and y coordinates. Dragging from a position to another one measures the distance in pixels.
-  If you drag diagonally, it will draw a triangle and show the separate distances in terms 
+  If you drag diagonally, it will draw a triangle and show the separate distances in terms
   of x, y, and total distance to the target, including the angles to the axes in degrees.
-  The :kbd:`R` key activates the ruler. If snapping is enabled, it also displays the 
+  The :kbd:`R` key activates the ruler. If snapping is enabled, it also displays the
   measurements in terms of grid count:
 
 .. figure:: img/2d_ruler_with_snap.webp
-   
+
    Using ruler with snapping enabled.
 
-- **Use Smart Snap**: Toggles smart snapping for move, rotate, and scale modes; and 
+- **Use Smart Snap**: Toggles smart snapping for move, rotate, and scale modes; and
   the rotation pivot. Customize it using the three-dot menu next to the snap tools.
-- **Use Grid Snap**: Toggles snapping to grid for move and scale mode, rotation pivot, 
+- **Use Grid Snap**: Toggles snapping to grid for move and scale mode, rotation pivot,
   and the ruler. Customize it using the three-dot menu next to the snap tools.
 
-You can customize the grid settings so that move mode, rotate mode, scale mode, ruler, 
+You can customize the grid settings so that move mode, rotate mode, scale mode, ruler,
 and rotation pivot uses snapping.
 Use the three-dot menu for this:
 
@@ -111,63 +111,63 @@ Use the three-dot menu for this:
 
 - **Use Rotation Snap**: Toggles snapping using the configured rotation setting.
 - **Use Scale Snap**: Toggles snapping using the configured scaling step setting.
-- **Snap Relative**: Toggles the usage of snapping based on the selected node's current 
-  transform values. For example, if the grids are set to 32x32 pixels and if the selected node 
-  is located at ``x: 1, y: 1``, then, enabling this option will temporarily shift the grids by 
+- **Snap Relative**: Toggles the usage of snapping based on the selected node's current
+  transform values. For example, if the grids are set to 32x32 pixels and if the selected node
+  is located at ``x: 1, y: 1``, then, enabling this option will temporarily shift the grids by
   ``x: 1, y: 1``.
-- **Use Pixel Snap**: Toggles the use of subpixels for snapping. If enabled, the position values 
-  will be integers, disabling will enable subpixel movement as decimal values. For the runtime 
-  property, consider checking `Project Settings > Rendering > 2D > Snapping` property for 
-  Node2D nodes, and `Project Settings > GUI > General > Snap Controls to Pixels` for 
+- **Use Pixel Snap**: Toggles the use of subpixels for snapping. If enabled, the position values
+  will be integers, disabling will enable subpixel movement as decimal values. For the runtime
+  property, consider checking `Project Settings > Rendering > 2D > Snapping` property for
+  Node2D nodes, and `Project Settings > GUI > General > Snap Controls to Pixels` for
   Control nodes.
 - **Smart Snapping**: Provides a set of options to snap to specific positions if they are enabled:
 
-  - Snap to Parent: Snaps to parent's edges. For example, scaling a child control node while 
+  - Snap to Parent: Snaps to parent's edges. For example, scaling a child control node while
     this is enabled will snap to the boundaries of the parent.
-  - Snap to Node Anchor: Snaps to the node's anchor. For example, if anchors of a control 
-    node is positioned at different positions, enabling this will snap to the sides and 
+  - Snap to Node Anchor: Snaps to the node's anchor. For example, if anchors of a control
+    node is positioned at different positions, enabling this will snap to the sides and
     corners of the anchor.
-  - Snap to Node Sides: Snaps to the node's sides, such as for the rotation pivot or anchor 
+  - Snap to Node Sides: Snaps to the node's sides, such as for the rotation pivot or anchor
     positioning.
-  - Snap to Node Center: Snaps to the node's center, such as for the rotation pivot or 
+  - Snap to Node Center: Snaps to the node's center, such as for the rotation pivot or
     anchor positioning.
-  - Snap to Other Nodes: Snaps to other nodes while moving or scaling. Useful to align nodes 
+  - Snap to Other Nodes: Snaps to other nodes while moving or scaling. Useful to align nodes
     in the editor.
-  - Snap to Guides: Snaps to custom guides drawn using the horizontal or vertical ruler. More 
+  - Snap to Guides: Snaps to custom guides drawn using the horizontal or vertical ruler. More
     on the ruler and guides below.
 
 .. image:: img/2d_snapping_options.webp
 
 - **Configure Snap**: Opens the window shown above, offering a set of snapping parameters.
 
-  - Grid Offset: Allows you to shift grids with respect to the origin. ``x`` and ``y`` can 
+  - Grid Offset: Allows you to shift grids with respect to the origin. ``x`` and ``y`` can
     be adjusted separately.
   - Grid Step: The distance between each grid in pixels. ``x`` and ``y`` can be adjusted separately.
-  - Primary Line Every: The number of grids in-between to draw infinite lines as indication of 
+  - Primary Line Every: The number of grids in-between to draw infinite lines as indication of
     main lines.
   - Rotation Offset: Sets the offset to shift rotational snapping.
-  - Rotation Step: Defines the snapping degree. E.g., 15 means the node will rotate and snap 
+  - Rotation Step: Defines the snapping degree. E.g., 15 means the node will rotate and snap
     at multiples of 15 degrees if rotation snap is enabled and the rotate mode is used.
-  - Scale Step: Determines the scaling increment factor. For example, if it is 0.1, it will 
+  - Scale Step: Determines the scaling increment factor. For example, if it is 0.1, it will
     change the scaling at 0.1 steps if scaling snap is enabled and the scaling mode is used.
 
-- **Lock selected nodes** (:kbd:`Ctrl + L`). Locks the selected nodes, preventing selection and movement in the 
-  viewport. Clicking the button again (or using :kbd:`Ctrl + Shift + L`) unlocks the selected 
+- **Lock selected nodes** (:kbd:`Ctrl + L`). Locks the selected nodes, preventing selection and movement in the
+  viewport. Clicking the button again (or using :kbd:`Ctrl + Shift + L`) unlocks the selected
   nodes. Locked nodes can only be selected in the scene tree.
-  They can easily be identified by a padlock next to their node names in the scene tree. 
+  They can easily be identified by a padlock next to their node names in the scene tree.
   Clicking on this padlock also unlocks the nodes.
-- **Group selected nodes** (:kbd:`Ctrl + G`). This allows selection of the root node if any 
+- **Group selected nodes** (:kbd:`Ctrl + G`). This allows selection of the root node if any
   of the children are selected. Using :kbd:`Ctrl + Shift + G` ungroups them. Additionally,
   clicking the ungroup button in the scene tree performs the same action.
 - **Skeleton Options**: Provides options to work with Skeleton2D and Bone2D.
 
   - Show Bones: Toggles the visibility of bones for the selected node.
-  - Make Bone2D Node(s) from Node(s): Converts selected node(s) into Bone2D. 
+  - Make Bone2D Node(s) from Node(s): Converts selected node(s) into Bone2D.
 
 .. seealso:: To learn more about Skeletons, see :ref:`doc_cutout_animation`.
-  
-- **View** menu: Provides options to control the viewport view. Since its options 
-  depend heavily on the viewport, it is covered in the :ref:`doc_introduction_to_2d_the_viewport` 
+
+- **View** menu: Provides options to control the viewport view. Since its options
+  depend heavily on the viewport, it is covered in the :ref:`doc_introduction_to_2d_the_viewport`
   section.
 
 Next to the View menu, additional buttons may be visible. In the toolbar image
@@ -180,22 +180,22 @@ provides buttons to add, modify, or remove points.
 Coordinate system
 ~~~~~~~~~~~~~~~~~
 
-In the 2D editor, unlike 3D, there are only two axes: ``x`` and ``y``. Also, the viewing 
+In the 2D editor, unlike 3D, there are only two axes: ``x`` and ``y``. Also, the viewing
 angle is fixed.
 
-In the viewport, you will see two lines in two colors going across the screen infinitely: 
+In the viewport, you will see two lines in two colors going across the screen infinitely:
 red for the x-axis, and green for the y-axis.
 In Godot, going right and down are positive directions.
 Where these two lines intersect is the origin: ``x: 0, y: 0``.
 
 A root node will have its origin at this position once added.
-Switching to the `move` or `scale` modes after selecting a node will display the gizmos at the 
+Switching to the `move` or `scale` modes after selecting a node will display the gizmos at the
 node's offset position.
 The gizmos will point to the positive directions of the x and y axes.
 In the move mode, you can drag the green line to move only in the ``y`` axis.
 Similarly, you can hold the red line to move only in the ``x`` axis.
 
-In the scale mode, the gizmos will have a square shape. You can hold and drag the green and 
+In the scale mode, the gizmos will have a square shape. You can hold and drag the green and
 red squares to scale the nodes in the ``y`` or ``x`` axes.
 Dragging in a negative direction flips the node horizontally or vertically.
 
@@ -204,92 +204,92 @@ Dragging in a negative direction flips the node horizontally or vertically.
 2D Viewport
 ~~~~~~~~~~~
 
-The viewport will be the area you spend the most time if you plan to design levels or user 
+The viewport will be the area you spend the most time if you plan to design levels or user
 interfaces visually:
 
 .. image:: img/2d_editor_viewport_with_viewmenu.webp
 
-Middle-clicking and dragging the mouse will pan the view. 
+Middle-clicking and dragging the mouse will pan the view.
 The scrollbars on the right or bottom of the viewport also move the view.
 Alternatively, the :kbd:`G` or :kbd:`Space` keys can be used.
 If you enable `Editor Settings > Editors > Panning > Simple Panning`, you can activate
 panning directly with :kbd:`Space` only, without requiring dragging.
 
 The viewport has buttons on the top-left.
-**Center View** centers the selected node(s) in the screen. Useful if you have a large scene 
+**Center View** centers the selected node(s) in the screen. Useful if you have a large scene
 with many nodes, and want to see the node selected in the scene tree.
-Next to it are the zoom controls. **-** zooms out, **+** zooms in, and clicking on the number 
+Next to it are the zoom controls. **-** zooms out, **+** zooms in, and clicking on the number
 with percentage defaults to 100%.
 Alternatively, you can use middle-mouse scrolling to zoom in (scroll up) and out (scroll down).
 
-The black bars at the viewport's left and top edges are the **rulers**. You can use them to 
+The black bars at the viewport's left and top edges are the **rulers**. You can use them to
 orient yourself in the viewport.
-By default, the rulers will display the pixel coordinates of the viewport, numbered at 
+By default, the rulers will display the pixel coordinates of the viewport, numbered at
 100 pixel steps. Changing the zoom factor will change the shown values.
-Enabling `Grid Snap` or changing the snapping options will update the ruler's scaling and 
+Enabling `Grid Snap` or changing the snapping options will update the ruler's scaling and
 the shown values.
 
-You can also create multiple custom guides to help you make measurements or align 
+You can also create multiple custom guides to help you make measurements or align
 nodes with them:
 
 .. image:: img/2d_editor_guidelines.webp
 
-If you have at least one node in the scene, you can create guides by dragging from the horizontal 
-or vertical ruler towards the viewport. A purple guide will appear, showing its position, and will 
-remain there when you release the mouse. You can create both horizontal and vertical guides 
-simultaneously by dragging from the gray square at the rulers' intersection. Guides can be 
-repositioned by dragging them back to their respective rulers, and they can be removed by 
+If you have at least one node in the scene, you can create guides by dragging from the horizontal
+or vertical ruler towards the viewport. A purple guide will appear, showing its position, and will
+remain there when you release the mouse. You can create both horizontal and vertical guides
+simultaneously by dragging from the gray square at the rulers' intersection. Guides can be
+repositioned by dragging them back to their respective rulers, and they can be removed by
 dragging them all the way back to the ruler.
 
 You can also enable snapping to the created guides using the `Smart Snap` menu.
 
-.. note:: If you cannot create a line, or do not see previously created guides, make sure that 
-          they are visible by checking the `View` menu of the viewport. :kbd:`Y` toggles their visibility, 
+.. note:: If you cannot create a line, or do not see previously created guides, make sure that
+          they are visible by checking the `View` menu of the viewport. :kbd:`Y` toggles their visibility,
           by default. Also, make sure you have at least one node in the scene.
 
-Depending on the tool chosen in the toolbar, left-clicking will have a primary action in the 
+Depending on the tool chosen in the toolbar, left-clicking will have a primary action in the
 viewport.
 For example, the `Select Mode` will select the left-clicked node in the viewport.
-Sometimes, left-clicking can be combined with a modifier (e.g., :kbd:`Ctrl`, or :kbd:`Shift`) to 
+Sometimes, left-clicking can be combined with a modifier (e.g., :kbd:`Ctrl`, or :kbd:`Shift`) to
 perform secondary actions.
-For example, keeping :kbd:`Shift` pressed while dragging a node in the Select or Move modes will 
+For example, keeping :kbd:`Shift` pressed while dragging a node in the Select or Move modes will
 try to snap the node in a single axis while moving.
 
-Right clicking in the viewport provides two options to create a node or instantiate a scene 
+Right clicking in the viewport provides two options to create a node or instantiate a scene
 at the chosen position.
-If at least one node is selected, right clicking also provides the option to move the selected 
+If at least one node is selected, right clicking also provides the option to move the selected
 node(s) to this position.
 
 
 Viewport has a **View** menu which provides several options to change the look of the viewport:
 
-- **Grid**: Allows you to show grids all the time, only when using snapping, or not at all. You 
+- **Grid**: Allows you to show grids all the time, only when using snapping, or not at all. You
   can also toggle them with the provided option.
-- **Show Helpers**: Toggles the temporary display of an outline of the node, with the previous 
-  transform properties (position, scaling, or rotation) if a transform operation has been 
+- **Show Helpers**: Toggles the temporary display of an outline of the node, with the previous
+  transform properties (position, scaling, or rotation) if a transform operation has been
   initiated. For `Control` nodes, it also shows the sizing parameters. Useful to see the deltas.
-- **Show Rulers**: Toggles the visibility of horizontal and vertical rulers. See 
+- **Show Rulers**: Toggles the visibility of horizontal and vertical rulers. See
   :ref:`doc_introduction_to_2d_the_viewport` more on rulers.
-- **Show Guides**: Toggles the visibility of created guides. See 
+- **Show Guides**: Toggles the visibility of created guides. See
   :ref:`doc_introduction_to_2d_the_viewport` for on how to create them.
 - **Show Origin**: Toggles the display of the green and red origin lines drawn at ``x: 0, y: 0``.
-- **Show Viewport**: Toggles the visibility of the game's default 
-  viewport, indicated by an indigo-colored rectangle. It is also the default window size on desktop 
-  platforms, which can be changed by going to `Project Settings > Display > Window > Size` and 
+- **Show Viewport**: Toggles the visibility of the game's default
+  viewport, indicated by an indigo-colored rectangle. It is also the default window size on desktop
+  platforms, which can be changed by going to `Project Settings > Display > Window > Size` and
   setting `Viewport Width` and `Viewport Height`.
-- **Gizmos**: Toggles the visibility of `Position` (shown with cross icon), `Lock` 
-  (shown with padlock), `Groups` (shown with two squares), and `Transformation` (shown with 
+- **Gizmos**: Toggles the visibility of `Position` (shown with cross icon), `Lock`
+  (shown with padlock), `Groups` (shown with two squares), and `Transformation` (shown with
   green and red lines) indicators.
-- **Center Selection**: The same as the **Center View** button inside the viewport. Centers the selected 
+- **Center Selection**: The same as the **Center View** button inside the viewport. Centers the selected
   node(s) in the view. :kbd:`F` is the default shortcut.
-- **Frame to Selection**: Similar to `Center Selection`, but also changes the zoom factor to fit the 
+- **Frame to Selection**: Similar to `Center Selection`, but also changes the zoom factor to fit the
   contents in the screen. :kbd:`Shift + F` is the default shortcut.
-- **Clear Guides**: Deletes all guides from the screen. You will need to recreate them if 
-  you plan to use them later. 
-- **Preview Canvas Scale**: Toggles the preview for scaling of canvas in the editor when the zoom 
-  factor or view of the viewport changes. Useful to see how the controls will look like after scaling 
+- **Clear Guides**: Deletes all guides from the screen. You will need to recreate them if
+  you plan to use them later.
+- **Preview Canvas Scale**: Toggles the preview for scaling of canvas in the editor when the zoom
+  factor or view of the viewport changes. Useful to see how the controls will look like after scaling
   and moving, without running the game.
-- **Preview Theme**: Allows to choose from the available themes to change the look of control items 
+- **Preview Theme**: Allows to choose from the available themes to change the look of control items
   in the editor, without requiring to run the game.
 
 
@@ -297,7 +297,7 @@ Node2D and Control node
 -----------------------
 
 :ref:`CanvasItem <class_CanvasItem>` is the base node for 2D. :ref:`Node2D <class_Node2D>` is the base node
-for 2D game objects, and :ref:`Control <class_Control>` is the base node 
+for 2D game objects, and :ref:`Control <class_Control>` is the base node
 for everything GUI. For 3D, Godot uses the :ref:`Node3D <class_Node3D>` node.
 
 Displaying 3D nodes in 2D

--- a/tutorials/3d/csg_tools.rst
+++ b/tutorials/3d/csg_tools.rst
@@ -92,7 +92,7 @@ Custom meshes
 
 Custom meshes can be used for :ref:`CSGMesh3D <class_CSGMesh3D>` as long as the
 mesh is *manifold*. The mesh can be modeled in other software and imported into
-Godot. Multiple materials are supported. 
+Godot. Multiple materials are supported.
 
 For a mesh to be used as a CSG mesh, it is required to:
 

--- a/tutorials/3d/introduction_to_3d.rst
+++ b/tutorials/3d/introduction_to_3d.rst
@@ -15,8 +15,8 @@ which are almost identical to their 2D counterparts.
    :align: center
    :alt: An example 3D game demo created using Godot
 
-   Godot Third Person Shooter (TPS) Demo, available on the 
-   `Github repository <https://github.com/godotengine/tps-demo>`__ or the 
+   Godot Third Person Shooter (TPS) Demo, available on the
+   `Github repository <https://github.com/godotengine/tps-demo>`__ or the
    :ref:`Asset Library <doc_project_manager_downloading_demos>`.
 
 In 3D, math is a little more complex than in 2D. For an introduction to the
@@ -43,23 +43,23 @@ Main toolbar
 ~~~~~~~~~~~~
 
 Some buttons in the main toolbar are the same as those in the 2D workspace. A brief explanation
-is given with the shortcut if the mouse cursor is hovered over a button for one second. 
-Some buttons may have additional functionality if another keypress is performed. A recap 
-of main functionality of each button with its default shortcut is provided below from 
+is given with the shortcut if the mouse cursor is hovered over a button for one second.
+Some buttons may have additional functionality if another keypress is performed. A recap
+of main functionality of each button with its default shortcut is provided below from
 left to right:
 
 .. image:: img/3d_toolbar.webp
 
-- **Transform Mode** (:kbd:`Q`): Enables a combined move + rotation mode for the selected nodes. 
-- **Move Mode** (:kbd:`W`): Enables move (or translate) mode for the selected nodes. 
+- **Transform Mode** (:kbd:`Q`): Enables a combined move + rotation mode for the selected nodes.
+- **Move Mode** (:kbd:`W`): Enables move (or translate) mode for the selected nodes.
   See :ref:`doc_introduction_to_3d_space_and_manipulation` for more details.
-- **Rotate Mode** (:kbd:`E`): Enables rotation mode for the selected nodes. See 
+- **Rotate Mode** (:kbd:`E`): Enables rotation mode for the selected nodes. See
   :ref:`doc_introduction_to_3d_space_and_manipulation` for more details.
-- **Scale Mode** (:kbd:`R`): Enables scaling and displays scaling gizmos in different 
-  axes for the selected nodes. See :ref:`doc_introduction_to_3d_space_and_manipulation` 
+- **Scale Mode** (:kbd:`R`): Enables scaling and displays scaling gizmos in different
+  axes for the selected nodes. See :ref:`doc_introduction_to_3d_space_and_manipulation`
   for more details.
 - **Select Mode** (:kbd:`V`): Allows selection of nodes in the viewport. Left clicking
-  on a node to select one. Left clicking and dragging a rectangle selects all 
+  on a node to select one. Left clicking and dragging a rectangle selects all
   nodes within the rectangle's boundaries, once released.
   Holding :kbd:`Shift` while selecting adds more nodes to the selection.
   Clicking on a selected node while holding :kbd:`Shift` deselects the node.
@@ -68,41 +68,41 @@ left to right:
   this provides a list of selectable nodes at the clicked position as a context menu,
   if there is more than one node in the clicked area.
 - **Lock** (:kbd:`Ctrl + L`) the selected nodes, preventing selection and movement in the viewport.
-  Clicking the button again (or using :kbd:`Ctrl + Shift + L`) unlocks the selected nodes. 
+  Clicking the button again (or using :kbd:`Ctrl + Shift + L`) unlocks the selected nodes.
   Locked nodes can only be selected in the scene tree.
-  They can easily be identified with a padlock next to their node names in the scene tree. 
+  They can easily be identified with a padlock next to their node names in the scene tree.
   Clicking on this padlock also unlocks the nodes.
-- **Group selected nodes** (:kbd:`Ctrl + G`). This allows selection of the root node if 
+- **Group selected nodes** (:kbd:`Ctrl + G`). This allows selection of the root node if
   any of the children are selected.
-  Using :kbd:`Ctrl + G` ungroups them. Additionally, clicking the ungroup button in 
+  Using :kbd:`Ctrl + G` ungroups them. Additionally, clicking the ungroup button in
   the scene tree performs the same action.
 - **Ruler Mode** (:kbd:`M`): When enabled you can click and drag to measure distance in the scene
   in meters.
-- **Use Local Space** (:kbd:`T`): If enabled, gizmos of a node are drawn using the current node's 
+- **Use Local Space** (:kbd:`T`): If enabled, gizmos of a node are drawn using the current node's
   rotation angle instead of the :ref:`global viewport axes <doc_introduction_to_3d_coordinate_system>`.
-- **Use Snap** (:kbd:`Y`): If enabled, movement, and rotation snap to grid. Snapping can also 
+- **Use Snap** (:kbd:`Y`): If enabled, movement, and rotation snap to grid. Snapping can also
   temporarily be activated using :kbd:`Ctrl` while performing the action.
   The settings for changing snap options are explained below.
 - **Use Trackball** (:kbd:`U`): When enabled, dragging the center of a node (represented by a
   subtle ray disc highlight) will rotate the node like a physical trackball.
 - **Preserve Children Transform** (:kbd:`P`): When enabled, transforming a node will preserve the
   global transform of its children.
-- **Toggle preview sunlight**: If no DirectionalLight3D exist in the scene, a preview 
-  of sunlight can be used as a light source. See 
+- **Toggle preview sunlight**: If no DirectionalLight3D exist in the scene, a preview
+  of sunlight can be used as a light source. See
   :ref:`doc_introduction_to_3d_preview_environment_light` for more details.
-- **Toggle preview environment**: If no WorldEnvironment exists in the scene, a preview of the 
-  environment can be used as a placeholder. See 
+- **Toggle preview environment**: If no WorldEnvironment exists in the scene, a preview of the
+  environment can be used as a placeholder. See
   :ref:`doc_introduction_to_3d_preview_environment_light` for more details.
-- **Edit Sun and Environment Settings (three dots)**: Opens the menu to configure preview 
-  sunlight and environment settings. See :ref:`doc_introduction_to_3d_preview_environment_light` 
+- **Edit Sun and Environment Settings (three dots)**: Opens the menu to configure preview
+  sunlight and environment settings. See :ref:`doc_introduction_to_3d_preview_environment_light`
   for more details.
 
 - **Transform menu**: It has three options:
 
    - *Snap Object to Floor*: Snaps an object to a solid floor.
-   - *Transform Dialog*: Opens a dialog to adjust transform parameters (translate, rotate, scale, 
+   - *Transform Dialog*: Opens a dialog to adjust transform parameters (translate, rotate, scale,
      and transform) manually.
-   - *Snap Settings*: Allows you to change transform, rotate snap (in degrees), and scale snap 
+   - *Snap Settings*: Allows you to change transform, rotate snap (in degrees), and scale snap
      (in percent) settings.
 
 - **View menu**: Controls the view options and enables additional viewports:
@@ -118,7 +118,7 @@ Moreover, specific types of gizmos can be toggled in this menu.
 An open eye means that the gizmo is visible, a closed eye means it is hidden.
 A half-open eye means that it is also visible through opaque surfaces.
 
-Clicking on *Settings* in this view menu opens a window to change the 
+Clicking on *Settings* in this view menu opens a window to change the
 *Vertical Field of View (VFOV)* parameter
 (in degrees), *Z-Near*, and *Z-Far* values.
 
@@ -137,8 +137,8 @@ this menu:
 
 .. image:: img/tuto_3d6_1.webp
 
-This menu also displays the current view type and enables quick adjustment of the 
-viewport's viewing angle. Additionally, it offers options to modify the appearance of 
+This menu also displays the current view type and enables quick adjustment of the
+viewport's viewing angle. Additionally, it offers options to modify the appearance of
 nodes within the viewport.
 
 .. _doc_introduction_to_3d_coordinate_system:
@@ -201,7 +201,7 @@ The arcs can be clicked and held to rotate the object.
 To lock one axis and move the object freely in the other two axes, the colored rectangles
 can be clicked, held, and dragged.
 
-If the transform mode is changed from *Select Mode* to *Scale Mode*, the arrows will be 
+If the transform mode is changed from *Select Mode* to *Scale Mode*, the arrows will be
 replaced by cubes, which can be dragged to scale an object as if the object is being moved.
 
 Navigating the 3D environment
@@ -224,7 +224,7 @@ Then, under *Navigation*, search for *Navigation Scheme*.
 Using the default settings, the following shortcuts control how one can
 navigate in the viewport:
 
-Pressing the middle mouse button and dragging the mouse allows you to orbit around 
+Pressing the middle mouse button and dragging the mouse allows you to orbit around
 the center of what is on the screen.
 
 It is also possible to left-click and hold the manipulator gizmo located
@@ -241,7 +241,7 @@ If the *Perspective* view is enabled on the viewport (can be seen on the viewpor
 not the View menu on the main toolbar), holding down the right mouse button on the viewport
 or pressing :kbd:`Shift + F` switches to "free-look" mode.
 In this mode you can move the mouse to look around, use the :kbd:`W` :kbd:`A`
-:kbd:`S` :kbd:`D` keys to fly around the view, :kbd:`E` to go up, and :kbd:`Q` to 
+:kbd:`S` :kbd:`D` keys to fly around the view, :kbd:`E` to go up, and :kbd:`Q` to
 go down. To disable this mode, release the right mouse button or press
 :kbd:`Shift + F` again.
 
@@ -318,7 +318,7 @@ Manually authored models (using 3D modeling software)
    (used to reference a non existing doc_importing_3d_meshes importer).
 
 It is possible to import 3D models in Godot created in external tools.
-Depending on the format, you can import entire scenes (exactly as they look in 
+Depending on the format, you can import entire scenes (exactly as they look in
 the 3D modeling software), including animation, skeletal rigs, blend shapes, or
 as simple resources.
 
@@ -393,8 +393,8 @@ by clicking on their respective icon.
 
 .. image:: img/tuto_3d8.webp
 
- 
-The three dots dropdown menu next to those icons can be used to adjust the properties 
+
+The three dots dropdown menu next to those icons can be used to adjust the properties
 of the preview environment and light if they are enabled.
 
 .. image:: img/tuto_3d9.webp

--- a/tutorials/3d/occlusion_culling.rst
+++ b/tutorials/3d/occlusion_culling.rst
@@ -66,7 +66,7 @@ performance gains.
 
     The greatest performance benefits can be observed when using the Mobile
     renderer, as it does not feature a depth prepass for performance reasons. As
-    a result, occlusion culling will actively decrease shading overdraw with 
+    a result, occlusion culling will actively decrease shading overdraw with
     that renderer.
 
     Nonetheless, even when using a depth prepass, there is still a noticeable

--- a/tutorials/3d/procedural_geometry/arraymesh.rst
+++ b/tutorials/3d/procedural_geometry/arraymesh.rst
@@ -29,40 +29,40 @@ See :ref:`Mesh.ArrayType <enum_Mesh_ArrayType>` for a full list.
     * - Index
       - Mesh.ArrayType Enum
       - Array type
-    
+
     * - 0
       - ``ARRAY_VERTEX``
       - :ref:`PackedVector3Array <class_PackedVector3Array>` or :ref:`PackedVector2Array <class_PackedVector2Array>`
-    
+
     * - 1
       - ``ARRAY_NORMAL``
       - :ref:`PackedVector3Array <class_PackedVector3Array>`
-    
+
     * - 2
       - ``ARRAY_TANGENT``
-      - :ref:`PackedFloat32Array <class_PackedFloat32Array>` or :ref:`PackedFloat64Array <class_PackedFloat64Array>` of groups of 4 floats. The first 3 floats determine the tangent, and the last float the binormal 
+      - :ref:`PackedFloat32Array <class_PackedFloat32Array>` or :ref:`PackedFloat64Array <class_PackedFloat64Array>` of groups of 4 floats. The first 3 floats determine the tangent, and the last float the binormal
         direction as -1 or 1.
-    
+
     * - 3
       - ``ARRAY_COLOR``
       - :ref:`PackedColorArray <class_PackedColorArray>`
-    
+
     * - 4
       - ``ARRAY_TEX_UV``
       - :ref:`PackedVector2Array <class_PackedVector2Array>` or :ref:`PackedVector3Array <class_PackedVector3Array>`
-    
+
     * - 5
       - ``ARRAY_TEX_UV2``
       - :ref:`PackedVector2Array <class_PackedVector2Array>` or :ref:`PackedVector3Array <class_PackedVector3Array>`
-    
+
     * - 10
       - ``ARRAY_BONES``
       - :ref:`PackedFloat32Array <class_PackedFloat32Array>` of groups of 4 floats or :ref:`PackedInt32Array <class_PackedInt32Array>` of groups of 4 ints. Each group lists indexes of 4 bones that affects a given vertex.
-    
+
     * - 11
       - ``ARRAY_WEIGHTS``
       - :ref:`PackedFloat32Array <class_PackedFloat32Array>` or :ref:`PackedFloat64Array <class_PackedFloat64Array>` of groups of 4 floats. Each float lists the amount of weight the corresponding bone in ``ARRAY_BONES`` has on a given vertex.
-    
+
     * - 12
       - ``ARRAY_INDEX``
       - :ref:`PackedInt32Array <class_PackedInt32Array>`
@@ -91,7 +91,7 @@ Under ``_ready()``, create a new Array.
   .. code-tab:: gdscript GDScript
 
     var surface_array = []
-  
+
   .. code-tab:: csharp C#
 
     Godot.Collections.Array surfaceArray = [];
@@ -105,7 +105,7 @@ size ``Mesh.ARRAY_MAX``, so resize it accordingly.
 
     var surface_array = []
     surface_array.resize(Mesh.ARRAY_MAX)
-  
+
  .. code-tab:: csharp C#
 
     Godot.Collections.Array surfaceArray = [];
@@ -153,7 +153,7 @@ by adding each array to ``surface_array`` and then committing to the mesh.
     if (arrMesh != null)
     {
         // No blendshapes, lods, or compression used.
-        arrMesh.AddSurfaceFromArrays(Mesh.PrimitiveType.Triangles, surfaceArray); 
+        arrMesh.AddSurfaceFromArrays(Mesh.PrimitiveType.Triangles, surfaceArray);
     }
 
 .. note:: In this example, we used ``Mesh.PRIMITIVE_TRIANGLES``, but you can use any primitive type

--- a/tutorials/3d/procedural_geometry/surfacetool.rst
+++ b/tutorials/3d/procedural_geometry/surfacetool.rst
@@ -26,7 +26,7 @@ Attributes are added before each vertex is added:
     st.set_normal() # Normal never added to a vertex.
 
  .. code-tab:: csharp
-    
+
     st.SetNormal(); // Overwritten by normal below.
     st.SetNormal(); // Added to next vertex.
     st.SetColor(); // Added to next vertex.
@@ -205,7 +205,7 @@ normals set already.
     st.commit(mesh)
 
  .. code-tab:: csharp
-    
+
     st.GenerateNormals();
     st.GenerateTangents();
 

--- a/tutorials/3d/using_decals.rst
+++ b/tutorials/3d/using_decals.rst
@@ -5,7 +5,7 @@ Using decals
 
 .. note::
 
-    Decals are only supported in the Forward+ and Mobile renderers, not the 
+    Decals are only supported in the Forward+ and Mobile renderers, not the
     Compatibility renderer.
 
     If using the Compatibility renderer, consider using Sprite3D as an alternative

--- a/tutorials/assets_pipeline/escn_exporter/index.rst
+++ b/tutorials/assets_pipeline/escn_exporter/index.rst
@@ -3,11 +3,11 @@
 Blender ESCN exporter
 =====================
 
-To export from Blender to Godot 4.x, use one of the 
+To export from Blender to Godot 4.x, use one of the
 :ref:`available 3D formats <doc_importing_3d_scenes_available_formats>`.
 
-The plugin `Godot Blender Exporter <https://github.com/godotengine/godot-blender-exporter>`__ 
-is not maintained or supported in Godot 4.x. While not officially supported, the plugin may 
+The plugin `Godot Blender Exporter <https://github.com/godotengine/godot-blender-exporter>`__
+is not maintained or supported in Godot 4.x. While not officially supported, the plugin may
 partially work for some Godot and Blender versions, particularly before Blender version 4.0.
-For complete docs on the Blender exporter, see the 
+For complete docs on the Blender exporter, see the
 `previous version of this page <https://docs.godotengine.org/en/4.0/tutorials/assets_pipeline/escn_exporter/index.html>`__.

--- a/tutorials/assets_pipeline/importing_audio_samples.rst
+++ b/tutorials/assets_pipeline/importing_audio_samples.rst
@@ -17,7 +17,7 @@ Each format has different advantages:
 - Ogg Vorbis files use a stronger compression that results in much smaller file
   size, but require significantly more processing power to play back.
 - MP3 files use better compression than WAV with IMA ADPCM or Quite OK Audio, but
-  worse than Ogg Vorbis. This means that an MP3 file with roughly equal quality 
+  worse than Ogg Vorbis. This means that an MP3 file with roughly equal quality
   to Ogg Vorbis will be significantly larger. On the bright side, MP3 requires
   less CPU usage to play back compared to Ogg Vorbis.
 
@@ -145,11 +145,11 @@ metadata, but you can choose to apply a specific loop mode:
 - **Detect from WAV:** Uses loop information from the WAV metadata.
 - **Disabled:** Don't loop audio, even if metadata indicates the file should be
   played back looping.
-- **Forward:** Standard audio looping. Plays the audio forward from the beginning 
+- **Forward:** Standard audio looping. Plays the audio forward from the beginning
   to the loop end, then returns to the loop beginning and repeats.
-- **Ping-Pong:** Plays the audio forward until the loop end, then backwards to 
+- **Ping-Pong:** Plays the audio forward until the loop end, then backwards to
   the loop beginning, repeating this cycle.
-- **Backward:** Plays the audio backwards from the loop end to the loop beginning, 
+- **Backward:** Plays the audio backwards from the loop end to the loop beginning,
   then repeats.
 
 When choosing one of the **Forward**, **Ping-Pong** or **Backward** loop modes,

--- a/tutorials/audio/sync_with_audio.rst
+++ b/tutorials/audio/sync_with_audio.rst
@@ -24,7 +24,7 @@ The most common way to reduce latency is to shrink the audio buffers (again, by 
 This is a common tradeoff, so Godot ships with sensible defaults that should not need to be altered.
 
 The problem, in the end, is not this slight delay but synchronizing graphics and
-audio for games that require it. Some helpers are available to obtain more 
+audio for games that require it. Some helpers are available to obtain more
 precise playback timing.
 
 Using the system clock to sync

--- a/tutorials/editor/inspector_dock.rst
+++ b/tutorials/editor/inspector_dock.rst
@@ -4,12 +4,12 @@ Inspector Dock
 ===============
 
 The Inspector dock lists all properties of an object, resource, or node.
-It will update the list of the properties as you select a different node from the 
+It will update the list of the properties as you select a different node from the
 Scene Tree dock, or if you use **Open** command from the FileSystem's context menu.
 
 .. image:: img/inspector_overview.webp
 
-This page explains how the Inspector dock works in-depth. You will learn how to edit 
+This page explains how the Inspector dock works in-depth. You will learn how to edit
 properties, fold and unfold areas, use the search bar, and more.
 
 Usage
@@ -35,22 +35,22 @@ From left to right:
   - **Copy Resource** to clipboard.
   - **Show in FileSystem** if the resource is already saved.
   - **Make Resource Built-In** to work in a built-in resource, not the one from the disk.
-  
+
 - The "<" and ">" arrows let you navigate through your edited object history.
-- The button next to them opens the history list for a quicker navigation. If you created multiple 
+- The button next to them opens the history list for a quicker navigation. If you created multiple
   resources in the memory, you will also see them here.
 
-Below, you can find the selected node's icon, its name, and the quick button to open 
+Below, you can find the selected node's icon, its name, and the quick button to open
 its documentation on the right side.
 Clicking on the node's name itself will list the sub-resources of this node if there are any.
 
-Then comes the search bar. Type anything in it to filter displayed properties. 
+Then comes the search bar. Type anything in it to filter displayed properties.
 Delete the text to clear the search.
 This search is case insensitive and also searches letter by letter as you type.
 For instance, if you type ``vsb``, one of the results you see will be
 Visibility property as this property contains all of these letters.
 
-Before discussing the tool button next to the filter bar, it is worth mentioning 
+Before discussing the tool button next to the filter bar, it is worth mentioning
 what you actually see below it and how it is structured.
 
 .. image:: img/inspector_dock_overlay.webp
@@ -61,19 +61,19 @@ You can expand each section to view the related properties.
 You can also open the documentation of each class by right-clicking on a class
 and selecting **Open Documentation**.
 Similarly, you can right click on a property and copy or paste its value,
-copy the property path, favorite it to be shown on the top of the inspector, or open its 
+copy the property path, favorite it to be shown on the top of the inspector, or open its
 documentation page.
 
-If you hover your mouse over a property, you will see the description of what 
+If you hover your mouse over a property, you will see the description of what
 it does as well as how it can be called inside the script.
 
 You can directly change the values by clicking, typing, or selecting from the menu.
-If the property is a number or a slider, you can keep your left mouse button 
+If the property is a number or a slider, you can keep your left mouse button
 pressed and drag to change the values.
 
 .. image:: img/inspector_dock_subresource.webp
 
-If a node's property is a sub-resource, you can click on the down arrow to pick a 
+If a node's property is a sub-resource, you can click on the down arrow to pick a
 resource type, or load one using the **Quick Load** or **Load** options.
 Alternatively, a supported resource can be dragged from the FileSystem.
 Once you start dragging, the compatible property will be highlighted.
@@ -89,10 +89,10 @@ If the values are linked with each other, they will have a chain icon and changi
 will change others as well. You can unchain them by clicking on this icon.
 
 If you are changing a property a lot, you may consider favoriting it by right-clicking and
-choosing **Favorite Property**. This will show it at the top of the inspector for all objects 
+choosing **Favorite Property**. This will show it at the top of the inspector for all objects
 of this class.
 
-Now that we have a better understanding of the terms, we can proceed with the tool menu. 
+Now that we have a better understanding of the terms, we can proceed with the tool menu.
 If you click the tool menu icon next to the filter bar, a drop-down menu will offer
 various view and edit options.
 
@@ -102,21 +102,21 @@ various view and edit options.
 - **Collapse All**: Collapses all properties showing only classes and the sections.
 - **Expand Non-Default**: Only expands the sections where the original value is different
   than the current value (the properties with a revert icon (|undo|)).
-- **Property Name Style**: This section determines how the properties' text is displayed in 
-  the inspector. ``Raw`` uses the property's own naming, ``Capitalized`` uses title 
-  case by changing the initial letters of each word to uppercase and removing underscores, 
-  ``Localized`` displays the translation of the properties if you are using the Editor 
+- **Property Name Style**: This section determines how the properties' text is displayed in
+  the inspector. ``Raw`` uses the property's own naming, ``Capitalized`` uses title
+  case by changing the initial letters of each word to uppercase and removing underscores,
+  ``Localized`` displays the translation of the properties if you are using the Editor
   in a language other than English.
 - **Copy Properties**: Copies all properties of the current node with their current values.
-- **Paste Properties**: Pastes the copied properties from the clipboard. Useful to apply 
+- **Paste Properties**: Pastes the copied properties from the clipboard. Useful to apply
   the common properties of one node to another.
 - **Make Sub-Resources Unique**: By default, a duplicated node shares the sub-resources of
-  the original node. Changing one parameter of the sub-resource in one node, affects 
+  the original node. Changing one parameter of the sub-resource in one node, affects
   the other one.
-  Clicking this option makes each sub-resource used in this node unique, separated from 
+  Clicking this option makes each sub-resource used in this node unique, separated from
   other nodes.
 
-.. tip:: If a node has exported variables in its attached script, you will also see these 
+.. tip:: If a node has exported variables in its attached script, you will also see these
   in the inspector. The first image in this section has one for the Player node:
   `Action Suffix`. See :ref:`doc_gdscript_exports` for more on this topic.
 

--- a/tutorials/editor/project_manager.rst
+++ b/tutorials/editor/project_manager.rst
@@ -17,11 +17,11 @@ In Project Manager Settings, you can change the interface **language** from the 
 dropdown menu, which is the system default language by default.
 
 You can also change the **theme** and **color preset** of the editor,
-the **display scale** for different interface 
+the **display scale** for different interface
 element sizes, and the availability of online functionality using **network mode**.
 If network mode is online, Godot will also check and inform you about new versions of Godot.
 
-The **directory naming convention** can also be changed to replace spaces according to the chosen format 
+The **directory naming convention** can also be changed to replace spaces according to the chosen format
 when creating folders automatically.
 
 .. image:: img/editor_ui_intro_project_manager_10.webp
@@ -44,8 +44,8 @@ To create a new project:
 
 .. image:: img/editor_ui_intro_project_manager_04.webp
 
-.. note:: You can optionally choose a version control system. Currently, only 
-	`git <https://git-scm.com>`__ is supported and it needs the Godot Git Plugin to be installed, 
+.. note:: You can optionally choose a version control system. Currently, only
+	`git <https://git-scm.com>`__ is supported and it needs the Godot Git Plugin to be installed,
 	either manually or using the :ref:`Asset Library <doc_using_assetlib>`. To learn more about the Godot Git Plugin, see its `wiki <https://github.com/godotengine/godot-git-plugin/wiki>`__.
 
 Using the file browser
@@ -133,12 +133,12 @@ This will open up the manage project tags window. To add a tag click the plus bu
 Type out the tag name, and click **OK**. Your project will now have a tag added to it.
 These tags can be used for any other project in your project manager.
 
-To show projects with a specific tag only, you can click on the tags or write ``tag:`` 
-and type the tag you would like to search for in the filter bar. To limit the results 
-using multiple tags, you can click on another tag or add ``tag:`` after 
+To show projects with a specific tag only, you can click on the tags or write ``tag:``
+and type the tag you would like to search for in the filter bar. To limit the results
+using multiple tags, you can click on another tag or add ``tag:`` after
 a space and type another tag in the filter bar.
 
-In addition, tags will stay with projects. So if you tag your project, send it to 
+In addition, tags will stay with projects. So if you tag your project, send it to
 another machine, and import it into the project manager you will see the tags
 you created.
 

--- a/tutorials/editor/project_settings.rst
+++ b/tutorials/editor/project_settings.rst
@@ -6,7 +6,7 @@ Project Settings
 There are dozens of settings you can change to control a project's execution,
 including physics, rendering, and windowing settings. These settings can be
 changed from the **Project Settings** window, from code, or by manually editing
-the ``project.godot`` file. You can see a full list of settings in the 
+the ``project.godot`` file. You can see a full list of settings in the
 :ref:`ProjectSettings <class_ProjectSettings>` class.
 
 Internally, Godot stores the settings for a project in a ``project.godot`` file,
@@ -48,7 +48,7 @@ change a setting's value from code:
 
 .. tabs::
     .. code-tab:: gdscript GDScript
-        
+
         ProjectSettings.set_setting("application/run/max_fps", 60)
         ProjectSettings.set_setting("display/window/size/mode", DisplayServer.WINDOW_MODE_WINDOWED)
 
@@ -58,13 +58,13 @@ change a setting's value from code:
         ProjectSettings.SetSetting("display/window/size/mode", (int)DisplayServer.WindowMode.Windowed);
 
 However, many project settings are only read once when the game starts. After
-that, changing the setting with ``set_setting()`` will have no effect. Instead, 
+that, changing the setting with ``set_setting()`` will have no effect. Instead,
 most settings have a corresponding property or method on a runtime class like
 :ref:`Engine <class_Engine>` or :ref:`DisplayServer <class_DisplayServer>`:
 
 .. tabs::
     .. code-tab:: gdscript GDScript
-        
+
         Engine.max_fps = 60
         DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
 
@@ -76,7 +76,7 @@ most settings have a corresponding property or method on a runtime class like
 In general, project settings are duplicated at runtime in the
 :ref:`Engine <class_Engine>`, :ref:`PhysicsServer2D <class_PhysicsServer2D>`,
 :ref:`PhysicsServer3D <class_PhysicsServer3D>`,
-:ref:`RenderingServer <class_RenderingServer>`, 
+:ref:`RenderingServer <class_RenderingServer>`,
 :ref:`Viewport <class_Viewport>`, or :ref:`Window <class_Window>` classes. In the
 :ref:`ProjectSettings <class_ProjectSettings>` class reference, settings
 links to their equivalent runtime property or method.
@@ -90,7 +90,7 @@ You can read project settings with
 
 .. tabs::
     .. code-tab:: gdscript GDScript
-        
+
         var max_fps = ProjectSettings.get_setting("application/run/max_fps")
         var window_mode = ProjectSettings.get_setting("display/window/size/mode")
 
@@ -105,7 +105,7 @@ the value from the runtime equivalent property or method:
 
 .. tabs::
     .. code-tab:: gdscript GDScript
-        
+
         var max_fps = Engine.max_fps
         var window_mode = DisplayServer.window_get_mode()
 

--- a/tutorials/editor/script_editor.rst
+++ b/tutorials/editor/script_editor.rst
@@ -59,34 +59,34 @@ the user interface can also be modified directly through code.
   also be customized by changing its settings to your liking. You can access
   these settings by opening **Editor > Editor Settings** and going to the **Text Editor**
   group.
-  
+
 .. image:: img/editor_ui_script_editor_open.webp
 
 You can open the Script Editor using the **Script** button in the workspace selector,
 located at the top center of Godot's interface.
 Alternatively, you can use the **Open Script** button next to a node in the
-Scene Tree dock, or double-click on a ``.gd`` file or a recognized text file in 
+Scene Tree dock, or double-click on a ``.gd`` file or a recognized text file in
 the FileSystem dock to open it directly in the Script Editor.
 
 .. image:: img/editor_ui_script_editor_menu.webp
 
-Once it is open, you will see the text editor menus at the top, below the scene 
-switcher. Next to the menus, you'll find buttons to open the online documentation 
-or search within the built-in class reference. To the right of these buttons are 
+Once it is open, you will see the text editor menus at the top, below the scene
+switcher. Next to the menus, you'll find buttons to open the online documentation
+or search within the built-in class reference. To the right of these buttons are
 two navigation arrows that allow you to navigate through your viewing history.
-Finally, you can use the float button to 
-separate the text editor from Godot's window, which is useful if you are working 
+Finally, you can use the float button to
+separate the text editor from Godot's window, which is useful if you are working
 with multiple monitors.
 
-Underneath the menus on the left, you will see the script panel. In the center, 
-adjacent to the script panel, is the coding area. Beneath the coding area is the 
-status bar, which displays the error and warning count in the code. 
-Clicking on the error or warning icons will show the list of errors with 
+Underneath the menus on the left, you will see the script panel. In the center,
+adjacent to the script panel, is the coding area. Beneath the coding area is the
+status bar, which displays the error and warning count in the code.
+Clicking on the error or warning icons will show the list of errors with
 the line numbers. Clicking on one will jump to that line.
-You can also choose to ignore warnings by opening the list and 
+You can also choose to ignore warnings by opening the list and
 clicking ``Ignore``.
-The status bar also lets you change the zoom level of the code by clicking 
-the percentage value. You can also use :kbd:`Ctrl + Mouse Wheel` 
+The status bar also lets you change the zoom level of the code by clicking
+the percentage value. You can also use :kbd:`Ctrl + Mouse Wheel`
 (:kbd:`Cmd + Mouse Wheel` on Mac) to achieve the same effect.
 The status bar also shows the current position of the caret in terms of line and
 column, and whether the indentation is done using tabs, or spaces.
@@ -113,15 +113,15 @@ Script Panel
 .. |scriptcsharp| image:: img/script_editor_icons/ScriptCSharp.webp
 .. |documentation| image:: img/script_editor_icons/Documentation.webp
 .. |toolscript| image:: img/script_editor_icons/ToolScript.webp
-	
+
 .. image:: img/editor_ui_script_editor_script_panel.webp
 
 Below the menus, on the left panel, you will see a list of opened files and documentation
 pages. Depending on the file type, this list will have an icon next
 to the file name. For example, the |script| icon means that it is a GDScript.
-the |scriptcsharp| means it is a C# script. The |documentation| means that this is a 
-built-in class reference. Finally, the |toolscript| means it is a currently running 
-script (See :ref:`tool annotation <doc_running_code_in_the_editor>` for more on this). 
+the |scriptcsharp| means it is a C# script. The |documentation| means that this is a
+built-in class reference. Finally, the |toolscript| means it is a currently running
+script (See :ref:`tool annotation <doc_running_code_in_the_editor>` for more on this).
 Hovering a file will show a tooltip with its relative location in the project folder.
 
 On the status bar, clicking the left arrow hides the script panel, clicking
@@ -135,7 +135,7 @@ properties in the **Text Editor** section.
 The filter bar above the file names introduces a handy case-insensitive search to
 find a specific file. Even if you just type the letters of a file name into the
 bar, files containing these letters in order will also appear. Assume that there
-is a file named ``button.gd`` in the list. If you type ``btn`` into the filter bar, 
+is a file named ``button.gd`` in the list. If you type ``btn`` into the filter bar,
 this file will appear in the results. To reset the filter, clear the filter bar.
 
 An asterisk (*) next to a file name indicates that the file has unsaved changes.
@@ -143,7 +143,7 @@ An asterisk (*) next to a file name indicates that the file has unsaved changes.
 .. tip:: If you just enter "*" in the filter bar, you can display all unsaved files.
 
 You can drag a file to change the ordering. Middle-clicking on a file closes it.
-Right-clicking on a file provides several options to save or close files, or to 
+Right-clicking on a file provides several options to save or close files, or to
 copy the relative path of the file. On this menu:
 
 You can also use **Move Up** and **Move Down** to change the order of the file, or use **Sort**
@@ -210,10 +210,10 @@ The **File** menu provides the following options:
   10 lines, you will first move it to its previous location in the same file.
 - **History Next**: After using `History Previous` to go back to an earlier script,
   this feature allows you to move forward through the script history, switching to
-  scripts that were previously accessed. Similar to above, if you also changed the 
-  caret position more than 10 lines, you will first move it to its next location in 
+  scripts that were previously accessed. Similar to above, if you also changed the
+  caret position more than 10 lines, you will first move it to its next location in
   the same file.
-- **Theme**: Provides options to import an existing theme, save, or reload it. Changing 
+- **Theme**: Provides options to import an existing theme, save, or reload it. Changing
   theme settings is performed via `Editor Settings`.
 - **Close**: Closes the active script.
 - **Close All**: Closes all open scripts and prompts to save if there are unsaved changes.
@@ -305,20 +305,20 @@ The **Search** menu provides the following options:
 - **Find Previous**: Similar to the up arrow, shows the previous occurrence.
 
 
-- **Replace...**: Opens the find and replace bar under the status bar to find text and replace it in the open file.  You can choose to replace them one 
-  at a time or all at once. Additionally, you can limit the replacement to the selected 
-  text by checking the **Selection Only** checkbox in the find and replace bar. You can also use :kbd:`Ctrl + D` to 
+- **Replace...**: Opens the find and replace bar under the status bar to find text and replace it in the open file.  You can choose to replace them one
+  at a time or all at once. Additionally, you can limit the replacement to the selected
+  text by checking the **Selection Only** checkbox in the find and replace bar. You can also use :kbd:`Ctrl + D` to
   additionally select the next instance of the currently selected text, allowing you to perform an in-line replacement on multiple occurrences.
-- **Find in Files...**: Opens a window to search for text within the files in the project 
-  folder. Selecting "Find..." starts with the chosen folder, and includes the file extensions 
-  checked in the filters. The results are shown in the bottom panel with the number of matches 
-  and total number of files found, in the **Search Results** tab. Clicking on a result opens 
+- **Find in Files...**: Opens a window to search for text within the files in the project
+  folder. Selecting "Find..." starts with the chosen folder, and includes the file extensions
+  checked in the filters. The results are shown in the bottom panel with the number of matches
+  and total number of files found, in the **Search Results** tab. Clicking on a result opens
   the file and jumps to the respective line.
-- **Replace in Files...**: Opens a window to search and replace text with different text within the 
-  found files in the project folder. After clicking **Replace...**, you can select in which files to 
-  replace using the **Search Results** tab in the bottom panel by (un)checking them and using 
+- **Replace in Files...**: Opens a window to search and replace text with different text within the
+  found files in the project folder. After clicking **Replace...**, you can select in which files to
+  replace using the **Search Results** tab in the bottom panel by (un)checking them and using
   **Replace All** button.
-  
+
 .. image:: img/editor_ui_script_editor_replaceinfiles.webp
 
 .. warning:: Note that "Replace in Files" operation cannot be undone!
@@ -391,11 +391,11 @@ display of the line can be toggled in the "Appearance" settings of the text edit
 .. |foldable| image:: img/script_editor_icons/Foldable.webp
 
 In the script, to the left of function definitions, you might see additional icons. The |override|
-icon indicates that this function is an :ref:`override <doc_overridable_functions>` of an existing 
-function. Clicking it opens the documentation of the original function. The |receiver| icon means 
-that it is a receiving method of a signal. Clicking it shows where the signal is coming 
-from. A |foldable| icon to the left of the line denotes a foldable block. You can 
-click to collapse or expand it. 
+icon indicates that this function is an :ref:`override <doc_overridable_functions>` of an existing
+function. Clicking it opens the documentation of the original function. The |receiver| icon means
+that it is a receiving method of a signal. Clicking it shows where the signal is coming
+from. A |foldable| icon to the left of the line denotes a foldable block. You can
+click to collapse or expand it.
 Alternatively, the ellipsis (...) icon can also be clicked to expand a folded block.
 
 The example below summarizes the paragraph above. Lines 52, 56, and 58 are foldable blocks,

--- a/tutorials/export/exporting_for_ios.rst
+++ b/tutorials/export/exporting_for_ios.rst
@@ -38,7 +38,7 @@ are required. Leaving them blank will cause the exporter to throw an error. The 
     A valid bundle ID can only contain alphanumeric characters, hyphens, and periods (``A-Z``, ``a-z``, ``0-9``, ``-``, and ``.``).
     Apple recommends using reverse-DNS format (e.g. ``com.example.your-game``) of a domain you own, so that your bundle ID is guaranteed to be unique.
     Bundle IDs are case-insensitive. See `CFBundleIdentifier <https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleidentifier>`__.
-    
+
 .. note:: | If you encounter an error during export similar to
           | ``JSON text did not start with array or object and option to allow fragments not set``
           | then it might be due to a malformated **App Store Team ID**!

--- a/tutorials/export/exporting_for_macos.rst
+++ b/tutorials/export/exporting_for_macos.rst
@@ -14,8 +14,8 @@ This bundle can be exported as is, packed in a ZIP archive, or packed in a DMG d
 `Universal binaries for macOS support both Intel x86_64 and ARM64 (Apple Silicon) architectures <https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary>`__.
 
 .. warning::
-    Due to file system limitations, ``.app`` bundles exported from Windows lack the 
-    ``executable`` flag and won't run on macOS. Projects exported as ``.zip`` are not 
+    Due to file system limitations, ``.app`` bundles exported from Windows lack the
+    ``executable`` flag and won't run on macOS. Projects exported as ``.zip`` are not
     affected by this issue. To run ``.app`` bundles exported from Windows on macOS,
     transfer the ``.app`` to a device running macOS or Linux and use the
     ``chmod +x {executable_name}`` terminal command to add the ``executable`` permission.

--- a/tutorials/inputs/custom_mouse_cursor.rst
+++ b/tutorials/inputs/custom_mouse_cursor.rst
@@ -94,6 +94,6 @@ Create a Node and attach the following script.
 Cursor list
 -----------
 
-There are multiple mouse cursors you can define, documented in the 
+There are multiple mouse cursors you can define, documented in the
 :ref:`Input.CursorShape <enum_Input_CursorShape>` enum. Which ones you want to use
 depends on your use case.

--- a/tutorials/inputs/handling_quit_requests.rst
+++ b/tutorials/inputs/handling_quit_requests.rst
@@ -54,18 +54,18 @@ procedure:
 On mobile devices
 -----------------
 
-There is no direct equivalent to ``NOTIFICATION_WM_CLOSE_REQUEST`` on mobile 
-platforms. Due to the nature of mobile operating systems, the only place 
-that you can run code prior to quitting is when the app is being suspended to 
-the background. On both Android and iOS, the app can be killed while suspended 
-at any time by either the user or the OS. A way to plan ahead for this 
-possibility is to utilize ``NOTIFICATION_APPLICATION_PAUSED`` in order to 
+There is no direct equivalent to ``NOTIFICATION_WM_CLOSE_REQUEST`` on mobile
+platforms. Due to the nature of mobile operating systems, the only place
+that you can run code prior to quitting is when the app is being suspended to
+the background. On both Android and iOS, the app can be killed while suspended
+at any time by either the user or the OS. A way to plan ahead for this
+possibility is to utilize ``NOTIFICATION_APPLICATION_PAUSED`` in order to
 perform any needed actions as the app is being suspended.
 
 .. note:: On iOS, you only have approximately 5 seconds to finish a task started by this signal. If you go over this allotment, iOS will kill the app instead of pausing it.
 
-On Android, pressing the Back button will exit the application if 
-**Application > Config > Quit On Go Back** is checked in the Project Settings 
+On Android, pressing the Back button will exit the application if
+**Application > Config > Quit On Go Back** is checked in the Project Settings
 (which is the default). This will fire ``NOTIFICATION_WM_GO_BACK_REQUEST``.
 
 

--- a/tutorials/inputs/inputevent.rst
+++ b/tutorials/inputs/inputevent.rst
@@ -130,9 +130,9 @@ and SubViewports.
 .. note::
 
    This order doesn't apply to :ref:`Control._gui_input() <class_Control_private_method__gui_input>`, which uses
-   a different method based on event location or focused Control. GUI **mouse** events also travel 
+   a different method based on event location or focused Control. GUI **mouse** events also travel
    up the scene tree, subject to the :ref:`Control.mouse_filter <class_Control_property_mouse_filter>`
-   restrictions described above. However, since these events target specific Controls, only direct ancestors of 
+   restrictions described above. However, since these events target specific Controls, only direct ancestors of
    the targeted Control node receive the event. GUI **keyboard and joypad** events *do not* travel
    up the scene tree, and can only be handled by the Control that received them. Otherwise, they will be
    propagated as non-GUI events through :ref:`Node._unhandled_input() <class_Node_private_method__unhandled_input>`.

--- a/tutorials/math/interpolation.rst
+++ b/tutorials/math/interpolation.rst
@@ -180,7 +180,7 @@ This is useful for smoothing camera movement, for allies following the player
                 float weight = 1f - Mathf.Exp(-FollowSpeed * (float)delta);
                 sprite.Position = sprite.Position.Lerp(mousePos, weight);
             }
-    
-    Deriving this formula is beyond the scope of this page. For an explanation, 
+
+    Deriving this formula is beyond the scope of this page. For an explanation,
     see `Improved Lerp Smoothing <https://www.gamedeveloper.com/programming/improved-lerp-smoothing->`__
     or watch `Lerp smoothing is broken <https://www.youtube.com/watch?v=LSNQuFEDOyQ>`__.

--- a/tutorials/math/vectors_advanced.rst
+++ b/tutorials/math/vectors_advanced.rst
@@ -590,5 +590,5 @@ For more information on using vector math in Godot, see the following article:
 - :ref:`doc_matrices_and_transforms`
 
 If you would like additional explanation, you should check out
-3Blue1Brown's excellent video series 
+3Blue1Brown's excellent video series
 `Essence of Linear Algebra <https://www.youtube.com/watch?v=fNk_zzaMoSs&list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab>`_.

--- a/tutorials/migrating/upgrading_to_godot_4.2.rst
+++ b/tutorials/migrating/upgrading_to_godot_4.2.rst
@@ -223,7 +223,7 @@ Property ``environment_blend_mode`` added                                       
 ========================================================================================================================  ===================  ====================  ====================  ===========
 
 .. note::
-    
+
     This change breaks compatibility in C# because the new property conflicts with the name of an existing enum
     and the C# bindings generator gives priority to properties, so the enum type was renamed from
     ``EnvironmentBlendMode`` to ``EnvironmentBlendModeEnum``.

--- a/tutorials/migrating/upgrading_to_godot_4.rst
+++ b/tutorials/migrating/upgrading_to_godot_4.rst
@@ -72,7 +72,7 @@ in future Godot releases:
   enable the project setting :ref:`HDR 2D<class_ProjectSettings_property_rendering/viewport/hdr_2d>`
   to perform 2D rendering in HDR. See also :ref:`doc_environment_and_post_processing_using_glow_in_2d`.
 - While rendering still happens in HDR in 3D when using the Forward+ or Mobile
-  renderers, Viewports cannot return HDR data anymore. This is planned to be 
+  renderers, Viewports cannot return HDR data anymore. This is planned to be
   restored at some point in the future.
 - Mono was replaced by .NET 6. This means exporting C# projects to Android, iOS
   and HTML5 is no longer supported for now. Exporting C# projects to desktop
@@ -409,7 +409,7 @@ table to find its new name.
 - AcceptDialog's ``set_autowrap()`` is now ``set_autowrap_mode()``.
 - AnimationNode's ``process()`` is now ``_process()``
   (note the leading underscore, which denotes a virtual method).
-- AnimationPlayer's ``add_animation()`` is now ``add_animation_library()`` and now uses an :ref:`class_AnimationLibrary`. 
+- AnimationPlayer's ``add_animation()`` is now ``add_animation_library()`` and now uses an :ref:`class_AnimationLibrary`.
 - AnimationTree's ``set_process_mode()`` is now ``set_process_callback()``.
 - Array's ``empty()`` is now ``is_empty()``.
 - Array's ``invert()`` is now ``reverse()``.
@@ -549,7 +549,7 @@ environment effect and its visual knobs remain within the Environment resource.
 Updating shaders
 ~~~~~~~~~~~~~~~~
 
-There have been some changes to shaders that aren't covered by the upgrade tool. 
+There have been some changes to shaders that aren't covered by the upgrade tool.
 You will need to make some manual changes, especially if your shader uses coordinate
 space transformations or a custom ``light()`` function.
 
@@ -567,19 +567,19 @@ Some notable changes you will need to perform in shaders are:
 - Particles shaders no longer use the ``vertex()`` processor function. Instead
   they use ``start()`` and ``process()``.
 - In the Forward+ and Mobile renderers, normalized device coordinates now have a Z-range of ``[0.0,1.0]``
-  instead of ``[-1.0,1.0]``. When reconstructing NDC from ``SCREEN_UV`` and depth, use 
-  ``vec3 ndc = vec3(SCREEN_UV * 2.0 - 1.0, depth);`` instead of 
+  instead of ``[-1.0,1.0]``. When reconstructing NDC from ``SCREEN_UV`` and depth, use
+  ``vec3 ndc = vec3(SCREEN_UV * 2.0 - 1.0, depth);`` instead of
   ``vec3 ndc = vec3(SCREEN_UV, depth) * 2.0 - 1.0;``. The Compatibility renderer is unchanged,
   using the same NDC Z-range as 3.x.
 - The lighting model changed. If your shader has a custom ``light()`` function,
   you may need to make changes to get the same visual result.
-- In 4.3 and up, the reverse Z depth buffer technique is now implemented, which 
-  may break advanced shaders. See 
+- In 4.3 and up, the reverse Z depth buffer technique is now implemented, which
+  may break advanced shaders. See
   `Introducing Reverse Z (AKA I'm sorry for breaking your shader) <https://godotengine.org/article/introducing-reverse-z/>`__.
 
 See :ref:`doc_shading_language` for more information.
 
-This list is not exhaustive. If you made all the changes mentioned here and your 
+This list is not exhaustive. If you made all the changes mentioned here and your
 shader still doesn't work, try asking for help in one of the `community channels <https://godotengine.org/community/>`__.
 
 Updating scripts to take backwards-incompatible changes into account

--- a/tutorials/navigation/navigation_different_actor_area_access.rst
+++ b/tutorials/navigation/navigation_different_actor_area_access.rst
@@ -5,7 +5,7 @@ Support different actor area access
 
 .. image:: img/nav_actor_doors.png
 
-A typical example for different area access in gameplay are doors that connect rooms 
+A typical example for different area access in gameplay are doors that connect rooms
 with different navigation meshes and are not accessible by all actors all the time.
 
 Add a NavigationRegion at the door position.
@@ -13,7 +13,7 @@ Add an appropriate navigation mesh the size of the door that can connect with th
 In order to control access, enable / disable navigation layer bits so path queries
 that use the same navigation layer bits can find a path through the "door" navigation mesh.
 
-The bitmask can act as a set of door keys or abilities and only actors with at least 
+The bitmask can act as a set of door keys or abilities and only actors with at least
 one matching and enabled bit layer in their pathfinding query will find a path through this region.
 See :ref:`doc_navigation_advanced_using_navigationlayers` for more information on how to work with navigation layers and the bitmask.
 
@@ -21,7 +21,7 @@ See :ref:`doc_navigation_advanced_using_navigationlayers` for more information o
 
 The entire "door" region can also be enabled / disable if required but if disabled will block access for all path queries.
 
-Prefer working with navigation layers in path queries whenever possible as enabling or disabling 
+Prefer working with navigation layers in path queries whenever possible as enabling or disabling
 navigation layers on a region triggers a costly recalculation of the navigation map connections.
 
 .. warning::

--- a/tutorials/navigation/navigation_introduction_2d.rst
+++ b/tutorials/navigation/navigation_introduction_2d.rst
@@ -14,7 +14,7 @@ Godot provides the following objects and classes for 2D navigation:
     The AStar2D class is best suited for cell-based 2D gameplay that does not require actors to reach any possible position within an area but only predefined, distinct positions.
 
 - :ref:`AstarGrid2D<class_AstarGrid2D>`
-    ``AstarGrid2D``  is a variant of AStar2D that is specialized for partial 2D grids. 
+    ``AstarGrid2D``  is a variant of AStar2D that is specialized for partial 2D grids.
 
     AstarGrid2D is simpler to use when applicable because it doesn't require you to manually create points and connect them together.
 

--- a/tutorials/navigation/navigation_optimizing_performance.rst
+++ b/tutorials/navigation/navigation_optimizing_performance.rst
@@ -21,7 +21,7 @@ Performance problems with parsing scene tree nodes
 .. tip::
 
     Prefer using simple shapes with as few edges as possible e.g. nothing rounded like a circle, sphere or torus.
-    
+
     Prefer using physics collision shapes over complex visual meshes as source geometry as meshes need to be copied from the GPU and are commonly much more detailed than necessary.
 
 In general avoid using very complex geometry as source geometry for baking navigation meshes.
@@ -40,9 +40,9 @@ Performance problems with navigation mesh baking
 .. tip::
 
     At runtime, always prefer to use a background thread for baking navigation meshes.
-    
+
     Increase NavigationMesh ``cell_size`` and ``cell_height`` to create less voxels.
-    
+
     Change the ``SamplePartitionType`` from watershed to monotone or layers to gain baking performance.
 
 .. warning::
@@ -66,7 +66,7 @@ Performance problems with NavigationAgent path queries
 .. tip::
 
     Avoid unnecessary path resets and queries every frame in NavigationAgent scripts.
-    
+
     Avoid updating all NavigationAgent paths in the same frame.
 
 Logical errors and wasteful operations in the custom NavigationAgent scripts are very common causes of performance issues, e.g. watch out for resetting the path every single frame.

--- a/tutorials/navigation/navigation_using_navigationpathqueryobjects.rst
+++ b/tutorials/navigation/navigation_using_navigationpathqueryobjects.rst
@@ -6,9 +6,9 @@ Using NavigationPathQueryObjects
 .. tip::
 
     Path query parameters expose various options to improve pathfinding performance or lower memory consumption.
-    
+
     They cater to more advanced pathfinding needs that the high-level nodes can not always cover.
-    
+
     See the respective option sections below.
 
 ``NavigationPathQueryObjects`` can be used together with ``NavigationServer.query_path()``
@@ -117,19 +117,19 @@ E.g. the closest edge point on a navigation mesh polygon might cause a huge deto
 In order to improve the quality of paths returned by the query various ``path_postprocessing`` options exist.
 
 - The ``PATH_POSTPROCESSING_CORRIDORFUNNEL`` post-processing shortens paths by funneling paths around corners **inside the available polygon corridor**.
-  
+
   This is the default post-processing and usually also the most useful as it gives the shortest path result **inside the available polygon corridor**.
   If the polygon corridor is already suboptimal, e.g. due to a suboptimal navigation mesh layout,
   the funnel can snap to unexpected polygon corners causing detours.
 
 - The ``PATH_POSTPROCESSING_EDGECENTERED`` post-processing forces all path points to be placed in the middle of the crossed polygon edges  **inside the available polygon corridor**.
-  
+
   This post-processing is usually only useful when used with strictly tile-like navigation mesh polygons that are all
   evenly sized and where the expected path following is also constrained to cell centers,
   e.g. typical grid game with movement constrained to grid cell centers.
 
 - The ``PATH_POSTPROCESSING_NONE`` post-processing returns the path as is how the pathfinding traveled **inside the available polygon corridor**.
-  
+
   This post-processing is very useful for debug as it shows how the path search traveled from closest edge point to closet edge point and what polygons it picked.
   A lot of unexpected or suboptimal path results can be immediately explained by looking at this raw path and polygon corridor.
 
@@ -253,7 +253,7 @@ This is not a full working example.
         # ...
 
         var regions_around_start_position: Array[RID] = []
-        
+
         var chunk_rings: int = 1 # Increase for very small regions or more quality.
         var start_chunk_id: Vector3i = floor(p_start_position / float(chunk_size))
         var y: int = 0 # Assume a planar navigation map for simplicity.
@@ -266,7 +266,7 @@ This is not a full working example.
                     regions_around_start_position.push_back(region)
 
         query_parameters.included_regions = regions_around_start_position
-        
+
         # ...
 
 Path clipping and limits

--- a/tutorials/physics/interpolation/advanced_physics_interpolation.rst
+++ b/tutorials/physics/interpolation/advanced_physics_interpolation.rst
@@ -24,13 +24,13 @@ an entire subscene.
 .. figure:: img/physics_interpolation_mode.webp
 
 It is worth noting that, both in 2D and 3D, physics interpolation is performed
-on the **local transform** of each instance. During rendering, interpolated local 
+on the **local transform** of each instance. During rendering, interpolated local
 transforms are passed down to children.
 
-This means that if a parent has ``physics_interpolation_mode`` set to ``On``, 
+This means that if a parent has ``physics_interpolation_mode`` set to ``On``,
 but the child is set to ``Off``, the child will still be interpolated if the parent
 is moving. *Only the child's local transform is uninterpolated.*
-Controlling the on / off behavior of nodes therefore requires some 
+Controlling the on / off behavior of nodes therefore requires some
 thought and planning.
 
 The most common situation where you may want to perform your own interpolation is
@@ -111,29 +111,29 @@ Here is an example of a simple fixed camera which follows an interpolated target
 .. code-block:: gdscript
 
     extends Camera3D
-        
+
     # Node that the camera will follow
     var _target
-        
+
     # We will smoothly lerp to follow the target
     # rather than follow exactly
     var _target_pos : Vector3 = Vector3()
-        
+
     func _ready() -> void:
         # Find the target node
         _target = get_node("../Player")
-        
+
         # Turn off automatic physics interpolation for the Camera3D,
         # we will be doing this manually
         set_physics_interpolation_mode(Node.PHYSICS_INTERPOLATION_MODE_OFF)
-        
+
     func _process(delta: float) -> void:
         # Find the current interpolated transform of the target
         var tr : Transform = _target.get_global_transform_interpolated()
-        
-        # Provide some delayed smoothed lerping towards the target position 
+
+        # Provide some delayed smoothed lerping towards the target position
         _target_pos = lerp(_target_pos, tr.origin, min(delta, 1.0))
-        
+
         # Fixed camera position, but it will follow the target
         look_at(_target_pos, Vector3(0, 1, 0))
 

--- a/tutorials/physics/rigid_body.rst
+++ b/tutorials/physics/rigid_body.rst
@@ -45,7 +45,7 @@ Here is a custom ``look_at()`` method called ``look_follow()`` that will work wi
         var local_speed: float = clampf(speed, 0, acos(forward_dir.dot(target_dir)))
         if forward_dir.dot(target_dir) > 1e-4:
             state.angular_velocity = local_speed * forward_dir.cross(target_dir) / state.step
-    
+
     func _integrate_forces(state):
         var target_position = $my_target_node3d_node.global_transform.origin
         look_follow(state, global_transform, target_position)
@@ -77,9 +77,9 @@ Here is a custom ``look_at()`` method called ``look_follow()`` that will work wi
     }
 
 
-This method uses the rigid body's ``angular_velocity`` property to rotate the body. 
-The axis to rotate around is given by the cross product between the current forward direction and the direction one wants to look in. 
-The ``clamp`` is a simple method used to prevent the amount of rotation from going past the direction which is wanted to be looked in, 
-as the total amount of rotation needed is given by the arccosine of the dot product. 
-This method can be used with ``axis_lock_angular_*`` as well. If more precise control is needed, solutions such as ones relying on :ref:`class_Quaternion` may be required, 
+This method uses the rigid body's ``angular_velocity`` property to rotate the body.
+The axis to rotate around is given by the cross product between the current forward direction and the direction one wants to look in.
+The ``clamp`` is a simple method used to prevent the amount of rotation from going past the direction which is wanted to be looked in,
+as the total amount of rotation needed is given by the arccosine of the dot product.
+This method can be used with ``axis_lock_angular_*`` as well. If more precise control is needed, solutions such as ones relying on :ref:`class_Quaternion` may be required,
 as discussed in :ref:`doc_using_transforms`.

--- a/tutorials/platform/android/android_library.rst
+++ b/tutorials/platform/android/android_library.rst
@@ -95,7 +95,7 @@ Below we break-down the steps used to create the GLTF Viewer app.
 - If using ``gradle``, include the following ``aaptOptions`` configuration under the ``android > defaultConfig`` section of the app's gradle build file. Doing so allows ``gradle`` to include Godot's hidden directories when building the app binary.
 
   - If your build system does not support including hidden directories, you can
-    configure the Godot project to not use hidden directories by deselecting 
+    configure the Godot project to not use hidden directories by deselecting
     :ref:`Application > Config > Use Hidden Project Data Directory<class_ProjectSettings_property_application/config/use_hidden_project_data_directory>`
     in the Project Settings.
 
@@ -182,7 +182,7 @@ Below we break-down the steps used to create the GLTF Viewer app.
   Example:
 
   .. code-block:: java
-  
+
     @Override
     public List<String> getCommandLine(){
         List<String> results = new ArrayList<>();

--- a/tutorials/platform/android/javaclasswrapper_and_androidruntimeplugin.rst
+++ b/tutorials/platform/android/javaclasswrapper_and_androidruntimeplugin.rst
@@ -20,7 +20,7 @@ which provides an interface to access and use Android APIs or third-party librar
     }
 
 
-Writing an Android plugin however requires knowledge of Java or Kotlin code, which most Godot developers do not have. 
+Writing an Android plugin however requires knowledge of Java or Kotlin code, which most Godot developers do not have.
 As such there are many Android APIs and third-party libraries that don't have a Godot plugin that developers can interface with.
 In fact, this is one of the main reasons that developers cite for not being able to switch to Godot from other game engines.
 
@@ -78,7 +78,7 @@ This is **huge** for the adoption of Godot for Android development:
     For exports using ``gradle``, Godot will automatically include ``.jar`` or ``.aar`` files it find in the project ``addons`` directory.
     So to use a third-party library, you can just drop its ``.jar`` or ``.aar`` file in the ``addons`` directory, and call its method directly from GDScript using ``JavaClassWrapper``.
 
-Example: Show an Android toast 
+Example: Show an Android toast
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: gdscript
@@ -109,7 +109,7 @@ Example: Vibrate the device
         # Retrieve the Android Vibrator system service and check if the device supports it.
         var vibrator_service = android_runtime.getApplicationContext().getSystemService("vibrator")
         if vibrator_service and vibrator_service.hasVibrator():
-            # Configure and run a VibrationEffect. 
+            # Configure and run a VibrationEffect.
             var VibrationEffect = JavaClassWrapper.wrap("android.os.VibrationEffect")
             var effect = VibrationEffect.createOneShot(500, VibrationEffect.DEFAULT_AMPLITUDE)
             vibrator_service.vibrate(effect)
@@ -155,7 +155,7 @@ Example: Saving an image to the Android gallery
 .. code-block:: gdscript
 
     # Retrieve the AndroidRuntime singleton.
-    var android_runtime = Engine.get_singleton("AndroidRuntime")	
+    var android_runtime = Engine.get_singleton("AndroidRuntime")
     if android_runtime:
         var Intent = JavaClassWrapper.wrap("android.content.Intent")
         var activity = android_runtime.getActivity()

--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -631,7 +631,7 @@ Scripts that extend EditorScript **must** be ``@tool`` scripts to function.
     an external editor, use one of the last two approaches to run the script.
 
 .. note::
-    
+
     C# EditorScripts cannot be run from the script editor as it only supports
     GDScript. Please refer to the above alternative approaches to run custom C#
     EditorScripts.
@@ -682,7 +682,7 @@ doubles the range of all OmniLight3D nodes:
             public override void _Run()
             {
                 var sceneNode = EditorInterface.Singleton.GetEditedSceneRoot();
-            
+
                 foreach (OmniLight3D node in sceneNode.FindChildren("", "OmniLight3D"))
                 {
                     // Don't operate on instanced subscene children, as changes are lost

--- a/tutorials/rendering/compositor.rst
+++ b/tutorials/rendering/compositor.rst
@@ -61,7 +61,7 @@ This is the boilerplate code that makes our compute shader work.
 
 .. tabs::
  .. code-tab:: gdscript GDScript
- 
+
     const template_shader: String = """
     #version 450
 
@@ -97,23 +97,23 @@ This is the boilerplate code that makes our compute shader work.
 
     private const string _templateShader = @"
     #version 450
-    
+
     // Invocations in the (x, y, z) dimension
     layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
-    
+
     layout(rgba16f, set = 0, binding = 0) uniform image2D color_image;
-    
+
     // Our push constant
     layout(push_constant, std430) uniform Params {
 	    vec2 raster_size;
 	    vec2 reserved;
     } params;
-    
+
     // The code we want to execute in each invocation
     void main() {
 	    ivec2 uv = ivec2(gl_GlobalInvocationID.xy);
 	    ivec2 size = ivec2(params.raster_size);
-    
+
 	    if (uv.x >= size.x || uv.y >= size.y) {
 		    return;
 	    }
@@ -141,7 +141,7 @@ We'll also define a few script variables we'll be using:
 
 .. tabs::
  .. code-tab:: gdscript GDScript
- 
+
     @export_multiline var shader_code: String = "":
         set(value):
             mutex.lock()
@@ -364,7 +364,7 @@ code was changed.
         {
             return false;
         }
-        
+
         _pipeline = _rd.ComputePipelineCreate(_shader);
         return _pipeline.IsValid;
     }
@@ -443,7 +443,7 @@ this at the right stage of rendering.
                     rd.compute_list_end()
 
  .. code-tab:: csharp
-    
+
     // Called by the rendering thread every frame.
     public override void _RenderCallback(int effectCallbackType, RenderData renderData)
     {
@@ -457,7 +457,7 @@ this at the right stage of rendering.
             {
                 // Get our render size, this is the 3D resolution!
                 var size = renderSceneBuffers.GetInternalSize();
-                if (size.X == 0 && size.Y == 0) 
+                if (size.X == 0 && size.Y == 0)
                 {
                     return;
                 }

--- a/tutorials/rendering/drawable_textures.rst
+++ b/tutorials/rendering/drawable_textures.rst
@@ -169,7 +169,7 @@ texture to a new DrawableTexture.
         texture.setup(500, 500, DrawableTexture2D.DRAWABLE_FORMAT_RGBA8, false)
 
  .. code-tab:: csharp
-    
+
     private DrawableTexture2D _texture = new DrawableTexture2D();
 
     public override void _Ready()
@@ -216,8 +216,8 @@ InputMouseMotion events:
             // Calculate rect to center our drawn rectangle on mouse position
             // instead of mouse at top left.
             var rect = new Rect2I(
-                (int)(eventMouseMotion.Position.X - 10),  
-                (int)(eventMouseMotion.Position.Y - 10), 
+                (int)(eventMouseMotion.Position.X - 10),
+                (int)(eventMouseMotion.Position.Y - 10),
                 20, 20);
             _texture.BlitRect(rect, null);
         }
@@ -248,7 +248,7 @@ and use a red color as the ``modulate`` parameter.
         // Calculate rect to center our drawn rectangle on mouse position
         // instead of mouse at top left.
         var rect = new Rect2I(
-            (int)(eventMouseMotion.Position.X - 10), 
+            (int)(eventMouseMotion.Position.X - 10),
             (int)(eventMouseMotion.Position.Y - 10),
             20, 20);
         _texture.BlitRect(rect, GD.Load<Texture2D>("res://circle.svg"), Colors.Red);
@@ -302,7 +302,7 @@ smaller strokes.
             // Calculate rect to center our drawn rectangle on mouse position
             // instead of mouse at top left.
             var rect = new Rect2I(
-                (int)(eventMouseMotion.Position.X - _mySize / 2), 
+                (int)(eventMouseMotion.Position.X - _mySize / 2),
                 (int)(eventMouseMotion.Position.Y - _mySize / 2),
                 _mySize, _mySize);
             _texture.BlitRect(rect, GD.Load<Texture2D>("res://circle.svg"), _myColor);
@@ -318,4 +318,4 @@ smaller strokes.
     {
         _mySize = (int)value;
     }
-    
+

--- a/tutorials/scripting/change_scenes_manually.rst
+++ b/tutorials/scripting/change_scenes_manually.rst
@@ -135,7 +135,7 @@ a scene's data between scene changes (adding the scene to the root node).
 
 Another case may be displaying multiple scenes at the same time using
 :ref:`SubViewportContainers <class_SubViewportContainer>`. This is optimal for
-rendering different content in different parts of the screen (e.g. minimaps, 
+rendering different content in different parts of the screen (e.g. minimaps,
 split-screen multiplayer).
 
 Each option will have cases where it is best appropriate, so you must examine

--- a/tutorials/scripting/filesystem.rst
+++ b/tutorials/scripting/filesystem.rst
@@ -96,7 +96,7 @@ the project) will break existing references to these assets. These references wi
 have to be re-defined to point at the new asset location.
 
 To avoid this, do all your move, delete and rename operations from within Godot, on
-the FileSystem dock. When you delete files in Godot, it will prompt you with a confirmation dialog 
+the FileSystem dock. When you delete files in Godot, it will prompt you with a confirmation dialog
 listing all selected files and any scenes that depend on those files.
 Never move assets from outside Godot, or dependencies will have
 to be fixed manually (Godot detects this and helps you fix them anyway, but why

--- a/tutorials/scripting/gdscript/gdscript_advanced.rst
+++ b/tutorials/scripting/gdscript/gdscript_advanced.rst
@@ -458,9 +458,9 @@ And it can be used like any other iterator:
     for i in itr:
         print(i) # Will print 0, 2, and 4.
 
-It is possible but discouraged to store the state in a member variable. 
+It is possible but discouraged to store the state in a member variable.
 Multiple states are necessary in cases such as nested loops where the same
-iterator instance is used simultaneously. The ``iter`` parameter in 
+iterator instance is used simultaneously. The ``iter`` parameter in
 ``_iter_init()`` and ``_iter_next()`` is a single-element array so that updates
 can persist. Whereas in ``_iter_get()``, the state is is not wrapped because it
 is supposed to be read-only.

--- a/tutorials/scripting/gdscript/gdscript_format_string.rst
+++ b/tutorials/scripting/gdscript/gdscript_format_string.rst
@@ -222,7 +222,7 @@ avoid reading it as a placeholder. This is done by doubling the character:
 String format method
 --------------------
 
-There is also another way to format text in GDScript, namely the 
+There is also another way to format text in GDScript, namely the
 :ref:`String.format() <class_String_method_format>`
 method. It replaces all occurrences of a key in the string with the corresponding
 value. The method can handle arrays or dictionaries for the key/value pairs.

--- a/tutorials/scripting/pausing_games.rst
+++ b/tutorials/scripting/pausing_games.rst
@@ -57,7 +57,7 @@ You can also alter the property with code:
         ProcessMode = Node.ProcessModeEnum.Pausable;
     }
 
-This is what each mode tells a node to do:  
+This is what each mode tells a node to do:
 
 -  **Inherit**: Process depending on the state of the parent,
    grandparent, etc. The first parent that has a non-Inherit state.

--- a/tutorials/shaders/shader_reference/fog_shader.rst
+++ b/tutorials/shaders/shader_reference/fog_shader.rst
@@ -21,8 +21,8 @@ touch a given :ref:`FogVolume <class_FogVolume>` will still be used.
 Built-ins
 ---------
 
-Values marked as ``in`` are read-only. Values marked as ``out`` can optionally 
-be written to and will not necessarily contain sensible values. Samplers cannot 
+Values marked as ``in`` are read-only. Values marked as ``out`` can optionally
+be written to and will not necessarily contain sensible values. Samplers cannot
 be written to so they are not marked.
 
 Global built-ins

--- a/tutorials/shaders/shader_reference/particle_shader.rst
+++ b/tutorials/shaders/shader_reference/particle_shader.rst
@@ -10,7 +10,7 @@ or Spatial, depending on whether they are 2D or 3D.
 
 Particle shaders are unique because they are not used to draw the object itself;
 they are used to calculate particle properties, which are then used by a
-:ref:`CanvasItem<doc_canvas_item_shader>` or :ref:`Spatial<doc_spatial_shader>` 
+:ref:`CanvasItem<doc_canvas_item_shader>` or :ref:`Spatial<doc_spatial_shader>`
 shader. They contain two processor functions: ``start()`` and ``process()``.
 
 Unlike other shader types, particle shaders keep the data that was output the

--- a/tutorials/shaders/shader_reference/sky_shader.rst
+++ b/tutorials/shaders/shader_reference/sky_shader.rst
@@ -139,8 +139,8 @@ a lower resolution than the rest of the sky:
 Built-ins
 ---------
 
-Values marked as ``in`` are read-only. Values marked as ``out`` can optionally 
-be written to and will not necessarily contain sensible values. Samplers cannot 
+Values marked as ``in`` are read-only. Values marked as ``out`` can optionally
+be written to and will not necessarily contain sensible values. Samplers cannot
 be written to so they are not marked.
 
 Global built-ins

--- a/tutorials/shaders/visual_shaders.rst
+++ b/tutorials/shaders/visual_shaders.rst
@@ -153,7 +153,7 @@ These ports are colored to differentiate type of port:
      - A texture sampler. It can be used to sample textures.
      - |sampler|
 
-All of the types are used in the calculations of vertices, fragments, and lights in the shader. For example: matrix multiplication, 
+All of the types are used in the calculations of vertices, fragments, and lights in the shader. For example: matrix multiplication,
 vector addition, or scalar division.
 
 There are other types but these are the main ones.

--- a/tutorials/shaders/your_first_shader/your_first_2d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_first_2d_shader.rst
@@ -206,14 +206,14 @@ which is called on the node's material resource. With a Sprite2D node, the
 following code can be used to set the ``blue`` uniform.
 
 .. tabs::
- 
+
  .. code-tab:: gdscript
 
   var blue_value = 1.0
   material.set_shader_parameter("blue", blue_value)
 
  .. code-tab:: csharp
-  
+
   var blueValue = 1.0;
   ((ShaderMaterial)Material).SetShaderParameter("blue", blueValue);
 

--- a/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
@@ -200,7 +200,7 @@ Now, access the noise texture using the ``texture()`` function:
 :ref:`texture() <shader_func_texture>` takes a texture as the first argument and
 a ``vec2`` for the position on the texture as the second argument. We use the
 ``x`` and ``z`` channels of ``VERTEX`` to determine where on the texture to look
-up. 
+up.
 
 Since the PlaneMesh coordinates are within the ``[-1.0, 1.0]`` range (for a size
 of ``2.0``), while the texture coordinates are within ``[0.0, 1.0]``, to remap
@@ -290,7 +290,7 @@ the 3D scene toolbar, turn off preview sunlight.
 Note how the mesh color goes flat. This is because the lighting on it is flat.
 Let's add a light!
 
-First, we will add an :ref:`OmniLight3D<class_OmniLight3D>` to the scene, and 
+First, we will add an :ref:`OmniLight3D<class_OmniLight3D>` to the scene, and
 drag it up so it is above the terrain.
 
 .. image:: img/light.webp

--- a/tutorials/xr/ar_passthrough.rst
+++ b/tutorials/xr/ar_passthrough.rst
@@ -53,8 +53,8 @@ This mode determines how the (real world) environment is blended with the virtua
       On see-through devices that support this, the alpha will control the translucency
       of the optics.
       On video-passthrough devices alpha blending is applied with the video image.
-      passthrough will also be enabled if applicable. 
-        
+      passthrough will also be enabled if applicable.
+
 You can set the environment blend mode for your application through the ``environment_blend_mode``
 property of the :ref:`XRInterface <class_xrinterface>` instance.
 

--- a/tutorials/xr/arcore_intro.rst
+++ b/tutorials/xr/arcore_intro.rst
@@ -3,7 +3,7 @@
 ARCore
 ======
 
-ARCore is an Android API that allows phone based AR applications to work on the device. 
+ARCore is an Android API that allows phone based AR applications to work on the device.
 Support for this API is offered through the `Godot ARCore plugin. <https://github.com/godotvr/godot_arcore>`__
 
 For more information, please consult the documentation provided with the plugin.

--- a/tutorials/xr/basic_xr_locomotion.rst
+++ b/tutorials/xr/basic_xr_locomotion.rst
@@ -23,7 +23,7 @@ This node governs the in game movement of your character and will immediately re
 So to prevent our player from infinitely falling down we'll quickly add a floor to our scene.
 
 We start by adding a :ref:`StaticBody3D <class_staticbody3d>` node to our root node and we rename this to ``Floor``.
-We add a :ref:`MeshInstance3D <class_meshinstance3d>` node as a child node for our ``Floor``. 
+We add a :ref:`MeshInstance3D <class_meshinstance3d>` node as a child node for our ``Floor``.
 Then create a new :ref:`PlaneMesh <class_planemesh>` as its mesh.
 For now we set the size of the mesh to 100 x 100 meters.
 Next we add a :ref:`CollisionShape3D <class_collisionshape3d>` node as a child node for our ``Floor``.
@@ -87,6 +87,6 @@ More advanced movement features
 
 Godot XR Tools adds many more movement features such as gliding, a grapple hook implementation, a jetpack, climbing mechanics, etc.
 
-Most work similarly to the basic movement features we've handled so far, simply add the relevant subscene from the plugin to the controller that implements it. 
+Most work similarly to the basic movement features we've handled so far, simply add the relevant subscene from the plugin to the controller that implements it.
 
 We'll look at some of these in more detail later on in this tutorial where additional setup is required (such as climbing) but for others please look at Godot XR Tools own help pages for details.

--- a/tutorials/xr/index.rst
+++ b/tutorials/xr/index.rst
@@ -11,7 +11,7 @@ Virtual Reality and Augmented Reality).
    :name: xr-overview
 
    xr_terminology
-   
+
 Getting Started
 ---------------
 

--- a/tutorials/xr/introducing_xr_tools.rst
+++ b/tutorials/xr/introducing_xr_tools.rst
@@ -8,7 +8,7 @@ XR specific game mechanics however need to be implemented on top of this foundat
 While Godot makes this relatively easy this can still be a daunting task.
 
 For this reason Godot has developed a toolkit called `Godot XR Tools <https://github.com/GodotVR/godot-xr-tools>`_
-that implements many of the basic mechanics found in XR games, from locomotion to object interaction to UI interaction. 
+that implements many of the basic mechanics found in XR games, from locomotion to object interaction to UI interaction.
 
 This toolkit is designed to work with both OpenXR and WebXR runtimes.
 We'll be using this as a base for our documentation here.

--- a/tutorials/xr/openxr_composition_layers.rst
+++ b/tutorials/xr/openxr_composition_layers.rst
@@ -6,14 +6,14 @@ OpenXR composition layers
 Introduction
 ------------
 
-In XR games you generally want to create user interactions that happen in 3D space 
+In XR games you generally want to create user interactions that happen in 3D space
 and involve users touching objects as if they are touching them in real life.
 
 Sometimes however creating a more traditional 2D interface is unavoidable.
 In XR however you can't just add 2D components to your scene.
 Godot needs depth information to properly position these elements so they appear at
 a comfortable place for the user.
-Even with depth information there are headsets with slanted displays that make it impossible 
+Even with depth information there are headsets with slanted displays that make it impossible
 for the standard 2D pipeline to correctly render the 2D elements.
 
 The solution then is to render the UI to a :ref:`SubViewport <class_subviewport>`
@@ -25,7 +25,7 @@ The :ref:`QuadMesh <class_quadmesh>` is a suitable option for this.
     example project for an example of this approach.
 
 The problem with displaying the viewport in this way is that the rendered result
-is sampled for lens distortion by the XR runtime and the resulting quality loss 
+is sampled for lens distortion by the XR runtime and the resulting quality loss
 can make UI text hard to read.
 
 OpenXR offers a solution to this problem through composition layers.
@@ -49,7 +49,7 @@ There are currently 3 nodes that expose this functionality:
 
 - :ref:`OpenXRCompositionLayerCylinder <class_OpenXRCompositionLayerCylinder>` shows the contents of the SubViewport on the inside of a cylinder (or "slice" of a cylinder).
 - :ref:`OpenXRCompositionLayerEquirect <class_OpenXRCompositionLayerEquirect>` shows the contents of the SubViewport on the interior of a sphere (or "slice" of a sphere).
-- :ref:`OpenXRCompositionLayerQuad <class_OpenXRCompositionLayerQuad>` shows the contents of the SubViewport on a flat rectangle. 
+- :ref:`OpenXRCompositionLayerQuad <class_OpenXRCompositionLayerQuad>` shows the contents of the SubViewport on a flat rectangle.
 
 Setting up the SubViewport
 --------------------------
@@ -208,7 +208,7 @@ to simulate our mouse moving and send that to our viewport for further processin
                     var from : Vector2 = _intersect_to_viewport_pos(was_intersect)
                     var to : Vector2 = _intersect_to_viewport_pos(intersect)
                     if was_pressed:
-                        event.button_mask = MOUSE_BUTTON_MASK_LEFT 
+                        event.button_mask = MOUSE_BUTTON_MASK_LEFT
                     event.relative = to - from
                     event.position = to
                     layer_viewport.push_input(event)

--- a/tutorials/xr/openxr_hand_tracking.rst
+++ b/tutorials/xr/openxr_hand_tracking.rst
@@ -97,7 +97,7 @@ Hand tracking node
 ~~~~~~~~~~~~~~~~~~
 
 The hand tracking system uses separate hand trackers to track the position of the player's hands
-within our tracking space. 
+within our tracking space.
 
 This information has been separated out for the following use cases:
 
@@ -117,7 +117,7 @@ For this you need to add an :ref:`XRNode3D <class_xrnode3d>` node to your ``XROr
     for the left or right hand respectively.
  *  The ``pose`` should remain set to ``default``, no other option will work here.
  *  The checkbox ``Show When Tracked`` will automatically hide this node if no tracking data is available,
-    or make this node visible if tracking data is available. 
+    or make this node visible if tracking data is available.
 
 Rigged hand mesh
 ~~~~~~~~~~~~~~~~
@@ -150,7 +150,7 @@ You can also set the ``Bone Update`` mode on this node.
  *  ``Rotation Only`` will only apply rotation to the bones of the hands and keep the bone length as is.
     In this mode the size of the hand mesh doesn't change.
 
-With this added, when we run the project we should see the hand correctly displayed if hand tracking is supported. 
+With this added, when we run the project we should see the hand correctly displayed if hand tracking is supported.
 
 The hand tracking data source
 -----------------------------
@@ -274,7 +274,7 @@ Note that in this profile the ``aim pose`` is redefined as a pose between thumb
 and index finger, oriented so a ray cast can be used to identify a target.
 
 Grasp support is exposed through the ``squeeze`` input, the value of which
-is 0.0 when the hand is open, and 1.0 when a fist is made. 
+is 0.0 when the hand is open, and 1.0 when a fist is made.
 
 With this setup the normal ``left_hand`` and ``right_hand`` trackers are used and you can
 thus seamlessly switch between controller and hand tracking input.

--- a/tutorials/xr/openxr_render_models.rst
+++ b/tutorials/xr/openxr_render_models.rst
@@ -42,7 +42,7 @@ OpenXR Render models node
 -------------------------
 
 The :ref:`OpenXRRenderModelManager<class_OpenXRRenderModelManager>`
-node can be used to automate most of the render models functionality. 
+node can be used to automate most of the render models functionality.
 This node keeps track of the active render models currently made
 available by the XR runtime.
 
@@ -123,7 +123,7 @@ This node has a collision shape that encapsulates the hand.
 
 .. note::
 
-    It is important to set the physics priority so that this logic runs 
+    It is important to set the physics priority so that this logic runs
     after any physics logic that moves the XROrigin3D node or the hand
     will lag a frame behind.
 
@@ -184,7 +184,7 @@ transform that places the render model in the correct place and
 animates all the sub objects.
 
 The ``get_top_level_path`` function will return the top level path
-associated with this render model. This will point to either the 
+associated with this render model. This will point to either the
 left or right hand. As the top level path can be set or cleared
 depending on whether the user picks up, or puts down, the controller
 you can connect to the ``render_model_top_level_path_changes`` signal
@@ -222,9 +222,9 @@ in a GDExtension plugin. Such a plugin can call
 create the object that will provide access to that render
 model through the core render models API.
 
-You should not destroy a render model outside of this logic. 
+You should not destroy a render model outside of this logic.
 
-You can connect to the ``render_model_added`` and 
+You can connect to the ``render_model_added`` and
 ``render_model_removed`` signals to be informed when new render
 models are added or removed.
 

--- a/tutorials/xr/openxr_settings.rst
+++ b/tutorials/xr/openxr_settings.rst
@@ -51,7 +51,7 @@ If the device on which you run your game does not match the selection here, Open
 .. note::
   OpenXR has additional view configurations for very specific devices that Godot doesn't support yet.
   For instance, Varjo headsets have a quad view configuration that outputs two sets of stereo images.
-  These may be supported in the near future. 
+  These may be supported in the near future.
 
 Reference Space
 ~~~~~~~~~~~~~~~
@@ -80,7 +80,7 @@ The :ref:`OpenXRInterface <class_openxrinterface>` will also emit the ``pose_rec
 so your game can react accordingly.
 
 .. Note::
-  Any other XR tracked elements such as controllers or anchors will also be adjusted accordingly. 
+  Any other XR tracked elements such as controllers or anchors will also be adjusted accordingly.
 
 .. Warning::
   You should **not** call ``center_on_hmd`` when using this reference space.
@@ -111,7 +111,7 @@ In Godot you can do this by calling the ``center_on_hmd`` function on the :ref:`
   above the :ref:`XROrigin3D <class_xrorigin3d>` node keeping the player's height, similar to the ``Local Floor`` reference space.
 
 .. Note::
-  Any other XR tracked elements such as controllers or anchors will also be adjusted accordingly. 
+  Any other XR tracked elements such as controllers or anchors will also be adjusted accordingly.
 
 Local Floor
 ^^^^^^^^^^^
@@ -143,7 +143,7 @@ so your game can react accordingly.
   It is better to use the Stage mode in this scenario and limit resetting to orientation only when a ``pose_recentered`` signal is received.
 
 .. Note::
-  Any other XR tracked elements such as controllers or anchors will also be adjusted accordingly. 
+  Any other XR tracked elements such as controllers or anchors will also be adjusted accordingly.
 
 .. Warning::
   You should **not** call ``center_on_hmd`` when using this reference space.
@@ -253,10 +253,10 @@ Hand Tracking
 
 This enables the hand tracking extension when supported by the device used. This is on by default for legacy reasons.
 The hand tracking extension provides access to data that allows you to visualise the user's hands with correct finger positions.
-Depending on platform capabilities the hand tracking data can be inferred from controller inputs, come from data gloves, 
+Depending on platform capabilities the hand tracking data can be inferred from controller inputs, come from data gloves,
 come from optical hand tracking sensors or any other applicable source.
 
-If your game only supports controllers this should be turned off. 
+If your game only supports controllers this should be turned off.
 
 See the page on :ref:`hand tracking <doc_openxr_hand_tracking>` for additional details.
 

--- a/tutorials/xr/xr_action_map.rst
+++ b/tutorials/xr/xr_action_map.rst
@@ -106,8 +106,8 @@ This is especially important if you wish to bind the same input on a controller
 to a different action.
 For instance:
 
-  * in your ``Character control`` set you may have an action ``Jump``, 
-  * in your ``Vehicle control`` set you may have an action ``Accelerate``, 
+  * in your ``Character control`` set you may have an action ``Jump``,
+  * in your ``Vehicle control`` set you may have an action ``Accelerate``,
   * in your ``Menu`` set you may have an action ``Select``.
 
 All are bound to the trigger on your controller.
@@ -245,11 +245,11 @@ for controllers.
 There are no rules for which poses are supported for different controllers.
 The poses OpenXR currently defines are:
 
-  * The aim pose on most controllers is positioned slightly in front of the controller 
+  * The aim pose on most controllers is positioned slightly in front of the controller
     and aims forward.
     This is a great pose to use for laser pointers or to align the muzzle of a weapon
     with.
-  * The grip pose on most controllers is positioned where the grip button is placed on 
+  * The grip pose on most controllers is positioned where the grip button is placed on
     the controller.
     The orientation of this pose differs between controllers and can differ for the same
     controller on different XR runtimes.
@@ -295,7 +295,7 @@ The appropriate :ref:`XRController3D <class_xrcontroller3d>` node will emit the 
   You can bind the same action to multiple inputs for the same controller on the same
   profile.
   In this case the XR runtime will attempt to combine the inputs.
-  
+
   * For ``Bool`` inputs, this will perform an ``OR`` operation between the buttons.
   * For ``Float`` inputs, this will take the highest value of the bound inputs.
   * The behavior for ``Pose`` inputs is undefined, but the first bound input is likely to
@@ -309,7 +309,7 @@ The appropriate :ref:`XRController3D <class_xrcontroller3d>` node will emit the 
 
   We are still investigating the restrictions around binding multiple actions to the same
   output as this scenario makes sense.
-  The OpenXR specification seems to not allow this.  
+  The OpenXR specification seems to not allow this.
 
 Now that we have our basic actions defined, it's time to hook them up.
 
@@ -424,23 +424,23 @@ given on that subject earlier in this document.
 
 .. note::
   Some of the inputs seem to appear in our list multiple times.
-  
+
   For instance we can find the ``X`` button twice, once as ``X click`` and then
   as ``X touch``.
   This is due to the Touch controller having a capacitive sensor.
-  
+
   * ``X touch`` will be true if the user is merely touching the X button.
   * ``X click`` will be true when the user is actually pressing down on the button.
 
   Similarly for the thumbstick we have:
-  
+
   * ``Thumbstick touch`` which will be true if the user is touching the thumbstick.
   * ``Thumbstick`` which gives a value for the direction the thumbstick is pushed to.
   * ``Thumbstick click`` which is true when the user is pressing down on the thumbstick.
 
   It is important to note that only a select number of XR controllers support
   touch sensors or have click features on thumbsticks.
-  Keep that in mind when designing your game/application. 
+  Keep that in mind when designing your game/application.
   Make sure these are used for optional features of your game/application.
 
 .. _doc_xr_action_map_simple:

--- a/tutorials/xr/xr_next_steps.rst
+++ b/tutorials/xr/xr_next_steps.rst
@@ -16,7 +16,7 @@ The vendor plugin isn't just for :ref:`deploying to Android <doc_deploying_to_an
 In the vendor plugin, we implement many OpenXR vendor extensions that unlock unique features on certain devices,
 or features that are new enough that a standardized implementation is not available yet.
 
-Together with the OpenXR working group we maintain a 
+Together with the OpenXR working group we maintain a
 `client support matrix <https://github.khronos.org/OpenXR-Inventory/extension_support.html#client_matrix>`_ that lists
 all the OpenXR extensions Godot supports and whether they require the vendor plugin.
 


### PR DESCRIPTION
That sure is a lot of whitespace.

This PR adds a `trailing-whitespace` hook to the pre-commit hook, akin to the `godot` repository.
All affected pages are cleared of trailing whitespace, of course.
Documents in the `classes` are exempt, since they're derived from the class reference and may sometimes be generated with inconsequential whitespace, for some reason.