### PR TITLE
Make default role highlight GDScript code

### DIFF
--- a/_extensions/gdscript.py
+++ b/_extensions/gdscript.py
@@ -1576,12 +1576,26 @@ class GDScriptLexer(RegexLexer):
         ],
     }
 
+from sphinx.application import Sphinx
+from sphinx.util.docutils import SphinxRole
+from sphinx.util.typing import ExtensionMetadata
 
-def setup(sphinx):
+
+def setup(sphinx: Sphinx) -> ExtensionMetadata:
     from sphinx.highlighting import lexers
+    from sphinx.roles import code_role
+    from docutils import nodes
 
     sphinx.add_lexer("gdscript", GDScriptLexer)
     lexers["gdscript"] = GDScriptLexer()
+
+    class GDScriptRole(SphinxRole):
+        def run(self) -> tuple[list[nodes.Node], list[nodes.system_message]]:
+            return code_role(self.name, self.rawtext, self.text,
+                             self.lineno, self.inliner,
+                             {"language": "gdscript"}, self.content)
+
+    sphinx.add_role("gdscript", GDScriptRole())
 
     return {
         "parallel_read_safe": True,

--- a/conf.py
+++ b/conf.py
@@ -243,6 +243,11 @@ rst_prolog = """
 
 """
 
+# This is the Sphinx role used for text formatted `like this`.
+# Many docs mistakenly use single backticks, instead of double backticks.
+# Default GDScript is the least intrusive, and happens to look quite nice.
+default_role = "gdscript"
+
 # -- I18n settings --------------------------------------------------------
 
 # Godot localization is handled via https://github.com/godotengine/godot-docs-l10n


### PR DESCRIPTION
Happens to close #11248
Related to #12272

Surrounding code with single backticks the docs has been a common mistake for a few reasons:
- Single backticks in typical Markdown denote literal text or code (\`this\` turns to `this`). That's the standard basically everywhere else (including this very website). Not in reStructured text, though.
- It's genuinely hard to infer the difference between \`this\` and \`\`this\`\` at a glance, especially without proper syntax highlighting in your IDE.
	- https://github.com/godotengine/godot-docs/pull/12272 proves it.
- Design-wise, one would assume that, because multiple asterisks denote increasingly stronger levels of emphasis, that backticks would behave similarly. But they don't.

In fact, and I've explained this [a while back](https://chat.godotengine.org/channel/documentation?msg=mzPLHQ8TfxrfcDQmK), single backticks denote [interpreted text](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#interpreted-text), with its role falling back to the **default role**. However, we have not defined a **default role**, so what ends up happening is that \`this text\` appears in italics:

<img width="25%" alt="image" src="https://github.com/user-attachments/assets/092034f6-ba2a-447c-891f-ac762f44adcd" />

---------------------------

This PR not only makes the single backticks purposeful, but it adds a new `gdscript` role. This allows the docs to feature syntax highlighting **inline** for GDScript.

In a nutshell, `` `text` `` becomes a shorthand for `` :gdscript:`text` ``.

It would allow for the following, but as of writing the PR does not currently use it intentionally.

<img width=40% alt="image" src="https://github.com/user-attachments/assets/9a583893-f12a-44d5-a9a4-c955c6cf7362" /> 
<img width=40% alt="image" src="https://github.com/user-attachments/assets/cac9b038-f6bd-49f1-bd28-c4c43d809b64" />

