### PR TITLE
Update gdextension_cpp_example.rst

### DIFF
--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -43,6 +43,7 @@ Note that this repository has different branches for different versions
 of Godot. GDExtensions will not work in older versions of Godot (only Godot 4 and up) and vice versa, so make sure you download the correct branch.
 
 .. note::
+
     Since Godot version 4.6 it is no longer necessary to match the version of godot-cpp with the Godot
     version you are using. Instead you will specify during the scons build with a parameter ``api_version=4.x``
 

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -108,7 +108,7 @@ You will need the example SConstruct file. Download :download:`the SConstruct fi
 into the gdextension_cpp_example project root folder.
 
 In the project's root folder run the following command to generate the ``compile_commands.json``
-``scons compiledb=yes api_version=4.7 compile_commands.json``
+``scons compiledb=yes api_version=4.7 compile_commands.json``.
 
 You should now be ready to move on to creating a simple plugin.
 

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -45,7 +45,7 @@ of Godot. GDExtensions will not work in older versions of Godot (only Godot 4 an
 .. note::
 
     Since Godot version 4.6 it is no longer necessary to match the version of godot-cpp with the Godot
-    version you are using. Instead you will specify during the scons build with a parameter ``api_version=4.x``
+    version you are using. Instead you will specify during the scons build with a parameter ``api_version=4.x``.
 
 .. warning::
     GDExtensions targeting an earlier version of Godot should work in later

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -105,7 +105,7 @@ Now that godot-cpp is built, you will most likely also want to create a ``compil
 in your gdextension_cpp_example directory if your IDE language server (e.g. clangd) requires it.
 Ensure your current directory is ``gdextension_cpp_example`` and no longer ``/godot-cpp``
 You will need the example SConstruct file. Download :download:`the SConstruct file we prepared <files/cpp_example/SConstruct>`
-into the gdextension_cpp_example project root folder
+into the gdextension_cpp_example project root folder.
 
 In the project's root folder run the following command to generate the ``compile_commands.json``
 ``scons compiledb=yes api_version=4.7 compile_commands.json``

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -97,6 +97,7 @@ you will be using for the plugin. Without it being built, for example, the ``spr
 file will not be available.
 
 .. code-block:: none
+
     cd godot-cpp
     scons platform=<platform> api_version=4.X # replace <platform> with the target platform e.g. linux, windows, macos, etc. Replace the 4.X with the version of godot you are building for e.g. 4.7
 

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -43,14 +43,8 @@ Note that this repository has different branches for different versions
 of Godot. GDExtensions will not work in older versions of Godot (only Godot 4 and up) and vice versa, so make sure you download the correct branch.
 
 .. note::
-    To use `GDExtension <https://godotengine.org/article/introducing-gd-extensions>`__
-    you need to use the godot-cpp branch that matches the version of Godot that you are
-    targeting. For example, if you're targeting Godot 4.1, use the ``4.1`` branch. Throughout
-    this tutorial we use ``4.x``, which will need to be replaced with the version of Godot you
-    are targeting.
-
-    The ``master`` branch is the development branch which is updated regularly
-    to work with Godot's ``master`` branch.
+    Since Godot version 4.6 it is no longer necessary to match the version of godot-cpp with the Godot
+    version you are using. Instead you will specify during the scons build with a parameter ``api_version=4.x``
 
 .. warning::
     GDExtensions targeting an earlier version of Godot should work in later
@@ -68,7 +62,7 @@ a Git submodule:
     mkdir gdextension_cpp_example
     cd gdextension_cpp_example
     git init
-    git submodule add -b 4.x https://github.com/godotengine/godot-cpp
+    git submodule add https://github.com/godotengine/godot-cpp
     cd godot-cpp
     git submodule update --init
 
@@ -78,7 +72,7 @@ Alternatively, you can also clone it to the project folder:
 
     mkdir gdextension_cpp_example
     cd gdextension_cpp_example
-    git clone -b 4.x https://github.com/godotengine/godot-cpp
+    git clone https://github.com/godotengine/godot-cpp
 
 .. note::
 
@@ -96,6 +90,25 @@ following commands:
     git submodule update --init
 
 This will initialize the repository in your project folder.
