### PR TITLE
Update YouTube link for video tutorials

### DIFF
--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -22,7 +22,7 @@ Some tutorials mentioned below cover more advanced subjects, e.g. on 3D or shade
 Video tutorials
 ---------------
 
-For video tutorials we recommend looking on `YouTube <https://www.youtube.com/>`_.
+For video tutorials we recommend looking on `YouTube <https://www.youtube.com/results?search_query=godot+engine+4+tutorial+and+guide+for+beginners>`_.
 There are many great channels covering a wide array of subjects.
 
 Text tutorials


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
Changed line 25 in **community/tutorials.rst**:
`https://www.youtube.com/` → `https://www.youtube.com/results?search_query=godot+engine+4+tutorial+and+guide+for+beginners`

```diff
- For video tutorials we recommend looking on `YouTube <https://www.youtube.com/>`_.
+ For video tutorials we recommend looking on `YouTube <https://www.youtube.com/results?search_query=godot+engine+4+tutorial+and+guide+for+beginners>`_.