### PR TITLE
Fix order of node renaming in spawning mobs guide

### DIFF
--- a/getting_started/first_3d_game/05.spawning_mobs.rst
+++ b/getting_started/first_3d_game/05.spawning_mobs.rst
@@ -143,8 +143,8 @@ Your path should look like this.
 |image18|
 
 To sample random positions on it, we need a :ref:`PathFollow3D <class_PathFollow3D>` node. Add a
-:ref:`PathFollow3D <class_PathFollow3D>` as a child of the ``Path3D``. Rename the two nodes to ``SpawnLocation`` and
-``SpawnPath``, respectively. It's more descriptive of what we'll use them for.
+:ref:`PathFollow3D <class_PathFollow3D>` as a child of the ``Path3D``. Rename the two nodes to ``SpawnPath`` and
+``SpawnLocation``, respectively. It's more descriptive of what we'll use them for.
 
 |image19|
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://contributing.godotengine.org/en/latest/documentation/guidelines/content_guidelines.html
-->
