### PR TITLE
Unlisted gdscript_basics setter exceptions

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -2580,6 +2580,26 @@ This also applies to the alternative syntax:
         func set_my_prop(value):
             my_prop = value # Infinite recursion, since `set_my_prop()` is not the setter.
 
+Setters are also not called when editing or instantiating a key in a dictionary variable
+
+::
+
+        var my_dict: Dictionary:
+            set(value):
+                my_dict = value
+
+        my_dict["key"] = "value" # this will not call the setter
+
+Only if you supplant the variable with another dictionary will the setter be called
+
+::
+
+        var my_dict: Dictionary:
+            set(value):
+                my_dict = value
+
+        my_dict = {} # this replaces the dictionary and calls the setter
+
 .. _doc_gdscript_tool_mode:
 
 Tool mode

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -2590,7 +2590,7 @@ Setters are also not called when editing or instantiating a key in a dictionary 
 
         my_dict["key"] = "value" # This will not call the setter.
 
-Only if you supplant the variable with another dictionary will the setter be called
+Only overwriting the variable will call the setter.
 
 ::
 
@@ -2598,7 +2598,7 @@ Only if you supplant the variable with another dictionary will the setter be cal
             set(value):
                 my_dict = value
 
-        my_dict = {} # this replaces the dictionary and calls the setter
+        my_dict = {} # This replaces the dictionary and calls the setter.
 
 .. _doc_gdscript_tool_mode:
 

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -2580,7 +2580,7 @@ This also applies to the alternative syntax:
         func set_my_prop(value):
             my_prop = value # Infinite recursion, since `set_my_prop()` is not the setter.
 
-Setters are also not called when editing or instantiating a key in a dictionary variable
+Setters are also not called when editing or instantiating a key in a dictionary variable:
 
 ::
 

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -2588,7 +2588,7 @@ Setters are also not called when editing or instantiating a key in a dictionary 
             set(value):
                 my_dict = value
 
-        my_dict["key"] = "value" # this will not call the setter
+        my_dict["key"] = "value" # This will not call the setter.
 
 Only if you supplant the variable with another dictionary will the setter be called
 


### PR DESCRIPTION
add more details to the exceptions of when a setter function for a variable isn't called as they can work differently than expected for dictionary variables.

see the following as evidence
[issue 85578](https://github.com/godotengine/godot/issues/85578)
[pull request 62462](github.com/godotengine/godot/pull/62462)

(my first time making a pull request, hope that was sufficient/alright)

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
