### PR TITLE
Document iOS 16 requirement for web exports

### DIFF
--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -14,6 +14,13 @@ This requires support for `WebAssembly
 <https://webassembly.org/>`__ and `WebGL 2.0 <https://www.khronos.org/webgl/>`__
 in the user's browser.
 
+.. note::
+
+    iOS 16 or later is required to run web exports on iOS devices. Web export
+    templates use WebAssembly SIMD, which is not supported on iOS 15 and
+    earlier. On those versions, the project will fail to load with a
+    WebAssembly ``CompileError``.
+
 .. attention::
 
     Projects written in C# using Godot 4 currently cannot be exported to the


### PR DESCRIPTION
Fixes #12231

Added a note to the web export page explaining that iOS 16 or later is
required, since web export templates use WebAssembly SIMD which iOS 15
does not support. Projects fail to load with a WebAssembly CompileError
on older versions.

Placed alongside the existing WebAssembly/WebGL 2.0 requirement in the
introduction.