### PR TITLE
Update the "Built-in types" section of the "GDScript basics" page to match `4.x`

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -685,168 +685,225 @@ A line can be continued multiple times like this:
 
 .. _doc_gdscript_builtin_types:
 
-Built-in types
---------------
+``Variant`` types
+-----------------
 
-Built-in types are stack-allocated. They are passed as values. This means a copy
-is created on each assignment or when passing them as arguments to functions.
-The exceptions are ``Object``, ``Array``, ``Dictionary``, and packed arrays
-(such as ``PackedByteArray``), which are passed by reference so they are shared.
-All arrays, ``Dictionary``, and some objects (``Node``, ``Resource``)
-have a ``duplicate()`` method that allows you to make a copy.
+:ref:`Variant types <doc_variant_class>` are stack-allocated in memory. They are passed
+as values, which means that a copy is created on each assignment or when passed as arguments
+to functions. The exceptions are ``Object``, ``Array``, ``Dictionary``, and packed arrays
+(such as ``PackedByteArray``), which are passed by reference, so every call to it points to
+the same value until assigned a new value. All array types, ``Dictionary``, and some ``Object``
+types (e.g. ``Node``, ``Resource``) have a ``duplicate()`` method that allow you to make a copy.
 
-Basic built-in types
-~~~~~~~~~~~~~~~~~~~~
+Every ``Variant`` type that is not ``null`` or ``Object`` is a built-in type.
 
-A variable in GDScript can be assigned to several built-in types.
+Base ``Variant`` types
+~~~~~~~~~~~~~~~~~~~~~~
 
-null
-^^^^
+``null``
+^^^^^^^^
 
-``null`` is an empty data type that contains no information and can not
-be assigned any other value.
+``null`` is an empty data type that cannot be assigned any other value.
 
-Only types that inherit from Object can have a ``null`` value
-(Object is therefore called a "nullable" type).
-:ref:`Variant types <doc_variant_class>` must have a valid value at all times,
-and therefore cannot have a ``null`` value.
+Only ``Variant`` types that inherit from ``Object`` can have a ``null`` value. ``Object``
+is therefore a "nullable" type. Built-in types must always have a valid value.
 
-:ref:`bool <class_bool>`
-^^^^^^^^^^^^^^^^^^^^^^^^
+:ref:`class_bool`
+^^^^^^^^^^^^^^^^^
 
-Short for "boolean", it can only contain ``true`` or ``false``.
+Short for "boolean", it can only represent ``true`` or ``false``.
 
-:ref:`int <class_int>`
-^^^^^^^^^^^^^^^^^^^^^^
+:ref:`class_int`
+^^^^^^^^^^^^^^^^
 
-Short for "integer", it stores whole numbers (positive and negative).
-It is stored as a 64-bit value, equivalent to ``int64_t`` in C++.
+Short for "integer", it represents whole numbers (positive and negative). It is stored as a
+signed 64-bit value, equivalent to ``int64_t`` in C++.
 
-:ref:`float <class_float>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+:ref:`class_float`
+^^^^^^^^^^^^^^^^^^
 
-Stores real numbers, including decimals, using floating-point values.
-It is stored as a 64-bit value, equivalent to ``double`` in C++.
-Note: Currently, data structures such as ``Vector2``, ``Vector3``, and
-``PackedFloat32Array`` store 32-bit single-precision ``float`` values.
+Represents real numbers, including decimals, using floating-point values. It is stored as a
+64-bit value, equivalent to ``double`` in C++.
 
-:ref:`String <class_String>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:ref:`class_String`
+^^^^^^^^^^^^^^^^^^^
 
 A sequence of characters in `Unicode format <https://en.wikipedia.org/wiki/Unicode>`_.
 
-:ref:`StringName <class_StringName>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:ref:`class_StringName`
+^^^^^^^^^^^^^^^^^^^^^^^
 
-An immutable string that allows only one instance of each name. They are slower to
-create and may result in waiting for locks when multithreading. In exchange, they're
-very fast to compare, which makes them good candidates for dictionary keys.
+An immutable string used for node names. Only one instance of a unique ``StringName`` string
+exists in memory at a time. Once created, all future ``StringName`` instances of the string
+point to it. It is automatically be converted to and from ``String`` when assigning a variable
+or passing a parameter.
 
-:ref:`NodePath <class_NodePath>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+They are slower to create and may result in waiting for locks when multithreading.
+In exchange, they are faster to compare than ``String``, which make them good candidates
+for dictionary keys.
 