+
+You must now build the godot-cpp module to generate the necessary include headers
+you will be using for the plugin. Without it being built, for example, the ``sprite2d.hpp``
+file will not be available.
+
+.. code-block:: none
+    cd godot-cpp
+    scons platform=<platform> api_version=4.X # replace <platform> with the target platform e.g. linux, windows, macos, etc. Replace the 4.X with the version of godot you are building for e.g. 4.7
+
+Now that godot-cpp is built, you will most likely also want to create a ``compile_commands.json``
+in your gdextension_cpp_example directory if your IDE language server (e.g. clangd) requires it.
+Ensure your current directory is ``gdextension_cpp_example`` and no longer ``/godot-cpp``
+You will need the example SConstruct file. Download :download:`the SConstruct file we prepared <files/cpp_example/SConstruct>`
+into the gdextension_cpp_example project root folder
+
+In the project's root folder run the following command to generate the ``compile_commands.json``
+``scons compiledb=yes api_version=4.7 compile_commands.json``
+
+You should now be ready to move on to creating a simple plugin.
 
 Creating a simple plugin
 ------------------------
@@ -126,6 +139,16 @@ Your folder structure should now look like this:
     +--godot-cpp/             # C++ bindings
     |
     +--src/                   # source code of the extension we are building
+
+.. warning::
+    The godot-cpp module must be compiled and built in order to generate the necessary
+    include files before moving on to crreating 
+    moving on to creating the gdexample.h. targeting an earlier version of Godot should work in later
+    minor versions, but not vice-versa. For example, a GDExtension targeting Godot 4.2
+    should work just fine in Godot 4.3, but one targeting Godot 4.3 won't work in Godot 4.2.
+
+    There is one exception to this: extensions targeting Godot 4.0 will **not** work with
+    Godot 4.1 and later (see :ref:`updating_your_gdextension_for_godot_4_1`).
 
 In the ``src`` folder, we'll start with creating our header file for the
 GDExtension node we'll be creating. We will name it ``gdexample.h``:

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -143,6 +143,7 @@ Your folder structure should now look like this:
     +--src/                   # source code of the extension we are building
 
 .. warning::
+
     The godot-cpp module must be compiled and built in order to generate the necessary
     include files before moving on to crreating 
     moving on to creating the gdexample.h. targeting an earlier version of Godot should work in later

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -145,7 +145,7 @@ Your folder structure should now look like this:
 .. warning::
 
     The godot-cpp module must be compiled and built in order to generate the necessary
-    moving on to creating the gdexample.h. targeting an earlier version of Godot should work in later
+    moving on to creating the ``gdexample.h`` file targeting an earlier version of Godot should work in later
     minor versions, but not vice-versa. For example, a GDExtension targeting Godot 4.2
     should work just fine in Godot 4.3, but one targeting Godot 4.3 won't work in Godot 4.2.
 

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -145,7 +145,6 @@ Your folder structure should now look like this:
 .. warning::
 
     The godot-cpp module must be compiled and built in order to generate the necessary
