### PR TITLE
Document Decal support in the Compatibility renderer

### DIFF
--- a/tutorials/3d/using_decals.rst
+++ b/tutorials/3d/using_decals.rst
@@ -3,14 +3,6 @@
 Using decals
 ============
 
-.. note::
-
-    Decals are only supported in the Forward+ and Mobile renderers, not the
-    Compatibility renderer.
-
-    If using the Compatibility renderer, consider using Sprite3D as an alternative
-    for projecting decals onto (mostly) flat surfaces.
-
 Decals are projected textures that apply on opaque or transparent surfaces in
 3D. This projection happens in real-time and doesn't rely on mesh generation.
 This allows you to move decals every frame with only a small performance impact,
@@ -270,3 +262,10 @@ in **Project Settings > Rendering > Limits > Cluster Builder**.
 When using the Mobile renderer, only 8 decals can be applied on each
 individual Mesh *resource*. If there are more decals affecting a single mesh,
 not all of them will be rendered on the mesh.
+
+When using the Compatibility renderer, only 8 decals can be applied on each
+individual Mesh *resource*. If there are more decals affecting a single mesh,
+not all of them will be rendered on the mesh. The maximum number of decals that
+can be rendered in a single view is 64. This limit can be changed by adjusting
+:ref:`Max Decals <class_ProjectSettings_property_rendering/limits/opengl/max_decals>`
+in **Project Settings > Rendering > Limits > OpenGL**.

--- a/tutorials/rendering/renderers.rst
+++ b/tutorials/rendering/renderers.rst
@@ -364,7 +364,9 @@ Other features
 | Variable rate           | ❌ Not supported.        | ✔️ Supported.            | ✔️ Supported.            |
 | shading                 |                          |                          |                          |
 +-------------------------+--------------------------+--------------------------+--------------------------+
-| Decals                  | ❌ Not supported.        | ✔️ Supported.            | ✔️ Supported.            |
+| Decals                  | ✔️ Supported. 8 per      | ✔️ Supported. 8          | ✔️ Supported. No limit   |
+|                         | surface, 64 per view     | per surface.             | per surface (clustered). |
+|                         | (adjustable).            |                          |                          |
 +-------------------------+--------------------------+--------------------------+--------------------------+
 | Particle trails         | ❌ Not supported.        | ✔️ Supported.            | ✔️ Supported.            |
 +-------------------------+--------------------------+--------------------------+--------------------------+


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/118070.

> [!NOTE]
>
> CI will fail until the class reference is synced, as this PR references a new project setting.