### PR TITLE
Update description about visible handlers in the getting started tutorial.

### DIFF
--- a/getting_started/first_3d_game/01.game_setup.rst
+++ b/getting_started/first_3d_game/01.game_setup.rst
@@ -77,7 +77,7 @@ and click the *<empty>* field next to the *Shape* property. Create a new *BoxSha
 The box shape is perfect for flat ground and walls. Its thickness makes it
 reliable to block even fast-moving objects.
 
-A box's wireframe appears in the viewport with three orange dots. You can click
+A box's wireframe appears in the viewport with orange dots at the center of each face. You can click
 and drag these to edit the shape's extents interactively. We can also precisely
 set the size in the inspector. Click on the :ref:`BoxShape3D <class_BoxShape3D>` to expand the resource.
 Set its *Size* to ``60`` on the X-axis, ``2`` for the Y-axis, and ``60`` for


### PR DESCRIPTION
Since https://github.com/godotengine/godot/pull/71092 the behavior of handlers changed so they are always visible even behind things. Now the visible orange dots are 6 most of the time.

But I removed the mention of how many dots appear because even before the change, the amount of visible handlers could be 5 if you looked at the cube on it's side. The same still happens.

(issue reported originally in rocket chat https://chat.godotengine.org/channel/documentation?msg=3tkQRgx2ySFGoDtGP)