-A pre-parsed path to a node or a node property.  It can be
-easily assigned to, and from, a String. They are useful to interact with
-the tree to get a node, or affecting properties like with :ref:`Tweens <class_Tween>`.
+:ref:`class_NodePath`
+^^^^^^^^^^^^^^^^^^^^^
 
-Vector built-in types
-~~~~~~~~~~~~~~~~~~~~~
+A pre-parsed path to a node or a node property. It is automatically be converted to and from
+``String`` when assigning a variable or passing a parameter. It is used to retrieve information
+from the :ref:`class_SceneTree`, like by using :ref:`Node.get_node() <class_Node_method_get_node>`,
+or to modify properties, such as with :ref:`Tweens <class_Tween>`.
 
-:ref:`Vector2 <class_Vector2>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Math ``Variant`` types
+~~~~~~~~~~~~~~~~~~~~~~
 
-2D vector type containing ``x`` and ``y`` fields. Can also be
+In official builds, these types store 32-bit single-precision values. On double-precision builds,
+they store 64-bit, except for the integer types.
+
+:ref:`class_Vector2`
+^^^^^^^^^^^^^^^^^^^^
+
+2D vector type that contains two float components: ``x`` and ``y``. It can also be
 accessed as an array.
 
-:ref:`Vector2i <class_Vector2i>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:ref:`class_Vector2i`
+^^^^^^^^^^^^^^^^^^^^^
 
-Same as a Vector2 but the components are integers. Useful for representing
-items in a 2D grid.
+Like ``Vector2``, but the components are integers. Used to index values in a 2D grid.
 
-:ref:`Rect2 <class_Rect2>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+:ref:`class_Vector3`
+^^^^^^^^^^^^^^^^^^^^
 
-2D Rectangle type containing two vectors fields: ``position`` and ``size``.
-Also contains an ``end`` field which is ``position + size``.
+3D vector type that contains three float components: ``x``, ``y``, and ``z``. It can also be
+accessed as an array.
 
-:ref:`Vector3 <class_Vector3>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:ref:`class_Vector3i`
+^^^^^^^^^^^^^^^^^^^^^
 
-3D vector type containing ``x``, ``y`` and ``z`` fields. This can also
-be accessed as an array.
+Like ``Vector3``, but the components are integers. Used to index values in a 3D grid.
 
-:ref:`Vector3i <class_Vector3i>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:ref:`class_Vector4`
+^^^^^^^^^^^^^^^^^^^^
 
-Same as Vector3 but the components are integers. Can be use for indexing items
-in a 3D grid.
+4D vector type that contains four float components: ``x``, ``y``, ``z``, and ``w``. It can also be
+accessed as an array.
 
-:ref:`Transform2D <class_Transform2D>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:ref:`class_Vector4i`
+^^^^^^^^^^^^^^^^^^^^^
 
-3×2 matrix used for 2D transforms.
+Like ``Vector4``, but the components are integers. Used to index values in a 4D grid.
 
-:ref:`Plane <class_Plane>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+:ref:`class_Rect2`
+^^^^^^^^^^^^^^^^^^
 
-3D Plane type in normalized form that contains a ``normal`` vector field
-and a ``d`` scalar distance.
+2D rectangle type that contains two ``Vector2`` components: ``position`` and ``size``.
+Also has an ``end`` property that represents ``position + size``.
 
-:ref:`Quaternion <class_Quaternion>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:ref:`class_Rect2i`
+^^^^^^^^^^^^^^^^^^^
 
-Quaternion is a datatype used for representing a 3D rotation. It's
-useful for interpolating rotations.
+Like ``Rect2``, but the components are ``Vector2i``. Used to represent 2D regions.
 
-:ref:`AABB <class_AABB>`
+:ref:`class_Transform2D`
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Axis-aligned bounding box (or 3D box) contains 2 vectors fields: ``position``
-and ``size``. Also contains an ``end`` field which is
-``position + size``.
+2×3 matrix used to represent 2D transformations, including translation, rotation, and scale.
+It contains three ``Vector2`` components: ``x``, ``y``, and ``origin``.
 
-:ref:`Basis <class_Basis>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+:ref:`class_Plane`
+^^^^^^^^^^^^^^^^^^
 
-3x3 matrix used for 3D rotation and scale. It contains 3 vector fields
-(``x``, ``y`` and ``z``) and can also be accessed as an array of 3D
-vectors.
+Normalized 3D plane type that contains a ``Vector3`` component ``normal`` and a float
+component ``d`` that represents scalar distance.
 
-:ref:`Transform3D <class_Transform3D>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:ref:`class_Quaternion`
+^^^^^^^^^^^^^^^^^^^^^^^
 
