### PR TITLE
correct FRAGCOORD ranges

### DIFF
--- a/tutorials/shaders/shader_reference/canvas_item_shader.rst
+++ b/tutorials/shaders/shader_reference/canvas_item_shader.rst
@@ -217,10 +217,10 @@ it to the ``NORMAL_MAP`` property. Godot will handle converting it for use in 2D
 +---------------------------------------------+---------------------------------------------------------------+
 | Built-in                                    | Description                                                   |
 +=============================================+===============================================================+
-| in vec4 **FRAGCOORD**                       | Coordinate of pixel center. In screen space. ``xy`` specifies |
+| in vec4 **FRAGCOORD**                       | Coordinate of pixel center, in pixels. ``xy`` specifies       |
 |                                             | position in viewport. Upper-left of the viewport is the       |
-|                                             | origin, ``(0.0, 0.0)``. Bottom-right of the viewport is       |
-|                                             | ``(1.0, 1.0)``.                                               |
+|                                             | origin, ``(0, 0)``. Multiply by ``SCREEN_PIXEL_SIZE`` for     |
+|                                             | values from ``0.0`` to ``1.0``.                               |
 +---------------------------------------------+---------------------------------------------------------------+
 | in vec2 **SCREEN_PIXEL_SIZE**               | Size of individual pixels. Equal to the inverse of resolution.|
 +---------------------------------------------+---------------------------------------------------------------+

--- a/tutorials/shaders/shader_reference/spatial_shader.rst
+++ b/tutorials/shaders/shader_reference/spatial_shader.rst
@@ -370,7 +370,7 @@ these properties, and if you don't write to them, Godot will optimize away the c
 | in vec2 **VIEWPORT_SIZE**              | Size of viewport (in pixels).                                                                    |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
 | in vec4 **FRAGCOORD**                  | Coordinate of pixel center in screen space. ``xy`` specifies position in window. Upper-left of   |
-|                                        | the viewport is the origin, ``(0.0, 0.0)``. Bottom-right of the viewport is ``(1.0, 1.0)``.      |
+|                                        | the viewport is the origin, ``(0.0, 0.0)``. Bottom-right of the viewport is ``VIEWPORT_SIZE``.   |
 |                                        | ``z`` specifies fragment depth. It is also used as the output value for the fragment depth       |
 |                                        | unless ``DEPTH`` is written to.                                                                  |
 +----------------------------------------+--------------------------------------------------------------------------------------------------+
@@ -578,7 +578,7 @@ If you want the lights to add together, add the light contribution to ``DIFFUSE_
 +-----------------------------------+------------------------------------------------------------------------+
 | in vec4 **FRAGCOORD**             | Coordinate of pixel center in screen space. ``xy`` specifies position  |
 |                                   | in window. Upper-left of the viewport is the origin, ``(0.0, 0.0)``.   |
-|                                   | Bottom-right of the viewport is ``(1.0, 1.0)``.                        |
+|                                   | Bottom-right of the viewport is ``VIEWPORT_SIZE``.                     |
 |                                   | ``z`` specifies fragment depth. It is also used as the output value    |
 |                                   | for the fragment depth unless ``DEPTH`` is written to.                 |
 +-----------------------------------+------------------------------------------------------------------------+

--- a/tutorials/shaders/shader_reference/texture_blit_shader.rst
+++ b/tutorials/shaders/shader_reference/texture_blit_shader.rst
@@ -85,9 +85,8 @@ accessed with a ``sampler2D`` using ``hint_blit_source0``,
 +---------------------------------------------+---------------------------------------------------------------+
 | Built-in                                    | Description                                                   |
 +=============================================+===============================================================+
-| in vec4 **FRAGCOORD**                       | Coordinate of pixel center. In screen space. ``xy`` specifies |
-|                                             | position in viewport. Upper-left of the viewport is the       |
-|                                             | origin, ``(0.0, 0.0)``.                                       |
+| in vec4 **FRAGCOORD**                       | Coordinate of pixel center, in screen space. ``xy`` specifies |
+|                                             | position in viewport in pixels from the upper-left.           |
 +---------------------------------------------+---------------------------------------------------------------+
 | in vec2 **UV**                              | UV from the ``vertex()`` function.                            |
 |                                             | This is set to sample all of a source texture.                |


### PR DESCRIPTION
In spatial shaders, FRAGCOORD was incorrectly listed as varying from 0.0 to 1.0. Now it correctly varies from 0.0 to VIEWPORT_SIZE
