### PR TITLE
Fix broken :ref: role in first_look_at_the_editor.html

### DIFF
--- a/getting_started/introduction/first_look_at_the_editor.rst
+++ b/getting_started/introduction/first_look_at_the_editor.rst
@@ -156,7 +156,7 @@ tools, and other resources to use in your projects.
 
 .. seealso::
 
-    You can learn more about the Asset Store in ref:`doc_what_is_asset_store`.
+    You can learn more about the Asset Store in :ref:`doc_what_is_asset_store`.
 
 .. _doc_intro_to_the_editor_interface_integrated_class_reference:
 


### PR DESCRIPTION
Added missing colon symbol that caused a broken visible link in the website.