### PR TITLE
docs: point Mutex example at templates/mutex.hpp post godot-cpp#2032

### DIFF
--- a/tutorials/performance/using_multiple_threads.rst
+++ b/tutorials/performance/using_multiple_threads.rst
@@ -214,7 +214,7 @@ Here is an example of using a Mutex:
 
     #pragma once
 
-    #include <godot_cpp/classes/mutex.hpp>
+    #include <godot_cpp/templates/mutex.hpp>
     #include <godot_cpp/classes/node.hpp>
     #include <godot_cpp/classes/thread.hpp>
 
@@ -381,7 +381,7 @@ ready to be processed:
 
     #pragma once
 
-    #include <godot_cpp/classes/mutex.hpp>
+    #include <godot_cpp/templates/mutex.hpp>
     #include <godot_cpp/classes/node.hpp>
     #include <godot_cpp/classes/semaphore.hpp>
     #include <godot_cpp/classes/thread.hpp>


### PR DESCRIPTION
Closes #12346

godot-cpp#2032 removed the old core-based Mutex in favor of the
upstream Mutex inlined into godot_cpp/templates/mutex.hpp, but the
"Using multiple threads" example still includes
godot_cpp/classes/mutex.hpp. I updated the include to the new path.