### PR TITLE
Add :classref: role for automatic class reference formatting

### DIFF
--- a/_extensions/classref_links.py
+++ b/_extensions/classref_links.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""
+    classref_links
+    ~~~~~~~~~~~~~~
+
+    Sphinx extension to format links to Godot's class reference,
+    including classes, methods, properties, etc.
+
+    :copyright: Copyright 2026 by The Godot Engine Community
+    :license: MIT.
+"""
+
+import re
+from dataclasses import dataclass
+
+from docutils import nodes
+
+from sphinx.addnodes import pending_xref
+from sphinx.application import Sphinx
+from sphinx.roles import XRefRole
+from sphinx.util.typing import ExtensionMetadata
+
+
+_NO_CLASS = "~"
+_THEME_ITEMS = r"(?:theme_(?:color|constant|font_size|font|icon|style))"
+_CLASS_DEFINITION = rf"class_(@?[A-Za-z0-9]+)(?:_(private_)?({_THEME_ITEMS}|[a-z]+)_([_a-zA-Z0-9]+))?"
+_ENUM = r"enum_(@?[A-Za-z0-9]+)_([A-Za-z0-9]+)"
+_CLASSREF_RE = re.compile(rf"^({_NO_CLASS})?(?:{_CLASS_DEFINITION}|{_ENUM})$")
+
+
+def parse_classref_label(label: str) -> str:
+    match = _CLASSREF_RE.fullmatch(label)
+    if match is None:
+        return label
+
+    no_class = match.group(1) == _NO_CLASS
+    is_enum = match.group(6) != None
+    class_name = match.group(6) if is_enum else match.group(2)
+    private_method = False if is_enum else match.group(3) == "private"
+    definition_type = "enum" if is_enum else match.group(4)
+    identifier = match.group(7) if is_enum else match.group(5)
+
+    if identifier == None:
+        return class_name
+    if private_method:
+        identifier = f"_{identifier}"
+    title = identifier
+    if not no_class:
+        title = f"{class_name}.{identifier}"
+    if definition_type == "method":
+        title += "()"
+    return title
+
+
+class ClassRefRole(XRefRole):
+    def __init__(self) -> None:
+        super().__init__(
+            lowercase=True,
+            innernodeclass=nodes.inline,
+            warn_dangling=True,
+        )
+
+    def process_link(
+        self,
+        env,
+        refnode,
+        has_explicit_title: bool,
+        title: str,
+        target: str,
+    ) -> tuple[str, str]:
+        if target[0] == _NO_CLASS:
+            target = target[1:]
+        return parse_classref_label(title), target
+
+    def run(self) -> tuple[list[nodes.Node], list[nodes.system_message]]:
+        self.has_explicit_title = True
+        result_nodes, messages = super().run()
+        final_nodes: list[nodes.Node] = []
+        for node in result_nodes:
+            if isinstance(node, pending_xref):
+                node["refdomain"] = "std"
+                node["reftype"] = "ref"
+                wrapper = nodes.literal("", "", classes=["classref"])
+                wrapper += node
+                final_nodes.append(wrapper)
+            else:
+                final_nodes.append(node)
+        return final_nodes, messages
+
+
+def setup(app: Sphinx) -> ExtensionMetadata:
+    app.add_role("classref", ClassRefRole())
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -500,6 +500,11 @@ a.btn:hover {
     padding-right: 20px;
 }
 
+/* Links to class reference using the :classref: role */
+.rst-content code.literal.classref {
+    background-color: transparent;
+}
+
 /* Distinguish class reference page links from "user manual" page links with a class reference badge. */
 
 /* Remove text wrapping so that the badge is always on the same line as the anchor's text. */

--- a/conf.py
+++ b/conf.py
@@ -21,6 +21,7 @@ extensions = [
     "sphinxcontrib.video",
     "gdscript",
     "classref_admonitions",
+    "classref_links",
 ]
 
 # Warning when the Sphinx Tabs extension is used with unknown


### PR DESCRIPTION
This adds a new `:classref:` role which automatically formats the cross-reference link's title depending on the nature of the target (for instance, linking to a method adds trailing parentheses). It also features a toggle character to include or exclude the class name from the title, see the image below.

The syntax for this role is exactly the same as the target part of `:ref:` links to the class reference, with the optional `-` character for class name display. For comparison, when linking to Node's `_ready()` method:
* `` :ref:`_ready() <class_Node_private_method__ready>` ``
* `` :classref:`-class_Node_private_method__ready` `` (including `-` to hide the leading `Node.`)

More examples in the following image:

<img width="800" height="560" alt="classref" src="https://github.com/user-attachments/assets/e771ab6b-845d-4885-81ae-da5e3cf5a72e" />

The regex includes all variations of theme properties (theme_color, theme_constant, theme_font_size, etc.), as multi-word types could otherwise result in wrong parsing of the identifier; single-word types like method or property are kept generic.

### AI disclosure

I used LLM help to get the extension started and test it, then fixed and cleaned up myself.