### PR TITLE
Remove dead link to tutorial

### DIFF
--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -28,7 +28,6 @@ There are many great channels covering a wide array of subjects.
 Text tutorials
 --------------
 
-- `FinePointCGI website by Mitch <https://finepointcgi.io/>`__
 - `Catlike Coding by Jasper Flick <https://catlikecoding.com/godot/>`__
 - `GDScript website by Andrew Wilkes <https://gdscript.com>`__
 - `Godot Recipes by KidsCanCode <https://kidscancode.org/godot_recipes/4.x/>`__


### PR DESCRIPTION
The FinePointCGI website no longer exists, so I have removed the link to it.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
