### PR TITLE
Properly link to code regions

### DIFF
--- a/tutorials/editor/script_editor.rst
+++ b/tutorials/editor/script_editor.rst
@@ -270,7 +270,7 @@ The **Edit** menu provides several options for line operations:
   - **Fold All Lines**: Folds all code blocks or code regions in the open document.
   - **Unfold All Lines**: Unfolds all code blocks and code regions in the open document.
   - **Create Code Region***: Wraps the selected text in a foldable code region to improve
-    the readability of larger scripts. See :ref:`doc_gdscript_builtin_types` for more.
+    the readability of larger scripts. See :ref:`doc_gdscript_code_regions` for more.
 
 - **Completion Query**: Suggests from built-in or user created symbols to auto-complete the
   partially written code. :kbd:`Up` and :kbd:`Down` arrows navigate up and down, pressing

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -592,6 +592,8 @@ of a file. Dedicated formatting options are also available. See
     ## This comment will appear in the inspector tooltip, and in the documentation.
     @export var exported_value
 
+.. _doc_gdscript_code_regions:
+
 Code regions
 ------------
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->

Docs mention code regions, but wrongly link to built-in types instead.