### PR TITLE
[WIP] [Engine Details] Add details about `.debugsymbols` changes

### DIFF
--- a/engine_details/development/compiling/compiling_for_linuxbsd.rst
+++ b/engine_details/development/compiling/compiling_for_linuxbsd.rst
@@ -375,6 +375,8 @@ To compile a *server* build which is optimized to run dedicated game servers, us
 Building export templates
 -------------------------
 
+.. TODO: Add details about debugsymbols here.
+
 .. warning:: Linux binaries usually won't run on distributions that are
              older than the distribution they were built on. If you wish to
              distribute binaries that work on most distributions,

--- a/engine_details/development/compiling/compiling_for_windows.rst
+++ b/engine_details/development/compiling/compiling_for_windows.rst
@@ -564,6 +564,8 @@ And for 32-bit:
 Creating Windows export templates
 ---------------------------------
 
+.. TODO: Add details about debugsymbols here.
+
 Windows export templates are created by compiling Godot without the editor,
 with the following flags:
 

--- a/engine_details/development/compiling/introduction_to_the_buildsystem.rst
+++ b/engine_details/development/compiling/introduction_to_the_buildsystem.rst
@@ -216,6 +216,8 @@ binary name.
 Debugging symbols
 -----------------
 
+.. TODO: Update this.
+
 By default, ``debug_symbols=no`` is used, which means **no** debugging symbols
 are included in compiled binaries. Use ``debug_symbols=yes`` to include debug
 symbols within compiled binaries, which allows debuggers and profilers to work
@@ -227,16 +229,18 @@ than the binaries themselves). As a result, official binaries currently do not
 include debugging symbols. This means you need to compile Godot yourself to have
 access to debugging symbols.
 
-When using ``debug_symbols=yes``, you can also use
-``separate_debug_symbols=yes`` to put debug information in a separate file with
-a ``.debug`` suffix. This allows distributing both files independently. Note
-that on Windows, when compiling with MSVC, debugging information is *always*
+When using ``debug_symbols=yes``, you can also use ``separate_debug_symbols=yes``
+to put debug information in a separate file with a ``.debugsymbols`` suffix.
+This allows distributing both files independently. Note that on Windows,
+when compiling with MSVC, debugging information is *always*
 written to a separate ``.pdb`` file regardless of ``separate_debug_symbols``.
 
 .. tip::
 
     Use the ``strip <path/to/binary>`` command to remove debugging symbols from
-    a binary you've already compiled.
+    a binary you've already compiled. This is not needed if using ``separate_debug_symbols``.
+
+.. TODO: Add details here about crash handler lookup.
 
 Optimization level
 ------------------


### PR DESCRIPTION
Still work in progress and waiting for the final details in:
* https://github.com/godotengine/godot/pull/114924
* https://github.com/godotengine/godot/pull/122764
* https://github.com/godotengine/godot/pull/122874

As well as a future macOS PR, and a possible future PR to integrate downloading debug symbols in the template manager

Not sure exactly where to detail this but I've added notes to the areas where it makes sense to me to place notes. Not sure about the best scope for this but will focus on the distribution and compilation details for now, might be good to add a note in the scripting/debug section as well as a follow-up for general crash handling but I think that's out of scope for this

Much of the specifics of the templates and the export process are in the respective export plugin pages (linked at the bottom of each `Exporting For` page) so currently not planning to add anything there to reduce duplication

Currently this is limited to a minor correction to the documentation I found when I was looking at what documentation already existed in preparation for making this PR.

Todo:
- [ ] Consider additional areas to change
- [ ] Document the general build instructions for debug symbols
- [ ] Document the Windows build instructions
- [ ] Document the Linux build instructions
- [ ] Document the macOS build instructions
- [ ] Document template download manager changes (if relevant)
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
