### PR TITLE
Fix infinite reload loop when a redirect target matches its own source

### DIFF
--- a/404.rst
+++ b/404.rst
@@ -49,14 +49,14 @@ Page not found
             continue;
           }
           const [from, to] = line.split(',').map(s => s.trim());
-          if (from && to) {
-            if (window.location.pathname.endsWith(from)) {
-              if (to.startsWith('https://')) {
-                window.location.replace(to);
-              } else {
-                const newUrl = window.location.href.replace(window.location.pathname, currentBasePath + to);
-                window.location.replace(newUrl);
-              }
+          if (from && to && window.location.pathname.endsWith(from)) {
+            const target = to.startsWith('https://')
+              ? to
+              : window.location.href.replace(window.location.pathname, currentBasePath + to);
+            // Skip redirects that resolve to the current URL, which would otherwise
+            // reload the page forever.
+            if (target !== window.location.href) {
+              window.location.replace(target);
               break;
             }
           }


### PR DESCRIPTION
Fixes #12360.

`404.rst` matches entries from `redirects.csv` with `window.location.pathname.endsWith(from)`. Some entries redirect to a path that itself ends with the matched `from` — for example `/development/file_formats/tscn.html` → `/engine_details/file_formats/tscn.html`. Visiting `.../engine_details/development/file_formats/tscn.html` therefore matches that entry, and the computed target is the current URL, so `location.replace()` reloads the same page forever.

This skips any redirect whose resolved target equals the current URL, so the loop cannot happen regardless of which CSV entries overlap. Behaviour for every other entry is unchanged, and no CSV entries are modified, so existing redirects keep working.

Repro (before the fix): open https://docs.godotengine.org/en/stable/engine_details/development/file_formats/tscn.html — the 404 page reloads indefinitely.

Verified by simulating both versions of the matching logic against the deployed `redirects.csv`: the previous code loops fore