-3D Transform contains a Basis field ``basis`` and a Vector3 field
-``origin``.
+Like ``Vector4``, but specifically used to represent 3D rotation and have specialized methods
+for this purpose. It is used to interpolate rotations.
 
-Engine built-in types
-~~~~~~~~~~~~~~~~~~~~~
+:ref:`class_AABB`
+^^^^^^^^^^^^^^^^^
 
-:ref:`Color <class_Color>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+3D axis-aligned bounding box that contains two ``Vector3`` components: ``position``
+and ``size``. Also has an ``end`` property that represents ``position + size``.
 
-Color data type contains ``r``, ``g``, ``b``, and ``a`` fields. It can
-also be accessed as ``h``, ``s``, and ``v`` for hue/saturation/value.
+:ref:`class_Basis`
+^^^^^^^^^^^^^^^^^^
 
-:ref:`RID <class_RID>`
-^^^^^^^^^^^^^^^^^^^^^^
+3x3 matrix used to represent 3D rotation and scale. It contains three ``Vector3`` components:
+``x``, ``y``, and ``z``. It can also be accessed as an array.
 
-Resource ID (RID). Servers use generic RIDs to reference opaque data.
+:ref:`class_Transform3D`
+^^^^^^^^^^^^^^^^^^^^^^^^
 
-:ref:`Object <class_Object>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3x4 matrix used to represent 3D transformations, including translation, rotation, and scale.
+It contains a ``Basis`` component ``basis`` and a ``Vector3`` component ``origin``.
 
-Base class for anything that is not a built-in type.
+:ref:`class_Projection`
+^^^^^^^^^^^^^^^^^^^^^^^
 
