### PR TITLE
Add BBCode syntax highlighting

### DIFF
--- a/_extensions/bbcode.py
+++ b/_extensions/bbcode.py
@@ -1,0 +1,55 @@
+
+from pygments.lexer import RegexLexer, bygroups
+from pygments.token import (
+    Name,
+    Comment,
+    String,
+    Operator,
+    Text,
+    Whitespace,
+)
+
+__all__ = ["BBCodeFormatter"]
+
+
+class BBCodeFormatter(RegexLexer):
+    name = "BBCode"
+    aliases = ["bbcode", "bb"]
+
+    STYLE_BRACKETS = Comment.Doc
+    STYLE_TAG_TYPE = Name.Builtin.Function
+    STYLE_EQUAL_SIGN = Operator
+    STYLE_OPTION = String.StringName
+    STYLE_VALUE = String
+
+    tokens = {
+        "root": [
+            (r"(\[)(\w*\b)", bygroups(STYLE_BRACKETS, STYLE_TAG_TYPE), "tag"),
+            (r"(\[)(\/)(\w*)(\])", bygroups(STYLE_BRACKETS, STYLE_BRACKETS, STYLE_TAG_TYPE, STYLE_BRACKETS)),
+            (r"[^\[]+", Text),
+        ],
+        "tag": [
+            (r"=", STYLE_EQUAL_SIGN, "tag_value"),
+            (r"[\w\.{}]+", STYLE_OPTION), # The docs use curly brackets as placeholders in examples.
+            (r"\s+", Whitespace),
+            (r"\]", STYLE_BRACKETS, "#pop"),
+        ],
+        "tag_value": [
+            (r"\"[^\r\n]*?\"", STYLE_VALUE, "#pop"), # Value surrounded by quotes.
+            # Sometimes the docs like to concatenate placeholders in curly brackets {like},{this}, or similar.
+            (r"\{[^\r\n]*?\}(?!,|x)", STYLE_VALUE, "#pop"), # Value surrounded by curly brackets.
+            (r"[^\s\]]+", STYLE_VALUE, "#pop"),
+        ],
+    }
+
+
+def setup(sphinx):
+    from sphinx.highlighting import lexers
+
+    sphinx.add_lexer("bbcode", BBCodeFormatter)
+    lexers["bbcode"] = BBCodeFormatter()
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/_extensions/bbcode.py
+++ b/_extensions/bbcode.py
@@ -1,0 +1,61 @@
+
+from pygments.lexer import RegexLexer, bygroups
+from pygments.token import (
+    Name,
+    Comment,
+    String,
+    Operator,
+    Text,
+    Whitespace,
+)
+
+__all__ = ["BBCodeFormatter"]
+
+
+class BBCodeFormatter(RegexLexer):
+    name = "BBCode"
+    aliases = ["bbcode", "bb"]
+
+    STYLE_BRACKETS = Comment.Doc #Comment.Region
+    STYLE_TAG_TYPE = Name.Builtin.Function #Comment.Region
+    STYLE_EQUAL_SIGN = Operator
+    STYLE_OPTION = String.StringName#Comment.Doc
+    STYLE_VALUE = String #Comment.Single
+
+    tokens = {
+        "root": [
+            (r"(\[)(\w*\b)", bygroups(STYLE_BRACKETS, STYLE_TAG_TYPE), "tag"),
+            (r"(\[)(\/)(\w*)(\])", bygroups(STYLE_BRACKETS, STYLE_BRACKETS, STYLE_TAG_TYPE, STYLE_BRACKETS)),
+            (r"[^\[]+", Text),
+        ],
+        "tag": [
+            (r"=", STYLE_EQUAL_SIGN, "tag_value"),
+            (r"[\w\.{}]+", STYLE_OPTION), # The docs use curly brackets as placeholders in examples.
+            (r"\s+", Whitespace),
+            (r"\]", STYLE_BRACKETS, "#pop"),
+        ],
+        "tag_value": [
+            (r"\"[^\r\n]*?\"", STYLE_VALUE, "#pop"), # Value surrounded by quotes.
+            # Sometimes the docs like to concatenate placeholders in curly brackets {like},{this}, or similar.
+            (r"\{[^\r\n]*?\}(?!,|x)", STYLE_VALUE, "#pop"), # Value surrounded by curly brackets.
+            (r"[^\s\]]+", STYLE_VALUE, "#pop"),
+        ],
+        # Known tags. Isn't working as intended.
+        # (
+        #     r"(\[\/?)(?:(b|i|u|s|code|char|p|br|hr|center|left|right|fill|indent|url|hint|img|font|font_size|dropcap|opentype_features|lang|color|bgcolor|fgcolor|outline_size|outline_color|table|cell|ul|ol|lb|rb)*\b)",
+        #     bygroups(Comment.Region, Name.Builtin.Function),
+        #     "tag"
+        # ),
+    }
+
+
+def setup(sphinx):
+    from sphinx.highlighting import lexers
+
+    sphinx.add_lexer("bbcode", BBCodeFormatter)
+    lexers["bbcode"] = BBCodeFormatter()
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/conf.py
+++ b/conf.py
@@ -21,6 +21,7 @@ extensions = [
     "sphinxcontrib.video",
     "gdscript",
     "classref_admonitions",
+    "bbcode",
 ]
 
 # Warning when the Sphinx Tabs extension is used with unknown