-    include files before moving on to crreating 
     moving on to creating the gdexample.h. targeting an earlier version of Godot should work in later
     minor versions, but not vice-versa. For example, a GDExtension targeting Godot 4.2
     should work just fine in Godot 4.3, but one targeting Godot 4.3 won't work in Godot 4.2.

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -45,7 +45,7 @@ of Godot. GDExtensions will not work in older versions of Godot (only Godot 4 an
 .. note::
 
     Since Godot version 4.6 it is no longer necessary to match the version of godot-cpp with the Godot
-    version you are using. Instead you will specify during the scons build with an argument ``api_version=4.x``.
+    version you are using. Instead you will specify it in the scons build with the argument ``api_version=4.x``.
 
 .. warning::
     GDExtensions targeting an earlier version of Godot should work in later

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -99,16 +99,19 @@ file will not be available.
 .. code-block:: none
 
     cd godot-cpp
-    scons platform=<platform> api_version=4.X # replace <platform> with the target platform e.g. linux, windows, macos, etc. Replace the 4.X with the version of godot you are building for e.g. 4.7
+    scons platform=<platform> api_version=4.X # Replace <platform> with the target platform e.g., linux, windows, macos, etc. Replace the 4.X with the version of godot you are building for, e.g., 4.7
 
 Now that godot-cpp is built, you may also need to create a ``compile_commands.json``
 in your gdextension_cpp_example directory if your IDE language server (e.g. clangd) requires it.
-Ensure your current directory is ``gdextension_cpp_example`` and no longer ``/godot-cpp``
+Ensure your current directory is ``gdextension_cpp_example`` and no longer ``/godot-cpp``.
 You will need the example SConstruct file. Download :download:`the SConstruct file we prepared <files/cpp_example/SConstruct>`
 into the gdextension_cpp_example project root folder.
 
-In the project's root folder run the following command to generate the ``compile_commands.json``
-``scons compiledb=yes api_version=4.7 compile_commands.json``.
+In the project's root folder run the following command to generate the ``compile_commands.json``:
+
+.. code-block:: none
+    
+    scons compiledb=yes api_version=4.7 compile_commands.json
 
 You should now be ready to move on to creating a simple plugin.
 

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -52,7 +52,7 @@ You can download the `godot-cpp repository <https://github.com/godotengine/godot
 
 .. note::
 
-    Branches of specific GDExtension API versions are no longer provided individually. Instead, you will select the version of the
+    Branches of specific GDExtension API versions are no longer provided individually. Instead, you should select the version of the
     GDExtension API you wish to use in the scons build with the argument ``api_version=4.x``.    
 
 If you are versioning your project using Git, it is recommended to add it as

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -45,7 +45,7 @@ of Godot. GDExtensions will not work in older versions of Godot (only Godot 4 an
 .. note::
 
     Since Godot version 4.6 it is no longer necessary to match the version of godot-cpp with the Godot
-    version you are using. Instead you will specify during the scons build with a parameter ``api_version=4.x``.
+    version you are using. Instead you will specify during the scons build with an argument ``api_version=4.x``.
 
 .. warning::
     GDExtensions targeting an earlier version of Godot should work in later
@@ -101,7 +101,7 @@ file will not be available.
     cd godot-cpp
     scons platform=<platform> api_version=4.X # replace <platform> with the target platform e.g. linux, windows, macos, etc. Replace the 4.X with the version of godot you are building for e.g. 4.7
 
-Now that godot-cpp is built, you will most likely also want to create a ``compile_commands.json``
+Now that godot-cpp is built, you may also need to create a ``compile_commands.json``
 in your gdextension_cpp_example directory if your IDE language server (e.g. clangd) requires it.
 Ensure your current directory is ``gdextension_cpp_example`` and no longer ``/godot-cpp``
 You will need the example SConstruct file. Download :download:`the SConstruct file we prepared <files/cpp_example/SConstruct>`
@@ -144,13 +144,7 @@ Your folder structure should now look like this:
 
 .. warning::
 
-    The godot-cpp module must be compiled and built in order to generate the necessary
-    moving on to creating the ``gdexample.h`` file targeting an earlier version of Godot should work in later
-    minor versions, but not vice-versa. For example, a GDExtension targeting Godot 4.2
-    should work just fine in Godot 4.3, but one targeting Godot 4.3 won't work in Godot 4.2.
-
-    There is one exception to this: extensions targeting Godot 4.0 will **not** work with
-    Godot 4.1 and later (see :ref:`updating_your_gdextension_for_godot_4_1`).
+    The godot-cpp module must be compiled and built before proceeding.
 
 In the ``src`` folder, we'll start with creating our header file for the
 GDExtension node we'll be creating. We will name it ``gdexample.h``:

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -101,7 +101,7 @@ file will not be available.
     cd godot-cpp
     scons platform=<platform> api_version=4.X # Replace <platform> with the target platform e.g., linux, windows, macos, etc. Replace the 4.X with the version of godot you are building for, e.g., 4.7
 
-Now that godot-cpp is built, you may also need to create a ``compile_commands.json``
+Now that godot-cpp is built, you may also need to create a ``compile_commands.json`` file
 in your gdextension_cpp_example directory if your IDE language server (e.g. clangd) requires it.
 Ensure your current directory is ``gdextension_cpp_example`` and no longer ``/godot-cpp``.
 You will need the example SConstruct file. Download :download:`the SConstruct file we prepared <files/cpp_example/SConstruct>`

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -98,6 +98,7 @@ file, for example, will not be available.
 
 .. code-block:: none
 
+
     cd godot-cpp
     scons platform=<platform> api_version=4.X # Replace <platform> with the target platform e.g., linux, windows, macos, etc. Replace the 4.X with the version of godot you are building for, e.g., 4.7
 

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -107,7 +107,7 @@ file, for example, will not be available.
     ``compile_commands.json`` file in your gdextension_cpp_example directory. Some language servers
     need this file to provide include path information and completion recommendations. To do this,
     ensure your current directory is ``gdextension_cpp_example`` and no longer ``/godot-cpp``.
-    You will also need to copy the example SConstruct file into the gdextension_cpp_example project root folder.. 
+    You will also need to copy the example SConstruct file into the gdextension_cpp_example project root folder.
     Download :download:`the SConstruct file we prepared <files/cpp_example/SConstruct>`.
  
     In the project's root folder run the following command to generate the ``compile_commands.json``:

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -43,7 +43,7 @@ You can download the `godot-cpp repository <https://github.com/godotengine/godot
 .. warning::
     GDExtensions targeting an earlier version of Godot should work in later
     minor versions, but not vice-versa. For example, a GDExtension targeting Godot 4.2
-    should work just fine in Godot 4.3, but one targeting Godot 4.3 won't work in Godot 4.2.    
+    should work just fine in Godot 4.3, but one targeting Godot 4.3 won't work in Godot 4.2.
 
     There is one exception to this: extensions targeting Godot 4.0 will **not** work with
     Godot 4.1 and later (see :ref:`updating_your_gdextension_for_godot_4_1`).

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -98,8 +98,6 @@ file, for example, will not be available.
 
 .. code-block:: none
 
-
-
     cd godot-cpp
     scons platform=<platform> api_version=4.X # Replace <platform> with the target platform e.g., linux, windows, macos, etc. Replace the 4.X with the version of godot you are building for, e.g., 4.7
 

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -44,7 +44,7 @@ of Godot. GDExtensions will not work in older versions of Godot (only Godot 4 an
 
 .. note::
 
-    Since Godot version 4.6 it is no longer necessary to match the version of godot-cpp with the Godot
+    Since Godot version 4.6 it is no longer necessary to match the godot-cpp version with the Godot
     version you are using. Instead you will specify it in the scons build with the argument ``api_version=4.x``.
 
 .. warning::

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -39,21 +39,21 @@ and :ref:`Compiling <toc-devel-compiling>` as the build tools are identical
 to the ones you need to compile Godot from source.
 
 You can download the `godot-cpp repository <https://github.com/godotengine/godot-cpp>`__ from GitHub or let Git do the work for you.
-Note that this repository has different branches for different versions
-of Godot. GDExtensions will not work in older versions of Godot (only Godot 4 and up) and vice versa, so make sure you download the correct branch.
-
-.. note::
-
-    Since Godot version 4.6 it is no longer necessary to match the godot-cpp version with the Godot
-    version you are using. Instead you will specify it in the scons build with the argument ``api_version=4.x``.
 
 .. warning::
     GDExtensions targeting an earlier version of Godot should work in later
     minor versions, but not vice-versa. For example, a GDExtension targeting Godot 4.2
-    should work just fine in Godot 4.3, but one targeting Godot 4.3 won't work in Godot 4.2.
+    should work just fine in Godot 4.3, but one targeting Godot 4.3 won't work in Godot 4.2.    
 
     There is one exception to this: extensions targeting Godot 4.0 will **not** work with
     Godot 4.1 and later (see :ref:`updating_your_gdextension_for_godot_4_1`).
+
+    GDExtensions will not work in older versions of Godot (only Godot 4 and up).
+
+.. note::
+
+    Branches of specific GDExtension API versions are no longer provided individually. Instead, you will select the version of the
+    GDExtension API you wish to use in the scons build with the argument ``api_version=4.x``.    
 
 If you are versioning your project using Git, it is recommended to add it as
 a Git submodule:
@@ -92,26 +92,29 @@ following commands:
 
 This will initialize the repository in your project folder.
 
-You must now build the godot-cpp module to generate the necessary include headers
+You should now build the godot-cpp module to generate the necessary include headers
 you will be using for the plugin. Without it being built, the ``sprite2d.hpp``
 file, for example, will not be available.
 
 .. code-block:: none
 
     cd godot-cpp
-    scons platform=<platform> api_version=4.X # Replace <platform> with the target platform e.g., linux, windows, macos, etc. Replace the 4.X with the version of godot you are building for, e.g., 4.7
+    scons platform=<platform> api_version=4.X # Replace <platform> with the target platform e.g., linux, windows, macos, etc. Replace the 4.X with the version of GDExtension you are building for, e.g., 4.7
 
-Now that godot-cpp is built, you may also need to create a ``compile_commands.json`` file
-in your gdextension_cpp_example directory if your IDE language server (e.g. clangd) requires it.
-Ensure your current directory is ``gdextension_cpp_example`` and no longer ``/godot-cpp``.
-You will need the example SConstruct file. Download :download:`the SConstruct file we prepared <files/cpp_example/SConstruct>`
-into the gdextension_cpp_example project root folder.
+.. note:: 
 
-In the project's root folder run the following command to generate the ``compile_commands.json``:
+    Depending on your IDE or Language Server (e.g., clangd), you may also want to create a
+    ``compile_commands.json`` file in your gdextension_cpp_example directory. Some language servers
+    need this file to provide include path information and completion recommendations. To do this,
+    ensure your current directory is ``gdextension_cpp_example`` and no longer ``/godot-cpp``.
+    You will also need to copy the example SConstruct file into the gdextension_cpp_example project root folder.. 
+    Download :download:`the SConstruct file we prepared <files/cpp_example/SConstruct>`
+ 
+    In the project's root folder run the following command to generate the ``compile_commands.json``:
 
-.. code-block:: none
+    .. code-block:: none
     
-    scons compiledb=yes api_version=4.7 compile_commands.json
+        scons compiledb=yes api_version=4.7 compile_commands.json
 
 You should now be ready to move on to creating a simple plugin.
 
@@ -145,9 +148,6 @@ Your folder structure should now look like this:
     |
     +--src/                   # source code of the extension we are building
 
-.. warning::
-
-    The godot-cpp module must be compiled and built before proceeding.
 
 In the ``src`` folder, we'll start with creating our header file for the
 GDExtension node we'll be creating. We will name it ``gdexample.h``:

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -93,7 +93,7 @@ following commands:
 This will initialize the repository in your project folder.
 
 You must now build the godot-cpp module to generate the necessary include headers
-you will be using for the plugin. Without it being built, for example, the ``sprite2d.hpp``
+you will be using for the plugin. Without it being built, the ``sprite2d.hpp``
 file will not be available.
 
 .. code-block:: none

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -94,7 +94,7 @@ This will initialize the repository in your project folder.
 
 You must now build the godot-cpp module to generate the necessary include headers
 you will be using for the plugin. Without it being built, the ``sprite2d.hpp``
-file will not be available.
+file, for example, will not be available.
 
 .. code-block:: none
 

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -108,7 +108,7 @@ file, for example, will not be available.
     need this file to provide include path information and completion recommendations. To do this,
     ensure your current directory is ``gdextension_cpp_example`` and no longer ``/godot-cpp``.
     You will also need to copy the example SConstruct file into the gdextension_cpp_example project root folder.. 
-    Download :download:`the SConstruct file we prepared <files/cpp_example/SConstruct>`
+    Download :download:`the SConstruct file we prepared <files/cpp_example/SConstruct>`.
  
     In the project's root folder run the following command to generate the ``compile_commands.json``:
 

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -99,6 +99,7 @@ file, for example, will not be available.
 .. code-block:: none
 
 
+
     cd godot-cpp
     scons platform=<platform> api_version=4.X # Replace <platform> with the target platform e.g., linux, windows, macos, etc. Replace the 4.X with the version of godot you are building for, e.g., 4.7
 

--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -92,9 +92,8 @@ following commands:
 
 This will initialize the repository in your project folder.
 
-You should now build the godot-cpp module to generate the necessary include headers
-you will be using for the plugin. Without it being built, the ``sprite2d.hpp``
-file, for example, will not be available.
+You should now build the godot-cpp module to generate the static library as well
+as additional headers you will be using for your GDExtension.
 
 .. code-block:: none
 
@@ -103,6 +102,10 @@ file, for example, will not be available.
 
 .. note:: 
 
+    There are three include paths that contain the headers you will need to build your GDExtension:
+    ``/godot-cpp/gdextension``, ``/godot-cpp/include``, and ``/godot-cpp/gen/include``. The last
+    of which is creeated when you build the godot-cpp module.
+    
     Depending on your IDE or Language Server (e.g., clangd), you may also want to create a
     ``compile_commands.json`` file in your gdextension_cpp_example directory. Some language servers
     need this file to provide include path information and completion recommendations. To do this,


### PR DESCRIPTION
The previous documentation appeared to be out of date with regards to the setup which had recommended getting godot-cpp -b 4.x which are no longer available since 4.6 and beyond. Further, I feel we need to add build instructions for the godot-cpp module since without building it, none of the includes used afterwards are present and can be confusing to someone starting out why sprite2d.hpp is not available. Finally, I think most people using an IDE requires compile_commands.json to be present for their LSPs to work (for example I'm using clangd, and autocomplete wouldn't work until it generated) so I added a section to generate it. This hopefully will provide a more fluid intro without having to use reddit or forum posts to patch it together.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