-Container built-in types
+4x4 matrix used to represent 3D perspective division. It contains four ``Vector4`` components:
+``x``, ``y``, ``z``, and ``w``. It can also be accessed as an array.
+
+Engine ``Variant`` types
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-:ref:`Array <class_Array>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+:ref:`class_Color`
+^^^^^^^^^^^^^^^^^^
 
-Generic sequence of arbitrary object types, including other arrays or dictionaries (see below).
-The array can resize dynamically. Arrays are indexed starting from index ``0``.
-Negative indices count from the end.
+``RGBA`` color data type that contains 32-bit float components: ``r``, ``g``, ``b``, and ``a``,
+ranging from ``0.0`` to ``1.0``. It can also be accessed as ``h``, ``s``, and ``v`` for
+hue, saturation, and value respectively.
+
+:ref:`class_RID`
+^^^^^^^^^^^^^^^^
+
+Resource ID (``RID``), internally stored as a signed 64-bit integer. Servers such as
+:ref:`class_PhysicsServer2D` use RIDs to reference unique resources in its underlying data.
+
+:ref:`class_Object`
+^^^^^^^^^^^^^^^^^^^
+
+Base data type for every native and user-defined class in the engine used by GDScript,
+as they inherit from ``Object``.
+
+:ref:`class_Signal`
+^^^^^^^^^^^^^^^^^^^
+
+An event that can be emitted to any object that listens for it. The ``Signal`` type
+is used for passing the emitter around.
+
+Signals are better used by getting them from objects, e.g. ``$Button.button_up``.
+
+:ref:`class_Callable`
+^^^^^^^^^^^^^^^^^^^^^
+
+Represents a method of an object, which is used for passing functions as values,
+like when connecting to signals.
+
+Getting a method as a member returns a callable. ``var x = $Sprite2D.rotate``
+will set the value of ``x`` to a callable with ``$Sprite2D`` as the object and
+``rotate`` as the method.
+
+You can call it using the :ref:`call <class_Callable_method_call>` method: ``x.call(PI)``.
+
+Collection ``Variant`` types
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Arrays and dictionaries can store any ``Variant`` type, including other arrays or
+dictionaries, native or user-defined classes, or even enums.
+
+They can also be typed, which means that they only allow a certain ``Variant`` type.
+Before adding a value, the engine will check if it matches the specified type. If it does not,
+it will throw an error and pause execution, so the collection will never contain invalid values.
+Unlike with untyped collections, the values of typed arrays and dictionaries will be inferred
+automatically, but methods like :ref:`Array.front() <class_Array_method_front>` and
+:ref:`Dictionary.get() <class_Dictionary_method_get>` still have the ``Variant`` return type.
+Operations on untyped arrays and dictionaries are considered type-unsafe. Nesting types
+(like ``Array[Array[int]]`` or ``Dictionary[String, Dictionary[String, int]]``) is not supported.
+
+:ref:`class_Array`
+^^^^^^^^^^^^^^^^^^
+
+Ordered sequence of ``Variant`` types. Arrays can resize dynamically and are indexed
+starting from index ``0``. Negative indices count from the end.
 
 ::
 
@@ -861,13 +918,9 @@ Negative indices count from the end.
 Typed arrays
 ^^^^^^^^^^^^
 
-Godot also features support for typed arrays. On write operations, Godot checks that
-element values match the specified type, so the array cannot contain invalid values.
-The GDScript static analyzer takes typed arrays into account, however array methods like
-``front()`` and ``back()`` still have the ``Variant`` return type.
+Typed arrays are usually faster to iterate on and modify than untyped arrays.
 
-Typed arrays have the syntax ``Array[Type]``, where ``Type`` can be any ``Variant`` type,
-native or user class, or enum. Nested array types (like ``Array[Array[int]]``) are not supported.
+They have the syntax ``Array[Type]``, where ``Type`` is a ``Variant`` type.
 
 ::
 
@@ -877,7 +930,7 @@ native or user class, or enum. Nested array types (like ``Array[Array[int]]``) a
     var d: Array[MyEnum]
     var e: Array[Variant]
 
-``Array`` and ``Array[Variant]`` are the same thing.
+``Array[Variant]`` is the same as ``Array`` and is untyped.
 
 .. note::
 
@@ -903,50 +956,47 @@ native or user class, or enum. Nested array types (like ``Array[Array[int]]``) a
         # the `assign()` method copies the contents of the array, not the reference.
         b.assign(a)
 
-    The only exception was made for the ``Array`` (``Array[Variant]``) type, for user convenience
-    and compatibility with old code. However, operations on untyped arrays are considered unsafe.
+    Only the untyped ``Array`` type can be assigned a typed array without using the ``assign()``
+    method. When initializing a typed array variable with an untyped array, it will automatically
+    be converted for user convenience.
 
 .. _doc_gdscript_packed_arrays:
 
 Packed arrays
 ^^^^^^^^^^^^^
 
-PackedArrays are generally faster to iterate on and modify compared to a typed
-Array of the same type (e.g. PackedInt64Array versus Array[int]) and consume
-less memory. In the worst case, they are expected to be as fast as an untyped
-Array. Conversely, non-Packed Arrays (typed or not) have extra convenience
-methods such as :ref:`Array.map <class_Array_method_map>` that PackedArrays
-lack. Consult the :ref:`class reference <class_PackedFloat32Array>` for details
-on the methods available. Typed Arrays are generally faster to iterate on and
-modify than untyped Arrays.
+Packed arrays are usually faster to iterate on and modify compared to a typed
+array of the same type (e.g. ``PackedInt64Array`` versus ``Array[int]``) and consume
+less memory. At worst, they are expected to be as fast as an untyped array.
+Non-packed arrays (regardless of type) have extra convenience methods such as
+:ref:`Array.map <class_Array_method_map>` that packed arrays lack. Consult the
+:ref:`class reference <class_PackedFloat32Array>` for details on the methods available.
 
-While all Arrays can cause memory fragmentation when they become large enough,
+While all arrays can cause memory fragmentation when they become large enough,
 if memory usage and performance (iteration and modification speed) is a concern
-and the type of data you're storing is compatible with one of the ``Packed``
-Array types, then using those may yield improvements. However, if you do not
-have such concerns (e.g. the size of your array does not reach the tens of
-thousands of elements) it is likely more helpful to use regular or typed
-Arrays, as they provide convenience methods that can make your code easier to
-write and maintain (and potentially faster if your data requires such
-operations a lot). If the data you will store is of a known type (including
-your own defined classes), prefer to use a typed Array as it may yield better
-performance in iteration and modification compared to an untyped Array.
+and the type of data you're storing is compatible with one of the packed array types,
+then using those may yield improvements. If you do not have such concerns (e.g. the size
+of your array does not reach the tens of thousands of elements), it is likely more helpful
+to use ``Array``, as they provide convenience methods that can make your code easier to write
+and maintain (and potentially faster if your data requires such operations a lot). If the data
+you will store is of a known type, prefer to use a typed array as it may yield better performance
+in iteration and modification compared to an untyped array.
 
-- :ref:`PackedByteArray <class_PackedByteArray>`: An array of bytes (integers from 0 to 255).
-- :ref:`PackedInt32Array <class_PackedInt32Array>`: An array of 32-bit integers.
-- :ref:`PackedInt64Array <class_PackedInt64Array>`: An array of 64-bit integers.
-- :ref:`PackedFloat32Array <class_PackedFloat32Array>`: An array of 32-bit floats.
-- :ref:`PackedFloat64Array <class_PackedFloat64Array>`: An array of 64-bit floats.
-- :ref:`PackedStringArray <class_PackedStringArray>`: An array of strings.
-- :ref:`PackedVector2Array <class_PackedVector2Array>`: An array of :ref:`Vector2 <class_Vector2>` values.
-- :ref:`PackedVector3Array <class_PackedVector3Array>`: An array of :ref:`Vector3 <class_Vector3>` values.
-- :ref:`PackedVector4Array <class_PackedVector4Array>`: An array of :ref:`Vector4 <class_Vector4>` values.
-- :ref:`PackedColorArray <class_PackedColorArray>`: An array of :ref:`Color <class_Color>` values.
+- :ref:`class_PackedByteArray`: An array of unsigned 8-bit integers (ranging from 0 to 255).
+- :ref:`class_PackedInt32Array`: An array of signed 32-bit integers.
+- :ref:`class_PackedInt64Array`: An array of signed 64-bit integers.
+- :ref:`class_PackedFloat32Array`: An array of 32-bit floats.
+- :ref:`class_PackedFloat64Array`: An array of 64-bit floats.
+- :ref:`class_PackedStringArray`: An array of strings.
+- :ref:`class_PackedVector2Array`: An array of :ref:`class_Vector2` values.
+- :ref:`class_PackedVector3Array`: An array of :ref:`class_Vector3` values.
+- :ref:`class_PackedVector4Array`: An array of :ref:`class_Vector4` values.
+- :ref:`class_PackedColorArray`: An array of :ref:`class_Color` values.
 
-:ref:`Dictionary <class_Dictionary>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:ref:`class_Dictionary`
+^^^^^^^^^^^^^^^^^^^^^^^
 
