### PR TITLE
Expand codespell coverage

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -43,7 +43,7 @@ platform:android:
     - tutorials/editor/using_the_android_editor.rst
     - tutorials/export/android_gradle_build.rst
     - tutorials/export/exporting_for_android.rst
-    - tutorials/platofrm/android/**
+    - tutorials/platform/android/**
 
 platform:ios:
 - changed-files:

--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -457,10 +457,10 @@ $(document).ready(() => {
           }
 
           // Hide other sections.
-          menuHeaders.forEach(ot => {
-            if (ot !== it && ot.classList.contains('active')) {
-              ot.nextElementSibling.classList.remove('active');
-              ot.classList.remove('active');
+          menuHeaders.forEach(other => {
+            if (other !== it && other.classList.contains('active')) {
+              other.nextElementSibling.classList.remove('active');
+              other.classList.remove('active');
             }
           });
 

--- a/engine_details/development/compiling/compiling_for_windows.rst
+++ b/engine_details/development/compiling/compiling_for_windows.rst
@@ -89,11 +89,15 @@ To install SCons, open the command prompt and run the following command:
 
     python -m pip install scons
 
+.. codespell:ignore-begin writeable
+
 If you are prompted with the message
 ``Defaulting to user installation because normal site-packages is not
 writeable``, you may have to run that command again using elevated
 permissions. Open a new command prompt as an Administrator then run the command
 again to ensure that SCons is available from the ``PATH``.
+
+.. codespell:ignore-end
 
 To check whether you have installed Python and SCons correctly, you can
 type ``python --version`` and ``scons --version`` into a command prompt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,26 +9,21 @@ quiet-level = 3
 dictionary = ["_tools/codespell-dict.txt", "-"]
 builtin = ["clear", "rare", "en-GB_to_en-US"]
 skip = [
-    "_build/*",
-    "_static/*",
+    "_static/css/*",
     "_styleguides/*",
     "classes/*",
-    ".github/*",
     "tutorials/i18n/locales.rst",
     "AUTHORS.md",
     "LICENSE.txt",
 ]
 ignore-words-list = [
     "dialogue",     # Common even in US spelling.
-    "doubleclick",
     "findn",        # Our case-insensitive `find` function.
-    "implementors",
     "inout",        # Shader attribute.
     "lod",          # "Level of Detail".
     "marshalled",   # Common spelling in IT.
     "marshalling",  # Common spelling in IT.
     "thirdparty",   # Prefer as one word.
     "uint",         # "Unsigned integer".
-    "writeable",    # Part of a Python error message.
 ]
 ignore-multiline-regex = "codespell:ignore-begin.*?codespell:ignore-end"

--- a/tutorials/editor/external_editor.rst
+++ b/tutorials/editor/external_editor.rst
@@ -99,7 +99,11 @@ We have official plugins for the following code editors:
 LSP/DAP support
 ---------------
 
+.. codespell:ignore-begin implementors
+
 Godot supports the `Language Server Protocol <https://microsoft.github.io/language-server-protocol/>`_ (**LSP**) for code completion and the `Debug Adapter Protocol <https://microsoft.github.io/debug-adapter-protocol/>`_ (**DAP**) for debugging. You can check the `LSP client list <https://microsoft.github.io/language-server-protocol/implementors/tools/>`_ and `DAP client list <https://microsoft.github.io/debug-adapter-protocol/implementors/tools/>`_ to find if your editor supports them. If this is the case, you should be able to take advantage of these features without the need of a custom plugin.
+
+.. codespell:ignore-end
 
 To use these protocols, a Godot instance must be running on your current project. You should then configure your editor to communicate to the running adapter ports in Godot, which by default are ``6005`` for **LSP**, and ``6006`` for **DAP**. You can change these ports and other settings in the **Editor Settings**, under the **Network > Language Server** and **Network > Debug Adapter** sections respectively.
 

--- a/tutorials/migrating/upgrading_to_godot_4.3.rst
+++ b/tutorials/migrating/upgrading_to_godot_4.3.rst
@@ -269,8 +269,8 @@ Animation
 .. note::
 
     ``AnimationNode`` has a reworked process for retrieving the semantic time info. This ensures that time-related
-    behavior works as expected, but changes the blending behavior. Implementors of the ``_process`` virtual method
-    should also note that this method is now deprecated and will be replaced by a new one in the future (`GH-87171`_).
+    behavior works as expected, but changes the blending behavior. It's also worth noting that the ``_process`` virtual method
+    is now deprecated and will be replaced by a new one in the future (`GH-87171`_).
 
 More information about the changes to Animation can be found in the
 `Migrating Animations from Godot 4.0 to 4.3 <https://godotengine.org/article/migrating-animations-from-godot-4-0-to-4-3>`__

--- a/tutorials/migrating/upgrading_to_godot_4.rst
+++ b/tutorials/migrating/upgrading_to_godot_4.rst
@@ -469,6 +469,8 @@ table to find its new name.
     and PathFollow3D's ``set_offset()`` and ``get_offset()`` must be renamed to
     ``set_progress()`` and ``get_progress()`` respectively.
 
+.. codespell:ignore-begin doubleclick
+
 - AudioServer's ``device`` is now ``output_device``.
 - BaseButton's ``group`` is now ``button_group``.
 - Camera3D's ``zfar`` is now ``far``.
@@ -500,6 +502,7 @@ table to find its new name.
   ``Engine.is_editor_hint()`` *method*. This is because it's read-only, and
   properties in Godot are not used for read-only values.
 
+.. codespell:ignore-end
 
 **Enums**
 


### PR DESCRIPTION
- Follow-up to #12223

Takes the foundation laid out by Micky in the above PR and further integrates it across additional files/directories. Slightly trims the excluded words, as a few of those cases only cropped up once or twice & could be suppressed in isolation

This expanded ruleset and coverage actually resulted in a proper bugfix, as `labeler.yml` would fail to properly apply a label for android tutorials, as it was looking for changes in the "platofrm" folder