### PR TITLE
2D collision shapes tutorial: document debug color

### DIFF
--- a/tutorials/physics/collision_shapes_2d.rst
+++ b/tutorials/physics/collision_shapes_2d.rst
@@ -6,6 +6,7 @@ Collision shapes (2D)
 This guide explains:
 
 - The types of collision shapes available in 2D in Godot.
+- Debugging collision shapes
 - Using an image converted to a polygon as a collision shape.
 - Performance considerations regarding 2D collisions.
 
@@ -87,6 +88,27 @@ You can configure the CollisionPolygon2D node's *build mode* in the inspector.
 If it is set to **Solids** (the default), collisions will include the polygon
 and its contained area. If it is set to **Segments**, collisions will only
 include the polygon edges.
+
+Debugging collision shapes
+--------------------------
+
+Use the :ref:`debug color<class_CollisionShape2D_property_debug_color>` to
+distinguish a shape from others. Turn on the
+:menu:`Debug > Visible Collision Shapes` menu option to also see them in the
+running project.
+
+.. tip::
+
+    If the project setting
+    :ref:`Debug > Shapes > Collision > Draw 2D Outlines<class_ProjectSettings_property_debug/shapes/collision/draw_2d_outlines>`
+    is enabled (which is the default), a solid outline will be derived from the
+    debug color, even if the debug color has full transparency. So you can use
+    this to have outline-only debug shapes. This is useful when multiple
+    collision shapes overlap in the same scene: a physics collider, a hitbox,
+    an interaction shape. For example, use `Color(255, 22, 22, 0)` for a red outline.
+
+Generating collision shapes from images
+---------------------------------------
 
 You can generate a concave collision shape from the editor by selecting a Sprite2D
 and using the **Sprite2D** menu at the top of the 2D viewport. The Sprite2D menu

--- a/tutorials/physics/collision_shapes_2d.rst
+++ b/tutorials/physics/collision_shapes_2d.rst
@@ -6,7 +6,7 @@ Collision shapes (2D)
 This guide explains:
 
 - The types of collision shapes available in 2D in Godot.
-- Debugging collision shapes
+- Debugging collision shapes.
 - Using an image converted to a polygon as a collision shape.
 - Performance considerations regarding 2D collisions.
 
@@ -100,12 +100,12 @@ running project.
 .. tip::
 
     If the project setting
-    :ref:`Debug > Shapes > Collision > Draw 2D Outlines<class_ProjectSettings_property_debug/shapes/collision/draw_2d_outlines>`
+    :ref:`Debug > Shapes > Collision > Draw 2D Outlines <class_ProjectSettings_property_debug/shapes/collision/draw_2d_outlines>`
     is enabled (which is the default), a solid outline will be derived from the
-    debug color, even if the debug color has full transparency. So you can use
+    debug color, even if the debug color has full transparency. You can use
     this to have outline-only debug shapes. This is useful when multiple
-    collision shapes overlap in the same scene: a physics collider, a hitbox,
-    an interaction shape. For example, use `Color(255, 22, 22, 0)` for a red outline.
+    collision shapes overlap in the same scene, such as a physics collider, a hitbox,
+    and an interaction shape. For example, use ``Color(1, 0, 0, 0)`` for a red outline.
 
 Generating collision shapes from images
 ---------------------------------------

--- a/tutorials/physics/collision_shapes_2d.rst
+++ b/tutorials/physics/collision_shapes_2d.rst
@@ -92,10 +92,10 @@ include the polygon edges.
 Debugging collision shapes
 --------------------------
 
-Use the :ref:`debug color<class_CollisionShape2D_property_debug_color>` to
-distinguish a shape from others. Turn on the
-:menu:`Debug > Visible Collision Shapes` menu option to also see them in the
-running project.
+Use the :ref:`Debug Color <class_CollisionShape2D_property_debug_color>` property
+in the CollisionShape2D resource to distinguish a shape from others.
+Turn on the :menu:`Debug > Visible Collision Shapes` menu option to also see them
+in the running project.
 
 .. tip::
 


### PR DESCRIPTION
And add a tip about having outline-only debug shapes.

Also add a title to the pre-existing "collision shapes from images" paragraphs, for better separation.

Resolve https://github.com/godotengine/godot-docs/issues/12364

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
