### PR TITLE
Fix typo in gdextension_cpp_example.rst

### DIFF
--- a/tutorials/scripting/cpp/gdextension_cpp_example.rst
+++ b/tutorials/scripting/cpp/gdextension_cpp_example.rst
@@ -294,7 +294,7 @@ At last, we need the header file for the ``register_types.cpp`` named
 Compiling the plugin
 --------------------
 
-To compile the project we need to define how SCons using should compile it
+To compile the project we need to define how SCons should compile it
 using an ``SConstruct`` file which references the one in ``godot-cpp``.
 Writing it from scratch is outside the scope of this tutorial, but you can download
 :download:`the SConstruct file we prepared <files/cpp_example/SConstruct>`.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->

Fix typo in the first sentence of **[Compiling the plugin](https://docs.godotengine.org/en/latest/tutorials/scripting/cpp/gdextension_cpp_example.html#compiling-the-plugin)** section of **C++ (godot-cpp) Getting started** article.