### PR TITLE
Add missing word in exporting_pcks.rst

### DIFF
--- a/tutorials/export/exporting_pcks.rst
+++ b/tutorials/export/exporting_pcks.rst
@@ -99,7 +99,7 @@ and go to :menu:`Project > Export`, select an export preset, and click on
 .. image:: img/export_pck.webp
 
 Another method would be to :ref:`export from the command line <doc_command_line_tutorial_exporting>`
-with ``--export-pack``. The output file must with a ``.pck`` or ``.zip``
+with ``--export-pack``. The output file must end with a ``.pck`` or ``.zip``
 file extension. The export process will build that type of file for the
 chosen platform.
 


### PR DESCRIPTION
Add missing word "end" to clarify that requried file extensions must be at the end of the filename

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
