### PR TITLE
Fix integer division causing unintended rounding

### DIFF
--- a/getting_started/first_3d_game/09.adding_animations.rst
+++ b/getting_started/first_3d_game/09.adding_animations.rst
@@ -281,7 +281,7 @@ the *Mob*'s script and at the end of the ``initialize()`` function, add the foll
 
    func initialize(start_position, player_position):
        #...
-       $AnimationPlayer.speed_scale = random_speed / min_speed
+       $AnimationPlayer.speed_scale = float(random_speed) / min_speed
 
  .. code-tab:: csharp
 


### PR DESCRIPTION
The line:

`$AnimationPlayer.speed_scale = random_speed / min_speed`

results in the warning `GDScript::reload: Integer division. Decimal part will be discarded.` and `speed_scale` will always evaluate to `1.0`.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
