### PR TITLE
Fix typo in data_preferences.rst

### DIFF
--- a/tutorials/best_practices/data_preferences.rst
+++ b/tutorials/best_practices/data_preferences.rst
@@ -45,7 +45,7 @@ Godot stores all variables in the scripting API in the
 :ref:`Variant <doc_variant_class>` class.
 Variants can store Variant-compatible data structures such as
 :ref:`Array <class_Array>` and :ref:`Dictionary <class_Dictionary>` as well
-as :ref:`Objects <class_Object>`.
+as :ref:`Object <class_Object>`s.
 
 Godot implements Array as a ``Vector<Variant>``. The engine stores the Array
 contents in a contiguous section of memory, i.e. they are in a row adjacent


### PR DESCRIPTION
The reference links to Object. I assume the reference text should only be 'Object' instead of 'Objects'.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
