### PR TITLE
Correct small typo: Missing `/`

### DIFF
--- a/tutorials/scripting/gdscript/gdscript_styleguide.rst
+++ b/tutorials/scripting/gdscript/gdscript_styleguide.rst
@@ -712,7 +712,7 @@ Use snake\_case to name functions and variables:
     var particle_effect
     func load_level():
 
-Prepend a single underscore (\_) to virtual methods functions the user must
+Prepend a single underscore (\_) to virtual methods/functions the user must
 override, private functions, and private variables:
 
 ::


### PR DESCRIPTION
Corrected a small typo in this sentence. I assumed there was a missing `/` character.
<img width="824" height="168" alt="image" src="https://github.com/user-attachments/assets/cc2edb2c-79fd-46c8-9541-bc303f0356ae" />