### PR TITLE
Fix StringName highlight color in light mode

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -145,7 +145,7 @@
     --highlight-string-color: #996b00;
     --highlight-get-node-shorthand-color: #2e8c00;
     --highlight-node-path-color: #008000;
-    --highlight-string-name-color: #ffc2a6;
+    --highlight-string-name-color: #cc8f73;
 
     --copybtn-background-color: #f6f8fa;
     --copybtn-background-color-hover: #f3f4f6;


### PR DESCRIPTION
Required for https://github.com/godotengine/godot-docs/pull/12271

Due to an oversight, the color used to highlight StringName literals in GDScript is the same between dark and light mode. This wasn't caught sooner because you can count the StringName literals in the docs with one hand.

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/fd5a91db-a048-4200-9034-b73f28c36ca0" />

This PR changes the color to match what the Godot Editor actually uses.