-Associative container which contains values referenced by unique keys.
+Collection type that uses unique keys to reference stored values.
 
 ::
 
@@ -961,8 +1011,8 @@ Associative container which contains values referenced by unique keys.
 
 Lua-style table syntax is also supported. Lua-style uses ``=`` instead of ``:``
 and doesn't use quotes to mark string keys (making for slightly less to write).
-However, keys written in this form can't start with a digit (like any GDScript
-identifier), and must be string literals.
+Keys written in this form can't start with a digit (like any GDScript identifier),
+and must be string literals.
 
 ::
 
@@ -973,8 +1023,7 @@ identifier), and must be string literals.
         more_key = "Hello"
     }
 
-To add a key to an existing dictionary, access it like an existing key and
-assign to it:
+To add a key to an existing dictionary, access it like an existing key and assign to it:
 
 ::
 
@@ -991,25 +1040,17 @@ assign to it:
 
 .. note::
 
-    The bracket syntax can be used to access properties of any
-    :ref:`class_Object`, not just Dictionaries. Keep in mind it will cause a
-    script error when attempting to index a non-existing property. To avoid
-    this, use the :ref:`Object.get() <class_Object_method_get>` and
-    :ref:`Object.set() <class_Object_method_set>` methods instead.
+    The bracket syntax can be used to access properties of any ``Object``, not only
+    ``Dictionary``. Keep in mind, attempting to index a non-existing property/key or assign the
+    wrong type, or for objects, attempting to assign to a non-existing property, will cause a
+    script error. To avoid this, use their respective ``get()`` and ``set()`` methods instead.
 
 Typed dictionaries
 ^^^^^^^^^^^^^^^^^^
 
-Godot 4.4 added support for typed dictionaries. On write operations, Godot checks that
-element keys and values match the specified type, so the dictionary cannot contain invalid
-keys or values. The GDScript static analyzer takes typed dictionaries into account. However,
-dictionary methods that return values still have the ``Variant`` return type.
-
-Typed dictionaries have the syntax ``Dictionary[KeyType, ValueType]``, where ``KeyType`` and ``ValueType``
-can be any ``Variant`` type, native or user class, or enum. Both the key and value type **must** be specified,
-but you can use ``Variant`` to make either of them untyped.
-Nested typed collections (like ``Dictionary[String, Dictionary[String, int]]``)
-are not supported.
+Typed dictionaries have the syntax ``Dictionary[KeyType, ValueType]``, where ``KeyType`` and
+``ValueType`` are ``Variant`` types. Both the key and value type **must** be specified, but
+you can use ``Variant`` to make either of them untyped.
 
 ::
 
