### PR TITLE
fix: add libX11-devel to Fedora compiling one-liner

### DIFF
--- a/engine_details/development/compiling/compiling_for_linuxbsd.rst
+++ b/engine_details/development/compiling/compiling_for_linuxbsd.rst
@@ -111,7 +111,8 @@ Distro-specific one-liners
               pkgconfig \
               gcc-c++ \
               libstdc++-static \
-              wayland-devel
+              wayland-devel \
+              libX11-devel 
 
     .. tab:: FreeBSD
 


### PR DESCRIPTION
fixes: #12254