@@ -240,6 +241,9 @@ rst_prolog = """
 
 .. role:: ui
     :class: role-ui
+
+.. role:: bbcode(code)
+    :language: bbcode
 
 """
 

--- a/tutorials/ui/bbcode_in_richtextlabel.rst
+++ b/tutorials/ui/bbcode_in_richtextlabel.rst
@@ -45,7 +45,7 @@ after selecting a RichTextLabel node.
 
 .. image:: img/bbcode_in_richtextlabel_inspector.webp
 
-For example, ``BBCode [color=green]test[/color]`` would render the word "test" with
+For example, :bbcode:`BBCode [color=green]test[/color]` would render the word "test" with
 a green color.
 
 .. image:: img/bbcode_in_richtextlabel_basic_example.webp
@@ -63,7 +63,7 @@ RichTextLabel upon display. Duplicate spaces are also displayed as-is in the
 final output. This means that when displaying a code block in a RichTextLabel,
 you don't need to use a preformatted text tag.
 
-.. code-block:: none
+.. code-block:: bbcode
 
   [tag]content[/tag]
   [tag=value]content[/tag]
@@ -76,13 +76,13 @@ you don't need to use a preformatted text tag.
     RichTextLabel doesn't support entangled BBCode tags. For example, instead of
     using:
 
-    ::
+    .. code-block:: bbcode
 
         [b]bold[i]bold italic[/b]italic[/i]
 
     Use:
 
-    ::
+    .. code-block:: bbcode
 
         [b]bold[i]bold italic[/i][/b][i]italic[/i]
 
@@ -94,10 +94,10 @@ Handling user input safely
 In a scenario where users may freely input text (such as chat in a multiplayer
 game), you should make sure users cannot use arbitrary BBCode tags that will be
 parsed by RichTextLabel. This is to avoid inappropriate use of formatting, which
