### PR TITLE
Document that preloaded resources are only freed on exit.

### DIFF
--- a/tutorials/scripting/resources.rst
+++ b/tutorials/scripting/resources.rst
@@ -97,6 +97,11 @@ You can also ``preload`` resources. Unlike ``load``, this function will read the
 file from disk and load it at compile-time. As a result, you cannot call ``preload``
 with a variable path: you need to use a constant string.
 
+.. warning::
+
+    Preloaded resources will only be freed on exit. However, users should not
+    rely on this behavior, as it may change in the near future.
+
 .. tabs::
  .. code-tab:: gdscript GDScript
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->

This issue happens since version v4.0.3~v4.0.4

Related issues:
- https://github.com/godotengine/godot/issues/77513
- https://github.com/godotengine/godot/issues/118528

PR that added similar warning in for `@static_unload`:
- https://github.com/godotengine/godot/pull/89484

My other PR that adds this warning in the class reference:
- https://github.com/godotengine/godot/pull/122351