### PR TITLE
Fix node Type contradiction

### DIFF
--- a/getting_started/first_2d_game/02.player_scene.rst
+++ b/getting_started/first_2d_game/02.player_scene.rst
@@ -23,7 +23,7 @@ what the object *is*. In the upper-left corner, in the "Scene" tab, click the
     Godot also provides the :ref:`CharacterBody2D <class_CharacterBody2D>` node,
     specifically designed for 2D characters, which includes built-in support for some
     of the processes explained in this tutorial. In many real world projects, CharacterBody2D
-    would be a better choice for players and enemies. However, this tutorial focuses on
+    would be a better choice for the player. However, this tutorial focuses on
     core concepts that apply to a wider range of nodes and use cases.
 
 .. image:: img/add_node.webp


### PR DESCRIPTION
On this page it is said: Area2D is used for players AND enemies. But later in the tutorial, the page after the next one, enemies will be constructed with RigidBody2D nodes.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