-can be problematic if ``[url]`` tags are handled by your RichTextLabel (as players
+can be problematic if:bbcode:`[url]` tags are handled by your RichTextLabel (as players
 may be able to create clickable links to phishing sites or similar).
 
-Using RichTextLabel's ``[lb]`` and/or ``[rb]`` tags, we can replace the opening and/or
+Using RichTextLabel's :bbcode:`[lb]` and/or :bbcode:`[rb]` tags, we can replace the opening and/or
 closing brackets of any BBCode tag in a message with those escaped tags. This
 prevents users from using BBCode that will be parsed as tags – instead, the
 BBCode will be displayed as text.
@@ -201,7 +201,7 @@ The ``pop()`` function is used to end *any* tag. Since BBCode is a tag *stack*,
 using ``pop()`` will close the most recently started tags first.
 
 The following script will result in the same visual output as using
-``BBCode [color=green]test [i]example[/i][/color]``:
+:bbcode:`BBCode [color=green]test [i]example[/i][/color]`:
 
 ::
 
@@ -243,85 +243,85 @@ Reference
   * - | **b**
       | Makes ``{text}`` use the bold (or bold italics) font of ``RichTextLabel``.
 
-    - ``[b]{text}[/b]``
+    - :bbcode:`[b]{text}[/b]`
 
   * - | **i**
       | Makes ``{text}`` use the italics (or bold italics) font of ``RichTextLabel``.
 
-    - ``[i]{text}[/i]``
+    - :bbcode:`[i]{text}[/i]`
 
   * - | **u**
       | Makes ``{text}`` underlined.
 
-    - ``[u]{text}[/u]``
-      ``[u color={color}]{text}[/u]``
+    - :bbcode:`[u]{text}[/u]`
+      :bbcode:`[u color={color}]{text}[/u]`
 
   * - | **s**
       | Makes ``{text}`` strikethrough.
 
-    - ``[s]{text}[/s]``
-      ``[s color={color}]{text}[/s]``
+    - :bbcode:`[s]{text}[/s]`
+      :bbcode:`[s color={color}]{text}[/s]`
 
   * - | **code**
       | Makes ``{text}`` use the mono font of ``RichTextLabel``.
 
-    - ``[code]{text}[/code]``
+    - :bbcode:`[code]{text}[/code]`
 
   * - | **char**
       | Adds Unicode character with hexadecimal UTF-32 ``{codepoint}``.
 
-    - ``[char={codepoint}]``
+    - :bbcode:`[char={codepoint}]`
 
   * - | **p**
       | Adds new paragraph with ``{text}``. Supports configuration options,
         see :ref:`doc_bbcode_in_richtextlabel_paragraph_options`.
 
-    - | ``[p]{text}[/p]``
-      | ``[p {options}]{text}[/p]``
+    - | :bbcode:`[p]{text}[/p]`
+      | :bbcode:`[p {options}]{text}[/p]`
 
   * - | **br**
       | Adds line break in a text, without adding a new paragraph.
         If used within a list, this won't create a new list item,
         but will add a line break within the current item instead.
 
-    - ``[br]``
+    - :bbcode:`[br]`
 
   * - | **hr**
       | Adds new a horizontal rule to separate content. Supports configuration options,
         see :ref:`doc_bbcode_in_richtextlabel_hr_options`.
 
-    - | ``[hr]``
-      | ``[hr {options}]``
+    - | :bbcode:`[hr]`
+      | :bbcode:`[hr {options}]`
 
   * - | **center**
       | Makes ``{text}`` horizontally centered.
-      | Same as ``[p align=center]``.
+      | Same as :bbcode:`[p align=center]`.
 
-    - ``[center]{text}[/center]``
+    - :bbcode:`[center]{text}[/center]`
 
   * - | **left**
       | Makes ``{text}`` horizontally left-aligned.
-      | Same as ``[p align=left]``.
+      | Same as :bbcode:`[p align=left]`.
 
-    - ``[left]{text}[/left]``
+    - :bbcode:`[left]{text}[/left]`
 
   * - | **right**
       | Makes ``{text}`` horizontally right-aligned.
-      | Same as ``[p align=right]``.
+      | Same as :bbcode:`[p align=right]`.
 
-    - ``[right]{text}[/right]``
+    - :bbcode:`[right]{text}[/right]`
 
   * - | **fill**
       | Makes ``{text}`` fill the full width of ``RichTextLabel``.
-      | Same as ``[p align=fill]``.
+      | Same as :bbcode:`[p align=fill]`.
 
-    - ``[fill]{text}[/fill]``
+    - :bbcode:`[fill]{text}[/fill]`
 
   * - | **indent**
       | Indents ``{text}`` once.
-        The indentation width is the same as with ``[ul]`` or ``[ol]``, but without a bullet point.
+        The indentation width is the same as with :bbcode:`[ul]` or :bbcode:`[ol]`, but without a bullet point.
 
-    - ``[indent]{text}[/indent]``
+    - :bbcode:`[indent]{text}[/indent]`
 
   * - | **url**
       | Creates a hyperlink (underlined and clickable text). Can contain optional
@@ -329,9 +329,9 @@ Reference
         see :ref:`doc_bbcode_in_richtextlabel_url_options`.
       | **Must be handled with the "meta_clicked" signal to have an effect,** see :ref:`doc_bbcode_in_richtextlabel_handling_url_tag_clicks`.
 
-    - | ``[url]{link}[/url]``
-      | ``[url={link}]{text}[/url]``
-      | ``[url {options}]{text}[/url]``
+    - | :bbcode:`[url]{link}[/url]`
+      | :bbcode:`[url={link}]{text}[/url]`
+      | :bbcode:`[url {options}]{text}[/url]`
 
   * - | **hint**
       | Creates a tooltip hint that is displayed when hovering the text with the mouse.
@@ -339,7 +339,7 @@ Reference
         Note that it is not possible to escape quotes using ``\"`` or ``\'``. To use
         single quotes for apostrophes in the hint string, you must use double quotes
         to surround the string.
-    - | ``[hint="{tooltip text displayed on hover}"]{text}[/hint]``
+    - | :bbcode:`[hint="{tooltip text displayed on hover}"]{text}[/hint]`
 
   * - | **img**
       | Inserts an image from the ``{path}`` (can be any valid :ref:`class_Texture2D` resource).
@@ -353,44 +353,44 @@ Reference
         surrounding text, see :ref:`doc_bbcode_in_richtextlabel_image_and_table_alignment`.
       | Supports configuration options, see :ref:`doc_bbcode_in_richtextlabel_image_options`.
 
-    - | ``[img]{path}[/img]``
-      | ``[img={width}]{path}[/img]``
-      | ``[img={width}x{height}]{path}[/img]``
-      | ``[img={valign}]{path}[/img]``
-      | ``[img {options}]{path}[/img]``
+    - | :bbcode:`[img]{path}[/img]`
+      | :bbcode:`[img={width}]{path}[/img]`
+      | :bbcode:`[img={width}x{height}]{path}[/img]`
+      | :bbcode:`[img={valign}]{path}[/img]`
+      | :bbcode:`[img {options}]{path}[/img]`
 
   * - | **font**
       | Makes ``{text}`` use a font resource from the ``{path}``.
       | Supports configuration options, see :ref:`doc_bbcode_in_richtextlabel_font_options`.
 
-    - | ``[font={path}]{text}[/font]``
-      | ``[font {options}]{text}[/font]``
+    - | :bbcode:`[font={path}]{text}[/font]`
+      | :bbcode:`[font {options}]{text}[/font]`
 
   * - | **font_size**
       | Use custom font size for ``{text}``.
 
-    - ``[font_size={size}]{text}[/font_size]``
+    - :bbcode:`[font_size={size}]{text}[/font_size]`
 
   * - | **dropcap**
       | Use a different font size and color for ``{text}``, while making the tag's contents
         span multiple lines if it's large enough.
       | A `drop cap <https://www.computerhope.com/jargon/d/dropcap.htm>`__ is typically one
-        uppercase character, but ``[dropcap]`` supports containing multiple characters.
+        uppercase character, but :bbcode:`[dropcap]` supports containing multiple characters.
         ``margins`` values are comma-separated and can be positive, zero or negative.
         Values must **not** be separated by spaces; otherwise, the values won't be parsed correctly.
         Negative top and bottom margins are particularly useful to allow the rest of
         the paragraph to display below the dropcap.
 
-    - ``[dropcap font={font} font_size={size} color={color} outline_size={size} outline_color={color} margins={left},{top},{right},{bottom}]{text}[/dropcap]``
+    - :bbcode:`[dropcap font={font} font_size={size} color={color} outline_size={size} outline_color={color} margins={left},{top},{right},{bottom}]{text}[/dropcap]`
 
   * - | **opentype_features**
       | Enables custom OpenType font features for ``{text}``. Features must be provided as
         a comma-separated ``{list}``. Values must **not** be separated by spaces;
         otherwise, the list won't be parsed correctly.
 
-    - | ``[opentype_features={list}]``
+    - | :bbcode:`[opentype_features={list}]`
       | ``{text}``
-      | ``[/opentype_features]``
+      | :bbcode:`[/opentype_features]`
 
   * - | **lang**
       | Overrides the language for ``{text}`` that is set by the **BiDi > Language** property
@@ -399,14 +399,14 @@ Reference
         starting a new paragraph. Some font files may contain script-specific substitutes,
         in which case they will be used.
 
-    - ``[lang={code}]{text}[/lang]``
+    - :bbcode:`[lang={code}]{text}[/lang]`
 
   * - | **color**
       | Changes the color of ``{text}``. Color must be provided by a common name (see
         :ref:`doc_bbcode_in_richtextlabel_named_colors`) or using the HEX format (e.g.
         ``#ff00ff``, see :ref:`doc_bbcode_in_richtextlabel_hex_colors`).
 
-    - ``[color={code/name}]{text}[/color]``
+    - :bbcode:`[color={code/name}]{text}[/color]`
 
   * - | **bgcolor**
       | Draws the color behind ``{text}``. This can be used to highlight text.
@@ -416,7 +416,7 @@ Reference
         in the RichTextLabel node. Set padding to ``0`` to avoid potential overlapping
         issues when there are background colors on neighboring lines/columns.
 
-    - ``[bgcolor={code/name}]{text}[/bgcolor]``
+    - :bbcode:`[bgcolor={code/name}]{text}[/bgcolor]`
 
   * - | **fgcolor**
       | Draws the color in front of ``{text}``. This can be used to "redact" text by using
@@ -426,21 +426,21 @@ Reference
         in the RichTextLabel node. Set padding to ``0`` to avoid potential overlapping
         issues when there are foreground colors on neighboring lines/columns.
 
-    - ``[fgcolor={code/name}]{text}[/fgcolor]``
+    - :bbcode:`[fgcolor={code/name}]{text}[/fgcolor]`
 
   * - | **outline_size**
       | Use custom font outline size for ``{text}``.
 
-    - | ``[outline_size={size}]``
-      | ``{text}``
-      | ``[/outline_size]``
+    - | :bbcode:`[outline_size={size}]`
+      | :bbcode:`{text}`
+      | :bbcode:`[/outline_size]`
 
   * - | **outline_color**
       | Use custom outline color for ``{text}``. Accepts same values as the ``color`` tag.
 
-    - | ``[outline_color={code/name}]``
-      | ``{text}``
-      | ``[/outline_color]``
+    - | :bbcode:`[outline_color={code/name}]`
+      | :bbcode:`{text}`
+      | :bbcode:`[/outline_color]`
 
   * - | **table**
       | Creates a table with the ``{number}`` of columns. Use the ``cell`` tag to define
@@ -450,10 +450,10 @@ Reference
       | If baseline alignment is used, the table is aligned to the baseline of the row with index ``{alignment_row}`` (zero-based).
       | ``{name}`` is a table name for assistive apps (screen reader).
 
-    - | ``[table={number}]{cells}[/table]``
-      | ``[table={number},{valign}]{cells}[/table]``
-      | ``[table={number},{valign},{alignment_row}]{cells}[/table]``
-      | ``[table={number},{valign},{alignment_row} name={name}]{cells}[/table]``
+    - | :bbcode:`[table={number}]{cells}[/table]`
+      | :bbcode:`[table={number},{valign}]{cells}[/table]`
+      | :bbcode:`[table={number},{valign},{alignment_row}]{cells}[/table]`
+      | :bbcode:`[table={number},{valign},{alignment_row} name={name}]{cells}[/table]`
 
   * - | **cell**
       | Adds a cell with ``{text}`` to the table.
@@ -461,9 +461,9 @@ Reference
         to other cells and their ratio values.
       | Supports configuration options, see :ref:`doc_bbcode_in_richtextlabel_cell_options`.
 
-    - | ``[cell]{text}[/cell]``
-      | ``[cell={ratio}]{text}[/cell]``
-      | ``[cell {options}]{text}[/cell]``
+    - | :bbcode:`[cell]{text}[/cell]`
+      | :bbcode:`[cell={ratio}]{text}[/cell]`
+      | :bbcode:`[cell {options}]{text}[/cell]`
 
   * - | **ul**
       | Adds an unordered list. List ``{items}`` must be provided by putting one item per
@@ -471,42 +471,42 @@ Reference
       | The bullet point can be customized using the ``{bullet}`` parameter,
         see :ref:`doc_bbcode_in_richtextlabel_unordered_list_bullet`.
 
-    - | ``[ul]{items}[/ul]``
-      | ``[ul bullet={bullet}]{items}[/ul]``
+    - | :bbcode:`[ul]{items}[/ul]`
+      | :bbcode:`[ul bullet={bullet}]{items}[/ul]`
 
   * - | **ol**
       | Adds an ordered (numbered) list of the given ``{type}`` (see :ref:`doc_bbcode_in_richtextlabel_list_types`).
         List ``{items}`` must be provided by putting one item per line of text.
 
-    - ``[ol type={type}]{items}[/ol]``
+    - :bbcode:`[ol type={type}]{items}[/ol]`
 
   * - | **lb**, **rb**
       | Adds ``[`` and ``]`` respectively. Allows escaping BBCode markup.
       | These are self-closing tags, which means you do not need to close them
         (and there is no ``[/lb]`` or ``[/rb]`` closing tag).
 
-    - | ``[lb]b[rb]text[lb]/b[rb]`` will display as ``[b]text[/b]``.
+    - | :bbcode:`[lb]b[rb]text[lb]/b[rb]` will display as :bbcode:`[b]text[/b]`.
 
   * - | Several Unicode control characters can be added using their own self-closing tags.
       | This can result in easier maintenance compared to pasting those
       | control characters directly in the text.
 
-    - | ``[lrm]`` (left-to-right mark), ``[rlm]`` (right-to-left mark), ``[lre]`` (left-to-right embedding),
-      | ``[rle]`` (right-to-left embedding), ``[lro]`` (left-to-right override), ``[rlo]`` (right-to-left override),
-      | ``[pdf]`` (pop directional formatting), ``[alm]`` (Arabic letter mark), ``[lri]`` (left-to-right isolate),
-      | ``[rli]`` (right-to-left isolate), ``[fsi]`` (first strong isolate), ``[pdi]`` (pop directional isolate),
-      | ``[zwj]`` (zero-width joiner), ``[zwnj]`` (zero-width non-joiner), ``[wj]`` (word joiner),
-      | ``[shy]`` (soft hyphen)
+    - | :bbcode:`[lrm]` (left-to-right mark), :bbcode:`[rlm]` (right-to-left mark), :bbcode:`[lre]` (left-to-right embedding),
+      | :bbcode:`[rle]` (right-to-left embedding), :bbcode:`[lro]` (left-to-right override), :bbcode:`[rlo]` (right-to-left override),
+      | :bbcode:`[pdf]` (pop directional formatting), :bbcode:`[alm]` (Arabic letter mark), :bbcode:`[lri]` (left-to-right isolate),
+      | :bbcode:`[rli]` (right-to-left isolate), :bbcode:`[fsi]` (first strong isolate), :bbcode:`[pdi]` (pop directional isolate),
+      | :bbcode:`[zwj]` (zero-width joiner), :bbcode:`[zwnj]` (zero-width non-joiner), :bbcode:`[wj]` (word joiner),
+      | :bbcode:`[shy]` (soft hyphen)
 
 .. note::
 
-    Tags for bold (``[b]``) and italics (``[i]``) formatting work best if the
+    Tags for bold (:bbcode:`[b]`) and italics (:bbcode:`[i]`) formatting work best if the
     appropriate custom fonts are set up in the RichTextLabelNode's theme
     overrides. If no custom bold or italic fonts are defined,
     `faux bold and italic fonts <https://fonts.google.com/knowledge/glossary/faux_fake_pseudo_synthesized>`__
     will be generated by Godot. These fonts rarely look good in comparison to hand-made bold/italic font variants.
 
-    The monospaced (``[code]``) tag **only** works if a custom font is set up in
+    The monospaced (:bbcode:`[code]`) tag **only** works if a custom font is set up in
     the RichTextLabel node's theme overrides. Otherwise, monospaced text will use the regular font.
 
     There are no BBCode tags to control vertical centering of text yet.
@@ -587,13 +587,13 @@ Paragraph options
 
 .. _doc_bbcode_in_richtextlabel_handling_url_tag_clicks:
 
-Handling ``[url]`` tag clicks
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Handling :bbcode:`[url]` tag clicks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, ``[url]`` tags do nothing when clicked. This is to allow flexible use
-of ``[url]`` tags rather than limiting them to opening URLs in a web browser.
+By default, :bbcode:`[url]` tags do nothing when clicked. This is to allow flexible use
+of :bbcode:`[url]` tags rather than limiting them to opening URLs in a web browser.
 
-To handle clicked ``[url]`` tags, connect the ``RichTextLabel`` node's
+To handle clicked :bbcode:`[url]` tags, connect the ``RichTextLabel`` node's
 :ref:`meta_clicked <class_RichTextLabel_signal_meta_clicked>` signal to a script function.
 
 For example, the following method can be connected to ``meta_clicked`` to open
@@ -608,11 +608,12 @@ clicked URLs using the user's default web browser:
         # to avoid script errors at runtime.
         OS.shell_open(str(meta))
 
-For more advanced use cases, it's also possible to store JSON in a ``[url]``
+For more advanced use cases, it's also possible to store JSON in a :bbcode:`[url]`
 tag's option and parse it in the function that handles the ``meta_clicked`` signal.
 For example:
 
-.. code-block:: none
+.. code-block:: bbcode
+  :force:
 
   [url={"example": "value"}]JSON[/url]
 
@@ -805,7 +806,7 @@ Image options
 Image and table vertical alignment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When a vertical alignment value is provided with the ``[img]`` or ``[table]`` tag
+When a vertical alignment value is provided with the :bbcode:`[img]` or :bbcode:`[table]` tag
 the image/table will try to align itself against the surrounding text. Alignment is
 performed using a vertical point of the image and a vertical point of the text.
 There are 3 possible points on the image (``top``, ``center``, and ``bottom``) and 4
@@ -814,14 +815,14 @@ which can be used in any combination.
 
 To specify both points, use their full or short names as a value of the image/table tag:
 
-.. code-block:: none
+.. code-block:: bbcode
 
     text [img=top,bottom]...[/img] text
     text [img=center,center]...[/img] text
 
 .. image:: img/bbcode_in_richtextlabel_image_align.webp
 
-.. code-block:: none
+.. code-block:: bbcode
 
     text [table=3,center]...[/table] text  # Center to center.
     text [table=3,top,bottom]...[/table] text # Top of the table to the bottom of text.
@@ -944,7 +945,7 @@ Font options
 
   Note: The value should be enclosed in ``"`` to allow using ``=`` inside it:
 
-.. code-block:: none
+.. code-block:: bbcode
 
     [font otv="wght=200,wdth=400"] # Sets variable font weight and width.
 
@@ -960,7 +961,7 @@ Font options
 
   Note: The value should be enclosed in ``"`` to allow using ``=`` inside it:
 
-.. code-block:: none
+.. code-block:: bbcode
 
     [font otf="calt=0,zero=1"] # Disable contextual alternates, enable slashed zero.
 
@@ -986,11 +987,11 @@ Hexadecimal color codes
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 For opaque RGB colors, any valid 6-digit hexadecimal code is supported, e.g.
-``[color=#ffffff]white[/color]``. Shorthand RGB color codes such as ``#6f2``
+:bbcode:`[color=#ffffff]white[/color]`. Shorthand RGB color codes such as ``#6f2``
 (equivalent to ``#66ff22``) are also supported.
 
 For transparent RGB colors, any RGBA 8-digit hexadecimal code can be used,
-e.g. ``[color=#ffffff88]translucent white[/color]``. Note that the alpha channel
+e.g. :bbcode:`[color=#ffffff88]translucent white[/color]`. Note that the alpha channel
 is the **last** component of the color code, not the first one. Short RGBA
 color codes such as ``#6f28`` (equivalent to ``#66ff2288``) are supported as well.
 
@@ -1056,11 +1057,11 @@ Cell options
 Unordered list bullet
 ~~~~~~~~~~~~~~~~~~~~~
 
-By default, the ``[ul]`` tag uses the ``U+2022`` "Bullet" Unicode glyph as the
+By default, the :bbcode:`[ul]` tag uses the ``U+2022`` "Bullet" Unicode glyph as the
 bullet character. This behavior is similar to web browsers. The bullet character
-can be customized using ``[ul bullet={bullet}]``. If provided, this ``{bullet}``
+can be customized using :bbcode:`[ul bullet={bullet}]`. If provided, this ``{bullet}``
 parameter must be a string with no enclosing quotes (for example,
-``[bullet=*]``). You can add trailing spaces after the bullet character
+:bbcode:`[bullet=*]`). You can add trailing spaces after the bullet character
 to increase the spacing between the bullet and the list item text.
 
 See `Bullet (typography) on Wikipedia <https://en.wikipedia.org/wiki/Bullet_(typography)>`__
@@ -1107,7 +1108,7 @@ Pulse
 
 Pulse creates an animated pulsing effect that multiplies each character's
 opacity and color. It can be used to bring attention to specific text. Its tag
-format is ``[pulse freq=1.0 color=#ffffff40 ease=-2.0]{text}[/pulse]``.
+format is :bbcode:`[pulse freq=1.0 color=#ffffff40 ease=-2.0]{text}[/pulse]`.
 
 ``freq`` controls the frequency of the half-pulsing cycle (higher is faster). A
 full pulsing cycle takes ``2 * (1.0 / freq)`` seconds. ``color`` is the target
@@ -1121,7 +1122,7 @@ Wave
 .. image:: img/bbcode_in_richtextlabel_effect_wave.webp
 
 Wave makes the text go up and down. Its tag format is
-``[wave amp=50.0 freq=5.0 connected=1]{text}[/wave]``.
+:bbcode:`[wave amp=50.0 freq=5.0 connected=1]{text}[/wave]`.
 
 ``amp`` controls how high and low the effect goes, and ``freq`` controls how
 fast the text goes up and down. A ``freq`` value of ``0`` will result in no
@@ -1137,7 +1138,7 @@ Tornado
 .. image:: img/bbcode_in_richtextlabel_effect_tornado.webp
 
 Tornado makes the text move around in a circle. Its tag format is
-``[tornado radius=10.0 freq=1.0 connected=1]{text}[/tornado]``.
+:bbcode:`[tornado radius=10.0 freq=1.0 connected=1]{text}[/tornado]`.
 
 ``radius`` is the radius of the circle that controls the offset, ``freq`` is how
 fast the text moves in a circle. A ``freq`` value of ``0`` will pause the
@@ -1153,7 +1154,7 @@ Shake
 .. image:: img/bbcode_in_richtextlabel_effect_shake.webp
 
 Shake makes the text shake. Its tag format is
-``[shake rate=20.0 level=5 connected=1]{text}[/shake]``.
+:bbcode:`[shake rate=20.0 level=5 connected=1]{text}[/shake]`.
 
 ``rate`` controls how fast the text shakes, ``level`` controls how far the text
 is offset from the origin. If ``connected`` is ``1`` (default), glyphs with
@@ -1167,7 +1168,7 @@ Fade
 .. image:: img/bbcode_in_richtextlabel_effect_fade.webp
 
 Fade creates a static fade effect that multiplies each character's opacity.
-Its tag format is ``[fade start=4 length=14]{text}[/fade]``.
+Its tag format is :bbcode:`[fade start=4 length=14]{text}[/fade]`.
 
 ``start`` controls the starting position of the falloff relative to where the fade
 command is inserted, ``length`` controls over how many characters should the fade
@@ -1179,7 +1180,7 @@ Rainbow
 .. image:: img/bbcode_in_richtextlabel_effect_rainbow.webp
 
 Rainbow gives the text a rainbow color that changes over time. Its tag format is
-``[rainbow freq=1.0 sat=0.8 val=0.8 speed=1.0]{text}[/rainbow]``.
+:bbcode:`[rainbow freq=1.0 sat=0.8 val=0.8 speed=1.0]{text}[/rainbow]`.
 
 ``freq`` determines how many letters the rainbow extends over before it repeats itself,
 ``sat`` is the saturation of the rainbow, ``val`` is the value of the rainbow. ``speed``
@@ -1240,8 +1241,8 @@ object, which holds a few variables to control how the associated glyph is rende
 - ``glyph_index`` and ``font`` is glyph being drawn and font data resource used to draw it.
 - Finally, ``env`` is a :ref:`class_Dictionary` of parameters assigned to a given custom
   effect. You can use :ref:`get() <class_Dictionary_method_get>` with an optional default value
-  to retrieve each parameter, if specified by the user. For example ``[custom_fx spread=0.5
-  color=#FFFF00]test[/custom_fx]`` would have a float ``spread`` and Color ``color``
+  to retrieve each parameter, if specified by the user. For example :bbcode:`[custom_fx spread=0.5
+  color=#FFFF00]test[/custom_fx]` would have a float ``spread`` and Color ``color``
   parameters in its ``env`` Dictionary. See below for more usage examples.
 
 The last thing to note about this function is that it is necessary to return a boolean
@@ -1315,7 +1316,7 @@ Matrix
 
 This will add a few new BBCode commands, which can be used like so:
 
-.. code-block:: none
+.. code-block:: bbcode
 
     [center][ghost]This is a custom [matrix]effect[/matrix][/ghost] made in
     [pulse freq=5.0 height=2.0][pulse color=#00FFAA freq=2.0]GDScript[/pulse][/pulse].[/center]


### PR DESCRIPTION

This PR does a few major things:
- Adds a new lexer for **BBCode**, which on its own makes it possible for code blocks to highlight BBCode in a way that suits the Godot documentation.
- Adds a new `bbcode` role, which can be used to highlight BBCode **inline** by marking it down ```:bbcode:`like this` ```.
- Applies both of the above to the **BBCode in RichTextLabel** page.
	- In the future a few more pages can benefit from this, but this is a good starting point.

Here's some previews on how it looks like (these screenshots may become outdated):
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/0009f65b-a9be-4ff2-a8e9-1cee85629a78" />
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/936fdb9d-ffea-472c-acf9-3b061216dffa" />
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/f6ad3dea-69b4-4216-95af-37dfdac1e0e8" />





This PR does need some clean-up, but that will be done when we agree it's good to go.