### PR TITLE
Fixed typo in the "changing scenes manually" documentation.

### DIFF
--- a/tutorials/scripting/change_scenes_manually.rst
+++ b/tutorials/scripting/change_scenes_manually.rst
@@ -83,7 +83,7 @@ access and integrity.
 
         - Pro: There's no need to move any more nodes around to save data.
 
-        - Con: More data is being kept in memory, which will be become a problem
+        - Con: More data is being kept in memory, which will become a problem
           on memory-sensitive platforms like web or mobile.
 
     - Processing continues.


### PR DESCRIPTION
In the second method of changing scenes manually described in this documentation, there was a type with "will be become", instead of "will be" or "will become", Here I chose for the latter.