@@ -1022,27 +1063,7 @@ are not supported.
     # Keys can be any type, boolean values.
     var f: Dictionary[Variant, bool]
 
-``Dictionary`` and ``Dictionary[Variant, Variant]`` are the same thing.
-
-:ref:`Signal <class_Signal>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-A signal is a message that can be emitted by an object to those who want to
-listen to it. The Signal type can be used for passing the emitter around.
-
-Signals are better used by getting them from actual objects, e.g. ``$Button.button_up``.
-
-:ref:`Callable <class_Callable>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Contains an object and a function, which is useful for passing functions as
-values (e.g. when connecting to signals).
-
-Getting a method as a member returns a callable. ``var x = $Sprite2D.rotate``
-will set the value of ``x`` to a callable with ``$Sprite2D`` as the object and
-``rotate`` as the method.
-
-You can call it using the ``call`` method: ``x.call(PI)``.
+``Dictionary[Variant, Variant]`` is the same as ``Dictionary`` and is untyped.
 
 Variables
 ---------


### PR DESCRIPTION
So this section smelled of Godot `3.x` (and even `2.x` in some places I'm sure), so I decided to revamp it to look better and be more accurate to what they actually are in `4.x`. (I didn't touch anything outside of it because that needs a separate PR to keep everything specific, but I do think the other sections have some dust, too. If cherrypicking to before 4.4, please remove the typed dictionaries part, of course. And if translating, I moved some sections around but most of what I did was adjust the grammar, and add or delete a few things, so no need to redo a translation from scratch!)

