### PR TITLE
Update macOS/iOS system requirements.

### DIFF
--- a/about/system_requirements.rst
+++ b/about/system_requirements.rst
@@ -55,8 +55,9 @@ Desktop or laptop PC - Minimum
 |                      | Exporting projects requires downloading export templates separately                     |
 |                      | (up to 1.5 GB after installation, depending on the target platforms chosen).            |
 +----------------------+-----------------------------------------------------------------------------------------+
-| **Operating system** | - **Native editor:** Windows 10, macOS 11 (Intel Macs), macOS 13 (Apple Silicon Macs),  |
-|                      |   Linux distribution released after 2018                                                |
+| **Operating system** | - **Native editor:** Windows 10, macOS 11 (Intel Macs, Compatibility), macOS 12 (Intel  |
+|                      |   Macs, Forward+/Mobile), macOS 13 (Apple Silicon Macs), Linux distribution released    |
+|                      |   after 2018                                                                            |
 |                      | - **Web editor:** Recent versions of mainstream browsers: Firefox and derivatives       |
 |                      |   (including ESR), Chrome and Chromium derivatives, Safari and WebKit derivatives.      |
 +----------------------+-----------------------------------------------------------------------------------------+
@@ -142,7 +143,7 @@ Desktop or laptop PC - Recommended
 +----------------------+---------------------------------------------------------------------------------------------+
 | **Storage**          | 2 GB (used for the executable, project files, all export templates, and cache)              |
 +----------------------+---------------------------------------------------------------------------------------------+
-| **Operating system** | - **Native editor:** Windows 11, macOS 13, Linux distribution released after 2020           |
+| **Operating system** | - **Native editor:** Windows 11, macOS 14, Linux distribution released after 2020           |
 |                      | - **Web editor:** Latest version of Firefox, Chrome, Edge, Safari, Opera                    |
 +----------------------+---------------------------------------------------------------------------------------------+
 
@@ -241,8 +242,9 @@ Desktop or laptop PC - Minimum
 +----------------------+-----------------------------------------------------------------------------------------+
 | **Storage**          | 150 MB (used for the executable, project files, and cache)                              |
 +----------------------+-----------------------------------------------------------------------------------------+
-| **Operating system** | - **For native exports:** Windows 10, macOS 11 (Intel Macs), macOS 13 (Apple Silicon    |
-|                      |   Macs), Linux distribution released after 2018                                         |
+| **Operating system** | - **For native exports:** Windows 10, macOS 11 (Intel Macs, Compatibility), macOS 12    |
+|                      |   (Intel Macs, Forward+/Mobile), macOS 13 (Apple Silicon Macs), Linux distribution      |
+|                      |   released after 2018                                                                   |
 |                      | - **Web editor:** Recent versions of mainstream browsers: Firefox and derivatives       |
 |                      |   (including ESR), Chrome and Chromium derivatives, Safari and WebKit derivatives.      |
 +----------------------+-----------------------------------------------------------------------------------------+
@@ -255,9 +257,9 @@ Mobile device (smartphone/tablet) - Minimum
 |                      |                                                                                         |
 |                      |   - *Example: Qualcomm Snapdragon 430, Samsung Exynos 5 Octa 5430*                      |
 |                      |                                                                                         |
-|                      | - **iOS:** SoC with any 64-bit ARM CPU                                                  |
+|                      | - **iOS:** SoC with 64-bit ARM CPU                                                      |
 |                      |                                                                                         |
-|                      |   - *Example: Apple A7 (iPhone 5S)*                                                     |
+|                      |   - *Example: Apple A9 (iPhone 6S)*                                                     |
 +----------------------+-----------------------------------------------------------------------------------------+
 | **GPU**              | - **Forward+ renderer:** SoC featuring GPU with full Vulkan 1.0 support, or             |
 |                      |   Metal 3 support (iOS/iPadOS)                                                          |
@@ -273,7 +275,7 @@ Mobile device (smartphone/tablet) - Minimum
 |                      |                                                                                         |
 |                      | - **Compatibility renderer:** SoC featuring GPU with full OpenGL ES 3.0 support         |
 |                      |                                                                                         |
-|                      |   - *Example: Qualcomm Adreno 306, Mali-T628 MP6, Apple A7 (iPhone 5S)*                 |
+|                      |   - *Example: Qualcomm Adreno 306, Mali-T628 MP6, Apple A9 (iPhone 6S)*                 |
 +----------------------+-----------------------------------------------------------------------------------------+
 | **RAM**              | - **For native exports:** 1 GB                                                          |
 |                      | - **For web exports:** 2 GB                                                             |
@@ -325,7 +327,7 @@ Desktop or laptop PC - Recommended
 +----------------------+----------------------------------------------------------------------------------------------+
 | **Storage**          | 150 MB (used for the executable, project files, and cache)                                   |
 +----------------------+----------------------------------------------------------------------------------------------+
-| **Operating system** | - **For native exports:** Windows 11, macOS 13, Linux distribution released after 2020       |
+| **Operating system** | - **For native exports:** Windows 11, macOS 14, Linux distribution released after 2020       |
 |                      | - **For web exports:** Latest version of Firefox, Chrome, Edge, Safari, Opera                |
 +----------------------+----------------------------------------------------------------------------------------------+
 


### PR DESCRIPTION
- MoltenVK dropped macOS 11 support, so it is updated to list separate min. version for Compatibility and Forward+/Mobile.
- Changed recommended macOS version to 14, since it is the oldest version still getting updates.
- Min. supported iOS was changed to 15.0, but example SOC was still A7 (iPhone 5S, which does not support iOS 15), changed it to A9 (iPhone 6S).