### PR TITLE
update older link of town truck to the new version in the asset store

### DIFF
--- a/classes/class_joint3d.rst
+++ b/classes/class_joint3d.rst
@@ -28,7 +28,7 @@ Abstract base class for all joints in 3D physics. 3D joints bind together two ph
 Tutorials
 ---------
 
-- `3D Truck Town Demo <https://godotengine.org/asset-library/asset/2752>`__
+- `3D Truck Town Demo <https://store.godotengine.org/asset/godot-foundation/truck-town-demo/>`__
 
 .. rst-class:: classref-reftable-group
 

--- a/classes/class_rigidbody3d.rst
+++ b/classes/class_rigidbody3d.rst
@@ -42,7 +42,7 @@ Tutorials
 
 - :doc:`Troubleshooting physics issues <../tutorials/physics/troubleshooting_physics_issues>`
 
-- `3D Truck Town Demo <https://godotengine.org/asset-library/asset/2752>`__
+- `3D Truck Town Demo <https://store.godotengine.org/asset/godot-foundation/truck-town-demo/>`__
 
 - `3D Physics Tests Demo <https://godotengine.org/asset-library/asset/2747>`__
 

--- a/classes/class_vehiclebody3d.rst
+++ b/classes/class_vehiclebody3d.rst
@@ -36,7 +36,7 @@ Tutorials
 
 - :doc:`Troubleshooting physics issues <../tutorials/physics/troubleshooting_physics_issues>`
 
-- `3D Truck Town Demo <https://godotengine.org/asset-library/asset/2752>`__
+- `3D Truck Town Demo <https://store.godotengine.org/asset/godot-foundation/truck-town-demo/>`__
 
 .. rst-class:: classref-reftable-group
 

--- a/classes/class_vehiclewheel3d.rst
+++ b/classes/class_vehiclewheel3d.rst
@@ -28,7 +28,7 @@ A node used as a child of a :ref:`VehicleBody3D<class_VehicleBody3D>` parent to 
 Tutorials
 ---------
 
-- `3D Truck Town Demo <https://godotengine.org/asset-library/asset/2752>`__
+- `3D Truck Town Demo <https://store.godotengine.org/asset/godot-foundation/truck-town-demo/>`__
 
 .. rst-class:: classref-reftable-group
 


### PR DESCRIPTION
Pretty much what it says in the tin.

Same thing, but for the class reference:
https://github.com/godotengine/godot/pull/122550