### PR TITLE
Removed outdated C++ example tab

### DIFF
--- a/getting_started/first_2d_game/01.project_setup.rst
+++ b/getting_started/first_2d_game/01.project_setup.rst
@@ -30,10 +30,6 @@ When creating the new project, you only need to choose a valid *Project Path*. Y
     You need the latest stable .NET SDK, and an editor such as VS Code.
     See :ref:`doc_c_sharp_setup`.
 
- .. tab:: C++
-
-    The C++ part of this tutorial wasn't rewritten for the new GDExtension system yet.
-
 Your project folder should look like this.
 
 .. image:: img/folder-content.webp


### PR DESCRIPTION
In the whole "Your first 2D game" tutorial, this is the only place where C++ example tab exists and that also giving a message that it's not complete.
For uniformity have removed the C++ tab from there.

I guess we're mostly following GDScript and C# examples unless specifically for GDExtension throughout godot docs. 

<img width="846" height="229" alt="Screenshot 2026-09-06 at 10 49 39 AM" src="https://github.com/user-attachments/assets/56801208-7621-4c2f-a81f-4e7bba470428" />

Documentation : https://docs.godotengine.org/en/stable/getting_started/first_2d_game/01.project_setup.html