### PR TITLE
Correction for example C# code in 'A custom dock'

### DIFF
--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -371,7 +371,7 @@ The script could look like this:
 
  .. code-tab:: csharp
 
-#if TOOLS
+    #if TOOLS
     using Godot;
 
     [Tool]

--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -371,7 +371,7 @@ The script could look like this:
 
  .. code-tab:: csharp
 
-    #if TOOLS
+#if TOOLS
     using Godot;
 
     [Tool]
@@ -390,10 +390,10 @@ The script could look like this:
             _dock.Title = "My Dock";
 
             // Note that LeftUl means the left of the editor, upper-left dock.
-            _dock.DefaultSlot = DockSlot.LeftUl;
+            _dock.DefaultSlot = EditorDock.DockSlot.LeftUl; //DockSlot.LeftUl;
 
             // Allow the dock to be on the left or right of the editor, and to be made floating.
-            _dock.AvailableLayouts = DockLayout.Horizontal | DockLayout.Floating;
+            _dock.AvailableLayouts = EditorDock.DockLayout.Horizontal | EditorDock.DockLayout.Floating;
 
             AddDock(_dock);
         }

--- a/tutorials/plugins/editor/making_plugins.rst
+++ b/tutorials/plugins/editor/making_plugins.rst
@@ -390,7 +390,7 @@ The script could look like this:
             _dock.Title = "My Dock";
 
             // Note that LeftUl means the left of the editor, upper-left dock.
-            _dock.DefaultSlot = EditorDock.DockSlot.LeftUl; //DockSlot.LeftUl;
+            _dock.DefaultSlot = EditorDock.DockSlot.LeftUl;
 
             // Allow the dock to be on the left or right of the editor, and to be made floating.
             _dock.AvailableLayouts = EditorDock.DockLayout.Horizontal | EditorDock.DockLayout.Floating;


### PR DESCRIPTION
Code has two errors:
 _dock.DefaultSlot = DockSlot.LeftUl;
 _dock.AvailableLayouts = DockLayout.Horizontal | DockLayout.Floating;

Lines corrected to the proper types:

_dock.DefaultSlot = EditorDock.DockSlot.LeftUl; _dock.AvailableLayouts = EditorDock.DockLayout.Horizontal | EditorDock.DockLayout.Floating;

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