Some changes and explanations (because the diff looks ugly now :p Therefore it's better to just build it and read through that section to see how it looks, and then you can have the original doc side-by-side to compare changes):
* I changed the headings to be `Variant` instead of "built-in" because that's actually what they are. Built-in types refer to everything that's not `Object` as it is in the code, but the docs clearly include `Object` there, so obviously `Variant` is intended. Therefore, I included a clear explanation of what a built-in type is and why it's different from `Variant` so users can follow. This means that I'm calling everything a `Variant` here. If `Variant` doesn't need to be formatted in some places, though, tell me so. But I think it should be since it's mostly being used a data type, not an actual object. I formatted every other data type that's specifically being used as such in code accordingly (including `null`, because it's being used as a data type here).
* Plus, some types (`Rect2i`, `Projection`, etc.) were missing, so I added those. If some of it sounds redundant, please tell me. I wanted everything to be consistent so people don't see new differences between things that don't actually have it.
* I renamed the "Basic" subsection to "Base" which is what I think was intended originally, because "basic" feels unspecific here (as the guidelines say). The word "base" is more often used to describe building blocks of stuff, which is especially true of `int` and `float`. Also "Vector" was changed to "Math" to encompass the other types as well (and also to prevent conflation with C++'s `Vector`, because the vector types are less `Vector`-like than the `Packed*Array`s are ironically!). And finally, "Container" was renamed to "Collection" because that's in the code.
* I also moved `Callable` and `Signal` to the appropriate heading because they're not container types, of course. And I also cleaned up where some line breaks were so it looked less unappealing (but it's aesthetic, only for the code, of course).
* Repeating the class name in the headings was unnecessary for the `:ref:` formatting, since the hyperlink already returns the class name as text.
* I also thought it was appropriate to explain a few things that were probably not clear to a newcomer from the original. Not too much since the class page is right there ofc, but just enough so that users don't need to do that just to understand what it does or used for (most new users would want to read straight through without clicking on any links that can lead them to discombobulating content, I'm sure). I didn't delete any info, but there's some stuff that probably isn't relevant to a newcomer (assuming new to programming). I suppose experienced programmers are reading it, too, whoever's new to Godot, but I assume majority of new users are also new to programming languages (as I was back in 2021).
* * The only thing I removed was variables storing `Variant` types, because I think that should be explained in the next section (which is "Variables").
* * I specified that `Variant` types are stack-allocated _in memory_, otherwise it can refer to anything for someone who doesn't already know what it means. (Stack can also refer to a function call stack, which is what I thought at first when reading it. Maybe I'm just overreacting here, but a little clarification with advanced topics never hurts.)
* * The `StringName` explanation includes stuff about locks in multithreading, which would fly over a newcomer's head for sure, and isn't really needed at that point since multithreading isn't something done automatically by the engine. The user has to do it themself, so they would probably learn this later. Therefore this should be explained on its class page itself for those who are interested (which it isn't currently, as far as I can tell, but it should be since that'll be far more often consulted than this page). Thoughts?
* * Added the `String` conversion aspect and that it's used by `Node` names to the `StringName` explanation so users don't feel like it's a high-tech thing they shouldn't mess with at all (because its explanation already feels like it). Also explained a bit further on what allowing only one instance means. (As it was, it could be interpreted as you can only use it _once_ and afterwards you're locked from using it for anything like the multithreading lock phrase suggests. In reality it just means ensuring uniqueness.) If it's too verbose, though, please tell me.
* * This is just me, but I think "immutable" is too high-tech of a word for a new user, because I doubt it's used outside of technology. I didn't know what it meant until Godot. I didn't change it, though, but still.
* * The `NodePath` explanation also feels a bit complex, but I think its uses are further explained close by to it, anyway.
* * `RID`s explanation didn't really tell me much about it since "opaque" data doesn't make sense to me, so I added an example of `PhysicsServer2D` and its reference to unique resources so users can see what a server actually is in Godot. (Otherwise people usually think of them as online databases.)
* * I moved the info about 32-bit numbers being used in the vectors to the "Math" section, and updated it to the current situation about double-precision builds existing etc.
* * I consolidated all the shared info about typed arrays and dictionaries into the "Container" explanation, to reduce redundancy. It made more sense to be in its own section before typed dictionaries, but I think it should be explained all at once, so the user knows they work mostly the same way, just with different ideas.
* * And I added the signed adjectives to the `int`s to differentiate it from unsigned (for the `PackedByteArray` explanation to make sense).
* * I changed some "store" wording to "represent" because it's not apparent to a user that they're stored someplace. (Also some of them _are_ the value, like `bool`, `int` and `float`. Not sure about `Callable`, but the way it's usually used is to represent an object's method.)
* * `Object`'s explanation was barebones so I added what it actually means in the engine. (And the way it currently was, it's contradictory because the section titles used "built-in type" for everything, including `Object`, but then it says it's not built-in!)
* * I mentioned the `RGBA` aspect of `Color` and its component ranges to make its explanation more useful. Maybe it's also helpful to know it's usually in nonlinear sRGB format in Godot, but IDK if that should be mentioned here.
* * Clarified what "transforms" actually are in `Transform2D` and `Transform3D` (so I used the full form "transformations" there).
* * Implied what the column/row order is in each transform type by specifying 3 `Vector2`s for `Transform2D` and a `Basis` with 3 `Vector3`s and an extra `Vector3` for `Transform3D`.
* * The bracket syntax for `Object`s explanation is weird because it's talking about an error that also applies for dictionaries, but it's hardly mentioned at all in a section about dictionaries, while this isn't mentioned in the `Object` explanation in any way. I don't really know what to do with it, so I just weaved the two together in a clearer explanation.
* * Does it really need to be mentioned for every math `Variant` type if it can be accessed as an array? Arrays aren't even introduced yet when those types are introduced. IDK how common their grid functionality is and if newcomers would want to use it as such (I'm sure most people would just use `PackedVector*Array`s for that purpose because that's far more flexible), but I kept it because I'm not sure.
* * `Quaternion`s weren't explained that well, so I specified that they're like `Vector4`s, but they are specialized to represent rotation.
* Unnecessary and inaccurate/outdated wording was removed. Meanwhile, some words were added to clarify vague wording and improve general consistency.
* * "Fields" were changed to "components", to be more accurate, since they _technically_ aren't objects to have fields/properties/members/etc. It was already used in some places, so I finished the job.
* * * Also I'm not sure if "contains" is needed for most of these, because "components" already implies they're contained, but I kept it for clarity.
* * * For the `end` properties of `Rect2` and `AABB`, I used "has an `end` property" instead to show that it's not actually contained.
* * I think "Normalized 3D plane type" is easier to understand than "3D plane type in normalized form".
* * In the typed arrays and typed dictionaries explanations, it seemed to be wording as if native and user classes weren't `Variant`s somehow. Therefore I changed the wording slightly. (Are enums `Variant`s? They could be since they're like dictionaries that hold `int`s and those are both `Variant`s, but of course, not every enum behaves like a dictionary and they're a specialized type.)
* * Lowercased some type names where it should be, because I think `Array` in the docs should be used to refer to the data type rather than to array objects, to be consistent with everything else. It's not a legal document to proper noun-ize array objects, ofc. If it is, then it should be lowercase. I don't know about `Variant`, though. Was non-capitalized "variant" ever used anywhere?
* * "Generic" doesn't add anything in the context they're used and is also generally unspecific (to speak of itself :p ). Maybe it should be a banned word, too? Because generics is a separate programming concept which doesn't exactly exist in GDScript (or can't be directly accessed anyway, since it's still used in C++). If it's ever added, the word as it's used in the thesaurus shouldn't be used in the docs. And where it's usually used, "untyped" is often more specific in programming anyway.
* * The `Array` explanation also included the phrase "arbitrary data types" which feels unspecific and sorta inaccurate to what they're actually used for in practice. Usually even for untyped arrays the object at each index is expected to have a specific type, like when passing it into a method etc. (I think dictionaries include more arbitrary objects anyways since their ordering is more arbitrary in general.) Therefore I changed it to "ordered sequence of `Variant` types".
* * Idk what "associative" means in the `Dictionary` explanation without searching it up, and it's already explained with the following text, so it feels unnecessary.
* * I thought mentioning that you can use your own defined classes as an array type in the `Packed*Array` section wasn't the right place and sorta redundant if the user already read it in the typed array section. I clarified it in the typed arrays and dictionaries section by adding "-defined" to "user" in "user classes".
* * `4.4` is ancient nowadays so I removed that statement of it adding typed dictionaries, as per the guidelines. (It was a celebrated addition back then, but we're three halves years ahead of that now, so it's totally engrained in Godot's current fabric, and I don't see anywhere that `4.3` or prior versions are being supported by maintainers or used by current users anyway.)
* * I moved the phrase about operations on typed arrays being unsafe to the first paragraph of the "Container" explanation, since that's more appropriate than where it used to be. Although I doubt this entire phrase is really needed since it's understood that not typing anything will make them unsafe, but I guess it's good for newcomers to understand.
* * * Clarified "unsafe" to "type-unsafe" because "unsafe" is usually referred to something _physically_ dangerous or risky, so it's not obvious to a non-programmer how code can be unsafe otherwise. (Probably would think it crashes their computer, which can be true in lower-level OS code, but Godot's GDScript can't do that, hopefully :p )
* * I was confused what the exception for untyped `Array` that typed arrays don't have even meant, so I had to test it out to clarify it. I think these two cases (untyped array being assigned typed and typed array variable init being assigned untyped) are what it was referring to originally, but I'm not sure.
* * * Also does it matter that a reason you can do both is for compatibility, since typed arrays have been around since `4.0` now (which is more ancient than `4.4`)? Most people reading `4.x` probably never used `3.x` or forgot about the old ways when upgrading their code.
* * `Array` and `Array[Variant]` "are the same _thing_" is a weird phrase to use in docs and isn't clear what kind of typing it has, so I rephrased it and mentioned `Array[Variant]` is untyped. Same for `Dictionary`.
* * "Nested typed collections" was changed to "Nesting types" because it's understood from the explanation. 
* * Some things are already _used_ in the engine, so I changed some instances of "useful" or "can be used" to "used" to reflect that. This means that users will know the actual practice of things instead of just that it _"could"_ do something. (I haven't seen `Vector3i` officially being used for 3D grids yet, but I'm sure that's what it's meant for. Anything else would use `Vector3`. But `Vector2i` definitely has with `Image`s and `Bitmap`s and such. Idk about `Vector4i`, I know someone is, though. :p )
* * In the `Signal` explanation, I doubt objects can have the desire to receive a signal ( ;P ), so I changed it to just "listens".
* * I think signals are more accurately "events" than "messages", so I changed that. It's clearer and more accurate to both newcomers and experienced programmers, I feel. "Message" is better used for actual displayed text, like for translations.

If asked, I can explain why I made any change that I didn't mention above. I scoured the codebase and class reference on the `master` branch to double-check all the info I added was accurate and referenced the [style guidelines](https://contributing.godotengine.org/en/latest/documentation/guidelines/docs_writing_guidelines.html), but still, if I missed anything or if I wrote something inaccurate, please suggest changes so I can implement them! (Also please don't mind if I keep force-pushing, I'm sure I'll always find something to change the longer I stare at it... :o I've already force-pushed a bajillion times while writing this PR description, so yep. I spent like 2 whole days on this already. :p )

Fixes #12185 as well. N/AI (all writing and editing was done using only my own intelligence)

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
