### PR TITLE
Add :ref: to the node AnimatedSprite2D in list_of_features.rst

### DIFF
--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -149,7 +149,7 @@ Godot 4 includes three renderers:
    - High-level tools to draw lines and polygons such as
      :ref:`class_Polygon2D` and :ref:`class_Line2D`, with support for texturing.
 
-- AnimatedSprite2D as a helper for creating animated sprites.
+- :ref:`class_AnimatedSprite2D` as a helper for creating animated sprites.
 - Parallax layers.
 
    - Pseudo-3D support including preview in the editor.


### PR DESCRIPTION
Add a reference to the AnimatedSprite2D node for consistency with the other nodes featured.