### PR TITLE
Fix incorrect Project Setting from Godot 3 and add links to roughness settings

### DIFF
--- a/tutorials/3d/3d_antialiasing.rst
+++ b/tutorials/3d/3d_antialiasing.rst
@@ -262,9 +262,16 @@ an effect on roughness map rendering itself, its impact is limited there.
 
 The screen-space roughness limiter is enabled by default; it doesn't require
 any manual setup. It has a small performance impact, so consider disabling it
-if your project isn't affected by specular aliasing much. You can disable it
-with the **Rendering > Quality > Screen Space Filters > Screen Space Roughness Limiter**
-project setting.
+if your project isn't much affected by specular aliasing.
+You can disable it in the Project Settings by turning off
+:ref:`Rendering > Anti Aliasing > Screen Space Roughness Limiter > Enabled <class_ProjectSettings_property_rendering/anti_aliasing/screen_space_roughness_limiter/enabled>`.
+
+If desired, the ``amount`` and ``limit`` can be configured
+in the Project Settings by changing the values of the
+:ref:`Rendering > Anti Aliasing > Screen Space Roughness Limiter > Amount <class_ProjectSettings_property_rendering/anti_aliasing/screen_space_roughness_limiter/amount>`
+and
+:ref:`Rendering > Anti Aliasing > Screen Space Roughness Limiter > Limit <class_ProjectSettings_property_rendering/anti_aliasing/screen_space_roughness_limiter/limit>`
+settings respectively.
 
 Texture roughness limiter on import
 -----------------------------------


### PR DESCRIPTION
Adds links to ProjectSettings settings for Screen-space roughness limiter, as consistent with the rest of the **3d Antialiasing** page.

The prior setting that was listed was not correct:

~~Rendering > Quality > Screen Space Filters > Screen Space Roughness Limiter~~
should be
Rendering > Anti Aliasing > Screen Space Roughness Limiter > Enabled

The setting listed appears to be from Godot 3...? I couldn't find the source of it but didn't search that hard.

This is partially in response to #12297 (though this PR doesn't close it).