### PR TITLE
fix: remove redundant "two"

### DIFF
--- a/engine_details/development/configuring_an_ide/xcode.rst
+++ b/engine_details/development/configuring_an_ide/xcode.rst
@@ -52,7 +52,7 @@ Importing the project
 
 - For this target open the **Build Settings** tab and look for **Header Search Paths**.
 - Set **Header Search Paths** to the absolute path to the Godot root folder. You need to
-  include subdirectories as well. To achieve that, add two two asterisks (``**``) to the
+  include subdirectories as well. To achieve that, add two asterisks (``**``) to the
   end of the path, e.g. ``/Users/me/repos/godot-source/**``.
 
 - Add the Godot source to the project by dragging and dropping it into the project file browser.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
