### PR TITLE
Fix macos dev program paths in launch.json

### DIFF
--- a/engine_details/development/configuring_an_ide/visual_studio_code.rst
+++ b/engine_details/development/configuring_an_ide/visual_studio_code.rst
@@ -153,7 +153,7 @@ To run and debug the project you need to create a new configuration in the ``lau
       "name": "Launch Project",
       "type": "lldb",
       "request": "launch",
-      "program": "${workspaceFolder}/bin/godot.macos.editor.x86_64",
+      "program": "${workspaceFolder}/bin/godot.macos.editor.dev.x86_64",
       // Change the arguments below for the project you want to test with.
       // To run the project instead of editing it, remove the "--editor" argument.
       "args": ["--editor", "--path", "path-to-your-godot-project-folder"],
@@ -167,7 +167,7 @@ To run and debug the project you need to create a new configuration in the ``lau
       "name": "Launch Project",
       "type": "lldb",
       "request": "launch",
-      "program": "${workspaceFolder}/bin/godot.macos.editor.arm64",
+      "program": "${workspaceFolder}/bin/godot.macos.editor.dev.arm64",
       // Change the arguments below for the project you want to test with.
       // To run the project instead of editing it, remove the "--editor" argument.
       "args": ["--editor", "--path", "path-to-your-godot-project-folder"],


### PR DESCRIPTION
It took me a while to realise why my changes weren't being picked up after following this setup guide. This should now match the recommended `dev_build=yes` in tasks.json.

https://docs.godotengine.org/en/latest/engine_details/development/configuring_an_ide/visual_studio_code.html